### PR TITLE
Add Mapbox to Partner Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,4 +91,5 @@ The markdown content below contains the instructions, examples, and guidelines t
 
 Skills are a great way to teach Claude how to get better at using specific pieces of software. As we see awesome example skills from partners, we may highlight some of them here:
 
+- **Mapbox** - [Mapbox Agent Skills](https://github.com/mapbox/mcp-devkit-server/tree/main/skills) - Four comprehensive skills teaching Claude about map design (cartography), security best practices (token management), common style patterns, and framework integration (React, Vue, Svelte, Angular)
 - **Notion** - [Notion Skills for Claude](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0)


### PR DESCRIPTION
## Summary

This PR adds Mapbox to the Partner Skills section of the README.

## What's Included

Mapbox has created four comprehensive Agent Skills for Claude that teach best practices for building maps:

- 🎨 **mapbox-cartography** - Map design principles, color theory, visual hierarchy, typography
- 🔐 **mapbox-token-security** - Token management, scope control, URL restrictions, rotation strategies  
- 📐 **mapbox-style-patterns** - Common style patterns and layer configurations
- 🔧 **mapbox-integration-patterns** - Framework integration patterns for React, Vue, Svelte, Angular

## Repository

All skills are available in the Mapbox MCP DevKit Server repository:
https://github.com/mapbox/mcp-devkit-server/tree/main/skills

These skills complement Mapbox's MCP server which provides tools for creating styles, managing tokens, and working with the Mapbox platform.