### PR TITLE
Add skill-discoverer: Search and install skills from PRPM registry (7,500+ packages)

### DIFF
--- a/skills/skill-discoverer/SKILL.md
+++ b/skills/skill-discoverer/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: skill-discoverer
+description: Use when starting infrastructure, testing, deployment, or framework-specific tasks - automatically searches PRPM registry for relevant expertise packages and suggests installation to enhance capabilities for the current task
+---
+
+# Self-Improving with PRPM
+
+## Purpose
+
+Automatically search and install PRPM packages to enhance Claude's capabilities for specific tasks. When working on infrastructure, testing, deployment, or framework-specific work, Claude searches the PRPM registry for relevant expertise and suggests packages to install.
+
+## When to Use
+
+**Automatically triggers when detecting:**
+- Infrastructure keywords: aws, pulumi, terraform, kubernetes, docker, beanstalk
+- Testing keywords: test, playwright, jest, cypress, vitest, e2e
+- Deployment keywords: ci/cd, github-actions, gitlab-ci, deploy, workflow
+- Framework keywords: react, vue, next.js, express, fastify, django
+
+## Workflow
+
+### 1. Task Analysis
+Analyze user request for keywords and extract relevant terms.
+
+### 2. Automatic Search
+
+**Choose the right search method:**
+
+**AI-Assisted Search** (for vague/broad queries):
+```bash
+npx prpm ai-search "natural language query"
+```
+Use when user request is:
+- Conceptual or vague (e.g., "help with deployments")
+- Describes a problem, not specific tools
+- Open-ended exploration
+
+**Keyword Search** (for specific tools/frameworks):
+```bash
+npx prpm search "<detected keywords>" --limit 5
+```
+Use when request mentions:
+- Specific technologies (e.g., "pulumi", "react")
+- Exact tool names
+- Known frameworks
+
+### 3. Package Suggestion
+Present top 3 most relevant packages with:
+- Package name and author
+- Download count
+- Brief description
+- Confidence level (official/featured/community)
+
+### 4. Installation (with approval)
+```bash
+npx prpm install <package-name> --as claude
+```
+
+### 5. Application
+Load package knowledge and apply to current task.
+
+## Decision Rules
+
+### High Confidence (Auto-suggest)
+- ✅ Official packages (`@prpm/*`)
+- ✅ Featured packages
+- ✅ High downloads (>1,000)
+- ✅ Verified authors
+
+### Medium Confidence (Present options)
+- ⚠️ Community packages (<1,000 downloads)
+- ⚠️ Multiple similar packages
+- ⚠️ Tangentially related packages
+
+### Low Confidence (Skip)
+- ❌ Unverified packages
+- ❌ Deprecated packages
+- ❌ Zero downloads
+
+## Example Interactions
+
+### Example 1: Specific Technology (Keyword Search)
+```
+User: "Help me build Pulumi + Beanstalk infrastructure"
+
+Analysis:
+  Keywords: Pulumi, Beanstalk, infrastructure (specific tools)
+  Search: npx prpm search "pulumi beanstalk infrastructure"
+  Found: @prpm/pulumi-infrastructure (Official, 3.2K downloads)
+  Confidence: High → Auto-suggest
+
+Response:
+"I found an official PRPM package that can help:
+
+📦 @prpm/pulumi-infrastructure (Official, 3.2K downloads)
+   - Pulumi TypeScript best practices
+   - AWS resource patterns
+   - Cost optimization guidelines
+
+Should I install this to enhance my Pulumi knowledge?"
+
+User: "Yes"
+
+Action:
+  ✅ Installing: npx prpm install @prpm/pulumi-infrastructure --as claude
+  ✅ Loading knowledge
+  ✅ Applying patterns to current task
+```
+
+### Example 2: Vague Request (AI-Assisted Search)
+```
+User: "I need help with deployments"
+
+Analysis:
+  Query: Vague, no specific tools mentioned
+  Search: npx prpm ai-search "help with deployments"
+  Found: Multiple relevant packages:
+    - @prpm/elastic-beanstalk-deployment (Official, 2.1K downloads)
+    - @sanjeed5/github-actions (Community, 892 downloads)
+    - @prpm/docker-deployment (Featured, 1.5K downloads)
+
+Response:
+"I found several deployment-related packages that might help:
+
+📦 @prpm/elastic-beanstalk-deployment (Official, 2.1K downloads)
+   - AWS Elastic Beanstalk deployment patterns
+
+📦 @prpm/docker-deployment (Featured, 1.5K downloads)
+   - Docker containerization and deployment
+
+📦 @sanjeed5/github-actions (Community, 892 downloads)
+   - GitHub Actions CI/CD workflows
+
+Which deployment platform are you using, or should I install the Elastic Beanstalk one?"
+
+User: "I'm using AWS"
+
+Action:
+  ✅ Installing: npx prpm install @prpm/elastic-beanstalk-deployment --as claude
+  ✅ Applying AWS deployment best practices
+```
+
+## Search Triggers
+
+### Infrastructure Tasks
+**Keywords**: aws, gcp, azure, kubernetes, docker, pulumi, terraform
+**Search**: `npx prpm search "infrastructure <cloud> <tool>"`
+
+### Testing Tasks
+**Keywords**: test, playwright, jest, cypress, vitest, e2e
+**Search**: `npx prpm search "testing <framework>"`
+
+### CI/CD Tasks
+**Keywords**: ci/cd, github-actions, gitlab-ci, deploy, workflow
+**Search**: `npx prpm search "deployment <platform>"`
+
+### Framework Tasks
+**Keywords**: react, vue, angular, next.js, express, django
+**Search**: `npx prpm search "<framework> best-practices"`
+
+## Search Commands
+
+### AI-Assisted Search (Semantic Search)
+```bash
+# Natural language queries
+npx prpm ai-search "help me deploy my app to the cloud"
+
+# Problem descriptions
+npx prpm ai-search "I need to improve my code review process"
+
+# Conceptual searches
+npx prpm ai-search "best practices for testing infrastructure"
+```
+
+**When to use AI search:**
+- User query is vague or open-ended
+- Searching by concept rather than specific tool
+- Exploring what's available for a problem domain
+- User doesn't know exact package names or tools
+
+### Package Search (Keyword Search)
+```bash
+# Basic search
+npx prpm search "keyword1 keyword2"
+
+# Subtype filter (rule, agent, skill, slash-command, prompt)
+npx prpm search "react" --subtype rule
+
+# Limit results
+npx prpm search "github actions" --limit 5
+
+# Sort by downloads
+npx prpm search "testing" --sort downloads
+```
+
+**When to use keyword search:**
+- Specific technology names known (pulumi, react, etc.)
+- Filtering by package subtype needed
+- Need sorting/filtering options
+- Exact match searches
+
+### Collection Search
+```bash
+# List all collections
+npx prpm collection list
+
+# Search for collections
+npx prpm collection search "frontend"
+
+# Get collection details
+npx prpm collection info essential-dev-agents
+
+# Install a collection (installs all packages in the collection)
+npx prpm install essential-dev-agents
+```
+
+**Note:** Collections bundle multiple related packages together. Use collections when you need a complete toolkit for a specific domain (e.g., "startup-mvp", "security-review-agents", "essential-dev-agents").
+
+## Best Practices
+
+1. **Be Proactive**: Search before starting complex tasks
+2. **Verify Quality**: Check download counts and official status
+3. **Ask Permission**: Always get user approval before installing
+4. **Apply Knowledge**: Immediately use installed package patterns
+5. **Track Helpfulness**: Note which packages were useful
+
+## Meta-Dogfooding
+
+Recognize packages PRPM used to build itself:
+- `@prpm/pulumi-infrastructure` → PRPM's own infrastructure (74% cost savings)
+- `@sanjeed5/github-actions` → PRPM's workflow validation
+- Testing packages → PRPM's E2E test patterns
+
+**Benefit**: Users get the same expertise that built PRPM.
+
+## Privacy
+
+- ✅ All searches are local
+- ✅ No data sent to PRPM for searches
+- ✅ Download tracking only on install
+- ✅ No personal data collected
+
+Remember: Self-improvement through package discovery makes Claude more capable for each specific task domain.


### PR DESCRIPTION
Adds skill-discoverer — a skill that enables Claude to search and install community-created   
skills from the https://prpm.dev on demand.                                                   
                                                                                                                                                                                                             
# PRPM? Huh?                                                                                              
- 7,500+ packages — Instant access to community-created skills, rules, and agents             
- AI-powered search — Natural language queries like "help with deployments" find relevant     
packages                                                                                      
- Zero friction — Uses npx prpm, no installation required                                     
- Quality signals — Download counts, verified authors, official/featured badges help Claude   
pick the best packages                                                                        
- Cross-tool content — Registry includes skills for Claude, Cursor, Windsurf, Copilot, and    
more                                                                                          
                                                                                              
# Still huh??                                                                                  
                                                                                              
User: "Help me set up Pulumi infrastructure"                                                  
                                                                                              
Claude:                                                                                       
  1. Detects keywords → pulumi, infrastructure                                                
  2. Searches → npx prpm search "pulumi infrastructure"                                       
  3. Finds → @prpm/pulumi-infrastructure (3.2K downloads)                                     
  4. Asks permission → "Should I install this?"                                               
  5. Installs → npx prpm install @prpm/pulumi-infrastructure                                  
  6. Applies knowledge to current task                                                        
                                                                                                                                                                                
# About PRPM                                                                                    
                                                                                              
https://prpm.dev (Prompt Package Manager) is an open-source registry and CLI for AI coding    
prompts. We've indexed 7,500+ packages across 100+ collections, with format conversion between
 18+ AI tools.                                                                                
                                                                                              
- Registry: https://prpm.dev                                                                  
- Docs: https://docs.prpm.dev                                                                 
- GitHub: https://github.com/pr-pm/prpm                                                       
- npm: https://www.npmjs.com/package/prpm   
