### PR TITLE
Fix(skill-creator): specify utf-8 encoding when reading SKILL.md

### DIFF
--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -19,7 +19,7 @@ def validate_skill(skill_path):
         return False, "SKILL.md not found"
 
     # Read and validate frontmatter
-    content = skill_md.read_text()
+    content = skill_md.read_text(encoding='utf-8')
     if not content.startswith('---'):
         return False, "No YAML frontmatter found"
 


### PR DESCRIPTION
Explicitly specifying utf-8 encoding when reading SKILL.md ensures consistent behavior across different operating systems and environments. It prevents potential UnicodeDecodeError exceptions that may occur if the system default encoding is not utf-8, especially on Windows. This change improves the script's robustness and compatibility when handling non-ASCII characters in SKILL.md files.
<img width="947" height="311" alt="image" src="https://github.com/user-attachments/assets/f2d8bae7-b0cc-4357-a543-9957d7e89342" />
