### PR TITLE
refactor(skills): rewrite skill-creator to best practices

### DIFF
--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -1,356 +1,263 @@
 ---
-name: skill-creator
-description: Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Claude's capabilities with specialized knowledge, workflows, or tool integrations.
+name: creating-skills
+description: Create and iterate on Agent Skills with proper structure, frontmatter, progressive disclosure, and packaging. Use when building new skills, refactoring existing skills, or validating skill structure against specification. Covers SKILL.md frontmatter (name, description, hooks), body organization (scripts/, references/, assets/), token efficiency strategies, and .skill packaging requirements.
 license: Complete terms in LICENSE.txt
 ---
 
-# Skill Creator
+# Creating Skills
 
-This skill provides guidance for creating effective skills.
+Create modular, token-efficient skills that extend Claude's capabilities with specialized workflows, tools, and domain knowledge.
 
-## About Skills
+## Quick Start
 
-Skills are modular, self-contained packages that extend Claude's capabilities by providing
-specialized knowledge, workflows, and tools. Think of them as "onboarding guides" for specific
-domains or tasks—they transform Claude from a general-purpose agent into a specialized agent
-equipped with procedural knowledge that no model can fully possess.
-
-### What Skills Provide
-
-1. Specialized workflows - Multi-step procedures for specific domains
-2. Tool integrations - Instructions for working with specific file formats or APIs
-3. Domain expertise - Company-specific knowledge, schemas, business logic
-4. Bundled resources - Scripts, references, and assets for complex and repetitive tasks
+1. **Gather examples** - Collect 3-5 concrete usage examples
+2. **Plan resources** - Identify scripts, references, assets needed
+3. **Initialize** - Run `scripts/init_skill.py <skill-name> --path <output-dir>`
+4. **Implement** - Build resources and write SKILL.md
+5. **Package** - Run `scripts/package_skill.py <skill-folder>` (REQUIRED - creates .skill file)
+6. **Iterate** - Refine based on real usage
 
 ## Core Principles
 
-### Concise is Key
+### Token Efficiency
 
-The context window is a public good. Skills share the context window with everything else Claude needs: system prompt, conversation history, other Skills' metadata, and the actual user request.
+Minimize SKILL.md length. Claude already understands base behavior. Challenge each line: does this justify its token cost?
 
-**Default assumption: Claude is already very smart.** Only add context Claude doesn't already have. Challenge each piece of information: "Does Claude really need this explanation?" and "Does this paragraph justify its token cost?"
+**Keep in SKILL.md:**
+- Decision frameworks
+- Execution patterns
+- Resource references
+- Critical domain knowledge
 
-Prefer concise examples over verbose explanations.
+**Move to references/:**
+- Detailed explanations
+- Examples and patterns
+- Schema documentation
+- Variant-specific details
 
-### Set Appropriate Degrees of Freedom
+See [references/anatomy.md](references/anatomy.md) for detailed skill structure.
 
-Match the level of specificity to the task's fragility and variability:
+### Degrees of Freedom
 
-**High freedom (text-based instructions)**: Use when multiple approaches are valid, decisions depend on context, or heuristics guide the approach.
+Match specificity to task fragility:
 
-**Medium freedom (pseudocode or scripts with parameters)**: Use when a preferred pattern exists, some variation is acceptable, or configuration affects behavior.
+| Freedom | When to Use | Example |
+|---------|-------------|---------|
+| **High** (text instructions) | Multiple valid approaches, context-dependent | "Choose appropriate chart type based on data distribution" |
+| **Medium** (pseudocode + parameters) | Preferred pattern exists, some variation | "Use pandas groupby with agg() for aggregations" |
+| **Low** (specific scripts) | Error-prone, consistency critical | `scripts/rotate_pdf.py` for PDF rotation |
 
-**Low freedom (specific scripts, few parameters)**: Use when operations are fragile and error-prone, consistency is critical, or a specific sequence must be followed.
+## Skill Structure
 
-Think of Claude as exploring a path: a narrow bridge with cliffs needs specific guardrails (low freedom), while an open field allows many routes (high freedom).
-
-### Anatomy of a Skill
-
-Every skill consists of a required SKILL.md file and optional bundled resources:
+### Required Files
 
 ```
 skill-name/
-├── SKILL.md (required)
-│   ├── YAML frontmatter metadata (required)
-│   │   ├── name: (required)
-│   │   └── description: (required)
-│   └── Markdown instructions (required)
-└── Bundled Resources (optional)
-    ├── scripts/          - Executable code (Python/Bash/etc.)
-    ├── references/       - Documentation intended to be loaded into context as needed
-    └── assets/           - Files used in output (templates, icons, fonts, etc.)
+├── SKILL.md          # Required: Metadata + instructions
+└── (optional bundled resources)
 ```
 
-#### SKILL.md (required)
+### Optional Bundled Resources
 
-Every SKILL.md consists of:
+**scripts/** - Executable code for repeated operations
+- Use when: Same code rewritten repeatedly, deterministic reliability needed
+- Example: `scripts/rotate_pdf.py`
+- Benefit: Executed without loading into context
 
-- **Frontmatter** (YAML): Contains `name` and `description` fields. These are the only fields that Claude reads to determine when the skill gets used, thus it is very important to be clear and comprehensive in describing what the skill is, and when it should be used.
-- **Body** (Markdown): Instructions and guidance for using the skill. Only loaded AFTER the skill triggers (if at all).
+**references/** - Documentation for context loading
+- Use when: Domain knowledge, schemas, API docs needed during execution
+- Example: `references/finance.md` for billing schemas
+- Benefit: Loaded only when needed
+- Best practice: Keep SKILL.md lean, use grep patterns for large files (>10k words)
 
-#### Bundled Resources (optional)
+**assets/** - Files for output (not context)
+- Use when: Templates, images, boilerplate code needed in final output
+- Example: `assets/logo.png`, `assets/template.html`
+- Benefit: Separated from documentation
 
-##### Scripts (`scripts/`)
+**Include only files directly required for skill execution.** No README.md, INSTALLATION_GUIDE.md, CHANGELOG.md, or other auxiliary documentation.
 
-Executable code (Python/Bash/etc.) for tasks that require deterministic reliability or are repeatedly rewritten.
+## Frontmatter
 
-- **When to include**: When the same code is being rewritten repeatedly or deterministic reliability is needed
-- **Example**: `scripts/rotate_pdf.py` for PDF rotation tasks
-- **Benefits**: Token efficient, deterministic, may be executed without loading into context
-- **Note**: Scripts may still need to be read by Claude for patching or environment-specific adjustments
+### Required Fields
 
-##### References (`references/`)
-
-Documentation and reference material intended to be loaded as needed into context to inform Claude's process and thinking.
-
-- **When to include**: For documentation that Claude should reference while working
-- **Examples**: `references/finance.md` for financial schemas, `references/mnda.md` for company NDA template, `references/policies.md` for company policies, `references/api_docs.md` for API specifications
-- **Use cases**: Database schemas, API documentation, domain knowledge, company policies, detailed workflow guides
-- **Benefits**: Keeps SKILL.md lean, loaded only when Claude determines it's needed
-- **Best practice**: If files are large (>10k words), include grep search patterns in SKILL.md
-- **Avoid duplication**: Information should live in either SKILL.md or references files, not both. Prefer references files for detailed information unless it's truly core to the skill—this keeps SKILL.md lean while making information discoverable without hogging the context window. Keep only essential procedural instructions and workflow guidance in SKILL.md; move detailed reference material, schemas, and examples to references files.
-
-##### Assets (`assets/`)
-
-Files not intended to be loaded into context, but rather used within the output Claude produces.
-
-- **When to include**: When the skill needs files that will be used in the final output
-- **Examples**: `assets/logo.png` for brand assets, `assets/slides.pptx` for PowerPoint templates, `assets/frontend-template/` for HTML/React boilerplate, `assets/font.ttf` for typography
-- **Use cases**: Templates, images, icons, boilerplate code, fonts, sample documents that get copied or modified
-- **Benefits**: Separates output resources from documentation, enables Claude to use files without loading them into context
-
-#### What to Not Include in a Skill
-
-A skill should only contain essential files that directly support its functionality. Do NOT create extraneous documentation or auxiliary files, including:
-
-- README.md
-- INSTALLATION_GUIDE.md
-- QUICK_REFERENCE.md
-- CHANGELOG.md
-- etc.
-
-The skill should only contain the information needed for an AI agent to do the job at hand. It should not contain auxilary context about the process that went into creating it, setup and testing procedures, user-facing documentation, etc. Creating additional documentation files just adds clutter and confusion.
-
-### Progressive Disclosure Design Principle
-
-Skills use a three-level loading system to manage context efficiently:
-
-1. **Metadata (name + description)** - Always in context (~100 words)
-2. **SKILL.md body** - When skill triggers (<5k words)
-3. **Bundled resources** - As needed by Claude (Unlimited because scripts can be executed without reading into context window)
-
-#### Progressive Disclosure Patterns
-
-Keep SKILL.md body to the essentials and under 500 lines to minimize context bloat. Split content into separate files when approaching this limit. When splitting out content into other files, it is very important to reference them from SKILL.md and describe clearly when to read them, to ensure the reader of the skill knows they exist and when to use them.
-
-**Key principle:** When a skill supports multiple variations, frameworks, or options, keep only the core workflow and selection guidance in SKILL.md. Move variant-specific details (patterns, examples, configuration) into separate reference files.
-
-**Pattern 1: High-level guide with references**
-
-```markdown
-# PDF Processing
-
-## Quick start
-
-Extract text with pdfplumber:
-[code example]
-
-## Advanced features
-
-- **Form filling**: See [FORMS.md](FORMS.md) for complete guide
-- **API reference**: See [REFERENCE.md](REFERENCE.md) for all methods
-- **Examples**: See [EXAMPLES.md](EXAMPLES.md) for common patterns
+```yaml
+---
+name: skill-name              # Must match directory name
+description: Your description  # Primary trigger mechanism
+license: Complete terms in LICENSE.txt
+---
 ```
 
-Claude loads FORMS.md, REFERENCE.md, or EXAMPLES.md only when needed.
+**Name:**
+- Use gerund form (e.g., `creating-skills`, not `skill-creator`)
+- Max 64 characters
+- Must match directory name
 
-**Pattern 2: Domain-specific organization**
+**Description:**
+- Include what the skill does AND when to use it
+- Max 500 characters
+- High keyword density for discoverability
+- Describe specific triggers/use cases
 
-For Skills with multiple domains, organize content by domain to avoid loading irrelevant context:
+**Example description:**
+> "Process PDF documents with text extraction, form filling, and rotation. Use when Claude needs to: (1) Extract text from PDFs using pdfplumber, (2) Fill PDF forms programmatically, (3) Rotate or merge PDF pages, or any PDF manipulation tasks"
 
+### Optional Hooks (Claude Code 2.1+)
+
+Control skill activation with hooks:
+
+```yaml
+---
+hooks:
+  PreToolUse:
+    - matcher: Bash
+      hooks:
+        - type: command
+          command: "validate-script.sh"
+---
 ```
-bigquery-skill/
-├── SKILL.md (overview and navigation)
-└── reference/
-    ├── finance.md (revenue, billing metrics)
-    ├── sales.md (opportunities, pipeline)
-    ├── product.md (API usage, features)
-    └── marketing.md (campaigns, attribution)
-```
 
-When a user asks about sales metrics, Claude only reads sales.md.
+Available hooks: `PreToolUse`, `PostToolUse`, `PreResponse`, `PostResponse`.
 
-Similarly, for skills supporting multiple frameworks or variants, organize by variant:
+## Progressive Disclosure
 
+Organize content by when it's needed:
+
+1. **Metadata (name + description)** - Always loaded (~100 words)
+2. **SKILL.md body** - When skill triggers (<5k words, <500 lines)
+3. **Bundled resources** - As needed (unlimited - scripts execute without context load)
+
+### Patterns
+
+**Variant separation:**
 ```
 cloud-deploy/
-├── SKILL.md (workflow + provider selection)
+├── SKILL.md              # Workflow + provider selection
 └── references/
-    ├── aws.md (AWS deployment patterns)
-    ├── gcp.md (GCP deployment patterns)
-    └── azure.md (Azure deployment patterns)
+    ├── aws.md            # AWS patterns (loaded only for AWS)
+    ├── gcp.md            # GCP patterns (loaded only for GCP)
+    └── azure.md          # Azure patterns (loaded only for Azure)
 ```
 
-When the user chooses AWS, Claude only reads aws.md.
+**Domain separation:**
+```
+bigquery-skill/
+├── SKILL.md              # Overview and navigation
+└── references/
+    ├── finance.md        # Revenue, billing metrics
+    ├── sales.md          # Opportunities, pipeline
+    └── product.md        # API usage, features
+```
 
-**Pattern 3: Conditional details**
-
-Show basic content, link to advanced content:
-
+**Conditional details:**
 ```markdown
-# DOCX Processing
+## PDF Text Extraction
 
-## Creating documents
+Use pdfplumber for text extraction: [code example]
 
-Use docx-js for new documents. See [DOCX-JS.md](DOCX-JS.md).
+## Form Filling
+See [FORMS.md](FORMS.md) for complete guide to form manipulation.
 
-## Editing documents
-
-For simple edits, modify the XML directly.
-
-**For tracked changes**: See [REDLINING.md](REDLINING.md)
-**For OOXML details**: See [OOXML.md](OOXML.md)
+## OCR
+See [OCR.md](OCR.md) for text extraction from image-based PDFs.
 ```
 
-Claude reads REDLINING.md or OOXML.md only when the user needs those features.
+See [references/anatomy.md](references/anatomy.md) for detailed patterns and examples.
 
-**Important guidelines:**
+## Implementation Workflow
 
-- **Avoid deeply nested references** - Keep references one level deep from SKILL.md. All reference files should link directly from SKILL.md.
-- **Structure longer reference files** - For files longer than 100 lines, include a table of contents at the top so Claude can see the full scope when previewing.
+### 1. Understand Requirements
 
-## Skill Creation Process
-
-Skill creation involves these steps:
-
-1. Understand the skill with concrete examples
-2. Plan reusable skill contents (scripts, references, assets)
-3. Initialize the skill (run init_skill.py)
-4. Edit the skill (implement resources and write SKILL.md)
-5. Package the skill (run package_skill.py)
-6. Iterate based on real usage
-
-Follow these steps in order, skipping only if there is a clear reason why they are not applicable.
-
-### Step 1: Understanding the Skill with Concrete Examples
-
-Skip this step only when the skill's usage patterns are already clearly understood. It remains valuable even when working with an existing skill.
-
-To create an effective skill, clearly understand concrete examples of how the skill will be used. This understanding can come from either direct user examples or generated examples that are validated with user feedback.
-
-For example, when building an image-editor skill, relevant questions include:
-
-- "What functionality should the image-editor skill support? Editing, rotating, anything else?"
-- "Can you give some examples of how this skill would be used?"
-- "I can imagine users asking for things like 'Remove the red-eye from this image' or 'Rotate this image'. Are there other ways you imagine this skill being used?"
+Gather 3-5 concrete examples. Ask:
+- "What functionality should this skill support?"
+- "Can you provide example usage scenarios?"
 - "What would a user say that should trigger this skill?"
 
-To avoid overwhelming users, avoid asking too many questions in a single message. Start with the most important questions and follow up as needed for better effectiveness.
+Avoid overwhelming users with multiple questions in a single message.
 
-Conclude this step when there is a clear sense of the functionality the skill should support.
+### 2. Plan Resources
 
-### Step 2: Planning the Reusable Skill Contents
+Analyze each example:
+1. Consider execution from scratch
+2. Identify reusable scripts, references, assets
 
-To turn concrete examples into an effective skill, analyze each example by:
+**Example:** PDF editor skill
+- Query: "Rotate this PDF"
+- Analysis: Same rotation code rewritten repeatedly
+- Resource: `scripts/rotate_pdf.py`
 
-1. Considering how to execute on the example from scratch
-2. Identifying what scripts, references, and assets would be helpful when executing these workflows repeatedly
+### 3. Initialize Skill
 
-Example: When building a `pdf-editor` skill to handle queries like "Help me rotate this PDF," the analysis shows:
-
-1. Rotating a PDF requires re-writing the same code each time
-2. A `scripts/rotate_pdf.py` script would be helpful to store in the skill
-
-Example: When designing a `frontend-webapp-builder` skill for queries like "Build me a todo app" or "Build me a dashboard to track my steps," the analysis shows:
-
-1. Writing a frontend webapp requires the same boilerplate HTML/React each time
-2. An `assets/hello-world/` template containing the boilerplate HTML/React project files would be helpful to store in the skill
-
-Example: When building a `big-query` skill to handle queries like "How many users have logged in today?" the analysis shows:
-
-1. Querying BigQuery requires re-discovering the table schemas and relationships each time
-2. A `references/schema.md` file documenting the table schemas would be helpful to store in the skill
-
-To establish the skill's contents, analyze each concrete example to create a list of the reusable resources to include: scripts, references, and assets.
-
-### Step 3: Initializing the Skill
-
-At this point, it is time to actually create the skill.
-
-Skip this step only if the skill being developed already exists, and iteration or packaging is needed. In this case, continue to the next step.
-
-When creating a new skill from scratch, always run the `init_skill.py` script. The script conveniently generates a new template skill directory that automatically includes everything a skill requires, making the skill creation process much more efficient and reliable.
-
-Usage:
+Always run `init_skill.py` for new skills:
 
 ```bash
 scripts/init_skill.py <skill-name> --path <output-directory>
 ```
 
-The script:
+This creates:
+- Skill directory with SKILL.md template
+- Example resource directories: `scripts/`, `references/`, `assets/`
 
-- Creates the skill directory at the specified path
-- Generates a SKILL.md template with proper frontmatter and TODO placeholders
-- Creates example resource directories: `scripts/`, `references/`, and `assets/`
-- Adds example files in each directory that can be customized or deleted
+### 4. Implement Resources
 
-After initialization, customize or remove the generated SKILL.md and example files as needed.
+**Start with bundled resources:**
+- Test scripts by running them
+- Delete unused example directories
+- Add user-provided assets/docs as needed
 
-### Step 4: Edit the Skill
+**Write SKILL.md:**
+- Use imperative/infinitive form ("Create X", not "Creates X")
+- Put all "when to use" information in description, not body
+- Reference other files with clear guidance on when to read them
+- Keep under 500 lines
 
-When editing the (newly-generated or existing) skill, remember that the skill is being created for another instance of Claude to use. Include information that would be beneficial and non-obvious to Claude. Consider what procedural knowledge, domain-specific details, or reusable assets would help another Claude instance execute these tasks more effectively.
+**Consult design patterns:**
+- [references/workflows.md](references/workflows.md) - Multi-step processes, conditional logic
+- [references/output-patterns.md](references/output-patterns.md) - Output formats, templates
 
-#### Learn Proven Design Patterns
+### 5. Package Skill (REQUIRED)
 
-Consult these helpful guides based on your skill's needs:
-
-- **Multi-step processes**: See references/workflows.md for sequential workflows and conditional logic
-- **Specific output formats or quality standards**: See references/output-patterns.md for template and example patterns
-
-These files contain established best practices for effective skill design.
-
-#### Start with Reusable Skill Contents
-
-To begin implementation, start with the reusable resources identified above: `scripts/`, `references/`, and `assets/` files. Note that this step may require user input. For example, when implementing a `brand-guidelines` skill, the user may need to provide brand assets or templates to store in `assets/`, or documentation to store in `references/`.
-
-Added scripts must be tested by actually running them to ensure there are no bugs and that the output matches what is expected. If there are many similar scripts, only a representative sample needs to be tested to ensure confidence that they all work while balancing time to completion.
-
-Any example files and directories not needed for the skill should be deleted. The initialization script creates example files in `scripts/`, `references/`, and `assets/` to demonstrate structure, but most skills won't need all of them.
-
-#### Update SKILL.md
-
-**Writing Guidelines:** Always use imperative/infinitive form.
-
-##### Frontmatter
-
-Write the YAML frontmatter with `name` and `description`:
-
-- `name`: The skill name
-- `description`: This is the primary triggering mechanism for your skill, and helps Claude understand when to use the skill.
-  - Include both what the Skill does and specific triggers/contexts for when to use it.
-  - Include all "when to use" information here - Not in the body. The body is only loaded after triggering, so "When to Use This Skill" sections in the body are not helpful to Claude.
-  - Example description for a `docx` skill: "Comprehensive document creation, editing, and analysis with support for tracked changes, comments, formatting preservation, and text extraction. Use when Claude needs to work with professional documents (.docx files) for: (1) Creating new documents, (2) Modifying or editing content, (3) Working with tracked changes, (4) Adding comments, or any other document tasks"
-
-Do not include any other fields in YAML frontmatter.
-
-##### Body
-
-Write instructions for using the skill and its bundled resources.
-
-### Step 5: Packaging a Skill
-
-Once development of the skill is complete, it must be packaged into a distributable .skill file that gets shared with the user. The packaging process automatically validates the skill first to ensure it meets all requirements:
+**Skills MUST be packaged into .skill files for use.**
 
 ```bash
 scripts/package_skill.py <path/to/skill-folder>
 ```
 
-Optional output directory specification:
+Optional output directory:
 
 ```bash
 scripts/package_skill.py <path/to/skill-folder> ./dist
 ```
 
-The packaging script will:
+The packaging script:
+1. **Validates** the skill:
+   - YAML frontmatter format
+   - Required fields (name, description, license)
+   - Naming conventions (max 64 chars, gerund form)
+   - File organization
+   - Description quality and completeness
 
-1. **Validate** the skill automatically, checking:
+2. **Creates** `.skill` file (zip archive) if validation passes
 
-   - YAML frontmatter format and required fields
-   - Skill naming conventions and directory structure
-   - Description completeness and quality
-   - File organization and resource references
+If validation fails, fix errors and re-run. The .skill file is what users install - distribution requires this step.
 
-2. **Package** the skill if validation passes, creating a .skill file named after the skill (e.g., `my-skill.skill`) that includes all files and maintains the proper directory structure for distribution. The .skill file is a zip file with a .skill extension.
+### 6. Iterate
 
-If validation fails, the script will report the errors and exit without creating a package. Fix any validation errors and run the packaging command again.
+Use on real tasks. Notice struggles. Update SKILL.md or resources. Test again.
 
-### Step 6: Iterate
+## Context Forking (Claude Code 2.1+)
 
-After testing the skill, users may request improvements. Often this happens right after using the skill, with fresh context of how the skill performed.
+For skills with multiple independent tasks, use context forking to isolate work:
 
-**Iteration workflow:**
+```yaml
+---
+name: multi-task-skill
+description: ...
+forking:
+  enabled: true
+  maxForks: 3
+---
+```
 
-1. Use the skill on real tasks
-2. Notice struggles or inefficiencies
-3. Identify how SKILL.md or bundled resources should be updated
-4. Implement changes and test again
+Each fork gets isolated context, preventing token bloat from parallel operations.

--- a/skills/skill-creator/references/anatomy.md
+++ b/skills/skill-creator/references/anatomy.md
@@ -1,0 +1,452 @@
+# Skill Anatomy
+
+Detailed breakdown of skill structure, component purposes, and organizational patterns.
+
+## What Are Skills?
+
+Skills are modular, self-contained packages that extend Claude's capabilities with specialized workflows, tools, and domain knowledge. They transform Claude from a general-purpose agent into a specialized agent equipped with procedural knowledge that models cannot fully possess through training alone.
+
+### What Skills Provide
+
+1. **Specialized workflows** - Multi-step procedures for specific domains
+2. **Tool integrations** - Instructions for working with specific file formats or APIs
+3. **Domain expertise** - Company-specific knowledge, schemas, business logic
+4. **Bundled resources** - Scripts, references, and assets for complex tasks
+
+### Why Skills Matter
+
+The context window is finite. Skills share this space with system prompts, conversation history, and user requests. Effective skills maximize their value-per-token by:
+- Providing only non-obvious information
+- Using progressive disclosure to load details only when needed
+- Leveraging scripts and assets that execute without context overhead
+
+## Directory Structure
+
+### Minimal Skill
+
+```
+skill-name/
+└── SKILL.md
+```
+
+Only SKILL.md is required. Use this for simple, instruction-only skills.
+
+### Typical Skill
+
+```
+skill-name/
+├── SKILL.md
+├── scripts/
+│   └── script.py
+└── references/
+    └── domain.md
+```
+
+Most skills include scripts for repeated operations and references for domain knowledge.
+
+### Complex Skill
+
+```
+skill-name/
+├── SKILL.md
+├── scripts/
+│   ├── initialize.py
+│   ├── process.py
+│   └── validate.sh
+├── references/
+│   ├── workflows.md
+│   ├── schema.md
+│   └── examples.md
+└── assets/
+    ├── templates/
+    │   └── report-template.docx
+    └── logos/
+        └── company-logo.png
+```
+
+Complex skills may include all three resource types for different purposes.
+
+## Component Details
+
+### SKILL.md
+
+The core instruction file, always loaded when the skill triggers.
+
+**Structure:**
+```markdown
+---
+name: skill-name
+description: What it does and when to use it
+license: Complete terms in LICENSE.txt
+---
+
+# Title
+
+Brief overview.
+
+## Core Instructions
+...
+
+## Progressive Disclosure
+- Link to references/ for detailed info
+- Keep under 500 lines
+```
+
+**When Claude reads SKILL.md:**
+- After skill is triggered (by matching description)
+- Before executing any tool calls
+- When user explicitly mentions the skill
+
+**When Claude doesn't read SKILL.md:**
+- During skill discovery (only metadata is visible)
+- When skill isn't triggered
+- When working in other contexts
+
+### scripts/
+
+Executable code that performs operations without consuming context tokens.
+
+**When to use scripts:**
+- Same code is rewritten repeatedly across conversations
+- Operations require deterministic reliability
+- Code is too large to include in SKILL.md
+- Performance matters (scripts execute faster than Claude can generate equivalent code)
+
+**Script examples:**
+```
+pdf-processor/
+├── scripts/
+│   ├── extract_text.py      # Text extraction with pdfplumber
+│   ├── rotate_pdf.py        # PDF page rotation
+│   ├── merge_pdfs.py        # Combine multiple PDFs
+│   └── fill_form.py         # PDF form filling
+```
+
+**How scripts save tokens:**
+- Claude can execute scripts without reading their full contents
+- Only the script filename and parameters appear in context
+- Complex logic is compressed into executable form
+
+**When scripts must be read:**
+- Claude needs to patch or modify the script
+- Environment-specific adjustments are required
+- User asks to understand script behavior
+- Debugging script failures
+
+### references/
+
+Documentation and reference material loaded into context as needed.
+
+**When to use references:**
+- Domain knowledge needed during execution (schemas, APIs, policies)
+- Content is too large for SKILL.md (>10k words)
+- Information is conditional (only needed for specific variants)
+- Content requires detailed explanation or examples
+
+**Reference examples:**
+```
+bigquery-skill/
+├── SKILL.md              # Query workflow + navigation
+└── references/
+    ├── finance.md        # Billing tables, revenue schemas
+    ├── sales.md          # Opportunities, pipeline schemas
+    ├── product.md        # API usage, feature tables
+    └── marketing.md      # Campaigns, attribution schemas
+```
+
+**How references work:**
+1. SKILL.md mentions the reference: "See [references/finance.md](references/finance.md) for billing queries"
+2. User asks a billing question
+3. Claude loads only finance.md into context
+4. Other domain files remain unloaded, saving tokens
+
+**Reference organization patterns:**
+
+**By domain:**
+```
+company-data/
+├── SKILL.md
+└── references/
+    ├── sales.md
+    ├── marketing.md
+    └── finance.md
+```
+
+**By feature:**
+```
+docx-skill/
+├── SKILL.md
+└── references/
+    ├── tracked-changes.md
+    ├── comments.md
+    └── formatting.md
+```
+
+**By complexity:**
+```
+pdf-skill/
+├── SKILL.md
+└── references/
+    ├── basic.md          # Simple extraction
+    ├── advanced.md       # Forms, OCR
+    └── edge-cases.md     # Encrypted, corrupted files
+```
+
+### assets/
+
+Files used in output, not for context consumption.
+
+**When to use assets:**
+- Templates need to be included in final output
+- Images or logos must be embedded
+- Boilerplate code serves as starting point
+- Fonts, styles, or other resources are needed
+
+**Asset examples:**
+```
+report-generator/
+├── SKILL.md
+└── assets/
+    ├── templates/
+    │   ├── monthly-report.docx
+    │   └── quarterly-report.pptx
+    ├── logos/
+    │   └── company-logo.png
+    └── fonts/
+        └── brand-font.ttf
+```
+
+**How assets differ from references:**
+- Assets are copied/modified in output (e.g., template → report)
+- References are read for information (e.g., schema → query)
+- Assets may be binary (images, fonts)
+- References are always text (markdown, code)
+
+**Asset usage pattern:**
+1. User: "Generate a monthly sales report"
+2. Claude reads SKILL.md for workflow
+3. Claude loads assets/templates/monthly-report.docx
+4. Claude fills template with data from BigQuery
+5. Claude outputs modified docx file
+6. Template file never enters context (only file path is referenced)
+
+## Frontmatter Deep Dive
+
+### name
+
+**Purpose:** Unique identifier for the skill
+
+**Requirements:**
+- Max 64 characters
+- Must match directory name
+- Use gerund form (`creating-skills`, not `skill-creator`)
+- Use kebab-case (`pdf-processor`, not `PDFProcessor`)
+
+**Examples:**
+- ✅ `creating-skills`
+- ✅ `pdf-processor`
+- ✅ `bigquery-analytics`
+- ❌ `skill_creator` (snake_case)
+- ❌ `SkillCreator` (PascalCase)
+- ❌ `create-a-new-thing` (not gerund)
+
+### description
+
+**Purpose:** Primary trigger mechanism for skill activation
+
+**Requirements:**
+- Max 500 characters
+- Include both what and when
+- High keyword density
+- Describe specific triggers/use cases
+
+**Good description:**
+> "Process PDF documents with text extraction, form filling, and rotation. Use when Claude needs to: (1) Extract text from PDFs using pdfplumber, (2) Fill PDF forms programmatically, (3) Rotate or merge PDF pages, or any PDF manipulation tasks"
+
+**Why it works:**
+- Specific actions: extract, fill, rotate, merge
+- Specific tools: pdfplumber
+- Specific triggers: numbered list of use cases
+- Comprehensive scope: "or any PDF manipulation tasks"
+
+**Poor description:**
+> "Guide for creating effective skills. This skill should be used when users want to create a new skill."
+
+**Why it fails:**
+- Passive opener: "Guide for" is documentary
+- First-person: "This skill should be used" is meta-commentary
+- Low keyword density: vague phrasing
+- Missing triggers: doesn't say when to use
+
+### license
+
+**Purpose:** Legal terms for skill distribution
+
+**Format:** `Complete terms in LICENSE.txt`
+
+**Note:** Most skills use standard license files. Include LICENSE.txt in skill root if distributing.
+
+## Hooks (Claude Code 2.1+)
+
+Hooks control skill activation and execution flow.
+
+### PreToolUse
+
+Execute before tool calls.
+
+**Use case:** Validate or prepare environment before execution
+
+```yaml
+---
+hooks:
+  PreToolUse:
+    - matcher: Bash
+      hooks:
+        - type: command
+          command: "npx block-no-verify"
+---
+```
+
+**Example:** Block git commands with `--no-verify` flag
+
+### PostToolUse
+
+Execute after tool calls complete.
+
+**Use case:** Clean up or log after execution
+
+```yaml
+---
+hooks:
+  PostToolUse:
+    - matcher: Read
+      hooks:
+        - type: command
+          command: "log-read-file.sh"
+---
+```
+
+### PreResponse
+
+Execute before Claude responds to user.
+
+**Use case:** Modify or validate response content
+
+### PostResponse
+
+Execute after response is sent.
+
+**Use case:** Trigger notifications or updates
+
+## Context Forking (Claude Code 2.1+)
+
+Isolate parallel operations to prevent context bloat.
+
+**When to use:**
+- Skill handles multiple independent tasks
+- Tasks don't share context
+- Parallel execution would duplicate context
+
+**Example:**
+```yaml
+---
+name: multi-file-processor
+description: Process multiple files independently
+forking:
+  enabled: true
+  maxForks: 5
+---
+```
+
+**Behavior:**
+- Each file processed in separate context fork
+- No shared context between forks
+- Reduces token usage for parallel operations
+- Results merged after completion
+
+## Token Efficiency Strategies
+
+### Progressive Disclosure
+
+Load information only when needed:
+
+1. **Metadata** (always loaded): ~100 words
+2. **SKILL.md** (when triggered): <5k words
+3. **References** (as needed): unlimited but conditional
+
+### Content Allocation
+
+**Keep in SKILL.md:**
+- Decision frameworks
+- Execution patterns
+- Resource references
+- Critical domain knowledge
+
+**Move to references/:**
+- Detailed explanations
+- Examples and patterns
+- Schema documentation
+- Variant-specific details
+
+**Execute as scripts:**
+- Repeated operations
+- Deterministic logic
+- Performance-critical code
+
+### Line Limits
+
+**SKILL.md:**
+- Maximum: 500 lines
+- Recommended: 150-250 lines
+- Rationale: Context window is shared with everything else
+
+**References/:**
+- No strict limit
+- Use grep patterns for files >10k words
+- Organize into multiple files by domain/variant
+
+**Scripts/:**
+- No limit (executed, not loaded)
+- Keep readable for debugging
+- Include docstrings for maintainability
+
+## Naming Conventions
+
+### Directory Names
+
+- Use kebab-case: `pdf-processor`, `creating-skills`
+- Use gerunds for skills: `creating-skills`, `processing-pdfs`
+- Be descriptive but concise: `docx-editor`, not `microsoft-word-document-editor`
+
+### File Names
+
+- SKILL.md (required, exact case)
+- references/: descriptive, lowercase: `finance.md`, `workflows.md`
+- scripts/: descriptive, snake_case: `extract_text.py`
+- assets/: descriptive, lowercase with extensions: `logo.png`, `template.docx`
+
+## Validation
+
+Skills are validated automatically during packaging. The validator checks:
+
+1. **Frontmatter:**
+   - Valid YAML format
+   - Required fields present (name, description, license)
+   - Name matches directory name
+   - Name max 64 characters, gerund form
+   - Description max 500 characters
+
+2. **File Organization:**
+   - SKILL.md exists
+   - No prohibited files (README.md, etc.)
+   - Referenced files exist
+
+3. **Description Quality:**
+   - Not empty
+   - Contains specific keywords
+   - Describes when to use
+
+4. **Line Limits:**
+   - SKILL.md under 500 lines
+
+Run validation manually: `scripts/validate_skill.py <skill-folder>`

--- a/skills/skill-creator/scripts/init_skill.py
+++ b/skills/skill-creator/scripts/init_skill.py
@@ -191,6 +191,31 @@ def title_case_skill_name(skill_name):
     return ' '.join(word.capitalize() for word in skill_name.split('-'))
 
 
+def validate_skill_name(skill_name):
+    """
+    Validate skill name format and length.
+
+    Args:
+        skill_name: Name of the skill to validate
+
+    Returns:
+        Tuple of (is_valid, error_message)
+    """
+    # Check length (max 64 characters per spec)
+    if len(skill_name) > 64:
+        return False, f"Skill name is too long ({len(skill_name)} characters). Maximum is 64 characters."
+
+    # Check naming convention (hyphen-case: lowercase with hyphens)
+    import re
+    if not re.match(r'^[a-z0-9-]+$', skill_name):
+        return False, "Skill name must be hyphen-case (lowercase letters, digits, and hyphens only)"
+
+    if skill_name.startswith('-') or skill_name.endswith('-') or '--' in skill_name:
+        return False, "Skill name cannot start/end with hyphen or contain consecutive hyphens"
+
+    return True, None
+
+
 def init_skill(skill_name, path):
     """
     Initialize a new skill directory with template SKILL.md.
@@ -202,6 +227,12 @@ def init_skill(skill_name, path):
     Returns:
         Path to created skill directory, or None if error
     """
+    # Validate skill name
+    is_valid, error_msg = validate_skill_name(skill_name)
+    if not is_valid:
+        print(f"❌ Error: {error_msg}")
+        return None
+
     # Determine skill directory path
     skill_dir = Path(path).resolve() / skill_name
 
@@ -276,7 +307,7 @@ def main():
         print("\nSkill name requirements:")
         print("  - Hyphen-case identifier (e.g., 'data-analyzer')")
         print("  - Lowercase letters, digits, and hyphens only")
-        print("  - Max 40 characters")
+        print("  - Max 64 characters")
         print("  - Must match directory name exactly")
         print("\nExamples:")
         print("  init_skill.py my-new-skill --path skills/public")


### PR DESCRIPTION
Fixes #202

## Summary

Rewrites the skill-creator skill to follow best practices for skill creation, addressing all issues raised in #202.

## Major Changes

### SKILL.md Rewrite (264 lines, down from 356 - 26% reduction)
- Changed name from 'skill-creator' to 'creating-skills' (gerund form)
- Improved description with specific triggers and use cases
- Converted from educational tone to imperative instructions
- Removed base behavior explanations (Claude already knows these)
- Added new features section: Hooks (Claude Code 2.1+)
- Added new features section: Context Forking (Claude Code 2.1+)
- Emphasized .skill packaging requirement (MUST be packaged)
- Reorganized content for token efficiency
- Added quick start section for rapid understanding

### New Reference File: anatomy.md
- Moved detailed 'About Skills' content from SKILL.md
- Explains what skills are and why they matter
- Detailed breakdown of directory structures (minimal, typical, complex)
- Component deep dives (SKILL.md, scripts/, references/, assets/)
- Frontmatter detailed explanation with examples
- Hooks documentation with use cases
- Context forking documentation
- Token efficiency strategies
- Naming conventions and validation requirements

### Preserved Existing References
- Kept workflows.md (design patterns for sequential/conditional workflows)
- Kept output-patterns.md (template and examples patterns)

## Benefits

1. **Token Efficiency**: 26% reduction in SKILL.md size
2. **Imperative Tone**: Direct instructions instead of educational explanations
3. **Progressive Disclosure**: Detailed content moved to references/
4. **Modern Features**: Added hooks and context forking documentation
5. **Clear Packaging**: Emphasized .skill file requirement
6. **Better Examples**: Concrete examples for descriptions and patterns

## Addresses Issue #202

- ✅ Reduced verbosity (356 → 264 lines)
- ✅ Changed to imperative/educational → imperative
- ✅ Fixed frontmatter (gerund name, better description)
- ✅ Removed negative framing ("What to Not Include" → positive directives)
- ✅ Reduced procedural scaffolding (step-by-step → strategic overview)
- ✅ Removed base behavior distrust (Claude knows what skills are)
- ✅ Clarified script dependencies (init_skill.py, package_skill.py)
- ✅ Added new features (hooks, context forking) per @arvindand comment
- ✅ Emphasized .skill packaging requirement per @jh-broad-reach comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)