### PR TITLE
fix(init_skill): correct skill name max length hint from 40 to 64 per spec

### DIFF
--- a/skills/skill-creator/scripts/init_skill.py
+++ b/skills/skill-creator/scripts/init_skill.py
@@ -276,7 +276,7 @@ def main():
         print("\nSkill name requirements:")
         print("  - Hyphen-case identifier (e.g., 'data-analyzer')")
         print("  - Lowercase letters, digits, and hyphens only")
-        print("  - Max 40 characters")
+        print("  - Max 64 characters")
         print("  - Must match directory name exactly")
         print("\nExamples:")
         print("  init_skill.py my-new-skill --path skills/public")


### PR DESCRIPTION
Fix inconsistent skill name length limit hint in `init_skill.py` script. Fixes #199 