### PR TITLE
Correct small filename typos in agent-skills-spec.md

### DIFF
--- a/spec/agent-skills-spec.md
+++ b/spec/agent-skills-spec.md
@@ -4,8 +4,8 @@ A skill is a folder of instructions, scripts, and resources that agents can disc
 
 ## Guides
 
-- [Skill Authoring Guide](skill_authoring.md) — How to create skills, including folder layout and SKILL.md format
-- [Skill Client Integration Guide](skill_client_integration.md) — How to add Skills support to a new agent or product
+- [Skill Authoring Guide](skill-authoring.md) — How to create skills, including folder layout and SKILL.md format
+- [Skill Client Integration Guide](skill-client-integration.md) — How to add Skills support to a new agent or product
 
 # Version History
 


### PR DESCRIPTION
2 typos where underscores used instead of dashes:
- skill_authoring.md -> `skill-authoring.md`
- skill_client_integration.md -> `skill-client-integration.md`

This broke the links inside `agent-skills-spec.md`