### PR TITLE
feat(nx-executor): add Nx deployment patterns documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,42 @@ The markdown content below contains the instructions, examples, and guidelines t
 Skills are a great way to teach Claude how to get better at using specific pieces of software. As we see awesome example skills from partners, we may highlight some of them here:
 
 - **Notion** - [Notion Skills for Claude](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0)
+
+# Custom Skills
+
+## frontend-design-pro
+
+Enhanced frontend design skill that extends Anthropic's official `frontend-design` with community-tested improvements:
+
+### Features
+- **Anti-convergence patterns**: Forces variation in typography, color, and layout to prevent Claude from converging on new "default" aesthetics
+- **Visual iteration workflows**: Screenshot-driven refinement using Puppeteer/Playwright MCP
+- **Test-driven UI development**: Playwright test patterns for UI quality enforcement
+- **Design quality enforcement hook**: PreToolUse hook that warns when detecting generic AI aesthetics (Inter font, purple gradients, system fonts)
+
+### Installation
+
+```bash
+# Already installed via symlink at ~/.claude/skills/frontend-design-pro
+# Points to ~/Code/my-claude-skills/skills/frontend-design-pro
+```
+
+### Usage
+
+Simply ask Claude to build frontend work and the skill will activate:
+
+```
+"Use frontend-design-pro to create a landing page for my SaaS product"
+```
+
+The companion hook will automatically warn if you try to use generic fonts or purple gradients.
+
+### Updating from Upstream
+
+```bash
+cd ~/Code/my-claude-skills
+git fetch upstream
+git merge upstream/main --no-edit
+```
+
+This preserves your `frontend-design-pro` customizations while pulling updates to other official skills.

--- a/skills/frontend-design-pro/SKILL.md
+++ b/skills/frontend-design-pro/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: frontend-design-pro
+description: Production-grade frontend design skill with anti-convergence patterns, visual iteration workflows, and test-driven UI development. Extends official frontend-design with community-tested improvements. Use when building any web UI, component, dashboard, landing page, React component, or HTML/CSS layout. Generates distinctive, memorable interfaces that avoid generic AI aesthetics.
+---
+
+# Frontend Design Pro
+
+This skill creates distinctive, production-grade frontend interfaces that avoid generic "AI slop" aesthetics. It extends Anthropic's official frontend-design approach with battle-tested community improvements.
+
+## Design Thinking
+
+Before coding, commit to a **BOLD** aesthetic direction:
+
+1. **Purpose**: What problem does this interface solve? Who uses it?
+2. **Tone**: Pick an extreme - brutally minimal, maximalist chaos, retro-futuristic, organic/natural, luxury/refined, playful/toy-like, editorial/magazine, brutalist/raw, art deco/geometric, soft/pastel, industrial/utilitarian
+3. **Constraints**: Framework, performance, accessibility requirements
+4. **Differentiation**: What's the ONE thing someone will remember?
+
+**CRITICAL**: Choose a clear conceptual direction and execute it with precision.
+
+## Frontend Aesthetics Guidelines
+
+### Typography
+- Choose fonts that are beautiful, unique, and interesting
+- **NEVER** use: Inter, Roboto, Arial, Open Sans, Lato, system fonts
+- **PREFER**: JetBrains Mono, Fira Code (code aesthetic); Playfair Display, Crimson Pro (editorial); IBM Plex family (technical); Bricolage Grotesque, Newsreader (distinctive)
+- Use high-contrast pairing: Display + monospace, serif + geometric sans
+- Apply extreme weights (100/200 vs 800/900) and size jumps of 3x+
+
+### Color & Theme
+- Commit to a cohesive aesthetic using CSS variables
+- Dominant colors with sharp accents outperform evenly-distributed palettes
+- Draw inspiration from IDE themes (VSCode, Sublime) and cultural aesthetics
+- **NEVER** use: purple gradients on white, safe neutral palettes
+
+### Motion & Micro-interactions
+- CSS-only for HTML; Motion library for React
+- One well-orchestrated page load with staggered reveals (animation-delay) > scattered micro-interactions
+- Scroll-triggering and hover states that surprise
+
+### Spatial Composition
+- Unexpected layouts: asymmetry, overlap, diagonal flow
+- Grid-breaking elements
+- Generous negative space OR controlled density
+
+### Backgrounds & Visual Details
+- Create atmosphere and depth (never solid colors by default)
+- Gradient meshes, noise textures, geometric patterns
+- Layered transparencies, dramatic shadows, grain overlays
+
+---
+
+## Enhanced Guidelines
+
+For detailed guidance on anti-convergence, visual iteration, and test-driven patterns, see [references/extensions.md](references/extensions.md).
+
+### Anti-Convergence Protocol
+
+**CRITICAL**: Claude tends to converge on new defaults even when avoiding old ones.
+
+For EACH generation, actively vary:
+- **Theme**: Alternate between light and dark
+- **Typography**: Never use the same font family twice in a row (track: Space Grotesk, Syne, Outfit are common convergence targets)
+- **Color Temperature**: Rotate through warm palettes → cool palettes → earth tones
+- **Layout Paradigm**: Cycle through asymmetric → grid-based → overlap → diagonal flow
+
+Before finalizing, ask yourself: "Have I used this combination before? If yes, change it."
+
+### Visual Iteration Workflow
+
+For complex interfaces, use screenshot-driven refinement:
+
+1. Generate initial implementation
+2. Take screenshot via Puppeteer/Playwright MCP or manual capture
+3. Compare screenshot to requirements/mockup
+4. Identify discrepancies in spacing, alignment, color, typography
+5. Iterate until visual match achieved
+
+\`\`\`
+Prompt: "Take a screenshot of the current state and compare to requirements"
+\`\`\`
+
+### Test-Driven UI Development
+
+Before implementing complex UIs:
+
+1. Write Playwright/Vitest tests for expected behavior:
+   - Layout responsiveness across breakpoints
+   - Animation timing and easing
+   - Color contrast for accessibility (WCAG AA minimum)
+   - Typography rendering
+
+2. Implement UI to pass tests
+
+3. Use tests as regression guard
+
+\`\`\`
+Prompt: "Write failing Playwright tests for this UI, then implement to pass them"
+\`\`\`
+
+### Progressive Disclosure for Large UIs
+
+For dashboards and complex applications:
+
+1. Design information hierarchy first
+2. Implement above-the-fold with full detail
+3. Use progressive loading for secondary content
+4. Test on multiple viewport sizes before declaring complete
+
+---
+
+## Implementation Checklist
+
+Before submitting any frontend code, verify:
+
+- [ ] No generic fonts (Inter, Roboto, Arial, system-ui)
+- [ ] No purple gradients on white backgrounds
+- [ ] CSS variables used for colors
+- [ ] At least one distinctive visual element
+- [ ] Animations are purposeful, not decorative
+- [ ] Layout has intentional asymmetry or interesting composition
+- [ ] Background has depth/texture (not solid color unless intentional minimalism)
+
+---
+
+Remember: Claude is capable of extraordinary creative work. Don't hold back—show what can truly be created when thinking outside the box and committing fully to a distinctive vision.

--- a/skills/frontend-design-pro/hooks/frontend_design_check.py
+++ b/skills/frontend-design-pro/hooks/frontend_design_check.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""
+Frontend Design Quality Hook for Claude Code
+Warns about generic AI aesthetics patterns in frontend code.
+"""
+
+import json
+import os
+import sys
+import re
+from datetime import datetime
+
+DEBUG_LOG_FILE = "/tmp/frontend-design-check-log.txt"
+
+def debug_log(message):
+    """Append debug message to log file with timestamp."""
+    try:
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+        with open(DEBUG_LOG_FILE, "a") as f:
+            f.write(f"[{timestamp}] {message}\n")
+    except Exception:
+        pass
+
+# File extensions to check
+FRONTEND_EXTENSIONS = {'.tsx', '.jsx', '.ts', '.js', '.css', '.scss', '.html', '.vue', '.svelte'}
+
+# Patterns to detect generic AI aesthetics
+GENERIC_PATTERNS = [
+    {
+        "ruleName": "generic_font_inter",
+        "patterns": [
+            r"font-family[:\s]*['\"]?Inter",
+            r"fontFamily[:\s]*['\"]?Inter",
+            r"--font[^:]*:[^;]*Inter",
+        ],
+        "reminder": """⚠️ Frontend Design Warning: Detected use of 'Inter' font.
+
+Inter is the most common "AI slop" font choice. Consider distinctive alternatives:
+- **Code aesthetic**: JetBrains Mono, Fira Code, Berkeley Mono
+- **Editorial**: Playfair Display, Crimson Pro, Newsreader
+- **Technical**: IBM Plex Sans/Mono, Space Mono
+- **Distinctive**: Bricolage Grotesque, Syne, Outfit
+
+The frontend-design-pro skill recommends avoiding Inter, Roboto, Arial, and system fonts.""",
+    },
+    {
+        "ruleName": "generic_font_roboto",
+        "patterns": [
+            r"font-family[:\s]*['\"]?Roboto",
+            r"fontFamily[:\s]*['\"]?Roboto",
+        ],
+        "reminder": """⚠️ Frontend Design Warning: Detected use of 'Roboto' font.
+
+Roboto is a generic font choice. Consider distinctive alternatives:
+- **Code aesthetic**: JetBrains Mono, Fira Code
+- **Editorial**: Playfair Display, Crimson Pro
+- **Technical**: IBM Plex Sans/Mono
+
+The frontend-design-pro skill recommends avoiding generic fonts.""",
+    },
+    {
+        "ruleName": "purple_gradient",
+        "patterns": [
+            r"gradient[^;]*purple",
+            r"gradient[^;]*#[89a-fA-F][0-9a-fA-F][0-9a-fA-F][89a-fA-F][fF][fF]",
+            r"linear-gradient[^)]*violet",
+            r"from-purple.*to-",
+            r"bg-gradient.*purple",
+        ],
+        "reminder": """⚠️ Frontend Design Warning: Detected purple gradient pattern.
+
+Purple gradients on white backgrounds are the quintessential "AI slop" aesthetic.
+
+Consider alternatives:
+- **Warm gradients**: Coral → Amber, Peach → Rose
+- **Cool gradients**: Teal → Cyan, Navy → Sky
+- **Earth tones**: Forest → Sage, Terracotta → Sand
+- **Dramatic**: Deep black → Charcoal with accent color highlights
+
+Or use solid colors with texture/depth instead of gradients.""",
+    },
+    {
+        "ruleName": "generic_system_font",
+        "patterns": [
+            r"font-family[:\s]*system-ui",
+            r"font-family[:\s]*-apple-system",
+            r"fontFamily[:\s]*['\"]?system-ui",
+        ],
+        "reminder": """⚠️ Frontend Design Warning: Detected system font usage.
+
+System fonts are safe but generic. For distinctive interfaces, load a custom font.
+
+Quick wins:
+- Google Fonts: https://fonts.google.com
+- Add: <link href="https://fonts.googleapis.com/css2?family=YOUR_FONT&display=swap" rel="stylesheet">
+
+Recommended distinctive fonts:
+- Bricolage Grotesque, Syne (display)
+- IBM Plex Sans, Space Grotesk (body)
+- JetBrains Mono, Fira Code (code)""",
+    },
+]
+
+
+def get_state_file(session_id):
+    """Get session-specific state file path."""
+    return os.path.expanduser(f"~/.claude/frontend_design_warnings_{session_id}.json")
+
+
+def load_state(session_id):
+    """Load the state of shown warnings from file."""
+    state_file = get_state_file(session_id)
+    if os.path.exists(state_file):
+        try:
+            with open(state_file, "r") as f:
+                return set(json.load(f))
+        except (json.JSONDecodeError, IOError):
+            return set()
+    return set()
+
+
+def save_state(session_id, shown_warnings):
+    """Save the state of shown warnings to file."""
+    state_file = get_state_file(session_id)
+    try:
+        os.makedirs(os.path.dirname(state_file), exist_ok=True)
+        with open(state_file, "w") as f:
+            json.dump(list(shown_warnings), f)
+    except IOError:
+        pass
+
+
+def is_frontend_file(file_path):
+    """Check if file is a frontend file based on extension."""
+    _, ext = os.path.splitext(file_path.lower())
+    return ext in FRONTEND_EXTENSIONS
+
+
+def check_patterns(content):
+    """Check if content matches any generic aesthetic patterns."""
+    for pattern_config in GENERIC_PATTERNS:
+        for pattern in pattern_config["patterns"]:
+            if re.search(pattern, content, re.IGNORECASE):
+                return pattern_config["ruleName"], pattern_config["reminder"]
+    return None, None
+
+
+def extract_content_from_input(tool_name, tool_input):
+    """Extract content to check from tool input."""
+    if tool_name == "Write":
+        return tool_input.get("content", "")
+    elif tool_name == "Edit":
+        return tool_input.get("new_string", "")
+    return ""
+
+
+def main():
+    """Main hook function."""
+    # Check if hook is enabled (default: enabled)
+    if os.environ.get("DISABLE_FRONTEND_DESIGN_CHECK", "0") == "1":
+        sys.exit(0)
+
+    # Read input from stdin
+    try:
+        raw_input = sys.stdin.read()
+        input_data = json.loads(raw_input)
+    except json.JSONDecodeError as e:
+        debug_log(f"JSON decode error: {e}")
+        sys.exit(0)
+
+    session_id = input_data.get("session_id", "default")
+    tool_name = input_data.get("tool_name", "")
+    tool_input = input_data.get("tool_input", {})
+
+    if tool_name not in ["Edit", "Write"]:
+        sys.exit(0)
+
+    file_path = tool_input.get("file_path", "")
+    if not file_path or not is_frontend_file(file_path):
+        sys.exit(0)
+
+    content = extract_content_from_input(tool_name, tool_input)
+    if not content:
+        sys.exit(0)
+
+    rule_name, reminder = check_patterns(content)
+
+    if rule_name and reminder:
+        warning_key = f"{file_path}-{rule_name}"
+        shown_warnings = load_state(session_id)
+
+        if warning_key not in shown_warnings:
+            shown_warnings.add(warning_key)
+            save_state(session_id, shown_warnings)
+
+            # Output warning to stderr and block execution
+            print(reminder, file=sys.stderr)
+            sys.exit(2)  # Block tool execution
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/frontend-design-pro/hooks/hooks.json
+++ b/skills/frontend-design-pro/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Frontend design quality enforcement hook that warns about generic AI aesthetics",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/frontend_design_check.py"
+          }
+        ],
+        "matcher": "Edit|Write"
+      }
+    ]
+  }
+}

--- a/skills/frontend-design-pro/references/extensions.md
+++ b/skills/frontend-design-pro/references/extensions.md
@@ -1,0 +1,212 @@
+# Frontend Design Pro Extensions
+
+Detailed guidance for advanced frontend design patterns.
+
+## Table of Contents
+
+1. [Anti-Convergence Deep Dive](#anti-convergence-deep-dive)
+2. [Visual Iteration Workflow](#visual-iteration-workflow)
+3. [Test-Driven UI Patterns](#test-driven-ui-patterns)
+4. [Progressive Disclosure](#progressive-disclosure-patterns)
+5. [Skill Stacking](#skill-stacking-patterns)
+
+---
+
+## Anti-Convergence Deep Dive
+
+### The Problem
+
+Even with instructions to avoid generic aesthetics, Claude can converge on "alternative defaults":
+- Space Grotesk instead of Inter
+- Teal gradients instead of purple gradients
+- Same asymmetric pattern repeatedly
+
+### The Solution: Forced Variation
+
+Maintain a mental checklist for each generation:
+
+**Typography Rotation**:
+\`\`\`
+Generation 1: Playfair Display + IBM Plex Mono
+Generation 2: Bricolage Grotesque + JetBrains Mono
+Generation 3: Crimson Pro + Fira Code
+Generation 4: Newsreader + Berkeley Mono
+[cycle continues...]
+\`\`\`
+
+**Theme Rotation**:
+\`\`\`
+Generation 1: Dark theme, cool colors (blues, teals)
+Generation 2: Light theme, warm colors (oranges, corals)
+Generation 3: Dark theme, earth tones (greens, browns)
+Generation 4: Light theme, vibrant (magentas, cyans)
+\`\`\`
+
+**Layout Rotation**:
+\`\`\`
+Generation 1: Asymmetric with left-heavy content
+Generation 2: Centered with grid structure
+Generation 3: Diagonal flow with overlapping elements
+Generation 4: Minimal with maximum whitespace
+\`\`\`
+
+### Implementation
+
+Add to your prompt:
+\`\`\`
+Before generating this UI, I'll check: which fonts/colors/layouts did I use in my last generation? I'll explicitly choose DIFFERENT ones for variation.
+\`\`\`
+
+---
+
+## Visual Iteration Workflow
+
+### Setup: Puppeteer MCP
+
+Add to your claude_desktop_config.json:
+\`\`\`json
+{
+  "mcpServers": {
+    "puppeteer": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-puppeteer"]
+    }
+  }
+}
+\`\`\`
+
+### Workflow Steps
+
+1. **Initial Generation**: Create first implementation
+2. **Screenshot Capture**:
+   \`\`\`
+   "Navigate to http://localhost:3000 and take a screenshot"
+   \`\`\`
+3. **Visual Comparison**:
+   \`\`\`
+   "Compare this screenshot to the design mockup. List all differences in:
+    - Spacing (padding, margins)
+    - Colors (exact hex values)
+    - Typography (font size, weight, line-height)
+    - Layout (alignment, positioning)"
+   \`\`\`
+4. **Targeted Fixes**: Address each discrepancy
+5. **Iterate**: Repeat until match achieved
+
+### Style Extraction
+
+To replicate a reference design:
+\`\`\`
+"Analyze https://stripe.com/design and extract a style.md file with:
+1. Typography system (families, scales, weights)
+2. Color palette (primary, secondary, accents)
+3. Spacing system (padding/margin patterns)
+4. Component patterns (buttons, cards, forms)
+5. Animation philosophy"
+\`\`\`
+
+---
+
+## Test-Driven UI Patterns
+
+### Playwright Visual Tests
+
+\`\`\`typescript
+// tests/ui.spec.ts
+import { test, expect } from '@playwright/test';
+
+test.describe('Landing Page UI', () => {
+  test('typography uses non-generic fonts', async ({ page }) => {
+    await page.goto('/');
+    const h1Font = await page.evaluate(() => {
+      const h1 = document.querySelector('h1');
+      return window.getComputedStyle(h1).fontFamily;
+    });
+    expect(h1Font).not.toContain('Inter');
+    expect(h1Font).not.toContain('Roboto');
+    expect(h1Font).not.toContain('Arial');
+  });
+
+  test('no purple gradients on white', async ({ page }) => {
+    await page.goto('/');
+    const backgrounds = await page.evaluate(() => {
+      const elements = document.querySelectorAll('*');
+      return Array.from(elements).map(el =>
+        window.getComputedStyle(el).background
+      );
+    });
+    const hasPurpleGradient = backgrounds.some(bg =>
+      bg.includes('gradient') && bg.includes('purple')
+    );
+    expect(hasPurpleGradient).toBe(false);
+  });
+
+  test('responsive breakpoints', async ({ page }) => {
+    const viewports = [
+      { width: 375, height: 667 },  // Mobile
+      { width: 768, height: 1024 }, // Tablet
+      { width: 1440, height: 900 }, // Desktop
+    ];
+
+    for (const viewport of viewports) {
+      await page.setViewportSize(viewport);
+      await page.goto('/');
+      // Add specific assertions for each breakpoint
+      await expect(page.locator('nav')).toBeVisible();
+    }
+  });
+
+  test('color contrast meets WCAG AA', async ({ page }) => {
+    await page.goto('/');
+    // Use axe-playwright for accessibility testing
+    const accessibilityScanResults = await new AxeBuilder({ page })
+      .withTags(['wcag2aa'])
+      .analyze();
+    expect(accessibilityScanResults.violations).toEqual([]);
+  });
+});
+\`\`\`
+
+---
+
+## Progressive Disclosure Patterns
+
+### For Skills
+- Keep SKILL.md under 500 lines
+- Split detailed guidance into references/
+- Reference files with clear "when to read" instructions
+
+### For UIs
+- Design information hierarchy first
+- Critical content above fold
+- Progressive loading for secondary content
+- Skeleton states during load
+
+---
+
+## Skill Stacking Patterns
+
+### With Brand Guidelines
+\`\`\`
+"Use two skills:
+1. sg-brand-guidelines - Apply company colors and typography
+2. frontend-design-pro - Ensure distinctive, non-generic aesthetics
+
+Create a dashboard for our internal analytics."
+\`\`\`
+
+### With Web Artifacts Builder
+\`\`\`
+"Use two skills:
+1. web-artifacts-builder - Build with React + Tailwind + shadcn/ui
+2. frontend-design-pro - Apply distinctive aesthetics
+
+Create an interactive data visualization dashboard."
+\`\`\`
+
+### Priority Order
+When skills conflict, follow this priority:
+1. Brand guidelines (company requirements)
+2. Accessibility requirements
+3. frontend-design-pro aesthetics
+4. Technical constraints

--- a/skills/nx-executor/SKILL.md
+++ b/skills/nx-executor/SKILL.md
@@ -1,0 +1,442 @@
+---
+name: nx-executor
+description: |
+  Nx monorepo workspace management for sgc-monorepo and other Nx workspaces. Use when exploring project structure, running builds/tests, checking affected projects, understanding dependencies, or generating code. Triggers for: (1) "what projects", "list apps", "show workspace", (2) "run build/test/lint", "nx run", (3) "what changed", "affected projects", (4) "generate component/service", "nx generate", (5) project dependencies, "who depends on".
+---
+
+# Nx Executor - Monorepo Workspace Management
+
+Manage Nx monorepo workspaces via the **nx executor** (code-execution MCP).
+
+## Scope
+
+**Auto-Detected Workspaces**:
+- Current Claude Code session directory (via `MCP_PROJECT_DIR`)
+- `~/Code/sgc-monorepo` (primary personal workspace)
+
+**Does NOT apply to**:
+- Non-Nx projects (no nx.json)
+- Standalone applications
+
+## When to Use This Executor
+
+| User Request | Use nx Executor |
+|-------------|-----------------|
+| "What projects are in this repo?" | `getWorkspace()` |
+| "Show me the project structure" | `getProjectGraphSummary()` |
+| "What changed since main?" | `getAffectedProjects({ base: 'main' })` |
+| "Run tests for harvest-backend" | `runTarget('harvest-backend', 'test')` |
+| "Build all affected projects" | `runAffected('build')` |
+| "What depends on harvest-kit?" | `getProjectDependents('harvest-kit')` |
+| "Generate a new component" | `listGenerators()`, then prompt user |
+
+## Common Patterns
+
+### Explore Workspace
+
+```typescript
+// Get workspace overview
+const workspace = await getWorkspace();
+console.log(`Workspace: ${workspace.workspacePath}`);
+console.log(`Nx Version: ${workspace.nxVersion}`);
+console.log(`Projects: ${workspace.projects.length}`);
+
+// List all projects with types
+workspace.projects.forEach(p => {
+  console.log(`- ${p.name} (${p.projectType})`);
+});
+
+return {
+  path: workspace.workspacePath,
+  nxVersion: workspace.nxVersion,
+  projectCount: workspace.projects.length,
+  projects: workspace.projects.map(p => ({
+    name: p.name,
+    type: p.projectType,
+    root: p.root
+  }))
+};
+```
+
+### Get Project Details
+
+```typescript
+// Get full project configuration
+const project = await getProjectDetails('harvest-backend');
+
+return {
+  name: project.name,
+  root: project.root,
+  sourceRoot: project.sourceRoot,
+  projectType: project.projectType,
+  targets: Object.keys(project.targets || {}),
+  tags: project.tags,
+  implicitDependencies: project.implicitDependencies
+};
+```
+
+### Run Targets
+
+```typescript
+// Run a single target
+const result = await runTarget('harvest-backend', 'serve');
+console.log(`Success: ${result.success}`);
+console.log(`Output:\n${result.output}`);
+
+return {
+  success: result.success,
+  cached: result.output?.includes('[local cache]') || false
+};
+```
+
+```typescript
+// Run for multiple projects
+const result = await runMany(['harvest-web', 'sgc-web'], 'build');
+return { success: result.success };
+```
+
+```typescript
+// Run for all affected projects
+const result = await runAffected('test', { base: 'main' });
+return { success: result.success };
+```
+
+### Affected Analysis
+
+```typescript
+// Get projects affected by recent changes
+const affected = await getAffectedProjects({ base: 'main' });
+
+return {
+  affectedCount: affected.length,
+  projects: affected,
+  message: affected.length === 0
+    ? 'No projects affected since main'
+    : `${affected.length} projects affected`
+};
+```
+
+### Dependency Graph
+
+```typescript
+// Get project graph summary
+const graph = await getProjectGraphSummary({ limit: 20 });
+
+return {
+  totalProjects: graph.totalProjects,
+  totalDependencies: graph.totalDependencies,
+  topProjects: graph.projects.slice(0, 5).map(p => ({
+    name: p.name,
+    dependencies: p.dependencies?.length || 0,
+    dependents: p.dependents?.length || 0
+  }))
+};
+```
+
+```typescript
+// Get dependencies of a specific project
+const deps = await getProjectDependencies('harvest-backend');
+return {
+  project: 'harvest-backend',
+  dependencies: deps
+};
+```
+
+```typescript
+// Get projects that depend on a library
+const dependents = await getProjectDependents('harvest-kit');
+return {
+  library: 'harvest-kit',
+  dependents: dependents
+};
+```
+
+### Generators
+
+```typescript
+// List available generators
+const generators = await listGenerators();
+return generators.slice(0, 10).map(g => ({
+  name: `${g.collection}:${g.name}`,
+  description: g.description
+}));
+```
+
+```typescript
+// Search for generators
+const results = await searchGenerators('component');
+return results.map(r => ({
+  name: `${r.generator.collection}:${r.generator.name}`,
+  description: r.generator.description
+}));
+```
+
+```typescript
+// Get generator schema (for prompting user)
+const schema = await getGeneratorSchema('@nx/react:component');
+return {
+  name: schema.name,
+  required: schema.required,
+  properties: Object.keys(schema.properties)
+};
+```
+
+## sgc-monorepo Project Structure
+
+| Project | Type | Purpose |
+|---------|------|---------|
+| `harvest-ios` | app | iOS app (Swift) |
+| `harvest-macos` | app | macOS app (Swift) |
+| `harvest-watch` | app | watchOS app (Swift) |
+| `harvest-web` | app | Web dashboard (Next.js 14) |
+| `harvest-console` | app | Log viewer (Python Flask) |
+| `harvest-backend` | service | Core API (Python FastAPI) |
+| `harvest-stt` | service | Speech-to-Text (Python MLX) |
+| `drizzle-site` | app | Drizzle website (Next.js 16) |
+| `drizzle-api` | service | Catering API (Python FastAPI) |
+| `sgc-web` | app | SGC website (Next.js 16) |
+| `harvest-kit` | lib | Swift package (shared code) |
+
+## Available Functions
+
+### Workspace
+- `getWorkspacePath()` - Auto-detect workspace root
+- `getWorkspace()` - Full workspace info (nx.json + projects)
+- `getWorkspaceInfo()` - Workspace summary
+- `getProjectGraphSummary(options)` - Project graph with dependencies
+- `getAffectedProjects(options)` - Git-affected projects
+
+### Projects
+- `getProjectDetails(name)` - Full project configuration
+- `getProjectTargets(name)` - Project targets
+- `getProjectDependencies(name)` - What this project depends on
+- `getProjectDependents(name)` - What depends on this project
+- `findProjects(options)` - Search projects by criteria
+
+### Generators
+- `listGenerators(options)` - List available generators
+- `getGeneratorSchema(name)` - Get generator schema
+- `searchGenerators(query)` - Search generators
+
+### Tasks
+- `runTarget(project, target)` - Run a target
+- `runMany(projects, target)` - Run target for multiple projects
+- `runAffected(target, options)` - Run target for affected projects
+- `getProjectsWithTarget(target)` - Find projects with target
+
+### Documentation
+- `searchDocs(query)` - Search Nx documentation
+- `listPlugins()` - List available plugins
+- `getPluginInfo(name)` - Get plugin details
+
+## Workflow Examples
+
+### "What needs to be rebuilt?"
+
+```typescript
+// Check what's affected since main
+const affected = await getAffectedProjects({ base: 'main' });
+
+if (affected.length === 0) {
+  return { message: 'Nothing changed - all up to date!' };
+}
+
+// Get details for each affected project
+const details = await Promise.all(
+  affected.map(name => getProjectDetails(name))
+);
+
+return {
+  affectedCount: affected.length,
+  projects: details.map(p => ({
+    name: p.name,
+    type: p.projectType,
+    targets: Object.keys(p.targets || {})
+  }))
+};
+```
+
+### "Build and test everything that changed"
+
+```typescript
+// Build affected
+const buildResult = await runAffected('build', { base: 'main' });
+if (!buildResult.success) {
+  return { success: false, phase: 'build', output: buildResult.output };
+}
+
+// Test affected
+const testResult = await runAffected('test', { base: 'main' });
+return {
+  success: testResult.success,
+  buildOutput: buildResult.output,
+  testOutput: testResult.output
+};
+```
+
+## Notes
+
+- **Auto-detection**: Workspace is auto-detected from Claude Code session
+- **Caching**: Nx caches task results; repeated runs are fast
+- **Parallel execution**: `runMany` and `runAffected` run in parallel by default
+- **Tags**: Use tags to filter projects (e.g., `scope:harvest`, `type:app`)
+
+---
+
+## Nx Deployment Patterns (CRITICAL)
+
+**NEVER create separate workflow files for individual projects in an Nx monorepo.**
+
+### The Nx Way
+
+In an Nx monorepo, ALL projects should use the unified `nx affected -t deploy` pattern:
+
+1. **Main CI workflow** runs `pnpm nx affected -t deploy`
+2. **Each project** defines a `deploy` target in its configuration
+3. **Nx determines** which projects need deployment based on git changes
+
+### Anti-Pattern (DO NOT DO THIS)
+
+```yaml
+# ❌ WRONG: .github/workflows/my-project.yml
+name: Deploy My Project
+on:
+  push:
+    paths:
+      - 'apps/my-project/**'
+# This defeats the purpose of Nx monorepo!
+```
+
+### Correct Pattern
+
+```json
+// ✅ CORRECT: apps/my-project/package.json (or project.json)
+{
+  "nx": {
+    "targets": {
+      "deploy": {
+        "executor": "@sg-ai/nx-deploy-executor:deploy",
+        "options": {
+          "type": "lambda",  // or "s3-static" or "ecs-codedeploy"
+          // ...options
+        }
+      }
+    }
+  }
+}
+```
+
+### Available Deployment Types
+
+The `@sg-ai/nx-deploy-executor:deploy` executor supports three deployment types:
+
+#### 1. Lambda Functions (`type: "lambda"`)
+
+Deploys Lambda functions via S3 artifact upload:
+
+```json
+{
+  "deploy": {
+    "executor": "@sg-ai/nx-deploy-executor:deploy",
+    "dependsOn": ["package-lambda"],
+    "options": {
+      "type": "lambda",
+      "functionName": "my-function-{stage}",
+      "bucket": "sg-codepipeline-artifacts",
+      "artifactKey": "deploys/my-project-{stage}/my-project.zip",
+      "localArtifactPath": "dist/apps/my-project/lambda.zip"
+    },
+    "configurations": {
+      "development": { "stage": "development" },
+      "production": { "stage": "production" }
+    }
+  }
+}
+```
+
+**Lambda Build Chain:**
+1. `build` - esbuild bundles to single JS file (with deps)
+2. `package-lambda` - zip the bundle
+3. `deploy` - upload to S3 + update Lambda function code
+
+#### 2. Static Sites (`type: "s3-static"`)
+
+Syncs static files to S3 with smart cache control:
+
+```json
+{
+  "deploy": {
+    "executor": "@sg-ai/nx-deploy-executor:deploy",
+    "dependsOn": ["build"],
+    "options": {
+      "type": "s3-static",
+      "bucket": "my-static-site-bucket",
+      "distPath": "dist/apps/my-site",
+      "cacheControl": "max-age=31536000,immutable",
+      "htmlCacheControl": "max-age=0,no-cache,no-store,must-revalidate"
+    }
+  }
+}
+```
+
+#### 3. ECS with CodeDeploy (`type: "ecs-codedeploy"`)
+
+Confirms ECR push; CodeDeploy auto-triggers on image update:
+
+```json
+{
+  "deploy": {
+    "executor": "@sg-ai/nx-deploy-executor:deploy",
+    "dependsOn": ["docker"],
+    "options": {
+      "type": "ecs-codedeploy"
+    }
+  }
+}
+```
+
+### Stage Substitution
+
+Use `{stage}` placeholder in options - it gets replaced with the configuration name:
+
+- `--configuration=development` → `{stage}` becomes `development`
+- `--configuration=production` → `{stage}` becomes `production`
+
+### Main CI Workflow Pattern
+
+```yaml
+# .github/workflows/main.yml
+- name: Deploy affected projects
+  run: |
+    pnpm nx affected -t deploy \
+      --configuration=development \
+      --parallel=1
+
+# For production (on release)
+- name: Deploy to production
+  run: |
+    pnpm nx affected -t deploy \
+      --configuration=production \
+      --parallel=1
+```
+
+### Why This Matters
+
+| Separate Workflows | Nx Affected Deploy |
+|-------------------|-------------------|
+| ❌ Duplicate CI logic | ✅ Single source of truth |
+| ❌ Path filters miss deps | ✅ Graph-aware changes |
+| ❌ Manual maintenance | ✅ Automatic detection |
+| ❌ Inconsistent deployments | ✅ Unified patterns |
+| ❌ Can't share cache | ✅ Full Nx caching |
+
+### Checklist for New Projects
+
+When adding a deployable project to an Nx monorepo:
+
+1. ✅ Add `deploy` target to project config (package.json or project.json)
+2. ✅ Use `@sg-ai/nx-deploy-executor:deploy` (or appropriate executor)
+3. ✅ Set `dependsOn` for build chain (`build`, `docker`, `package-lambda`)
+4. ✅ Define `configurations` for development/production stages
+5. ❌ Do NOT create a separate workflow file
+6. ❌ Do NOT add path filters in workflows


### PR DESCRIPTION
## Summary

- Add comprehensive documentation for Nx-native deployment patterns to the `nx-executor` skill
- Document the anti-pattern of creating separate workflow files per project
- Document the correct pattern using `deploy` target in project config
- Detail three deployment types: `lambda`, `s3-static`, `ecs-codedeploy`
- Include stage substitution with `{stage}` placeholder
- Add comparison table showing benefits of Nx-native approach
- Include checklist for adding new deployable projects

## Motivation

This documentation prevents the mistake of creating separate GitHub Actions workflow files for individual projects in an Nx monorepo, which defeats the purpose of `nx affected` based deployments.

## Test plan

- [ ] Verify skill loads correctly with `/nx-executor`
- [ ] Review documentation for accuracy against actual `@sg-ai/nx-deploy-executor` implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)