### PR TITLE
Improve frontend-design skill clarity and actionability

### DIFF
--- a/skills/frontend-design/SKILL.md
+++ b/skills/frontend-design/SKILL.md
@@ -12,14 +12,14 @@ The user provides frontend requirements: a component, page, application, or inte
 
 Before coding, understand the context and commit to a BOLD aesthetic direction:
 - **Purpose**: What problem does this interface solve? Who uses it?
-- **Tone**: Pick an extreme: brutally minimal, maximalist chaos, retro-futuristic, organic/natural, luxury/refined, playful/toy-like, editorial/magazine, brutalist/raw, art deco/geometric, soft/pastel, industrial/utilitarian, etc. There are so many flavors to choose from. Use these for inspiration but design one that is true to the aesthetic direction.
+- **Tone**: Commit to a distinct direction: brutally minimal, maximalist chaos, luxury/refined, lo-fi/zine, dark/moody, soft/pastel, editorial/magazine, brutalist/raw, retro-futuristic, handcrafted/artisanal, organic/natural, art deco/geometric, playful/whimsical, industrial/utilitarian, etc. There are infinite varieties to start from and surpass. Use these as inspiration, but the final design should feel singular, with every detail working in service of one cohesive direction.
 - **Constraints**: Technical requirements (framework, performance, accessibility).
 - **Differentiation**: What makes this UNFORGETTABLE? What's the one thing someone will remember?
 
-**CRITICAL**: Choose a clear conceptual direction and execute it with precision. Bold maximalism and refined minimalism both work - the key is intentionality, not intensity.
+**CRITICAL**: Choose a clear conceptual direction and execute it vigorously. Bold maximalism and refined minimalism both work - the key is intentionality, not intensity.
 
 Then implement working code (HTML/CSS/JS, React, Vue, etc.) that is:
-- Production-grade and functional
+- Production-grade, functional, and responsive
 - Visually striking and memorable
 - Cohesive with a clear aesthetic point-of-view
 - Meticulously refined in every detail
@@ -27,16 +27,17 @@ Then implement working code (HTML/CSS/JS, React, Vue, etc.) that is:
 ## Frontend Aesthetics Guidelines
 
 Focus on:
-- **Typography**: Choose fonts that are beautiful, unique, and interesting. Avoid generic fonts like Arial and Inter; opt instead for distinctive choices that elevate the frontend's aesthetics; unexpected, characterful font choices. Pair a distinctive display font with a refined body font.
-- **Color & Theme**: Commit to a cohesive aesthetic. Use CSS variables for consistency. Dominant colors with sharp accents outperform timid, evenly-distributed palettes.
+- **Typography**: Typography carries the design's singular voice. Choose fonts with interesting personality. Default fonts signal default thinking: skip Arial, Inter, Roboto, system stacks. Font choices should be inseparable from the aesthetic direction. Display type should be expressive, even risky. Body text should be legible, refined. Pair them like actors in a scene. Work the full typographic range: size, weight, case, spacing to establish hierarchy.
+- **Color & Theme**: Commit to a cohesive aesthetic. Palettes should take a clear position: bold and saturated, moody and restrained, or high-contrast and minimal. Lead with a dominant color, punctuate with sharp accents. Avoid timid, non-committal distributions. Use CSS variables for consistency.
 - **Motion**: Use animations for effects and micro-interactions. Prioritize CSS-only solutions for HTML. Use Motion library for React when available. Focus on high-impact moments: one well-orchestrated page load with staggered reveals (animation-delay) creates more delight than scattered micro-interactions. Use scroll-triggering and hover states that surprise.
-- **Spatial Composition**: Unexpected layouts. Asymmetry. Overlap. Diagonal flow. Grid-breaking elements. Generous negative space OR controlled density.
-- **Backgrounds & Visual Details**: Create atmosphere and depth rather than defaulting to solid colors. Add contextual effects and textures that match the overall aesthetic. Apply creative forms like gradient meshes, noise textures, geometric patterns, layered transparencies, dramatic shadows, decorative borders, custom cursors, and grain overlays.
+- **Spatial Composition**: Unexpected layouts. Asymmetry. Overlap and z-depth. Diagonal flow. Grid-breaking elements. Dramatic scale jumps. Full-bleed moments. Generous negative space OR controlled density.
+- **Backgrounds & Visual Details**: Create atmosphere and depth rather than defaulting to solid colors. Add contextual effects and textures that match the overall aesthetic. Apply creative forms like gradient meshes, noise and grain overlays, geometric patterns, layered transparencies and glassmorphism, dramatic or soft shadows and glows, parallax depth, decorative borders and clip-path shapes, print-inspired textures (halftone, duotone, stipple), knockout typography, and custom cursors.
 
-NEVER use generic AI-generated aesthetics like overused font families (Inter, Roboto, Arial, system fonts), cliched color schemes (particularly purple gradients on white backgrounds), predictable layouts and component patterns, and cookie-cutter design that lacks context-specific character.
+NEVER use generic AI-generated aesthetics like overused font families (Inter, Roboto, Arial, Space Grotesk, system fonts), cliched color schemes (particularly purple gradients on white backgrounds), predictable layouts and component patterns, and cookie-cutter designs that lack context-specific character. 
+INSTEAD: distinctive fonts. Bold, committed palettes. Layouts that surprise. Bespoke details. Every choice rooted in rich context.
 
-Interpret creatively and make unexpected choices that feel genuinely designed for the context. No design should be the same. Vary between light and dark themes, different fonts, different aesthetics. NEVER converge on common choices (Space Grotesk, for example) across generations.
+Build creatively on the user's intent, and make unexpected choices that feel genuinely designed for the context. Every design should feel distinct. Actively explore the full range: light and dark themes, unexpected font pairings, substantially varied aesthetic directions. Let the specific context drive choices, NOT familiar defaults. 
 
-**IMPORTANT**: Match implementation complexity to the aesthetic vision. Maximalist designs need elaborate code with extensive animations and effects. Minimalist or refined designs need restraint, precision, and careful attention to spacing, typography, and subtle details. Elegance comes from executing the vision well.
+**IMPORTANT**: Match implementation complexity to the aesthetic vision. Maximalist designs need elaborate code with extensive animations and effects. Minimalist or refined designs need restraint, elegance, and precision. All designs need careful attention to spacing, typography, and subtle details. Excellence comes from executing the vision well.
 
-Remember: Claude is capable of extraordinary creative work. Don't hold back, show what can truly be created when thinking outside the box and committing fully to a distinctive vision.
+Remember: Claude is capable of extraordinary, award-worthy creative work. Don't hold back, show what's truly possible, and commit relentlessly to a distinctive and unforgettable vision.


### PR DESCRIPTION
## Summary

This PR revises the frontend-design skill to improve clarity, actionability, and internal coherence. The goal was to ensure every instruction is something Claude can actually follow within a single conversation, and that the skill's guidance is specific enough to steer behavior without being prescriptive.

## Background

I've been exploring Anthropic's open-source ecosystem after building a [GUI for Bloom](https://www.justinwetch.com/blog/anthropicbloom) and [proposing new behaviors](https://www.justinwetch.com/blog/10behaviorsbloom) for it. Looking through the Skills repo, the frontend-design skill caught my attention. Reading through it, I noticed a few places where the instructions, while well-intentioned, weren't quite actionable from the model's perspective.

For example, the original skill said "NEVER converge on common choices (Space Grotesk, for example) across generations" and "No design should be the same." The intent is clear: avoid repetitive patterns. But Claude can't see its other generations. Each conversation is isolated. These instructions are impossible to follow because they reference information the model doesn't have access to.

This got me thinking about what I call "model theory of mind": reasoning about what the model can actually know and how it processes instructions. A prompt can sound good to humans but be confusing or non-actionable for the model. I wrote up my thinking in more detail [here](https://www.justinwetch.com/blog/scaffold).

## Key Changes

**Coherence fixes:**
- Removed instructions assuming cross-session awareness ("never converge across generations," "no design should be the same")
- Resolved internal contradictions ("pick an extreme" conflicted with "the key is intentionality, not intensity")

**Clarity improvements:**
- Replaced vague adjectives ("beautiful, unique, interesting") with concrete guidance
- Rewrote the Typography section to focus on actionable instructions rather than aesthetic judgments
- Added specific palette directions to Color guidance (bold/saturated, moody/restrained, high-contrast/minimal)

**Structural additions:**
- Added INSTEAD block to pair positive instructions with existing NEVER guidance
- Expanded aesthetic direction list (added dark/moody, lo-fi/zine, handcrafted/artisanal)
- Expanded spatial composition guidance (z-depth, full-bleed, dramatic scale jumps)
- Unified imperative voice throughout

## Validation

I built an evaluation system to test whether the changes actually improved outputs. The setup:

- 50 representative prompts covering different design contexts (landing pages, dashboards, portfolios, menus, band pages, etc.)
- Each prompt executed twice via API: once with original skill, once with revised skill
- Puppeteer captures full-page screenshots of both outputs
- Claude Opus 4.5 judges blind (screenshots anonymized as A/B) on five criteria: Prompt Adherence, Aesthetic Fit, Visual Polish, UX & Usability, Creative Distinction

Results across the Claude 4.5 model family: Haiku showed the strongest improvement (8-2), followed by Sonnet (7-3), then Opus (6-4). Across all three tiers, the revised skill won 21 of 28 decisive comparisons (75% win rate, p = 0.006).

Interestingly, the revised skill helped smaller models more than larger ones. My hypothesis is that Opus can compensate for ambiguous instructions, while Haiku benefits more from explicit guidance.

## More Detail

For a full walkthrough of the approach, reasoning, and specific edits: [Teaching Claude to Design Better: Improving Anthropic's Frontend Design Skill](https://www.justinwetch.com/blog/improvingclaudefrontend)

Happy to discuss any of the changes or adjust based on feedback.
