### PR TITLE
Add The LLM Council to Partner Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,4 @@ The markdown content below contains the instructions, examples, and guidelines t
 Skills are a great way to teach Claude how to get better at using specific pieces of software. As we see awesome example skills from partners, we may highlight some of them here:
 
 - **Notion** - [Notion Skills for Claude](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0)
+- **The LLM Council** - [Multi-LLM Council for adversarial debate and cross-validation](https://github.com/sherifkozman/the-llm-council) - Orchestrates Claude, GPT-4, and Gemini for production-grade implementation, code review, architecture design, and security analysis


### PR DESCRIPTION
## Summary

Adds [The LLM Council](https://github.com/sherifkozman/the-llm-council) to the Partner Skills section.

## What is The LLM Council?

A multi-LLM council framework that orchestrates Claude, GPT-4, and Gemini for adversarial debate, cross-validation, and structured decision-making.

**Key features:**
- Runs multiple models in parallel
- Adversarial critique phase identifies weaknesses
- Synthesizes best elements with schema validation
- 10 specialized subagents (implementer, reviewer, architect, red-team, etc.)

## Installation

```bash
/plugin marketplace add sherifkozman/the-llm-council
/plugin install llm-council@the-llm-council
```

## Links

- **GitHub**: https://github.com/sherifkozman/the-llm-council
- **PyPI**: https://pypi.org/project/the-llm-council/
- **License**: MIT