### PR TITLE
skill-creator: permit optional frontmatter fields per Agent Skills spec

### DIFF
--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -303,7 +303,9 @@ Any example files and directories not needed for the skill should be deleted. Th
 
 ##### Frontmatter
 
-Write the YAML frontmatter with `name` and `description`:
+Write the YAML frontmatter with required and optional fields per the Agent Skills specification:
+
+**Required fields:**
 
 - `name`: The skill name
 - `description`: This is the primary triggering mechanism for your skill, and helps Claude understand when to use the skill.
@@ -311,7 +313,14 @@ Write the YAML frontmatter with `name` and `description`:
   - Include all "when to use" information here - Not in the body. The body is only loaded after triggering, so "When to Use This Skill" sections in the body are not helpful to Claude.
   - Example description for a `docx` skill: "Comprehensive document creation, editing, and analysis with support for tracked changes, comments, formatting preservation, and text extraction. Use when Claude needs to work with professional documents (.docx files) for: (1) Creating new documents, (2) Modifying or editing content, (3) Working with tracked changes, (4) Adding comments, or any other document tasks"
 
-Do not include any other fields in YAML frontmatter.
+**Optional fields:**
+
+- `license`: License name or reference to a bundled license file (e.g., "MIT", "Apache-2.0", "Proprietary. LICENSE.txt has complete terms")
+- `compatibility`: Environment requirements (max 500 characters, e.g., "Requires Python 3.8+" or "Node.js 18+ required")
+- `metadata`: Arbitrary key-value mapping for additional metadata
+- `allowed-tools`: Space-delimited list of pre-approved tools (experimental)
+
+Only use fields defined in the Agent Skills specification.
 
 ##### Body
 

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -303,7 +303,7 @@ Any example files and directories not needed for the skill should be deleted. Th
 
 ##### Frontmatter
 
-Write the YAML frontmatter with required and optional fields per the Agent Skills specification:
+Write the YAML frontmatter with required and optional fields:
 
 **Required fields:**
 
@@ -320,7 +320,7 @@ Write the YAML frontmatter with required and optional fields per the Agent Skill
 - `metadata`: Arbitrary key-value mapping for additional metadata
 - `allowed-tools`: Space-delimited list of pre-approved tools (experimental)
 
-Only use fields defined in the Agent Skills specification.
+Only use the fields documented above.
 
 ##### Body
 

--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -39,7 +39,7 @@ def validate_skill(skill_path):
         return False, f"Invalid YAML in frontmatter: {e}"
 
     # Define allowed properties
-    ALLOWED_PROPERTIES = {'name', 'description', 'license', 'allowed-tools', 'metadata'}
+    ALLOWED_PROPERTIES = {'name', 'description', 'license', 'compatibility', 'allowed-tools', 'metadata'}
 
     # Check for unexpected properties (excluding nested keys under metadata)
     unexpected_keys = set(frontmatter.keys()) - ALLOWED_PROPERTIES


### PR DESCRIPTION
Summary: Align `skill-creator` guidance and validation with the Agent Skills specification for YAML frontmatter.

Changes:
- Docs: Update frontmatter section in skills/skill-creator/SKILL.md to:
  - Separate required fields (`name`, `description`) from optional fields.
  - Document optional fields: `license`, `compatibility`, `metadata`, `allowed-tools`.
  - Replace “Do not include any other fields” with “Only use fields defined in the Agent Skills specification”.
- Validation: Allow `compatibility` in skills/skill-creator/scripts/quick_validate.py.

Motivation: Existing guidance incorrectly prohibited valid optional fields and the validator missed `compatibility`. This aligns authoring docs and validation with the official spec and avoids false validation failures.

Reference: https://agentskills.io/specification#frontmatter-required
Issue: Fixes #249
