### PR TITLE
Align skill-creator with Agent Skills specification

### DIFF
--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -38,8 +38,8 @@ def validate_skill(skill_path):
     except yaml.YAMLError as e:
         return False, f"Invalid YAML in frontmatter: {e}"
 
-    # Define allowed properties
-    ALLOWED_PROPERTIES = {'name', 'description', 'license', 'allowed-tools', 'metadata'}
+    # Define allowed properties per Agent Skills spec
+    ALLOWED_PROPERTIES = {'name', 'description', 'license', 'compatibility', 'allowed-tools', 'metadata'}
 
     # Check for unexpected properties (excluding nested keys under metadata)
     unexpected_keys = set(frontmatter.keys()) - ALLOWED_PROPERTIES


### PR DESCRIPTION
## Summary

Align `skill-creator` documentation and validation with the [Agent Skills specification](https://agentskills.io/specification).

### Changes

**Documentation (`SKILL.md`):**
- Add comprehensive frontmatter field constraints table documenting all 6 fields
- Document `name` field validation rules (64 chars max, no consecutive hyphens, must match directory name)
- Document `description` field limit (1024 chars max)
- Include example YAML demonstrating optional fields usage
- Update progressive disclosure units from "words" to "tokens" per spec
- Add `skills-ref validate` tool reference

**Validation (`quick_validate.py`):**
- Add `compatibility` to `ALLOWED_PROPERTIES`

## Motivation

I encountered this issue while creating a skill. Initially, I built my skill by referencing the spec documentation directly, which resulted in a valid `SKILL.md` with optional fields like `compatibility`.

Later, when I used the `skill-creator` skill to refine my work, the agent removed all fields except `name` and `description` from my frontmatter because the skill's guidance stated "Do not include any other fields in YAML frontmatter."

This PR updates `skill-creator` to accurately reflect the full specification, preventing agents from incorrectly stripping valid optional fields.