### PR TITLE
Add Docling document processing skill

### DIFF
--- a/skills/docling/LICENSE.txt
+++ b/skills/docling/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/docling/SKILL.md
+++ b/skills/docling/SKILL.md
@@ -1,0 +1,426 @@
+---
+name: docling
+description: "Universal document conversion and parsing using Docling. Converts PDF, DOCX, PPTX, XLSX, HTML, images, and audio files to Markdown, HTML, or JSON with advanced table extraction, OCR support, and Vision Language Model capabilities. Use when Claude needs to: (1) Convert documents to Markdown/HTML/JSON, (2) Extract tables from PDFs or other documents, (3) Process scanned documents with OCR, (4) Prepare documents for RAG pipelines (LangChain, LlamaIndex, Haystack), (5) Use VLM-based document understanding with GraniteDocling, or (6) Batch convert multiple documents."
+license: MIT
+---
+
+# Docling Document Processing Guide
+
+## Overview
+
+Docling is a universal document parser that converts various file formats into structured output. It excels at:
+
+- **Layout-aware PDF parsing**: Reading order, table structure, figures, formulas
+- **Multi-format support**: PDF, DOCX, PPTX, XLSX, HTML, images (PNG, JPEG, TIFF), audio (WAV, MP3)
+- **Unified output**: DoclingDocument format exports to Markdown, HTML, JSON
+- **OCR integration**: Tesseract, EasyOCR, RapidOCR for scanned documents
+- **VLM pipeline**: GraniteDocling Vision Language Model for complex layouts
+- **RAG-ready**: Built-in integrations with LangChain, LlamaIndex, Haystack
+
+**When to use Docling vs other tools:**
+- Use Docling for: Complex layouts, multi-format conversion, RAG pipelines, scanned docs
+- Use pdfplumber for: Simple PDF text/table extraction when Docling overhead is unnecessary
+- Use pypdf for: Basic PDF manipulation (merge, split, rotate)
+- Use pandoc for: Simple format conversion without layout analysis
+
+For advanced topics see:
+- [OCR Configuration](references/ocr-configuration.md) - OCR engine setup
+- [VLM Pipelines](references/vlm-pipelines.md) - Vision Language Model usage
+- [RAG Integrations](references/rag-integrations.md) - Framework integration patterns
+- [Advanced Options](references/advanced-options.md) - Export formats, chunking, document model
+
+## Quick Start
+
+### Installation
+
+```bash
+# Basic installation
+pip install docling
+
+# With OCR support
+pip install "docling[tesserocr]"  # or easyocr, rapidocr
+
+# With VLM support
+pip install "docling[vlm]"
+
+# With audio support (ASR)
+pip install "docling[asr]"
+
+# Full installation
+pip install "docling[tesserocr,vlm,asr]"
+```
+
+### Basic Usage (Python)
+
+```python
+from docling.document_converter import DocumentConverter
+
+# Convert a document
+converter = DocumentConverter()
+result = converter.convert("document.pdf")
+doc = result.document
+
+# Export to Markdown
+markdown = doc.export_to_markdown()
+print(markdown)
+
+# Export to other formats
+html = doc.export_to_html()
+json_dict = doc.export_to_dict()
+json_str = doc.model_dump_json(indent=2)
+```
+
+### Basic Usage (CLI)
+
+```bash
+# Convert to Markdown (default)
+docling document.pdf
+
+# Convert to specific format
+docling document.pdf --output-format md
+docling document.pdf --output-format json
+docling document.pdf --output-format html
+
+# Convert from URL
+docling https://arxiv.org/pdf/2408.09869
+```
+
+## Common Workflows
+
+### Convert Single Document
+
+**Python:**
+```python
+from docling.document_converter import DocumentConverter
+from pathlib import Path
+
+converter = DocumentConverter()
+result = converter.convert("report.pdf")
+
+# Save as Markdown
+Path("report.md").write_text(result.document.export_to_markdown())
+```
+
+**CLI:**
+```bash
+docling report.pdf -o output_dir/
+```
+
+**Script:** Use `scripts/convert_document.py` for a ready-to-run converter.
+
+### Convert from URL
+
+```python
+from docling.document_converter import DocumentConverter
+
+converter = DocumentConverter()
+result = converter.convert("https://example.com/document.pdf")
+print(result.document.export_to_markdown())
+```
+
+### Extract Tables
+
+```python
+from docling.document_converter import DocumentConverter
+import pandas as pd
+
+converter = DocumentConverter()
+result = converter.convert("document.pdf")
+
+# Access tables from the document
+for i, table in enumerate(result.document.tables):
+    # Export table to pandas DataFrame
+    df = table.export_to_dataframe()
+    df.to_csv(f"table_{i}.csv", index=False)
+    print(f"Table {i}: {df.shape[0]} rows x {df.shape[1]} cols")
+```
+
+**Script:** Use `scripts/extract_tables.py` for batch table extraction.
+
+### Batch Conversion
+
+```python
+from docling.document_converter import DocumentConverter
+from pathlib import Path
+
+converter = DocumentConverter()
+input_dir = Path("documents/")
+output_dir = Path("converted/")
+output_dir.mkdir(exist_ok=True)
+
+for doc_path in input_dir.glob("*.pdf"):
+    result = converter.convert(str(doc_path))
+    output_path = output_dir / f"{doc_path.stem}.md"
+    output_path.write_text(result.document.export_to_markdown())
+    print(f"Converted: {doc_path.name}")
+```
+
+**Script:** Use `scripts/batch_convert.py` for parallel batch processing.
+
+### OCR for Scanned Documents
+
+```python
+from docling.document_converter import DocumentConverter
+from docling.datamodel.pipeline_options import PipelineOptions
+from docling.datamodel.document import InputFormat
+
+# Configure OCR
+pipeline_options = PipelineOptions()
+pipeline_options.do_ocr = True
+
+converter = DocumentConverter(
+    format_options={
+        InputFormat.PDF: {"pipeline_options": pipeline_options}
+    }
+)
+
+result = converter.convert("scanned_document.pdf")
+print(result.document.export_to_markdown())
+```
+
+**CLI with OCR:**
+```bash
+docling scanned_document.pdf --ocr
+```
+
+For detailed OCR configuration (engine selection, languages), see [ocr-configuration.md](references/ocr-configuration.md).
+
+**Script:** Use `scripts/check_ocr_engines.py` to verify which OCR engines are available.
+
+### VLM Pipeline (GraniteDocling)
+
+For complex documents with intricate layouts, use the Vision Language Model pipeline:
+
+**CLI:**
+```bash
+docling --pipeline vlm --vlm-model granite_docling document.pdf
+```
+
+**Python:**
+```python
+from docling.document_converter import DocumentConverter, PdfFormatOption
+from docling.datamodel.pipeline_options import VlmPipelineOptions
+from docling.datamodel.document import InputFormat
+
+vlm_options = VlmPipelineOptions(
+    model_name="granite_docling"
+)
+
+converter = DocumentConverter(
+    format_options={
+        InputFormat.PDF: PdfFormatOption(pipeline_options=vlm_options)
+    }
+)
+
+result = converter.convert("complex_document.pdf")
+```
+
+For VLM configuration (GPU, MLX acceleration), see [vlm-pipelines.md](references/vlm-pipelines.md).
+
+## Export Formats
+
+### Markdown
+
+```python
+markdown = doc.export_to_markdown()
+# Options: image_mode, table_mode, etc.
+markdown = doc.export_to_markdown(image_mode="embedded")
+```
+
+### HTML
+
+```python
+html = doc.export_to_html()
+```
+
+### JSON
+
+```python
+# As Python dict
+data = doc.export_to_dict()
+
+# As JSON string
+json_str = doc.model_dump_json(indent=2)
+
+# Save to file
+import json
+with open("output.json", "w") as f:
+    json.dump(doc.export_to_dict(), f, indent=2)
+```
+
+### DocTags (for LLM training)
+
+```python
+doctags = doc.export_to_document_tokens()
+```
+
+## RAG Integration Quick Reference
+
+### LangChain
+
+```python
+from langchain_community.document_loaders import DoclingLoader
+
+loader = DoclingLoader(file_path="document.pdf")
+docs = loader.load()
+
+# Use with any LangChain chain
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=200)
+chunks = splitter.split_documents(docs)
+```
+
+### LlamaIndex
+
+```python
+from llama_index.readers.docling import DoclingReader
+
+reader = DoclingReader()
+documents = reader.load_data(file_path="document.pdf")
+
+# Build index
+from llama_index.core import VectorStoreIndex
+index = VectorStoreIndex.from_documents(documents)
+```
+
+### Haystack
+
+```python
+from haystack_integrations.components.converters.docling import DoclingConverter
+
+converter = DoclingConverter()
+docs = converter.run(sources=["document.pdf"])
+```
+
+For complete RAG examples with vector stores, see [rag-integrations.md](references/rag-integrations.md).
+
+**Script:** Use `scripts/prepare_rag_chunks.py` to prepare documents for RAG ingestion.
+
+## CLI Reference
+
+```bash
+docling [OPTIONS] SOURCE
+
+Arguments:
+  SOURCE          File path or URL to convert
+
+Options:
+  -o, --output    Output directory (default: current directory)
+  --output-format Format: md, json, html, doctags (default: md)
+  --pipeline      Pipeline: standard, vlm (default: standard)
+  --vlm-model     VLM model name (default: granite_docling)
+  --ocr           Enable OCR for scanned documents
+  --no-ocr        Disable OCR
+  --ocr-lang      OCR languages (comma-separated, e.g., "eng,deu")
+  --pages         Page range (e.g., "1-5" or "1,3,5")
+  --help          Show help message
+```
+
+### Common CLI Examples
+
+```bash
+# Convert PDF to Markdown
+docling report.pdf -o output/
+
+# Convert with OCR enabled
+docling scanned.pdf --ocr --ocr-lang eng,fra
+
+# Convert specific pages
+docling large_doc.pdf --pages 1-10
+
+# Use VLM for complex layouts
+docling complex.pdf --pipeline vlm --vlm-model granite_docling
+
+# Convert URL
+docling https://arxiv.org/pdf/2408.09869
+
+# Output as JSON
+docling document.pdf --output-format json
+```
+
+## Supported Formats
+
+| Input Format | Extensions | Notes |
+|--------------|------------|-------|
+| PDF | .pdf | Native + scanned with OCR |
+| Word | .docx | Office Open XML |
+| PowerPoint | .pptx | Office Open XML |
+| Excel | .xlsx | Office Open XML |
+| HTML | .html, .htm | Web pages |
+| Images | .png, .jpg, .jpeg, .tiff | OCR extraction |
+| Audio | .wav, .mp3 | Requires ASR extra |
+
+| Output Format | Method | Use Case |
+|---------------|--------|----------|
+| Markdown | `export_to_markdown()` | Documentation, RAG |
+| HTML | `export_to_html()` | Web display |
+| JSON | `export_to_dict()` | Structured data, APIs |
+| DocTags | `export_to_document_tokens()` | LLM training |
+
+## Installation Notes
+
+### System Dependencies
+
+**For Tesseract OCR:**
+```bash
+# macOS
+brew install tesseract tesseract-lang
+
+# Ubuntu/Debian
+sudo apt-get install tesseract-ocr tesseract-ocr-eng
+
+# Set TESSDATA_PREFIX if needed
+export TESSDATA_PREFIX=/usr/share/tesseract-ocr/4.00/tessdata/
+```
+
+**For poppler (PDF rendering):**
+```bash
+# macOS
+brew install poppler
+
+# Ubuntu/Debian
+sudo apt-get install poppler-utils
+```
+
+### Optional Extras
+
+```bash
+# OCR engines (choose one or more)
+pip install "docling[tesserocr]"    # Tesseract (needs system install)
+pip install "docling[easyocr]"      # EasyOCR (pure Python, easiest)
+pip install "docling[rapidocr]"     # RapidOCR (CPU-optimized)
+
+# Vision Language Model
+pip install "docling[vlm]"
+
+# Audio/Speech Recognition
+pip install "docling[asr]"
+
+# All extras
+pip install "docling[tesserocr,easyocr,vlm,asr]"
+```
+
+### Apple Silicon (M1/M2/M3)
+
+For MLX acceleration with VLM:
+```bash
+pip install "docling[vlm]"
+# MLX backend is automatically used on Apple Silicon
+```
+
+## Scripts Reference
+
+| Script | Purpose | Usage |
+|--------|---------|-------|
+| `convert_document.py` | Convert single document | `python scripts/convert_document.py input.pdf output.md` |
+| `batch_convert.py` | Batch convert directory | `python scripts/batch_convert.py input_dir/ output_dir/` |
+| `extract_tables.py` | Extract tables to CSV/Excel | `python scripts/extract_tables.py input.pdf tables/` |
+| `check_ocr_engines.py` | Check OCR availability | `python scripts/check_ocr_engines.py` |
+| `prepare_rag_chunks.py` | Prepare for RAG | `python scripts/prepare_rag_chunks.py input.pdf chunks.json` |
+
+## Next Steps
+
+- For OCR engine setup and configuration: [ocr-configuration.md](references/ocr-configuration.md)
+- For VLM pipeline details: [vlm-pipelines.md](references/vlm-pipelines.md)
+- For RAG framework integrations: [rag-integrations.md](references/rag-integrations.md)
+- For advanced export options and document model: [advanced-options.md](references/advanced-options.md)

--- a/skills/docling/SKILL.md
+++ b/skills/docling/SKILL.md
@@ -160,7 +160,7 @@ for doc_path in input_dir.glob("*.pdf"):
 ### OCR for Scanned Documents
 
 ```python
-from docling.document_converter import DocumentConverter
+from docling.document_converter import DocumentConverter, PdfFormatOption
 from docling.datamodel.pipeline_options import PipelineOptions
 from docling.datamodel.document import InputFormat
 
@@ -170,7 +170,7 @@ pipeline_options.do_ocr = True
 
 converter = DocumentConverter(
     format_options={
-        InputFormat.PDF: {"pipeline_options": pipeline_options}
+        InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)
     }
 )
 

--- a/skills/docling/references/advanced-options.md
+++ b/skills/docling/references/advanced-options.md
@@ -311,7 +311,7 @@ files = [str(f) for f in Path("documents/").glob("*.pdf")]
 with ProcessPoolExecutor(max_workers=4) as executor:
     results = list(executor.map(convert_file, files))
 
-success = sum(1 for _, ok in results if ok)
+success = sum(1 for _, converted in results if converted)
 print(f"Converted {success}/{len(files)} files")
 ```
 

--- a/skills/docling/references/advanced-options.md
+++ b/skills/docling/references/advanced-options.md
@@ -1,0 +1,377 @@
+# Advanced Options Guide
+
+This guide covers advanced Docling features including the document model, export options, chunking strategies, and audio processing.
+
+## DoclingDocument Model
+
+The `DoclingDocument` is Docling's unified document representation.
+
+### Structure
+
+```python
+from docling.document_converter import DocumentConverter
+
+result = converter.convert("document.pdf")
+doc = result.document
+
+# Document properties
+doc.name           # Source filename
+doc.origin         # Original source path/URL
+doc.num_pages      # Number of pages (if applicable)
+
+# Content elements
+doc.texts          # Text elements
+doc.tables         # Table elements
+doc.pictures       # Image/figure elements
+doc.key_value_items # Key-value pairs (forms)
+```
+
+### Accessing Elements
+
+```python
+# Iterate through text elements
+for text in doc.texts:
+    print(f"Text: {text.text[:100]}...")
+    print(f"  Page: {text.prov[0].page_no if text.prov else 'N/A'}")
+
+# Iterate through tables
+for i, table in enumerate(doc.tables):
+    df = table.export_to_dataframe()
+    print(f"Table {i}: {df.shape}")
+
+# Iterate through figures
+for picture in doc.pictures:
+    print(f"Figure: {picture.caption}")
+```
+
+### Confidence Scores
+
+Some elements include confidence scores from AI models:
+
+```python
+for text in doc.texts:
+    if hasattr(text, 'confidence'):
+        print(f"Confidence: {text.confidence}")
+```
+
+## Export Options
+
+### Markdown Export
+
+```python
+# Basic export
+markdown = doc.export_to_markdown()
+
+# With options
+markdown = doc.export_to_markdown(
+    image_mode="embedded",  # "embedded", "referenced", or "placeholder"
+    strict_text=False,      # Preserve original formatting
+)
+```
+
+### HTML Export
+
+```python
+html = doc.export_to_html()
+
+# Save with proper encoding
+with open("output.html", "w", encoding="utf-8") as f:
+    f.write(html)
+```
+
+### JSON Export
+
+```python
+# As Python dict
+data = doc.export_to_dict()
+
+# As JSON string (pretty printed)
+json_str = doc.model_dump_json(indent=2)
+
+# As JSON string (compact)
+json_str = doc.model_dump_json()
+
+# Save to file
+import json
+with open("output.json", "w") as f:
+    json.dump(doc.export_to_dict(), f, indent=2, ensure_ascii=False)
+```
+
+### DocTags Export (for LLM training)
+
+```python
+# Document tokens format
+doctags = doc.export_to_document_tokens()
+```
+
+## Chunking Strategies
+
+### Basic Chunking
+
+```python
+def simple_chunk(text: str, chunk_size: int = 1000) -> list[str]:
+    """Split text into fixed-size chunks."""
+    return [text[i:i+chunk_size] for i in range(0, len(text), chunk_size)]
+
+markdown = doc.export_to_markdown()
+chunks = simple_chunk(markdown, 1000)
+```
+
+### Overlapping Chunks
+
+```python
+def overlap_chunk(text: str, chunk_size: int = 1000, overlap: int = 100) -> list[str]:
+    """Split text into overlapping chunks."""
+    chunks = []
+    start = 0
+    while start < len(text):
+        end = start + chunk_size
+        chunks.append(text[start:end])
+        start = end - overlap
+    return chunks
+```
+
+### Sentence-Aware Chunking
+
+```python
+import re
+
+def sentence_chunk(text: str, max_chunk_size: int = 1000) -> list[str]:
+    """Split text at sentence boundaries."""
+    sentences = re.split(r'(?<=[.!?])\s+', text)
+
+    chunks = []
+    current_chunk = []
+    current_size = 0
+
+    for sentence in sentences:
+        if current_size + len(sentence) > max_chunk_size and current_chunk:
+            chunks.append(' '.join(current_chunk))
+            current_chunk = []
+            current_size = 0
+        current_chunk.append(sentence)
+        current_size += len(sentence) + 1
+
+    if current_chunk:
+        chunks.append(' '.join(current_chunk))
+
+    return chunks
+```
+
+### Semantic Chunking (with embeddings)
+
+```python
+from sentence_transformers import SentenceTransformer
+import numpy as np
+
+def semantic_chunk(text: str, max_chunk_size: int = 1000, similarity_threshold: float = 0.5):
+    """Split text based on semantic similarity."""
+    model = SentenceTransformer('all-MiniLM-L6-v2')
+
+    # Split into paragraphs
+    paragraphs = text.split('\n\n')
+
+    # Get embeddings
+    embeddings = model.encode(paragraphs)
+
+    chunks = []
+    current_chunk = [paragraphs[0]]
+
+    for i in range(1, len(paragraphs)):
+        similarity = np.dot(embeddings[i], embeddings[i-1])
+
+        if similarity < similarity_threshold or sum(len(p) for p in current_chunk) > max_chunk_size:
+            chunks.append('\n\n'.join(current_chunk))
+            current_chunk = []
+
+        current_chunk.append(paragraphs[i])
+
+    if current_chunk:
+        chunks.append('\n\n'.join(current_chunk))
+
+    return chunks
+```
+
+## Pipeline Customization
+
+### Custom Pipeline Options
+
+```python
+from docling.document_converter import DocumentConverter, PdfFormatOption
+from docling.datamodel.pipeline_options import PipelineOptions
+from docling.datamodel.document import InputFormat
+
+pipeline_options = PipelineOptions()
+
+# OCR settings
+pipeline_options.do_ocr = True
+pipeline_options.ocr_options.engine = "tesseract"
+pipeline_options.ocr_options.lang = ["eng"]
+
+# Table detection settings
+pipeline_options.do_table_structure = True
+
+# Figure extraction
+pipeline_options.generate_picture_images = True
+
+converter = DocumentConverter(
+    format_options={
+        InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)
+    }
+)
+```
+
+### Processing Multiple Formats
+
+```python
+from docling.datamodel.document import InputFormat
+
+converter = DocumentConverter(
+    format_options={
+        InputFormat.PDF: PdfFormatOption(pipeline_options=pdf_options),
+        InputFormat.DOCX: DocxFormatOption(),
+        InputFormat.PPTX: PptxFormatOption(),
+    }
+)
+```
+
+## Audio Processing (ASR)
+
+Docling supports audio transcription via Automatic Speech Recognition.
+
+### Installation
+
+```bash
+pip install "docling[asr]"
+```
+
+### Usage
+
+```python
+from docling.document_converter import DocumentConverter
+
+converter = DocumentConverter()
+result = converter.convert("recording.wav")
+transcript = result.document.export_to_markdown()
+```
+
+### Supported Audio Formats
+
+- WAV
+- MP3
+- VTT (subtitles)
+
+### Configuration
+
+```python
+from docling.datamodel.pipeline_options import AsrPipelineOptions
+
+asr_options = AsrPipelineOptions(
+    model_name="whisper-base",  # or larger models
+    language="en",
+)
+```
+
+## Batch Processing Patterns
+
+### Sequential with Progress
+
+```python
+from pathlib import Path
+from tqdm import tqdm
+
+converter = DocumentConverter()
+files = list(Path("documents/").glob("*.pdf"))
+
+for file in tqdm(files, desc="Converting"):
+    result = converter.convert(str(file))
+    output = Path("output") / f"{file.stem}.md"
+    output.write_text(result.document.export_to_markdown())
+```
+
+### Parallel Processing
+
+```python
+from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path
+
+def convert_file(file_path: str) -> tuple[str, bool]:
+    from docling.document_converter import DocumentConverter
+    try:
+        converter = DocumentConverter()
+        result = converter.convert(file_path)
+        output = Path("output") / f"{Path(file_path).stem}.md"
+        output.write_text(result.document.export_to_markdown())
+        return file_path, True
+    except Exception as e:
+        return file_path, False
+
+files = [str(f) for f in Path("documents/").glob("*.pdf")]
+
+with ProcessPoolExecutor(max_workers=4) as executor:
+    results = list(executor.map(convert_file, files))
+
+success = sum(1 for _, ok in results if ok)
+print(f"Converted {success}/{len(files)} files")
+```
+
+### Error Handling
+
+```python
+from docling.document_converter import DocumentConverter, ConversionError
+
+converter = DocumentConverter()
+
+try:
+    result = converter.convert("document.pdf")
+except ConversionError as e:
+    print(f"Conversion failed: {e}")
+except FileNotFoundError:
+    print("File not found")
+except Exception as e:
+    print(f"Unexpected error: {e}")
+```
+
+## Memory Management
+
+For large documents or batch processing:
+
+```python
+import gc
+
+converter = DocumentConverter()
+
+for file in files:
+    result = converter.convert(str(file))
+    # Process result...
+
+    # Clear memory
+    del result
+    gc.collect()
+```
+
+## Debugging
+
+### Verbose Output
+
+```python
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger("docling")
+logger.setLevel(logging.DEBUG)
+
+converter = DocumentConverter()
+result = converter.convert("document.pdf")
+```
+
+### Inspect Conversion Result
+
+```python
+result = converter.convert("document.pdf")
+
+print(f"Status: {result.status}")
+print(f"Errors: {result.errors}")
+print(f"Document: {result.document}")
+print(f"Pages: {result.document.num_pages}")
+```

--- a/skills/docling/references/ocr-configuration.md
+++ b/skills/docling/references/ocr-configuration.md
@@ -1,0 +1,243 @@
+# OCR Configuration Guide
+
+This guide covers OCR engine setup and configuration for processing scanned documents with Docling.
+
+## Available OCR Engines
+
+| Engine | Installation | Pros | Cons |
+|--------|--------------|------|------|
+| EasyOCR | Pure Python | Easiest setup, good accuracy | Slower, larger models |
+| Tesseract | System + Python | Fast, widely supported | Requires system install |
+| RapidOCR | Pure Python | CPU-optimized, fast | Less language support |
+| OcrMac | macOS only | Native performance | macOS only |
+
+## Quick Setup
+
+### EasyOCR (Recommended for beginners)
+
+```bash
+pip install "docling[easyocr]"
+```
+
+No system dependencies required. Models download automatically on first use.
+
+### Tesseract
+
+**1. Install system binary:**
+
+```bash
+# macOS
+brew install tesseract tesseract-lang
+
+# Ubuntu/Debian
+sudo apt-get install tesseract-ocr tesseract-ocr-eng tesseract-ocr-deu
+
+# Fedora
+sudo dnf install tesseract tesseract-langpack-eng
+
+# Windows (via chocolatey)
+choco install tesseract
+```
+
+**2. Install Python binding:**
+
+```bash
+pip install "docling[tesserocr]"
+```
+
+**3. Set TESSDATA_PREFIX (if needed):**
+
+```bash
+# Find tessdata location
+tesseract --list-langs 2>&1 | head -1
+
+# Export (add to .bashrc/.zshrc)
+export TESSDATA_PREFIX=/usr/share/tesseract-ocr/4.00/tessdata/
+```
+
+### RapidOCR
+
+```bash
+pip install "docling[rapidocr]"
+```
+
+CPU-optimized, no GPU required. Good balance of speed and accuracy.
+
+### OcrMac (macOS only)
+
+```bash
+pip install "docling[ocrmac]"
+```
+
+Uses macOS native Vision framework. Best performance on Apple Silicon.
+
+## Configuration in Python
+
+### Basic OCR
+
+```python
+from docling.document_converter import DocumentConverter, PdfFormatOption
+from docling.datamodel.pipeline_options import PipelineOptions
+from docling.datamodel.document import InputFormat
+
+# Enable OCR
+pipeline_options = PipelineOptions()
+pipeline_options.do_ocr = True
+
+converter = DocumentConverter(
+    format_options={
+        InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)
+    }
+)
+
+result = converter.convert("scanned_document.pdf")
+```
+
+### Specify OCR Engine
+
+```python
+from docling.datamodel.pipeline_options import PipelineOptions, OcrOptions
+
+# Use specific engine
+pipeline_options = PipelineOptions()
+pipeline_options.do_ocr = True
+pipeline_options.ocr_options = OcrOptions(
+    engine="tesseract"  # or "easyocr", "rapidocr", "ocrmac"
+)
+```
+
+### Specify Languages
+
+```python
+pipeline_options.ocr_options = OcrOptions(
+    engine="tesseract",
+    lang=["eng", "deu", "fra"]  # English, German, French
+)
+```
+
+### EasyOCR with GPU
+
+```python
+pipeline_options.ocr_options = OcrOptions(
+    engine="easyocr",
+    lang=["en", "de"],
+    gpu=True  # Use GPU if available
+)
+```
+
+## CLI Configuration
+
+```bash
+# Basic OCR
+docling --ocr document.pdf
+
+# Specify languages
+docling --ocr --ocr-lang eng,deu document.pdf
+
+# Specify engine (if supported by CLI version)
+docling --ocr --ocr-engine tesseract document.pdf
+```
+
+## Language Codes
+
+### Tesseract Language Codes
+
+| Language | Code | Install |
+|----------|------|---------|
+| English | eng | Default |
+| German | deu | tesseract-ocr-deu |
+| French | fra | tesseract-ocr-fra |
+| Spanish | spa | tesseract-ocr-spa |
+| Italian | ita | tesseract-ocr-ita |
+| Chinese (Simplified) | chi_sim | tesseract-ocr-chi-sim |
+| Chinese (Traditional) | chi_tra | tesseract-ocr-chi-tra |
+| Japanese | jpn | tesseract-ocr-jpn |
+| Korean | kor | tesseract-ocr-kor |
+| Arabic | ara | tesseract-ocr-ara |
+
+List all installed: `tesseract --list-langs`
+
+### EasyOCR Language Codes
+
+| Language | Code |
+|----------|------|
+| English | en |
+| German | de |
+| French | fr |
+| Spanish | es |
+| Chinese (Simplified) | ch_sim |
+| Chinese (Traditional) | ch_tra |
+| Japanese | ja |
+| Korean | ko |
+
+Full list: https://www.jaided.ai/easyocr/
+
+## Performance Comparison
+
+| Engine | Speed | Accuracy | GPU Support | Languages |
+|--------|-------|----------|-------------|-----------|
+| Tesseract | Fast | Good | No | 100+ |
+| EasyOCR | Medium | Very Good | Yes | 80+ |
+| RapidOCR | Fast | Good | No | Limited |
+| OcrMac | Fast | Good | N/A (Metal) | System |
+
+## Troubleshooting
+
+### Tesseract not found
+
+```
+Error: tesseract is not installed or not in PATH
+```
+
+**Solution:** Install tesseract binary and ensure it's in PATH:
+```bash
+which tesseract  # Should return path
+tesseract --version  # Should show version
+```
+
+### TESSDATA_PREFIX not set
+
+```
+Error: Could not find tessdata
+```
+
+**Solution:** Set TESSDATA_PREFIX environment variable:
+```bash
+export TESSDATA_PREFIX=/usr/share/tesseract-ocr/4.00/tessdata/
+```
+
+### Language not available
+
+```
+Error: Failed to load language 'xxx'
+```
+
+**Solution:** Install the language pack:
+```bash
+# Ubuntu/Debian
+sudo apt-get install tesseract-ocr-xxx
+
+# macOS
+brew install tesseract-lang  # Installs all languages
+```
+
+### EasyOCR model download fails
+
+**Solution:** Download models manually to `~/.EasyOCR/model/`
+
+### Low OCR accuracy
+
+1. Try a different engine
+2. Increase image DPI (300+ recommended)
+3. Pre-process image (deskew, denoise)
+4. Use VLM pipeline for complex layouts
+
+## Combining with VLM
+
+For complex documents with mixed content, consider using VLM instead of traditional OCR:
+
+```bash
+docling --pipeline vlm --vlm-model granite_docling document.pdf
+```
+
+VLM provides better understanding of document structure but requires more compute resources.

--- a/skills/docling/references/rag-integrations.md
+++ b/skills/docling/references/rag-integrations.md
@@ -249,6 +249,7 @@ from haystack.components.retrievers.in_memory import InMemoryEmbeddingRetriever
 from haystack.components.builders import PromptBuilder
 from haystack.components.generators import HuggingFaceLocalGenerator
 from haystack.document_stores.in_memory import InMemoryDocumentStore
+from haystack.components.writers import DocumentWriter
 from haystack_integrations.components.converters.docling import DoclingConverter
 
 # Document store

--- a/skills/docling/references/rag-integrations.md
+++ b/skills/docling/references/rag-integrations.md
@@ -1,0 +1,454 @@
+# RAG Framework Integrations Guide
+
+This guide covers integrating Docling with popular RAG (Retrieval-Augmented Generation) frameworks.
+
+## Overview
+
+Docling provides native integrations with:
+
+- **LangChain** - Most popular LLM framework
+- **LlamaIndex** - Data framework for LLM apps
+- **Haystack** - End-to-end NLP framework
+
+Each integration provides document loaders that convert files to framework-native document formats.
+
+## LangChain Integration
+
+### Installation
+
+```bash
+pip install langchain-community docling
+```
+
+### Basic Usage
+
+```python
+from langchain_community.document_loaders import DoclingLoader
+
+# Load single document
+loader = DoclingLoader(file_path="document.pdf")
+docs = loader.load()
+
+# Each page becomes a Document
+for doc in docs:
+    print(f"Content: {doc.page_content[:200]}...")
+    print(f"Metadata: {doc.metadata}")
+```
+
+### Multiple Documents
+
+```python
+from langchain_community.document_loaders import DoclingLoader
+from pathlib import Path
+
+# Load multiple files
+files = list(Path("documents/").glob("*.pdf"))
+all_docs = []
+
+for file in files:
+    loader = DoclingLoader(file_path=str(file))
+    docs = loader.load()
+    all_docs.extend(docs)
+
+print(f"Loaded {len(all_docs)} documents")
+```
+
+### With Text Splitting
+
+```python
+from langchain_community.document_loaders import DoclingLoader
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+
+loader = DoclingLoader(file_path="document.pdf")
+docs = loader.load()
+
+# Split into chunks
+splitter = RecursiveCharacterTextSplitter(
+    chunk_size=1000,
+    chunk_overlap=200,
+    separators=["\n\n", "\n", ". ", " ", ""]
+)
+chunks = splitter.split_documents(docs)
+
+print(f"Created {len(chunks)} chunks")
+```
+
+### Complete RAG Pipeline
+
+```python
+from langchain_community.document_loaders import DoclingLoader
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain_community.vectorstores import Chroma
+from langchain_community.embeddings import HuggingFaceEmbeddings
+from langchain_community.llms import Ollama
+from langchain.chains import RetrievalQA
+
+# 1. Load document
+loader = DoclingLoader(file_path="document.pdf")
+docs = loader.load()
+
+# 2. Split into chunks
+splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=200)
+chunks = splitter.split_documents(docs)
+
+# 3. Create embeddings and vector store
+embeddings = HuggingFaceEmbeddings(model_name="all-MiniLM-L6-v2")
+vectorstore = Chroma.from_documents(chunks, embeddings)
+
+# 4. Create retrieval chain
+llm = Ollama(model="llama2")
+qa_chain = RetrievalQA.from_chain_type(
+    llm=llm,
+    chain_type="stuff",
+    retriever=vectorstore.as_retriever(search_kwargs={"k": 3})
+)
+
+# 5. Query
+response = qa_chain.invoke({"query": "What is the main topic?"})
+print(response["result"])
+```
+
+## LlamaIndex Integration
+
+### Installation
+
+```bash
+pip install llama-index llama-index-readers-docling docling
+```
+
+### Basic Usage
+
+```python
+from llama_index.readers.docling import DoclingReader
+
+reader = DoclingReader()
+documents = reader.load_data(file_path="document.pdf")
+
+for doc in documents:
+    print(f"Content: {doc.text[:200]}...")
+    print(f"Metadata: {doc.metadata}")
+```
+
+### Building an Index
+
+```python
+from llama_index.readers.docling import DoclingReader
+from llama_index.core import VectorStoreIndex, Settings
+from llama_index.embeddings.huggingface import HuggingFaceEmbedding
+
+# Load documents
+reader = DoclingReader()
+documents = reader.load_data(file_path="document.pdf")
+
+# Configure embeddings
+Settings.embed_model = HuggingFaceEmbedding(model_name="all-MiniLM-L6-v2")
+
+# Build index
+index = VectorStoreIndex.from_documents(documents)
+
+# Query
+query_engine = index.as_query_engine()
+response = query_engine.query("What is the main topic?")
+print(response)
+```
+
+### With Custom Chunking
+
+```python
+from llama_index.readers.docling import DoclingReader
+from llama_index.core import VectorStoreIndex
+from llama_index.core.node_parser import SentenceSplitter
+
+# Load documents
+reader = DoclingReader()
+documents = reader.load_data(file_path="document.pdf")
+
+# Custom node parser
+parser = SentenceSplitter(chunk_size=1024, chunk_overlap=100)
+
+# Build index with custom parser
+index = VectorStoreIndex.from_documents(
+    documents,
+    transformations=[parser]
+)
+```
+
+### Multiple File Types
+
+```python
+from llama_index.readers.docling import DoclingReader
+from pathlib import Path
+
+reader = DoclingReader()
+
+# Load different file types
+files = [
+    "report.pdf",
+    "presentation.pptx",
+    "data.xlsx",
+    "article.html"
+]
+
+all_documents = []
+for file in files:
+    docs = reader.load_data(file_path=file)
+    all_documents.extend(docs)
+```
+
+## Haystack Integration
+
+### Installation
+
+```bash
+pip install haystack-ai haystack-integrations-docling docling
+```
+
+### Basic Usage
+
+```python
+from haystack_integrations.components.converters.docling import DoclingConverter
+
+converter = DoclingConverter()
+result = converter.run(sources=["document.pdf"])
+
+for doc in result["documents"]:
+    print(f"Content: {doc.content[:200]}...")
+    print(f"Metadata: {doc.meta}")
+```
+
+### Building a Pipeline
+
+```python
+from haystack import Pipeline
+from haystack.components.writers import DocumentWriter
+from haystack.document_stores.in_memory import InMemoryDocumentStore
+from haystack_integrations.components.converters.docling import DoclingConverter
+
+# Create document store
+document_store = InMemoryDocumentStore()
+
+# Build pipeline
+pipeline = Pipeline()
+pipeline.add_component("converter", DoclingConverter())
+pipeline.add_component("writer", DocumentWriter(document_store=document_store))
+pipeline.connect("converter", "writer")
+
+# Run pipeline
+pipeline.run({"converter": {"sources": ["document.pdf"]}})
+
+print(f"Stored {document_store.count_documents()} documents")
+```
+
+### Complete RAG Pipeline
+
+```python
+from haystack import Pipeline
+from haystack.components.embedders import SentenceTransformersDocumentEmbedder
+from haystack.components.embedders import SentenceTransformersTextEmbedder
+from haystack.components.retrievers.in_memory import InMemoryEmbeddingRetriever
+from haystack.components.builders import PromptBuilder
+from haystack.components.generators import HuggingFaceLocalGenerator
+from haystack.document_stores.in_memory import InMemoryDocumentStore
+from haystack_integrations.components.converters.docling import DoclingConverter
+
+# Document store
+document_store = InMemoryDocumentStore()
+
+# Indexing pipeline
+indexing = Pipeline()
+indexing.add_component("converter", DoclingConverter())
+indexing.add_component("embedder", SentenceTransformersDocumentEmbedder())
+indexing.add_component("writer", DocumentWriter(document_store=document_store))
+indexing.connect("converter", "embedder")
+indexing.connect("embedder", "writer")
+
+# Index documents
+indexing.run({"converter": {"sources": ["document.pdf"]}})
+
+# Query pipeline
+prompt_template = """
+Given the context, answer the question.
+Context: {% for doc in documents %}{{ doc.content }}{% endfor %}
+Question: {{ question }}
+Answer:
+"""
+
+query_pipeline = Pipeline()
+query_pipeline.add_component("embedder", SentenceTransformersTextEmbedder())
+query_pipeline.add_component("retriever", InMemoryEmbeddingRetriever(document_store))
+query_pipeline.add_component("prompt", PromptBuilder(template=prompt_template))
+query_pipeline.add_component("llm", HuggingFaceLocalGenerator(model="google/flan-t5-base"))
+
+query_pipeline.connect("embedder.embedding", "retriever.query_embedding")
+query_pipeline.connect("retriever", "prompt.documents")
+query_pipeline.connect("prompt", "llm")
+
+# Query
+result = query_pipeline.run({
+    "embedder": {"text": "What is the main topic?"},
+    "prompt": {"question": "What is the main topic?"}
+})
+print(result["llm"]["replies"][0])
+```
+
+## Vector Store Integration
+
+### Chroma
+
+```python
+from langchain_community.vectorstores import Chroma
+from langchain_community.embeddings import HuggingFaceEmbeddings
+
+embeddings = HuggingFaceEmbeddings(model_name="all-MiniLM-L6-v2")
+
+# Create from documents
+vectorstore = Chroma.from_documents(
+    documents=chunks,
+    embedding=embeddings,
+    persist_directory="./chroma_db"
+)
+
+# Query
+results = vectorstore.similarity_search("query text", k=5)
+```
+
+### Qdrant
+
+```python
+from langchain_community.vectorstores import Qdrant
+from langchain_community.embeddings import HuggingFaceEmbeddings
+
+embeddings = HuggingFaceEmbeddings(model_name="all-MiniLM-L6-v2")
+
+vectorstore = Qdrant.from_documents(
+    documents=chunks,
+    embedding=embeddings,
+    location=":memory:",  # or URL for remote
+    collection_name="documents"
+)
+```
+
+### Milvus
+
+```python
+from langchain_community.vectorstores import Milvus
+from langchain_community.embeddings import HuggingFaceEmbeddings
+
+embeddings = HuggingFaceEmbeddings(model_name="all-MiniLM-L6-v2")
+
+vectorstore = Milvus.from_documents(
+    documents=chunks,
+    embedding=embeddings,
+    connection_args={"host": "localhost", "port": "19530"},
+    collection_name="documents"
+)
+```
+
+### Weaviate
+
+```python
+from langchain_community.vectorstores import Weaviate
+from langchain_community.embeddings import HuggingFaceEmbeddings
+import weaviate
+
+client = weaviate.Client(url="http://localhost:8080")
+embeddings = HuggingFaceEmbeddings(model_name="all-MiniLM-L6-v2")
+
+vectorstore = Weaviate.from_documents(
+    documents=chunks,
+    embedding=embeddings,
+    client=client,
+    index_name="Documents"
+)
+```
+
+## Chunking Strategies for RAG
+
+### Recommended Chunk Sizes
+
+| Use Case | Chunk Size | Overlap |
+|----------|------------|---------|
+| Q&A | 500-1000 | 100-200 |
+| Summarization | 2000-4000 | 200-400 |
+| Code | 1500-2500 | 300-500 |
+| Legal/Technical | 1000-1500 | 200-300 |
+
+### Hybrid Chunking
+
+Combine semantic and size-based chunking:
+
+```python
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+
+# First pass: semantic boundaries
+semantic_splitter = RecursiveCharacterTextSplitter(
+    chunk_size=2000,
+    chunk_overlap=0,
+    separators=["\n\n\n", "\n\n", "\n# ", "\n## "]
+)
+
+# Second pass: size-based
+size_splitter = RecursiveCharacterTextSplitter(
+    chunk_size=500,
+    chunk_overlap=100
+)
+
+# Apply both
+docs = loader.load()
+semantic_chunks = semantic_splitter.split_documents(docs)
+final_chunks = size_splitter.split_documents(semantic_chunks)
+```
+
+## Best Practices
+
+### 1. Preserve Metadata
+
+Always include source information in chunks:
+
+```python
+for chunk in chunks:
+    chunk.metadata["source"] = file_path
+    chunk.metadata["chunk_index"] = i
+```
+
+### 2. Handle Tables Separately
+
+Tables often need special treatment:
+
+```python
+from docling.document_converter import DocumentConverter
+
+converter = DocumentConverter()
+result = converter.convert("document.pdf")
+doc = result.document
+
+# Extract tables separately
+for table in doc.tables:
+    df = table.export_to_dataframe()
+    # Index table content differently
+```
+
+### 3. Use Appropriate Embeddings
+
+| Embedding Model | Dimensions | Quality | Speed |
+|-----------------|------------|---------|-------|
+| all-MiniLM-L6-v2 | 384 | Good | Fast |
+| all-mpnet-base-v2 | 768 | Better | Medium |
+| text-embedding-ada-002 | 1536 | Best | API |
+
+### 4. Test Retrieval Quality
+
+```python
+# Test retrieval before deploying
+test_queries = [
+    "What is the main topic?",
+    "What are the key findings?",
+    "Who are the authors?"
+]
+
+for query in test_queries:
+    results = vectorstore.similarity_search(query, k=3)
+    print(f"\nQuery: {query}")
+    for i, doc in enumerate(results):
+        print(f"  {i+1}. {doc.page_content[:100]}...")
+```

--- a/skills/docling/references/vlm-pipelines.md
+++ b/skills/docling/references/vlm-pipelines.md
@@ -146,7 +146,7 @@ For large documents or limited VRAM:
 vlm_options = VlmPipelineOptions(
     model_name="granite_docling",
     batch_size=1,           # Process one page at a time
-    offload_to_cpu=True,    # Offload model weights to CPU when idle
+    offload_to_cpu=True,    # Offload model weights from GPU to CPU to save VRAM
 )
 ```
 

--- a/skills/docling/references/vlm-pipelines.md
+++ b/skills/docling/references/vlm-pipelines.md
@@ -1,0 +1,361 @@
+# Vision Language Model (VLM) Pipelines Guide
+
+This guide covers using Vision Language Models with Docling for advanced document understanding.
+
+## Overview
+
+VLM pipelines use vision-language models to understand document structure, making them ideal for:
+
+- Complex layouts with mixed content
+- Documents with unusual formatting
+- Scientific papers with equations
+- Forms and invoices
+- Handwritten content mixed with printed text
+
+## When to Use VLM vs Standard Pipeline
+
+| Use Case | Recommended Pipeline |
+|----------|---------------------|
+| Clean PDF with text | Standard |
+| Scanned document (mostly text) | Standard + OCR |
+| Complex multi-column layout | VLM |
+| Mixed tables/figures/text | VLM |
+| Scientific papers | VLM |
+| Forms and invoices | VLM |
+| Low-quality scans | VLM |
+
+## Installation
+
+```bash
+# Install VLM support
+pip install "docling[vlm]"
+
+# Full installation with VLM and OCR
+pip install "docling[vlm,tesserocr]"
+```
+
+## Quick Start
+
+### CLI
+
+```bash
+# Basic VLM conversion
+docling --pipeline vlm document.pdf
+
+# Specify model
+docling --pipeline vlm --vlm-model granite_docling document.pdf
+```
+
+### Python
+
+```python
+from docling.document_converter import DocumentConverter, PdfFormatOption
+from docling.datamodel.pipeline_options import VlmPipelineOptions
+from docling.datamodel.document import InputFormat
+
+vlm_options = VlmPipelineOptions(
+    model_name="granite_docling"
+)
+
+converter = DocumentConverter(
+    format_options={
+        InputFormat.PDF: PdfFormatOption(pipeline_options=vlm_options)
+    }
+)
+
+result = converter.convert("complex_document.pdf")
+print(result.document.export_to_markdown())
+```
+
+## Available Models
+
+### GraniteDocling (Recommended)
+
+IBM's document-focused vision-language model.
+
+```python
+vlm_options = VlmPipelineOptions(model_name="granite_docling")
+```
+
+**Strengths:**
+- Optimized for document understanding
+- Good table structure recognition
+- MLX support for Apple Silicon
+
+## Hardware Requirements
+
+### CPU Only
+
+Works but slow. Expect 1-5 minutes per page depending on complexity.
+
+```python
+vlm_options = VlmPipelineOptions(
+    model_name="granite_docling",
+    device="cpu"
+)
+```
+
+### GPU (CUDA)
+
+Recommended for production. 5-30 seconds per page.
+
+```python
+vlm_options = VlmPipelineOptions(
+    model_name="granite_docling",
+    device="cuda"
+)
+```
+
+### Apple Silicon (MLX)
+
+Automatic MLX acceleration on M1/M2/M3 Macs. 10-60 seconds per page.
+
+```python
+# MLX is auto-detected on Apple Silicon
+vlm_options = VlmPipelineOptions(model_name="granite_docling")
+```
+
+## Configuration Options
+
+### Full Configuration Example
+
+```python
+from docling.document_converter import DocumentConverter, PdfFormatOption
+from docling.datamodel.pipeline_options import VlmPipelineOptions
+from docling.datamodel.document import InputFormat
+
+vlm_options = VlmPipelineOptions(
+    model_name="granite_docling",
+    device="cuda",              # "cpu", "cuda", or "mps"
+    batch_size=1,               # Pages to process in parallel
+    max_new_tokens=4096,        # Max output tokens per page
+)
+
+converter = DocumentConverter(
+    format_options={
+        InputFormat.PDF: PdfFormatOption(pipeline_options=vlm_options)
+    }
+)
+```
+
+### Memory Management
+
+For large documents or limited VRAM:
+
+```python
+vlm_options = VlmPipelineOptions(
+    model_name="granite_docling",
+    batch_size=1,           # Process one page at a time
+    offload_to_cpu=True,    # Offload model weights to CPU when idle
+)
+```
+
+## Batch Processing with VLM
+
+VLM is compute-intensive. For batch processing:
+
+```python
+from docling.document_converter import DocumentConverter, PdfFormatOption
+from docling.datamodel.pipeline_options import VlmPipelineOptions
+from docling.datamodel.document import InputFormat
+from pathlib import Path
+from tqdm import tqdm
+
+vlm_options = VlmPipelineOptions(model_name="granite_docling")
+
+converter = DocumentConverter(
+    format_options={
+        InputFormat.PDF: PdfFormatOption(pipeline_options=vlm_options)
+    }
+)
+
+files = list(Path("documents/").glob("*.pdf"))
+
+for file in tqdm(files, desc="Converting with VLM"):
+    try:
+        result = converter.convert(str(file))
+        output = Path("output") / f"{file.stem}.md"
+        output.write_text(result.document.export_to_markdown())
+    except Exception as e:
+        print(f"Error processing {file}: {e}")
+```
+
+## Combining VLM with OCR
+
+For documents with both complex layouts and scanned content:
+
+```python
+from docling.datamodel.pipeline_options import VlmPipelineOptions, OcrOptions
+
+vlm_options = VlmPipelineOptions(
+    model_name="granite_docling",
+    do_ocr=True,
+    ocr_options=OcrOptions(
+        engine="tesseract",
+        lang=["eng"]
+    )
+)
+```
+
+## Performance Optimization
+
+### 1. Use Appropriate Hardware
+
+| Hardware | Expected Speed | Memory |
+|----------|---------------|--------|
+| M1/M2/M3 Mac | 10-60s/page | 16GB+ RAM |
+| CUDA GPU | 5-30s/page | 8GB+ VRAM |
+| CPU only | 1-5min/page | 16GB+ RAM |
+
+### 2. Reduce Page Count
+
+Process only needed pages:
+
+```bash
+docling --pipeline vlm --pages 1-10 large_document.pdf
+```
+
+### 3. Pre-filter Documents
+
+Use standard pipeline for simple documents, VLM only for complex ones:
+
+```python
+def needs_vlm(file_path: str) -> bool:
+    """Heuristic to determine if VLM is needed."""
+    # Check if document is likely complex
+    # (e.g., multi-column, many images, etc.)
+    return True  # Implement your logic
+
+converter_standard = DocumentConverter()
+converter_vlm = DocumentConverter(
+    format_options={
+        InputFormat.PDF: PdfFormatOption(
+            pipeline_options=VlmPipelineOptions(model_name="granite_docling")
+        )
+    }
+)
+
+for file in files:
+    converter = converter_vlm if needs_vlm(str(file)) else converter_standard
+    result = converter.convert(str(file))
+```
+
+## Troubleshooting
+
+### Out of Memory (OOM)
+
+**Symptom:** Process killed or CUDA out of memory error
+
+**Solutions:**
+1. Reduce batch_size to 1
+2. Enable CPU offloading
+3. Use smaller model
+4. Process fewer pages at once
+
+```python
+vlm_options = VlmPipelineOptions(
+    model_name="granite_docling",
+    batch_size=1,
+    offload_to_cpu=True,
+)
+```
+
+### Slow Processing
+
+**Symptom:** Very slow conversion (>5 min/page)
+
+**Solutions:**
+1. Ensure GPU is being used: check `device` setting
+2. Install CUDA/MLX properly
+3. Use standard pipeline for simple documents
+
+### Model Download Fails
+
+**Symptom:** Model download hangs or fails
+
+**Solutions:**
+1. Check internet connection
+2. Set HF_HOME for custom cache location:
+   ```bash
+   export HF_HOME=/path/to/cache
+   ```
+3. Pre-download model:
+   ```python
+   from huggingface_hub import snapshot_download
+   snapshot_download("ibm-granite/granite-vision-docling")
+   ```
+
+### Poor Quality Output
+
+**Symptom:** VLM output is worse than expected
+
+**Solutions:**
+1. Ensure document image quality is good (300+ DPI)
+2. Try different model
+3. Check if standard pipeline + OCR works better
+4. Report issue with sample document
+
+## Model Comparison
+
+| Model | Size | Speed | Quality | Best For |
+|-------|------|-------|---------|----------|
+| granite_docling | ~7B | Medium | High | General documents |
+
+## Environment Variables
+
+```bash
+# Hugging Face cache location
+export HF_HOME=/path/to/cache
+
+# CUDA device selection
+export CUDA_VISIBLE_DEVICES=0
+
+# Disable telemetry
+export DOCLING_TELEMETRY=false
+```
+
+## Complete Example
+
+```python
+#!/usr/bin/env python3
+"""Convert complex document with VLM pipeline."""
+
+from docling.document_converter import DocumentConverter, PdfFormatOption
+from docling.datamodel.pipeline_options import VlmPipelineOptions
+from docling.datamodel.document import InputFormat
+from pathlib import Path
+import sys
+
+def convert_with_vlm(input_path: str, output_path: str):
+    """Convert document using VLM pipeline."""
+
+    # Configure VLM
+    vlm_options = VlmPipelineOptions(
+        model_name="granite_docling",
+        batch_size=1,
+    )
+
+    # Create converter
+    converter = DocumentConverter(
+        format_options={
+            InputFormat.PDF: PdfFormatOption(pipeline_options=vlm_options)
+        }
+    )
+
+    # Convert
+    print(f"Processing: {input_path}")
+    print("This may take several minutes for large documents...")
+
+    result = converter.convert(input_path)
+
+    # Save output
+    Path(output_path).write_text(result.document.export_to_markdown())
+    print(f"Output: {output_path}")
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: python script.py <input.pdf> <output.md>")
+        sys.exit(1)
+
+    convert_with_vlm(sys.argv[1], sys.argv[2])
+```

--- a/skills/docling/scripts/batch_convert.py
+++ b/skills/docling/scripts/batch_convert.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Batch convert documents using Docling."""
+
+import argparse
+import sys
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+
+
+def convert_single(args_tuple):
+    """Convert a single document (for multiprocessing)."""
+    input_path, output_path, output_format, use_ocr = args_tuple
+
+    from docling.document_converter import DocumentConverter
+
+    converter_kwargs = {}
+    if use_ocr:
+        from docling.datamodel.pipeline_options import PipelineOptions
+        from docling.datamodel.document import InputFormat
+        from docling.document_converter import PdfFormatOption
+
+        pipeline_options = PipelineOptions()
+        pipeline_options.do_ocr = True
+        converter_kwargs["format_options"] = {
+            InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)
+        }
+
+    try:
+        converter = DocumentConverter(**converter_kwargs)
+        result = converter.convert(str(input_path))
+        doc = result.document
+
+        if output_format == "md":
+            content = doc.export_to_markdown()
+        elif output_format == "html":
+            content = doc.export_to_html()
+        elif output_format == "json":
+            content = doc.model_dump_json(indent=2)
+        else:
+            raise ValueError(f"Unknown format: {output_format}")
+
+        Path(output_path).write_text(content)
+        return str(input_path), True, None
+    except Exception as e:
+        return str(input_path), False, str(e)
+
+
+def batch_convert(
+    input_dir: str,
+    output_dir: str,
+    pattern: str = "*",
+    output_format: str = "md",
+    use_ocr: bool = False,
+    workers: int = 4,
+):
+    """Batch convert documents from a directory.
+
+    Args:
+        input_dir: Input directory containing documents
+        output_dir: Output directory for converted files
+        pattern: Glob pattern for input files (default: *)
+        output_format: Output format (md, html, json)
+        use_ocr: Enable OCR for scanned documents
+        workers: Number of parallel workers
+    """
+    input_path = Path(input_dir)
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    # Supported extensions
+    supported_exts = {".pdf", ".docx", ".pptx", ".xlsx", ".html", ".htm", ".png", ".jpg", ".jpeg", ".tiff"}
+
+    # Find files matching pattern
+    if pattern == "*":
+        files = [f for f in input_path.iterdir() if f.is_file() and f.suffix.lower() in supported_exts]
+    else:
+        files = [f for f in input_path.glob(pattern) if f.is_file() and f.suffix.lower() in supported_exts]
+
+    if not files:
+        print(f"No supported files found in {input_dir}")
+        print(f"Supported formats: {', '.join(sorted(supported_exts))}")
+        return
+
+    print(f"Found {len(files)} file(s) to convert")
+    print(f"Output format: {output_format}")
+    print(f"Workers: {workers}")
+    print("-" * 50)
+
+    # Determine output extension
+    ext_map = {"md": ".md", "html": ".html", "json": ".json"}
+    out_ext = ext_map[output_format]
+
+    # Prepare conversion tasks
+    tasks = []
+    for f in files:
+        out_file = output_path / f"{f.stem}{out_ext}"
+        tasks.append((f, out_file, output_format, use_ocr))
+
+    # Process files
+    success_count = 0
+    error_count = 0
+
+    if workers == 1:
+        # Sequential processing
+        for i, task in enumerate(tasks, 1):
+            input_file, success, error = convert_single(task)
+            if success:
+                print(f"[{i}/{len(tasks)}] OK: {Path(input_file).name}")
+                success_count += 1
+            else:
+                print(f"[{i}/{len(tasks)}] ERROR: {Path(input_file).name} - {error}")
+                error_count += 1
+    else:
+        # Parallel processing
+        with ProcessPoolExecutor(max_workers=workers) as executor:
+            futures = {executor.submit(convert_single, task): task for task in tasks}
+            for i, future in enumerate(as_completed(futures), 1):
+                input_file, success, error = future.result()
+                if success:
+                    print(f"[{i}/{len(tasks)}] OK: {Path(input_file).name}")
+                    success_count += 1
+                else:
+                    print(f"[{i}/{len(tasks)}] ERROR: {Path(input_file).name} - {error}")
+                    error_count += 1
+
+    print("-" * 50)
+    print(f"Complete: {success_count} succeeded, {error_count} failed")
+    print(f"Output directory: {output_dir}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Batch convert documents using Docling",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s input_dir/ output_dir/
+  %(prog)s input_dir/ output_dir/ --pattern "*.pdf"
+  %(prog)s input_dir/ output_dir/ --format html
+  %(prog)s input_dir/ output_dir/ --ocr --workers 2
+        """,
+    )
+    parser.add_argument("input_dir", help="Input directory containing documents")
+    parser.add_argument("output_dir", help="Output directory for converted files")
+    parser.add_argument(
+        "--pattern",
+        default="*",
+        help="Glob pattern for input files (default: *)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["md", "html", "json"],
+        default="md",
+        help="Output format (default: md)",
+    )
+    parser.add_argument(
+        "--ocr",
+        action="store_true",
+        help="Enable OCR for scanned documents",
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=4,
+        help="Number of parallel workers (default: 4, use 1 for sequential)",
+    )
+
+    args = parser.parse_args()
+
+    if not Path(args.input_dir).is_dir():
+        print(f"Error: {args.input_dir} is not a directory", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        batch_convert(
+            args.input_dir,
+            args.output_dir,
+            args.pattern,
+            args.format,
+            args.ocr,
+            args.workers,
+        )
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/docling/scripts/check_ocr_engines.py
+++ b/skills/docling/scripts/check_ocr_engines.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Check which OCR engines are available for Docling."""
+
+import shutil
+import sys
+from importlib.util import find_spec
+
+
+def check_tesseract():
+    """Check Tesseract OCR availability."""
+    # Check system binary
+    binary = shutil.which("tesseract")
+    if not binary:
+        return False, "tesseract binary not found in PATH"
+
+    # Check Python binding
+    if not find_spec("tesserocr"):
+        return False, f"tesseract binary found at {binary}, but tesserocr not installed (pip install tesserocr)"
+
+    return True, f"Available (binary: {binary})"
+
+
+def check_easyocr():
+    """Check EasyOCR availability."""
+    if not find_spec("easyocr"):
+        return False, "easyocr not installed (pip install easyocr)"
+    return True, "Available"
+
+
+def check_rapidocr():
+    """Check RapidOCR availability."""
+    if not find_spec("rapidocr_onnxruntime"):
+        return False, "rapidocr not installed (pip install rapidocr-onnxruntime)"
+    return True, "Available"
+
+
+def check_ocrmac():
+    """Check OcrMac availability (macOS only)."""
+    if sys.platform != "darwin":
+        return False, "OcrMac only available on macOS"
+    if not find_spec("ocrmac"):
+        return False, "ocrmac not installed (pip install ocrmac)"
+    return True, "Available"
+
+
+def check_docling():
+    """Check Docling installation."""
+    if not find_spec("docling"):
+        return False, "docling not installed (pip install docling)"
+    return True, "Available"
+
+
+def main():
+    print("=" * 60)
+    print("Docling OCR Engine Availability Check")
+    print("=" * 60)
+    print()
+
+    # Check Docling first
+    docling_ok, docling_msg = check_docling()
+    print(f"Docling:     {'[OK]' if docling_ok else '[MISSING]':10} {docling_msg}")
+    print()
+
+    if not docling_ok:
+        print("Install Docling first: pip install docling")
+        sys.exit(1)
+
+    print("OCR Engines:")
+    print("-" * 60)
+
+    engines = [
+        ("Tesseract", check_tesseract),
+        ("EasyOCR", check_easyocr),
+        ("RapidOCR", check_rapidocr),
+        ("OcrMac", check_ocrmac),
+    ]
+
+    available = []
+    for name, check_fn in engines:
+        ok, msg = check_fn()
+        status = "[OK]" if ok else "[MISSING]"
+        print(f"  {name:12} {status:10} {msg}")
+        if ok:
+            available.append(name)
+
+    print()
+    print("-" * 60)
+
+    if available:
+        print(f"Available engines: {', '.join(available)}")
+        print("\nTo use OCR with Docling:")
+        print("  docling --ocr document.pdf")
+    else:
+        print("No OCR engines available.")
+        print("\nTo install an OCR engine:")
+        print('  pip install "docling[easyocr]"    # Easiest, pure Python')
+        print('  pip install "docling[tesserocr]"  # Requires tesseract binary')
+        print('  pip install "docling[rapidocr]"   # CPU-optimized')
+
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/docling/scripts/convert_document.py
+++ b/skills/docling/scripts/convert_document.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Convert a document to Markdown, HTML, or JSON using Docling."""
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def convert_document(
+    input_path: str,
+    output_path: str,
+    output_format: str = "md",
+    use_ocr: bool = False,
+    use_vlm: bool = False,
+    vlm_model: str = "granite_docling",
+):
+    """Convert a document using Docling.
+
+    Args:
+        input_path: Path to input file or URL
+        output_path: Path for output file
+        output_format: Output format (md, html, json)
+        use_ocr: Enable OCR for scanned documents
+        use_vlm: Use VLM pipeline for complex layouts
+        vlm_model: VLM model name (default: granite_docling)
+    """
+    from docling.document_converter import DocumentConverter
+
+    # Configure converter based on options
+    converter_kwargs = {}
+
+    if use_vlm:
+        from docling.datamodel.pipeline_options import VlmPipelineOptions
+        from docling.datamodel.document import InputFormat
+        from docling.document_converter import PdfFormatOption
+
+        vlm_options = VlmPipelineOptions(model_name=vlm_model)
+        converter_kwargs["format_options"] = {
+            InputFormat.PDF: PdfFormatOption(pipeline_options=vlm_options)
+        }
+    elif use_ocr:
+        from docling.datamodel.pipeline_options import PipelineOptions
+        from docling.datamodel.document import InputFormat
+        from docling.document_converter import PdfFormatOption
+
+        pipeline_options = PipelineOptions()
+        pipeline_options.do_ocr = True
+        converter_kwargs["format_options"] = {
+            InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)
+        }
+
+    # Convert document
+    converter = DocumentConverter(**converter_kwargs)
+
+    print(f"Converting: {input_path}")
+    result = converter.convert(input_path)
+    doc = result.document
+
+    # Export based on format
+    if output_format == "md":
+        content = doc.export_to_markdown()
+    elif output_format == "html":
+        content = doc.export_to_html()
+    elif output_format == "json":
+        content = doc.model_dump_json(indent=2)
+    else:
+        raise ValueError(f"Unknown format: {output_format}")
+
+    # Write output
+    Path(output_path).write_text(content)
+    print(f"Output: {output_path}")
+
+    return output_path
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert document to Markdown/HTML/JSON using Docling",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s document.pdf output.md
+  %(prog)s document.pdf output.html --format html
+  %(prog)s scanned.pdf output.md --ocr
+  %(prog)s complex.pdf output.md --vlm
+  %(prog)s https://example.com/doc.pdf output.md
+        """,
+    )
+    parser.add_argument("input", help="Input file path or URL")
+    parser.add_argument("output", help="Output file path")
+    parser.add_argument(
+        "--format",
+        choices=["md", "html", "json"],
+        default="md",
+        help="Output format (default: md)",
+    )
+    parser.add_argument(
+        "--ocr",
+        action="store_true",
+        help="Enable OCR for scanned documents",
+    )
+    parser.add_argument(
+        "--vlm",
+        action="store_true",
+        help="Use VLM pipeline for complex layouts",
+    )
+    parser.add_argument(
+        "--vlm-model",
+        default="granite_docling",
+        help="VLM model name (default: granite_docling)",
+    )
+
+    args = parser.parse_args()
+
+    if args.ocr and args.vlm:
+        print("Error: Cannot use both --ocr and --vlm. Choose one.", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        convert_document(
+            args.input,
+            args.output,
+            args.format,
+            args.ocr,
+            args.vlm,
+            args.vlm_model,
+        )
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/docling/scripts/extract_tables.py
+++ b/skills/docling/scripts/extract_tables.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Extract tables from a document using Docling."""
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def extract_tables(
+    input_path: str,
+    output_dir: str,
+    output_format: str = "csv",
+    use_ocr: bool = False,
+):
+    """Extract tables from a document.
+
+    Args:
+        input_path: Path to input file or URL
+        output_dir: Directory for output files
+        output_format: Output format (csv, xlsx)
+        use_ocr: Enable OCR for scanned documents
+    """
+    from docling.document_converter import DocumentConverter
+
+    # Configure converter
+    converter_kwargs = {}
+    if use_ocr:
+        from docling.datamodel.pipeline_options import PipelineOptions
+        from docling.datamodel.document import InputFormat
+        from docling.document_converter import PdfFormatOption
+
+        pipeline_options = PipelineOptions()
+        pipeline_options.do_ocr = True
+        converter_kwargs["format_options"] = {
+            InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)
+        }
+
+    # Convert document
+    converter = DocumentConverter(**converter_kwargs)
+
+    print(f"Processing: {input_path}")
+    result = converter.convert(input_path)
+    doc = result.document
+
+    # Create output directory
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    # Extract tables
+    tables = list(doc.tables)
+    if not tables:
+        print("No tables found in document.")
+        return []
+
+    print(f"Found {len(tables)} table(s)")
+
+    input_stem = Path(input_path).stem if not input_path.startswith("http") else "document"
+    output_files = []
+
+    if output_format == "xlsx":
+        # All tables in one Excel file
+        import pandas as pd
+
+        xlsx_path = output_path / f"{input_stem}_tables.xlsx"
+        with pd.ExcelWriter(xlsx_path, engine="openpyxl") as writer:
+            for i, table in enumerate(tables):
+                df = table.export_to_dataframe()
+                sheet_name = f"Table_{i + 1}"
+                df.to_excel(writer, sheet_name=sheet_name, index=False)
+                print(f"  Table {i + 1}: {df.shape[0]} rows x {df.shape[1]} cols -> {sheet_name}")
+
+        output_files.append(str(xlsx_path))
+        print(f"\nSaved to: {xlsx_path}")
+
+    else:  # csv
+        for i, table in enumerate(tables):
+            df = table.export_to_dataframe()
+            csv_path = output_path / f"{input_stem}_table_{i + 1}.csv"
+            df.to_csv(csv_path, index=False)
+            output_files.append(str(csv_path))
+            print(f"  Table {i + 1}: {df.shape[0]} rows x {df.shape[1]} cols -> {csv_path.name}")
+
+        print(f"\nSaved {len(output_files)} CSV file(s) to: {output_dir}")
+
+    return output_files
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Extract tables from document using Docling",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s document.pdf tables/
+  %(prog)s document.pdf tables/ --format xlsx
+  %(prog)s scanned.pdf tables/ --ocr
+        """,
+    )
+    parser.add_argument("input", help="Input file path or URL")
+    parser.add_argument("output_dir", help="Output directory for tables")
+    parser.add_argument(
+        "--format",
+        choices=["csv", "xlsx"],
+        default="csv",
+        help="Output format (default: csv)",
+    )
+    parser.add_argument(
+        "--ocr",
+        action="store_true",
+        help="Enable OCR for scanned documents",
+    )
+
+    args = parser.parse_args()
+
+    try:
+        extract_tables(args.input, args.output_dir, args.format, args.ocr)
+    except ImportError as e:
+        if "openpyxl" in str(e):
+            print("Error: xlsx format requires openpyxl. Install with: pip install openpyxl", file=sys.stderr)
+        else:
+            print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/docling/scripts/prepare_rag_chunks.py
+++ b/skills/docling/scripts/prepare_rag_chunks.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Prepare documents for RAG ingestion using Docling."""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+def chunk_text(text: str, chunk_size: int, overlap: int) -> list[dict]:
+    """Split text into overlapping chunks.
+
+    Args:
+        text: Text to chunk
+        chunk_size: Target chunk size in characters
+        overlap: Overlap between chunks in characters
+
+    Returns:
+        List of chunk dictionaries with text and metadata
+    """
+    chunks = []
+    start = 0
+    chunk_id = 0
+
+    while start < len(text):
+        end = start + chunk_size
+
+        # Try to break at sentence boundary
+        if end < len(text):
+            # Look for sentence end within last 20% of chunk
+            search_start = start + int(chunk_size * 0.8)
+            for i in range(end, search_start, -1):
+                if text[i] in ".!?\n" and (i + 1 >= len(text) or text[i + 1].isspace()):
+                    end = i + 1
+                    break
+
+        chunk_text = text[start:end].strip()
+        if chunk_text:
+            chunks.append({
+                "chunk_id": chunk_id,
+                "text": chunk_text,
+                "start_char": start,
+                "end_char": end,
+            })
+            chunk_id += 1
+
+        start = end - overlap
+        if start <= chunks[-1]["start_char"] if chunks else 0:
+            start = end  # Prevent infinite loop
+
+    return chunks
+
+
+def prepare_rag_chunks(
+    input_path: str,
+    output_path: str,
+    chunk_size: int = 512,
+    overlap: int = 50,
+    use_ocr: bool = False,
+    include_metadata: bool = True,
+):
+    """Prepare a document for RAG ingestion.
+
+    Args:
+        input_path: Path to input file or URL
+        output_path: Path for output JSON file
+        chunk_size: Target chunk size in characters
+        overlap: Overlap between chunks in characters
+        use_ocr: Enable OCR for scanned documents
+        include_metadata: Include document metadata in output
+    """
+    from docling.document_converter import DocumentConverter
+
+    # Configure converter
+    converter_kwargs = {}
+    if use_ocr:
+        from docling.datamodel.pipeline_options import PipelineOptions
+        from docling.datamodel.document import InputFormat
+        from docling.document_converter import PdfFormatOption
+
+        pipeline_options = PipelineOptions()
+        pipeline_options.do_ocr = True
+        converter_kwargs["format_options"] = {
+            InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)
+        }
+
+    # Convert document
+    converter = DocumentConverter(**converter_kwargs)
+
+    print(f"Processing: {input_path}")
+    result = converter.convert(input_path)
+    doc = result.document
+
+    # Export to markdown for text extraction
+    markdown = doc.export_to_markdown()
+
+    # Chunk the text
+    print(f"Chunking with size={chunk_size}, overlap={overlap}")
+    chunks = chunk_text(markdown, chunk_size, overlap)
+
+    # Build output structure
+    output = {
+        "source": input_path,
+        "chunk_size": chunk_size,
+        "overlap": overlap,
+        "total_chunks": len(chunks),
+        "chunks": [],
+    }
+
+    # Add metadata if requested
+    if include_metadata:
+        output["metadata"] = {
+            "num_pages": getattr(doc, "num_pages", None),
+            "num_tables": len(list(doc.tables)) if hasattr(doc, "tables") else 0,
+        }
+
+    # Add chunks with metadata
+    for chunk in chunks:
+        chunk_entry = {
+            "id": f"{Path(input_path).stem}_chunk_{chunk['chunk_id']}",
+            "text": chunk["text"],
+            "metadata": {
+                "source": input_path,
+                "chunk_index": chunk["chunk_id"],
+                "start_char": chunk["start_char"],
+                "end_char": chunk["end_char"],
+            },
+        }
+        output["chunks"].append(chunk_entry)
+
+    # Write output
+    Path(output_path).write_text(json.dumps(output, indent=2))
+    print(f"Created {len(chunks)} chunks")
+    print(f"Output: {output_path}")
+
+    return output
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Prepare document for RAG ingestion using Docling",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s document.pdf chunks.json
+  %(prog)s document.pdf chunks.json --chunk-size 1000 --overlap 100
+  %(prog)s scanned.pdf chunks.json --ocr
+  %(prog)s document.pdf chunks.json --no-metadata
+
+Output format:
+  {
+    "source": "document.pdf",
+    "chunk_size": 512,
+    "overlap": 50,
+    "total_chunks": 10,
+    "metadata": {...},
+    "chunks": [
+      {
+        "id": "document_chunk_0",
+        "text": "...",
+        "metadata": {"source": "...", "chunk_index": 0, ...}
+      },
+      ...
+    ]
+  }
+        """,
+    )
+    parser.add_argument("input", help="Input file path or URL")
+    parser.add_argument("output", help="Output JSON file path")
+    parser.add_argument(
+        "--chunk-size",
+        type=int,
+        default=512,
+        help="Target chunk size in characters (default: 512)",
+    )
+    parser.add_argument(
+        "--overlap",
+        type=int,
+        default=50,
+        help="Overlap between chunks in characters (default: 50)",
+    )
+    parser.add_argument(
+        "--ocr",
+        action="store_true",
+        help="Enable OCR for scanned documents",
+    )
+    parser.add_argument(
+        "--no-metadata",
+        action="store_true",
+        help="Exclude document metadata from output",
+    )
+
+    args = parser.parse_args()
+
+    if args.chunk_size <= args.overlap:
+        print("Error: chunk-size must be greater than overlap", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        prepare_rag_chunks(
+            args.input,
+            args.output,
+            args.chunk_size,
+            args.overlap,
+            args.ocr,
+            not args.no_metadata,
+        )
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/docling/scripts/prepare_rag_chunks.py
+++ b/skills/docling/scripts/prepare_rag_chunks.py
@@ -5,7 +5,6 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from typing import Optional
 
 
 def chunk_text(text: str, chunk_size: int, overlap: int) -> list[dict]:
@@ -46,7 +45,7 @@ def chunk_text(text: str, chunk_size: int, overlap: int) -> list[dict]:
             chunk_id += 1
 
         start = end - overlap
-        if start <= chunks[-1]["start_char"] if chunks else 0:
+        if chunks and start <= chunks[-1]["start_char"]:
             start = end  # Prevent infinite loop
 
     return chunks


### PR DESCRIPTION
## Summary

Adds a new skill for universal document conversion using the [Docling](https://docling-project.github.io/docling/) library.

**Capabilities:**
- Converts PDF, DOCX, PPTX, XLSX, HTML, images, audio to Markdown/HTML/JSON
- OCR support (Tesseract, EasyOCR, RapidOCR, OcrMac)
- Vision Language Model pipeline (GraniteDocling) for complex layouts
- Table extraction to CSV/Excel
- RAG framework integrations (LangChain, LlamaIndex, Haystack)
- Batch processing with parallel execution

**Structure:**
- `SKILL.md` - Main skill file (~380 lines)
- `references/` - 4 detailed guides (OCR, VLM, RAG, advanced options)
- `scripts/` - 5 Python helper scripts

## Test plan

- [ ] Verify SKILL.md frontmatter triggers correctly
- [ ] Test scripts with sample documents
- [ ] Validate reference file links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)