### PR TITLE
Fix skill-creator frontmatter validation

### DIFF
--- a/skill-creator/SKILL.md
+++ b/skill-creator/SKILL.md
@@ -41,7 +41,20 @@ skill-name/
 
 #### SKILL.md (required)
 
-**Metadata Quality:** The `name` and `description` in YAML frontmatter determine when Claude will use the skill. Be specific about what the skill does and when to use it. Use the third-person (e.g. "This skill should be used when..." instead of "Use this skill when...").
+**YAML Frontmatter:** Every SKILL.md must start with YAML frontmatter delimited by `---`. The frontmatter contains metadata that determines when and how Claude will use the skill.
+
+**Required Fields:**
+- `name` - Hyphen-case identifier (lowercase letters, digits, and hyphens only, max 40 characters)
+- `description` - Clear explanation of what the skill does and when to use it (max 1024 characters)
+
+**Optional Fields:**
+- `license` - License information for the skill
+- `allowed-tools` - List of pre-approved tools the skill can use (security feature for Claude Code)
+- `metadata` - Arbitrary key-value pairs for client-specific extensions
+
+**Metadata Quality:** The `name` and `description` determine when Claude will use the skill. Be specific about what the skill does and when to use it. Use the third-person (e.g. "This skill should be used when..." instead of "Use this skill when...").
+
+**Important:** Only use the allowed frontmatter properties listed above. Properties like `version` are not supported and will cause validation errors.
 
 #### Bundled Resources (optional)
 

--- a/skill-creator/scripts/init_skill.py
+++ b/skill-creator/scripts/init_skill.py
@@ -17,7 +17,13 @@ from pathlib import Path
 
 SKILL_TEMPLATE = """---
 name: {skill_name}
-description: [TODO: Complete and informative explanation of what the skill does and when to use it. Include WHEN to use this skill - specific scenarios, file types, or tasks that trigger it.]
+description: [TODO: Complete and informative explanation of what the skill does and when to use it. Include WHEN to use this skill - specific scenarios, file types, or tasks that trigger it. Max 1024 characters.]
+# Optional fields (uncomment and fill in as needed):
+# license: Complete terms in LICENSE.txt
+# allowed-tools: [Read, Write, Bash]
+# metadata:
+#   key1: value1
+#   key2: value2
 ---
 
 # {skill_title}

--- a/skill-creator/scripts/quick_validate.py
+++ b/skill-creator/scripts/quick_validate.py
@@ -11,30 +11,54 @@ from pathlib import Path
 def validate_skill(skill_path):
     """Basic validation of a skill"""
     skill_path = Path(skill_path)
-    
+
     # Check SKILL.md exists
     skill_md = skill_path / 'SKILL.md'
     if not skill_md.exists():
         return False, "SKILL.md not found"
-    
+
     # Read and validate frontmatter
     content = skill_md.read_text()
     if not content.startswith('---'):
         return False, "No YAML frontmatter found"
-    
+
     # Extract frontmatter
     match = re.match(r'^---\n(.*?)\n---', content, re.DOTALL)
     if not match:
         return False, "Invalid frontmatter format"
-    
+
     frontmatter = match.group(1)
-    
+
+    # Define allowed frontmatter properties
+    allowed_properties = {'name', 'description', 'license', 'allowed-tools', 'metadata'}
+
+    # Extract all property keys from frontmatter (only top-level keys)
+    property_keys = set()
+    for line in frontmatter.split('\n'):
+        # Skip comments
+        if line.strip().startswith('#'):
+            continue
+        # Only consider lines that start at column 0 (top-level keys)
+        # Indented lines are nested values (like metadata children)
+        if ':' in line and not line.startswith(' ') and not line.startswith('\t'):
+            # Extract key before the colon
+            key = line.split(':')[0].strip()
+            if key:  # Skip empty keys
+                property_keys.add(key)
+
+    # Check for unexpected properties
+    unexpected_properties = property_keys - allowed_properties
+    if unexpected_properties:
+        unexpected_list = ', '.join(sorted(unexpected_properties))
+        allowed_list = ', '.join(sorted(allowed_properties))
+        return False, f"Unexpected key(s) in SKILL.md frontmatter: {unexpected_list}. Allowed properties: {allowed_list}"
+
     # Check required fields
-    if 'name:' not in frontmatter:
+    if 'name' not in property_keys:
         return False, "Missing 'name' in frontmatter"
-    if 'description:' not in frontmatter:
+    if 'description' not in property_keys:
         return False, "Missing 'description' in frontmatter"
-    
+
     # Extract name for validation
     name_match = re.search(r'name:\s*(.+)', frontmatter)
     if name_match:
@@ -52,6 +76,9 @@ def validate_skill(skill_path):
         # Check for angle brackets
         if '<' in description or '>' in description:
             return False, "Description cannot contain angle brackets (< or >)"
+        # Check description length (max 1024 characters)
+        if len(description) > 1024:
+            return False, f"Description too long ({len(description)} characters). Maximum 1024 characters allowed"
 
     return True, "Skill is valid!"
 


### PR DESCRIPTION
This update fixes this issue https://github.com/anthropics/skills/issues/37 : the skill-creator skill to properly validate YAML frontmatter properties and prevent common errors during skill creation.



Changes:
- Enhanced quick_validate.py to check for allowed frontmatter properties (name, description, license, allowed-tools, metadata)
- Added validation to reject unsupported properties like 'version', 'author', 'category'
- Fixed nested YAML handling to correctly ignore keys under 'metadata'
- Added description length validation (max 1024 characters)
- Updated SKILL.md documentation to clearly list required and optional frontmatter fields
- Updated init_skill.py template to include commented examples of all optional fields
- Improved error messages to list both unexpected and allowed properties

Fixes the issue where skills with invalid frontmatter properties would fail with unclear error messages during packaging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)