### PR TITLE
Clarify the need to run `/plugin` to see the plugin menu options

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,11 @@ You can register this repository as a Claude Code Plugin marketplace by running 
 ```
 
 Then, to install a specific set of skills:
-1. Select `Browse and install plugins`
-2. Select `anthropic-agent-skills`
-3. Select `document-skills` or `example-skills`
-4. Select `Install now`
+1. Run `/plugin` again
+2. Select `Browse and install plugins`
+3. Select `anthropic-agent-skills`
+4. Select `document-skills` or `example-skills`
+5. Select `Install now`
 
 Alternatively, directly install either Plugin via:
 ```


### PR DESCRIPTION
I was confused by where the menu options were because I've not used `/plugin` before.