### PR TITLE
feat: Add faf-context skill - the missing link between package.json and README

### DIFF
--- a/skills/faf-context/LICENSE.txt
+++ b/skills/faf-context/LICENSE.txt
@@ -1,0 +1,11 @@
+Apache License 2.0
+
+Copyright 2024-2026 wolfejam
+
+Licensed under the Apache License, Version 2.0.
+http://www.apache.org/licenses/LICENSE-2.0
+
+---
+FAF (Foundational AI-context Format)
+IANA Media Type: application/vnd.faf+yaml
+Anthropic MCP Registry: #2759

--- a/skills/faf-context/SKILL.md
+++ b/skills/faf-context/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: faf-context
+description: Generate AI-context DNA for ANY project - new, legacy, famous, or forgotten. Creates .faf files that eliminate "explain your codebase again" across ALL AI tools. IANA-registered format (application/vnd.faf+yaml), 21,000+ npm downloads, Anthropic MCP ecosystem. Use when Claude asks "what does this project do?", when context drifts between sessions, or when onboarding AI to any codebase. Works with Claude, Cursor, Gemini CLI, WARP, Windsurf.
+---
+
+# FAF Context - AI-Context DNA for Any Project
+
+Generate `.faf` files that give any AI instant, persistent understanding of your project.
+
+## The Truth About AI Context
+
+**Even famous repos score 0%.** React. Kubernetes. Rails. Django. None have AI-context.
+
+Why? Because **AI-context is a NEW requirement.** It didn't exist until AI became a coding partner.
+
+| What exists | What it answers |
+|-------------|-----------------|
+| README.md | "What does this do?" (for humans) |
+| docs/ | "How do I use this?" (for humans) |
+| **project.faf** | "How should AI help build this?" (for AI) |
+
+Documentation tells humans how to use code. AI-context tells AI how to help you write it. **They're not the same thing.**
+
+## Works on ANY Project
+
+| Project State | What FAF Context Adds |
+|--------------|----------------------|
+| **Brand new** | Optimized AI context from line one |
+| **Legacy codebase** | AI finally understands the archaeology |
+| **Famous OSS** | Even React needs this (it doesn't have one) |
+| **Side project** | Stop re-explaining every session |
+| **Client handoff** | Portable context for any AI tool |
+
+## Workflow
+
+### Step 1: Detect Stack
+
+Look for manifest files:
+- `package.json` → Node.js/TypeScript
+- `Cargo.toml` → Rust
+- `pyproject.toml` → Python
+- `go.mod` → Go
+- `pom.xml` → Java
+- `Gemfile` → Ruby
+
+No manifest? Still generate - ask user for stack info.
+
+### Step 2: Mine Existing Context
+
+Pull signals from what exists:
+- README.md (description, purpose)
+- docs/ (architecture decisions)
+- CLAUDE.md or .cursorrules (existing AI context - migrate it)
+- Package manifests (dependencies reveal intent)
+- Directory structure (architecture patterns)
+
+### Step 3: Generate project.faf
+
+Create focused AI context at project root:
+
+```yaml
+faf_version: "2.0"
+project:
+  name: my-project
+  description: One-line purpose
+  stack: [typescript, react]
+
+context:
+  architecture: |
+    Brief system overview.
+  key_files:
+    - src/index.ts: Entry point
+    - src/api/: API handlers
+  conventions:
+    - TypeScript strict mode
+    - Composition over inheritance
+
+ai_guidance:
+  priorities: [correctness, simplicity, performance]
+  avoid: [over-engineering, premature optimization]
+  testing: Jest with >80% coverage
+```
+
+Keep under 200 lines. Only what changes AI behavior.
+
+### Step 4: Score and Report
+
+```
+Generated: project.faf (147 lines)
+AI-Readiness: 87% [BRONZE] - Production ready
+
+To reach Silver (95%):
+  - Add deployment section (+5%)
+  - Document API patterns (+3%)
+```
+
+## AI-Readiness Tiers
+
+| Tier | Score | Meaning |
+|------|-------|---------|
+| Big Orange | 105% | Michelin Star - Perfect + bonus |
+| Trophy | 100% | Perfect compliance |
+| Gold | 99%+ | Exceptional |
+| Silver | 95%+ | Excellent |
+| Bronze | 85%+ | Production ready |
+| Green | 70%+ | Solid foundation |
+| Yellow | 55%+ | Needs improvement |
+| Red | <55% | Major gaps |
+
+**Target: Bronze (85%+).** This is where AI collaboration becomes productive.
+
+## Stack Templates
+
+See [references/templates.md](references/templates.md) for TypeScript, Rust, Python, Go templates.
+
+## Migration
+
+When CLAUDE.md or .cursorrules exist:
+- Offer to migrate to .faf (portable format)
+- .faf works in Cursor, Gemini, WARP - not just Claude
+- YAML structure parses better than freeform markdown
+
+## Validation
+
+Generated files must:
+- Be valid YAML
+- Have `faf_version` and `project.name`
+- Contain NO secrets or credentials
+- Stay under 500 lines
+
+## Credentials
+
+- **IANA Media Type:** `application/vnd.faf+yaml` (registered Oct 31, 2025)
+- **npm Downloads:** 21,000+
+- **Anthropic MCP:** Registry #2759 (merged)
+- **Website:** https://faf.one
+
+## Resources
+
+- [Format Specification](references/format-spec.md) - Complete .faf schema
+- [Tier System](references/tier-system.md) - Scoring methodology
+- [Stack Templates](references/templates.md) - Per-language examples

--- a/skills/faf-context/SKILL.md
+++ b/skills/faf-context/SKILL.md
@@ -5,8 +5,8 @@ description: Generate AI-context DNA for ANY project - new, legacy, famous, or f
 
 # FAF Context - AI-Context DNA for Any Project
 
-> The pit crew. Detects your stack, mines existing context, generates a .faf — right now.
-> See also: `faf-expert` (the mechanic's manual — install, configure, troubleshoot, score).
+> **Done for you.** The pit crew — detects your stack, mines existing context, generates a .faf right now.
+> See also: `faf-expert` — the "become an expert" mechanic's manual for install, configure, troubleshoot, score.
 
 Generate `.faf` files that give any AI instant, persistent understanding of your project.
 

--- a/skills/faf-context/SKILL.md
+++ b/skills/faf-context/SKILL.md
@@ -5,6 +5,9 @@ description: Generate AI-context DNA for ANY project - new, legacy, famous, or f
 
 # FAF Context - AI-Context DNA for Any Project
 
+> The pit crew. Detects your stack, mines existing context, generates a .faf — right now.
+> See also: `faf-expert` (the mechanic's manual — install, configure, troubleshoot, score).
+
 Generate `.faf` files that give any AI instant, persistent understanding of your project.
 
 ## The Truth About AI Context
@@ -131,7 +134,8 @@ Generated files must:
 ## Credentials
 
 - **IANA Media Type:** `application/vnd.faf+yaml` (registered Oct 31, 2025)
-- **npm Downloads:** 21,000+
+- **36,400+ downloads** across npm, PyPI, crates.io (94+ releases)
+- **IETF Internet-Draft:** draft-wolfe-faf-format
 - **Anthropic MCP:** Registry #2759 (merged)
 - **Website:** https://faf.one
 

--- a/skills/faf-context/references/format-spec.md
+++ b/skills/faf-context/references/format-spec.md
@@ -1,0 +1,67 @@
+# FAF Format Specification
+
+**Version:** 2.0
+**IANA Media Type:** `application/vnd.faf+yaml`
+**File Extension:** `.faf`
+
+## Required Fields
+
+```yaml
+faf_version: "2.0"        # Format version
+project:
+  name: string            # Project name
+  description: string     # One-line purpose
+```
+
+## Recommended Fields
+
+```yaml
+project:
+  stack: [string]         # Languages/frameworks
+  repository: url         # Git remote
+
+context:
+  architecture: string    # System overview
+  key_files:              # Important paths
+    - path: description
+  conventions: [string]   # Coding standards
+
+ai_guidance:
+  priorities: [string]    # Optimize for
+  avoid: [string]         # Anti-patterns
+  testing: string         # Test approach
+```
+
+## Optional Sections
+
+```yaml
+deployment:
+  platform: string
+  environments: [string]
+
+integrations:
+  apis: [string]
+  services: [string]
+```
+
+## Validation Rules
+
+1. Must be valid YAML
+2. `faf_version` required
+3. `project.name` required
+4. No secrets or credentials
+5. Under 500 lines recommended
+
+## File Placement
+
+```
+project-root/
+├── project.faf     # Core DNA (root)
+├── .taf            # Testing context (optional)
+└── FAF/            # Extended context (optional)
+    └── *.faf
+```
+
+## Cross-Platform
+
+Works with: Claude, Cursor, Gemini CLI, WARP, Windsurf, any AI tool reading YAML.

--- a/skills/faf-context/references/templates.md
+++ b/skills/faf-context/references/templates.md
@@ -1,0 +1,135 @@
+# Stack Templates
+
+## TypeScript/React
+
+```yaml
+faf_version: "2.0"
+project:
+  name: # from package.json
+  description: # from README
+  stack: [typescript, react]
+
+context:
+  architecture: |
+    React SPA with component-based architecture.
+    State: [Redux/Zustand/Context].
+  key_files:
+    - src/App.tsx: Root component
+    - src/components/: Reusable UI
+    - src/hooks/: Custom hooks
+    - src/api/: API client
+  conventions:
+    - Functional components with hooks
+    - TypeScript strict mode
+    - Props interfaces co-located
+
+ai_guidance:
+  priorities: [type-safety, component-reuse, a11y]
+  avoid: [class-components, any-type, inline-styles]
+  testing: Vitest + React Testing Library
+```
+
+## Rust
+
+```yaml
+faf_version: "2.0"
+project:
+  name: # from Cargo.toml
+  description: # from Cargo.toml
+  stack: [rust]
+
+context:
+  architecture: |
+    [Binary/Library] crate.
+    Error handling: thiserror + anyhow.
+  key_files:
+    - src/main.rs: Entry point
+    - src/lib.rs: Public API
+    - src/error.rs: Error types
+  conventions:
+    - No unwrap in library code
+    - Prefer &str over String for inputs
+
+ai_guidance:
+  priorities: [safety, performance, ergonomic-api]
+  avoid: [unwrap, unnecessary-clone, panic-in-lib]
+  testing: cargo test, proptest for properties
+```
+
+## Python
+
+```yaml
+faf_version: "2.0"
+project:
+  name: # from pyproject.toml
+  description: # from README
+  stack: [python]
+
+context:
+  architecture: |
+    [CLI/API/Library] using [framework].
+  key_files:
+    - src/main.py: Entry point
+    - src/core/: Business logic
+    - tests/: Test suite
+  conventions:
+    - Type hints on public functions
+    - Google-style docstrings
+
+ai_guidance:
+  priorities: [readability, type-safety, testability]
+  avoid: [bare-except, mutable-defaults]
+  testing: pytest, >80% coverage
+```
+
+## Go
+
+```yaml
+faf_version: "2.0"
+project:
+  name: # from go.mod
+  description: # from README
+  stack: [go]
+
+context:
+  architecture: |
+    [CLI/API/Library] with standard layout.
+  key_files:
+    - cmd/: Entry points
+    - internal/: Private packages
+    - pkg/: Public packages
+  conventions:
+    - Accept interfaces, return structs
+    - Table-driven tests
+
+ai_guidance:
+  priorities: [simplicity, performance, explicit-errors]
+  avoid: [interface-pollution, panic-for-errors]
+  testing: go test with testify
+```
+
+## Node.js/Express
+
+```yaml
+faf_version: "2.0"
+project:
+  name: # from package.json
+  description: # from README
+  stack: [node, express]
+
+context:
+  architecture: |
+    Express API with [MVC/layered] structure.
+  key_files:
+    - src/index.js: Server entry
+    - src/routes/: Route handlers
+    - src/middleware/: Express middleware
+  conventions:
+    - Async/await for async ops
+    - Centralized error handling
+
+ai_guidance:
+  priorities: [security, performance, error-handling]
+  avoid: [callback-hell, sync-file-ops]
+  testing: Jest + supertest
+```

--- a/skills/faf-context/references/tier-system.md
+++ b/skills/faf-context/references/tier-system.md
@@ -1,0 +1,47 @@
+# FAF AI-Readiness Tier System
+
+The Michelin Star rating for AI context quality.
+
+## Tiers
+
+| Tier | Score | Meaning |
+|------|-------|---------|
+| Big Orange | 105% | Michelin Star - Perfect + bonus |
+| Trophy | 100% | Perfect compliance |
+| Gold | 99%+ | Exceptional |
+| Silver | 95%+ | Excellent |
+| Bronze | 85%+ | Production ready |
+| Green | 70%+ | Solid foundation |
+| Yellow | 55%+ | Needs improvement |
+| Red | <55% | Major gaps |
+| White | 0% | No context |
+
+## Scoring
+
+### Core (40 pts)
+- `faf_version`: 5 pts
+- `project.name`: 10 pts
+- `project.description` (>20 chars): 15 pts
+- `project.stack`: 10 pts
+
+### Context (30 pts)
+- `context.architecture`: 10 pts
+- `context.key_files` (3+): 10 pts
+- `context.conventions` (2+): 10 pts
+
+### AI Guidance (20 pts)
+- `ai_guidance.priorities`: 8 pts
+- `ai_guidance.avoid`: 7 pts
+- `ai_guidance.testing`: 5 pts
+
+### Bonus (15 pts max)
+- Deployment section: +5 pts
+- Integrations: +5 pts
+- Under 200 lines: +3 pts
+- Doc cross-refs: +2 pts
+
+## Philosophy
+
+> AI-Readiness is not documentation. It's the minimum context that changes AI behavior.
+
+**Target: Bronze (85%+)** - where AI collaboration becomes productive.


### PR DESCRIPTION
## Summary

Adds `faf-context` - a skill for generating `.faf` files that give any AI instant, persistent understanding of a project.

### The Missing Link

`project.faf` sits alphabetically between `package.json` and `README.md` — because that is exactly where it belongs conceptually:

```
package.json      ← What you HAVE (dependencies)
project.faf       ← How AI USES IT (context)   ← THE MISSING LINK
README.md         ← What it DOES (for humans)
```

> "package.json gives me a list of dependencies, .faf shows me how to use them"
> — Claude Code

**The gap this fills:** Every AI session wastes time reverse-engineering the bridge between "what dependencies do I have" and "what does this project do." That bridge is `project.faf`.

### What AI Tools Say About .faf

| AI Tool | Rating | Quote |
|---------|--------|-------|
| **Grok by xAI** | 9.5/10 | "Game-changer for eternal AI context" *(Jan 2026)* |
| **Google Gemini CLI** | 9.5/10 | "README evolution for AI era" *(Sep 2025)* |
| **OpenAI Codex CLI** | 9/10 | "Every project should have one" *(Sep 2025)* |
| **Claude Code** | — | "Should become the standard" *(Sep 2025 → IANA registered 42 days later)* |

### The Reality

**Every repo starts at 0%.** React. Kubernetes. Your codebase. ALL of them.

Why? Because AI-context does not exist until you create it. Documentation ≠ AI-context.

```
Before faf init:    0%   [RED]     - AI guesses everything
After faf init:    ~60%  [GREEN]   - AI understands basics
After faf auto:    85%+  [BRONZE]  - AI collaboration is productive
After faf go:      100%  [TROPHY]  - Championship-grade context
```

**The good news:** Getting to 100% is easy. `faf init` bootstraps, `faf auto` optimizes, `faf go` guides you to perfection - all with minimal technical input.

### The Problem This Solves

Even React, Kubernetes, and Rails score 0% for AI-context. Why? Because AI-context is a NEW requirement - it did not exist until AI became a coding partner.

| File | What it answers |
|------|-----------------|
| package.json | "What dependencies?" (for tools) |
| **project.faf** | "How should AI help build this?" (for AI) |
| README.md | "What does this do?" (for humans) |

### What This Skill Does

- Generates `project.faf` for ANY project (new, legacy, famous, or forgotten)
- Detects stack from manifests (package.json, Cargo.toml, pyproject.toml, go.mod)
- Mines existing context from README, docs/, CLAUDE.md, .cursorrules
- Scores AI-readiness (Bronze 85%+ = production ready)
- Portable across Claude, Cursor, Gemini CLI, WARP, Windsurf, Grok

### Credentials

- **IANA-registered:** `application/vnd.faf+yaml` (Oct 31, 2025)
- **21,000+ npm downloads**
- **Anthropic MCP Registry:** #2759 (merged)
- **Website:** https://faf.one

## Files Added

```
skills/faf-context/
├── SKILL.md              # 142 lines
├── LICENSE.txt           # Apache 2.0
└── references/
    ├── format-spec.md    # .faf schema
    ├── tier-system.md    # Scoring methodology
    └── templates.md      # Per-stack examples
```

## Why This Belongs Here

Current skills cover documents (pdf, docx), creation (art, design), and dev tools (mcp-builder) — but nothing for **project context**.

This is the "BEFORE you code" skill:
- mcp-builder = build servers
- webapp-testing = test apps
- **faf-context = give AI context first**

## Test Plan

- [ ] SKILL.md frontmatter validates
- [ ] Triggers on "what does this project do?"
- [ ] Stack detection works (TS, Rust, Python, Go)
- [ ] Generated .faf is valid YAML
- [ ] References load via progressive disclosure

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)