### PR TITLE
Add agents configuration for multi-agent routing

### DIFF
--- a/agents.json
+++ b/agents.json
@@ -1,0 +1,39 @@
+{
+  "agents": {
+    "list": [
+      {
+        "id": "main",
+        "default": true,
+        "name": "Personal Assistant",
+        "workspace": "~/clawd",
+        "sandbox": { "mode": "off" }
+      },
+      {
+        "id": "family",
+        "name": "Family Bot",
+        "workspace": "~/clawd-family",
+        "sandbox": {
+          "mode": "all",
+          "scope": "agent"
+        },
+        "tools": {
+          "allow": ["read"],
+          "deny": ["exec", "write", "edit", "apply_patch", "process", "browser"]
+        }
+      }
+    ]
+  },
+  "bindings": [
+    {
+      "agentId": "family",
+      "match": {
+        "provider": "whatsapp",
+        "accountId": "*",
+        "peer": {
+          "kind": "group",
+          "id": "120363424282127706@g.us"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Configures two agents:
- main: Personal Assistant (default) with full tool access
- family: Family Bot with read-only access, sandboxed

Includes WhatsApp group binding for family agent routing.

https://claude.ai/code/session_01NdVWReumvCVgXM626WofkJ