### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Skills
+
+[![Run in Smithery](https://smithery.ai/badge/skills/anthropics)](https://smithery.ai/skills?ns=anthropics&utm_source=github&utm_medium=badge)
+
 Skills are folders of instructions, scripts, and resources that Claude loads dynamically to improve performance on specialized tasks. Skills teach Claude how to complete specific tasks in a repeatable way, whether that's creating documents with your company's brand guidelines, analyzing data using your organization's specific workflows, or automating personal tasks.
 
 For more information, check out:


### PR DESCRIPTION
## Add "Run in Smithery" Badge

Hi! We'd like to add a badge to your README that lets users instantly discover and try your Claude Skills in [Smithery](https://smithery.ai).

[![Run in Smithery](https://smithery.ai/badge/skills/anthropics)](https://smithery.ai/skills?ns=anthropics&utm_source=github&utm_medium=badge)

### What's Smithery?
Smithery is a platform for discovering and installing Claude Skills and MCP servers. Your 15 skills have been installed **230 times** by **193 users** in the last 30 days.

### Top Skills
- **frontend-design** (129 activations, 105 users)
- **skill-creator** (73 activations, 62 users)
- **docx** (12 activations, 11 users)
- **pptx** (11 activations, 10 users)
- **pdf** (3 activations, 3 users)

### What This PR Does
- Adds a badge to your README linking to your skills collection on Smithery
- Lets users browse and install your skills with one click
- Shows aggregate usage metrics across all your skills

### Suggested Placement
We recommend placing the badge at the top of your README, below the title or alongside other badges.

---

Feel free to adjust the placement or close this PR if you're not interested. Thanks for building awesome skills!