### PR TITLE
Add session-memory skill for context persistence

### DIFF
--- a/skills/session-memory/README.md
+++ b/skills/session-memory/README.md
@@ -1,0 +1,63 @@
+# Session Memory Skill
+
+A Claude skill for maintaining context across chat sessions using a Load-Work-Save protocol.
+
+## Installation
+
+### Claude Code
+```bash
+# Copy to your Claude skills directory
+cp -r session-memory ~/.claude/skills/
+```
+
+### Claude.ai
+Upload the `SKILL.md` file or paste its contents into your project's custom instructions.
+
+## Getting Started
+
+After installing, type:
+```
+/memory-help
+```
+
+This displays all available commands.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/memory-help` | Show command list |
+| `/junior` | Enable Junior Mode (explains reasoning) |
+| `/senior` | Enable Senior Mode (concise, default) |
+| `/save` | Manually trigger a context save |
+| `/status` | Show current mode and state file locations |
+
+## How It Works
+
+1. **LOAD**: At session start, Claude reads your state files (`CONTEXT.md`, `TASKS.md`).
+2. **WORK**: Claude works on your task, noting key decisions.
+3. **SAVE**: Claude auto-saves after significant work, or when you type `/save`.
+
+## Modes
+
+- **Junior Mode** (`/junior`): Claude explains reasoning at each step. Great for learning.
+- **Senior Mode** (`/senior`): Concise, action-focused. Default behavior.
+
+## Example State File
+
+Create a `CONTEXT.md` in your project:
+
+```markdown
+# Project State
+
+## Summary
+Building a REST API. Auth module complete.
+
+## Next Steps
+- [ ] Implement GET /users/:id
+- [ ] Add unit tests
+```
+
+## License
+
+Apache 2.0

--- a/skills/session-memory/SKILL.md
+++ b/skills/session-memory/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: session-memory
+description: Teaches Claude to persist context across sessions using a Load-Work-Save protocol with auto-save and configurable modes.
+---
+
+# Session Memory Skill
+
+Maintain continuity across chat sessions by treating context like a "save game."
+
+## Available Commands
+
+| Command | Description |
+|---------|-------------|
+| `/memory-help` | Show this command list |
+| `/junior` | Enable Junior Mode (explains reasoning) |
+| `/senior` | Enable Senior Mode (concise, default) |
+| `/save` | Manually trigger a context save |
+| `/status` | Show current mode and state file locations |
+
+## Modes
+
+### Junior Mode
+When the user types `/junior`:
+- Explain the "why" behind each action.
+- Include reasoning and decision context.
+- Teach as you work.
+
+### Senior Mode (Default)
+When the user types `/senior` or by default:
+- Be concise. Focus on outcomes.
+- Skip explanations unless asked.
+
+## The Protocol
+
+### 1. LOAD (Session Start)
+Automatically check for and read common state files (`CONTEXT.md`, `TODO.md`, `TASKS.md`) in the project root or workspace. If none exist, ask if the user wants to create one.
+
+### 2. WORK
+Proceed with tasks. Note significant decisions for the save phase.
+
+### 3. SAVE (Auto + Manual)
+- **Auto-Save**: After completing significant work (feature, bugfix, decision), proactively update the state file. Keep updates concise.
+- **Manual Save**: When the user types `/save`, immediately update all state files.
+
+### End of Session
+Before ending, ensure state files include:
+- Summary of what was accomplished.
+- Current state of work.
+- Clear "Next Steps."
+
+## Core Principle
+
+**Separate persistent state from ephemeral work.**
+
+- **Persistent**: Architecture, schemas, decisions. Update on major changes only.
+- **Ephemeral**: Session notes, task lists. Update frequently, clean up when done.


### PR DESCRIPTION
## Summary
Adds the `session-memory` skill for maintaining context across chat sessions using a Load-Work-Save protocol.

## Features
- Auto-save after significant work
- Junior/Senior modes (`/junior`, `/senior`)
- Slash commands for control (`/save`, `/status`, `/memory-help`)

## Use Case
For multi-session projects where losing track of progress is a risk.