### PR TITLE
Fix typos in pdf Skill

### DIFF
--- a/skills/pdf/forms.md
+++ b/skills/pdf/forms.md
@@ -1,7 +1,7 @@
 **CRITICAL: You MUST complete these steps in order. Do not skip ahead to writing code.**
 
 If you need to fill out a PDF form, first check to see if the PDF has fillable form fields. Run this script from this file's directory:
- `python scripts/check_fillable_fields <file.pdf>`, and depending on the result go to either the "Fillable fields" or "Non-fillable fields" and follow those instructions.
+ `python scripts/check_fillable_fields.py <file.pdf>`, and depending on the result go to either the "Fillable fields" or "Non-fillable fields" and follow those instructions.
 
 # Fillable fields
 If the PDF has fillable form fields:
@@ -202,4 +202,4 @@ If there are errors, reanalyze the relevant fields, adjust the bounding boxes, a
 
 ### Step 4: Add annotations to the PDF
 Run this script from this file's directory to create a filled-out PDF using the information in fields.json:
-`python scripts/fill_pdf_form_with_annotations.py <input_pdf_path> <path_to_fields.json> <output_pdf_path>
+`python scripts/fill_pdf_form_with_annotations.py <input_pdf_path> <path_to_fields.json> <output_pdf_path>`


### PR DESCRIPTION
Thank you for helpful examples of Agent Skills.

I found typos (script filename and code markup), so I'll send a pull request