### PR TITLE
Enforce and document skill naming conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ description: A clear description of what this skill does and when to use it
 ```
 
 The frontmatter requires only two fields:
-- `name` - A unique identifier for your skill (lowercase, hyphens for spaces)
+- `name` - A unique identifier for your skill. This **must** be lowercase, numbers, and hyphens only (e.g. `my-awesome-skill`). Spaces and uppercase letters are not allowed.
 - `description` - A complete description of what the skill does and when to use it
 
 The markdown content below contains the instructions, examples, and guidelines that Claude will follow. For more details, see [How to create custom skills](https://support.claude.com/en/articles/12512198-creating-custom-skills).

--- a/skills/skill-creator/scripts/init_skill.py
+++ b/skills/skill-creator/scripts/init_skill.py
@@ -12,6 +12,7 @@ Examples:
 """
 
 import sys
+import re
 from pathlib import Path
 
 
@@ -202,6 +203,17 @@ def init_skill(skill_name, path):
     Returns:
         Path to created skill directory, or None if error
     """
+    # Validate skill name
+    if not re.match(r'^[a-z0-9-]+$', skill_name):
+        print(f"❌ Error: Invalid skill name '{skill_name}'")
+        print("   Skill names must be lowercase, alphanumeric, and hyphenated only.")
+        return None
+
+    if skill_name.startswith('-') or skill_name.endswith('-') or '--' in skill_name:
+        print(f"❌ Error: Invalid skill name '{skill_name}'")
+        print("   Skill names cannot start/end with hyphen or contain consecutive hyphens.")
+        return None
+
     # Determine skill directory path
     skill_dir = Path(path).resolve() / skill_name
 

--- a/template/SKILL.md
+++ b/template/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: template-skill
+name: template-skill # Must be lowercase, numbers, and hyphens only (e.g., my-skill-name)
 description: Replace with description of the skill and when Claude should use it.
 ---
 


### PR DESCRIPTION
This change addresses user frustration regarding inconsistent documentation for skill naming conventions. It updates the documentation to clearly state that skill names must be lowercase, numbers, and hyphens only, matching the platform's validation. It also adds validation to the skill initialization script to enforce this rule at creation time.