### PR TITLE
Add gospelo-md2pdf skill

### DIFF
--- a/skills/gospelo-md2pdf/SKILL.md
+++ b/skills/gospelo-md2pdf/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: gospelo-md2pdf
-description: Convert Markdown files to PDF with Japanese font support and MermaidJS diagram rendering. Use when creating PDFs from markdown, documents with Japanese text, or technical docs with Mermaid diagrams.
+description: Convert Markdown files to PDF with Japanese font support, MermaidJS diagram rendering, and automatic image embedding. Use when creating PDFs from markdown, documents with Japanese text, technical docs with Mermaid diagrams, or documents with images.
 allowed-tools: Read, Bash(gospelo-md2pdf:*), Bash(pip install:*)
 ---
 
 # Markdown to PDF Converter
 
-Convert Markdown to beautifully formatted PDFs with Japanese text and MermaidJS diagrams.
+Convert Markdown to beautifully formatted PDFs with Japanese text, MermaidJS diagrams, and embedded images.
 
 ## Quick Start
 
@@ -25,6 +25,7 @@ Activate this skill when asked to:
 - Generate/export a PDF document
 - Create PDFs with Japanese text
 - Create PDFs with Mermaid diagrams
+- Create PDFs with embedded images
 
 ## Installation
 
@@ -43,6 +44,9 @@ apt-get update && apt-get install -y fonts-noto-cjk
 ```bash
 brew install pango glib gdk-pixbuf font-noto-sans-cjk-jp
 pip install --upgrade gospelo-md2pdf
+
+# Set library path (required for WeasyPrint)
+export DYLD_LIBRARY_PATH=/opt/homebrew/lib:$DYLD_LIBRARY_PATH
 ```
 
 ## Mermaid Diagrams Setup
@@ -80,6 +84,7 @@ gospelo-md2pdf input.md output.pdf
 
 - **Japanese Text**: Noto Sans CJK font support
 - **MermaidJS**: Flowcharts, sequence diagrams, ER diagrams, etc. (via Kroki API)
+- **Image Embedding**: Local and remote images automatically embedded as Base64 data URIs
 - **Tables**: GitHub-flavored markdown tables
 - **Code Blocks**: Syntax highlighting
 - **Special Classes**: summary, warning, info boxes
@@ -101,3 +106,4 @@ gospelo-md2pdf input.md output.pdf
 | Japanese not rendering | `apt-get install fonts-noto-cjk` |
 | Mermaid not rendering | Add `kroki.io` to allowed domains (Settings → Capabilities) |
 | Kroki connection error | Check network settings and allowed domains |
+| macOS: libgobject error | `export DYLD_LIBRARY_PATH=/opt/homebrew/lib:$DYLD_LIBRARY_PATH` |

--- a/skills/gospelo-md2pdf/SKILL.md
+++ b/skills/gospelo-md2pdf/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: gospelo-md2pdf
 description: Convert Markdown files to PDF with Japanese font support and MermaidJS diagram rendering. Use when creating PDFs from markdown, documents with Japanese text, or technical docs with Mermaid diagrams.
+allowed-tools: Read, Bash(gospelo-md2pdf:*), Bash(pip install:*)
 ---
 
 # Markdown to PDF Converter

--- a/skills/gospelo-md2pdf/SKILL.md
+++ b/skills/gospelo-md2pdf/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: gospelo-md2pdf
+description: Convert Markdown files to PDF with Japanese font support and MermaidJS diagram rendering. Use when creating PDFs from markdown, documents with Japanese text, or technical docs with Mermaid diagrams.
+---
+
+# Markdown to PDF Converter
+
+Convert Markdown to beautifully formatted PDFs with Japanese text and MermaidJS diagrams.
+
+## Quick Start
+
+```bash
+# 1. Install or upgrade (requires v1.2.0+ for Kroki support)
+pip install --upgrade gospelo-md2pdf
+
+# 2. Convert markdown to PDF
+gospelo-md2pdf input.md
+```
+
+## When to Use
+
+Activate this skill when asked to:
+- Convert markdown to PDF
+- Generate/export a PDF document
+- Create PDFs with Japanese text
+- Create PDFs with Mermaid diagrams
+
+## Installation
+
+### For Claude Web Environment (Ubuntu)
+
+```bash
+# Install gospelo-md2pdf (v1.2.0+ required for Mermaid/Kroki support)
+pip install --upgrade gospelo-md2pdf
+
+# Japanese fonts (if Japanese text doesn't render)
+apt-get update && apt-get install -y fonts-noto-cjk
+```
+
+### For macOS
+
+```bash
+brew install pango glib gdk-pixbuf font-noto-sans-cjk-jp
+pip install --upgrade gospelo-md2pdf
+```
+
+## Mermaid Diagrams Setup
+
+Mermaid diagrams are rendered using the [Kroki API](https://kroki.io) (no local installation required). Supported Mermaid version depends on Kroki (currently v11.x).
+
+**For Claude Web Environment**: Add `kroki.io` to allowed domains:
+1. Settings (gear icon) → Capabilities
+2. Find "Additional allowed domains"
+3. Add `kroki.io`
+
+## Usage
+
+```bash
+# Basic (outputs PDF in same directory)
+gospelo-md2pdf input.md
+
+# Specify output directory
+gospelo-md2pdf input.md -o ./output
+
+# Specify output filename
+gospelo-md2pdf input.md output.pdf
+```
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `-o, --output-dir` | Output directory |
+| `-c, --css` | Custom CSS file |
+| `--debug` | Keep intermediate files |
+| `-q, --quiet` | Suppress messages |
+
+## Features
+
+- **Japanese Text**: Noto Sans CJK font support
+- **MermaidJS**: Flowcharts, sequence diagrams, ER diagrams, etc. (via Kroki API)
+- **Tables**: GitHub-flavored markdown tables
+- **Code Blocks**: Syntax highlighting
+- **Special Classes**: summary, warning, info boxes
+
+## Special HTML Classes
+
+```html
+<div class="summary">Summary box (green)</div>
+<div class="warning">Warning box (orange)</div>
+<div class="info">Info box (blue)</div>
+<div class="page-break"></div>
+```
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| Command not found | `pip install gospelo-md2pdf` |
+| Japanese not rendering | `apt-get install fonts-noto-cjk` |
+| Mermaid not rendering | Add `kroki.io` to allowed domains (Settings → Capabilities) |
+| Kroki connection error | Check network settings and allowed domains |


### PR DESCRIPTION
## Summary

Add gospelo-md2pdf skill for converting Markdown to PDF with:
- Japanese text support (Noto Sans CJK JP, Hiragino, Yu Gothic)
- MermaidJS diagram rendering via Kroki API
- Custom CSS styling options
- Special HTML classes (summary, warning, info boxes)

## PyPI Package

https://pypi.org/project/gospelo-md2pdf/

## Key Features

- No npm dependencies required (uses Kroki API for Mermaid)
- Works in Claude Web environment
- v1.2.0+ required for Kroki support

## Testing

Tested successfully in Claude Web environment with Mermaid diagrams and Japanese text.