### PR TITLE
Fix Windows file:// URL path handling in image processing

### DIFF
--- a/skills/pptx/scripts/html2pptx.js
+++ b/skills/pptx/scripts/html2pptx.js
@@ -134,6 +134,10 @@ function addElements(slideData, targetSlide, pres) {
   for (const el of slideData.elements) {
     if (el.type === 'image') {
       let imagePath = el.src.startsWith('file://') ? el.src.replace('file://', '') : el.src;
+      // Fix Windows file:// paths: /D:/path -> D:/path
+      if (imagePath.match(/^\/[A-Za-z]:\//)) {
+        imagePath = imagePath.substring(1);
+      }
       targetSlide.addImage({
         path: imagePath,
         x: el.position.x,


### PR DESCRIPTION
### Problem

When using `html2pptx` on Windows with relative image paths in HTML files (e.g., `<img src="assets/icon.png">`), the image loading fails with a "file not found" error.

**Root Cause:**

When Playwright renders HTML, relative image paths are automatically converted to absolute `file://` URLs. For example:
- Input: `assets/icon.png`
- After Playwright: `file:///D:/project/slides/assets/icon.png`

The existing code strips the `file://` prefix:
```javascript
let imagePath = el.src.startsWith('file://') ? el.src.replace('file://', '') : el.src;
```

However, this leaves a path like `/D:/project/slides/assets/icon.png` (note the leading slash). When PptxGenJS processes this path, it interprets it as a relative path and prepends the current working directory, resulting in a malformed path:
```
d:\D:\project\slides\assets\icon.png
```

### Solution

Added a check to detect and fix Windows-style paths that start with `/[drive-letter]:/`:

```javascript
// Fix Windows file:// paths: /D:/path -> D:/path
if (imagePath.match(/^\/[A-Za-z]:\//)) {
  imagePath = imagePath.substring(1);
}
```

This removes the leading slash, producing a valid Windows absolute path like `D:/project/slides/assets/icon.png`.

### Testing

- Tested with relative image paths on Windows 10
- Verified that images are correctly embedded in generated PowerPoint files
- No impact on Unix/Linux paths (which don't match the `/[A-Z]:/` pattern)

---