### PR TITLE
docs(webapp-testing): add requirements.txt for dependencies

### DIFF
--- a/skills/webapp-testing/SKILL.md
+++ b/skills/webapp-testing/SKILL.md
@@ -6,7 +6,7 @@ license: Complete terms in LICENSE.txt
 
 # Web Application Testing
 
-To test local web applications, write native Python Playwright scripts.
+To test local web applications, write native Python Playwright scripts. See `requirements.txt` for dependencies.
 
 **Helper Scripts Available**:
 - `scripts/with_server.py` - Manages server lifecycle (supports multiple servers)

--- a/skills/webapp-testing/requirements.txt
+++ b/skills/webapp-testing/requirements.txt
@@ -1,0 +1,1 @@
+playwright>=1.40.0


### PR DESCRIPTION
# Why?

Every time I install and run this skill on a new machine, Claude Code writes scripts, runs them, THEN realizes that it may not yet have Playwright. This is a minimal change to hint to Claude Code (or whatever skills supporting agent) that playwright is needed. Follows the `requirements.txt` pattern as per `slack-gif-creator`, though personally I would have rather altered the skill to just advise `uv`. 