### PR TITLE
Add endpoints skill for document management API

### DIFF
--- a/skills/endpoints/SKILL.md
+++ b/skills/endpoints/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: endpoints
+description: Interact with the Endpoints API to manage document endpoints, scan files, and retrieve extracted data. Use when users want to list endpoints, inspect endpoint contents, scan documents, create/delete endpoints, download files, or check usage stats. Requires ENDPOINTS_API_URL and ENDPOINTS_API_KEY environment variables.
+---
+
+# Endpoints API Skill
+
+Interact with the Endpoints document management API. This skill enables listing, inspecting, creating, and managing document endpoints with AI-extracted metadata.
+
+## Prerequisites
+
+Ensure these environment variables are set:
+- `ENDPOINTS_API_URL` - Base URL (e.g., `https://endpoints.work`)
+- `ENDPOINTS_API_KEY` - API key with `ep_` prefix (generate from dashboard)
+
+## Quick Reference
+
+### List All Endpoints (Overview)
+```bash
+curl -s -H "Authorization: Bearer $ENDPOINTS_API_KEY" \
+  "$ENDPOINTS_API_URL/api/endpoints/tree" | jq
+```
+
+### Inspect Endpoint
+```bash
+curl -s -H "Authorization: Bearer $ENDPOINTS_API_KEY" \
+  "$ENDPOINTS_API_URL/api/endpoints/category/slug" | jq
+```
+
+### Scan Text Content
+```bash
+curl -s -X POST -H "Authorization: Bearer $ENDPOINTS_API_KEY" \
+  -F "texts=Your text content here" \
+  -F "prompt=job tracker" \
+  "$ENDPOINTS_API_URL/api/scan" | jq
+```
+
+### Scan File
+```bash
+curl -s -X POST -H "Authorization: Bearer $ENDPOINTS_API_KEY" \
+  -F "files=@/path/to/file.pdf" \
+  -F "prompt=invoice tracker" \
+  "$ENDPOINTS_API_URL/api/scan" | jq
+```
+
+### Create Empty Endpoint
+```bash
+curl -s -X POST -H "Authorization: Bearer $ENDPOINTS_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"path": "/category/slug", "items": []}' \
+  "$ENDPOINTS_API_URL/api/endpoints" | jq
+```
+
+### Delete Endpoint
+```bash
+curl -s -X DELETE -H "Authorization: Bearer $ENDPOINTS_API_KEY" \
+  "$ENDPOINTS_API_URL/api/endpoints/category/slug" | jq
+```
+
+### Delete Individual Item
+```bash
+curl -s -X DELETE -H "Authorization: Bearer $ENDPOINTS_API_KEY" \
+  "$ENDPOINTS_API_URL/api/items/abc12345" | jq
+```
+
+### Get File URL
+```bash
+curl -s -H "Authorization: Bearer $ENDPOINTS_API_KEY" \
+  "$ENDPOINTS_API_URL/api/files/userid/category/slug/filename.pdf?format=json" | jq
+```
+
+### Check Usage Stats
+```bash
+curl -s -H "Authorization: Bearer $ENDPOINTS_API_KEY" \
+  "$ENDPOINTS_API_URL/api/billing/stats" | jq
+```
+
+## Helper Script
+
+Use `scripts/endpoints.sh` for simplified commands:
+
+```bash
+# List all endpoints
+scripts/endpoints.sh overview
+
+# Inspect specific endpoint
+scripts/endpoints.sh inspect /job-tracker/january
+
+# Scan text
+scripts/endpoints.sh scan-text "Meeting with John about Q1 goals" "meeting tracker"
+
+# Scan file
+scripts/endpoints.sh scan-file /path/to/document.pdf "invoice tracker"
+
+# Delete endpoint
+scripts/endpoints.sh delete /category/slug
+
+# Delete individual item
+scripts/endpoints.sh delete-item abc12345
+
+# Check stats
+scripts/endpoints.sh stats
+```
+
+Run `scripts/endpoints.sh --help` for full usage details.
+
+## Workflow Guidance
+
+### When to Use Each Command
+
+1. **overview** - Start here to see all endpoints organized by category
+2. **inspect** - View specific endpoint data and all extracted metadata items
+3. **scan** - Add new documents or text; AI extracts structured data
+4. **create** - Programmatically create endpoint with pre-structured data
+5. **delete** - Remove endpoint and all associated files
+6. **delete-item** - Remove a single item from an endpoint by its ID
+
+### Response Structure
+
+Endpoints use the Living JSON pattern:
+- `metadata.oldMetadata` - Historical items (rotated from previous scans)
+- `metadata.newMetadata` - Recent items (from latest scan)
+- Items are keyed by unique 8-character IDs (e.g., `abc12345`)
+
+### Error Handling
+
+| Status | Meaning |
+|--------|---------|
+| 401 | Invalid or missing API key |
+| 404 | Endpoint or item not found |
+| 409 | Endpoint already exists (use scan to add items) |
+| 429 | Rate/usage limit exceeded |
+
+## See Also
+
+- [API Reference](references/api-reference.md) - Complete endpoint documentation

--- a/skills/endpoints/SKILL.md
+++ b/skills/endpoints/SKILL.md
@@ -43,6 +43,29 @@ curl -s -X POST -H "Authorization: Bearer $ENDPOINTS_API_KEY" \
   "$ENDPOINTS_API_URL/api/scan" | jq
 ```
 
+### Prompt Routing
+
+The `prompt` parameter controls which endpoint items are added to:
+
+| Prompt Format | Behavior | Example |
+|---------------|----------|---------|
+| `category name` | Creates new endpoint with AI-generated slug | `job tracker` → `/job-tracker/january-2026` |
+| `category - slug` | Adds to existing endpoint | `job-tracker - usds` → `/job-tracker/usds` |
+
+**Examples:**
+```bash
+# Create new endpoint (AI determines slug based on content)
+-F "prompt=job tracker"
+
+# Add to existing endpoint /job-tracker/usds
+-F "prompt=job-tracker - usds"
+
+# Add to existing endpoint /invoices/acme-corp
+-F "prompt=invoices - acme-corp"
+```
+
+Use `category - slug` format when adding multiple documents to the same endpoint.
+
 ### Create Empty Endpoint
 ```bash
 curl -s -X POST -H "Authorization: Bearer $ENDPOINTS_API_KEY" \

--- a/skills/endpoints/references/api-reference.md
+++ b/skills/endpoints/references/api-reference.md
@@ -1,0 +1,234 @@
+# Endpoints API Reference
+
+Complete API documentation for the Endpoints document management platform.
+
+## Base URL
+
+```
+Production: https://endpoints.work/api
+Development: http://localhost:3000/api
+```
+
+## Authentication
+
+All endpoints require Bearer token authentication:
+
+```
+Authorization: Bearer ep_your_api_key_here
+```
+
+Generate API keys from the dashboard at `/api-keys`.
+
+## Core Endpoints
+
+### GET /api/endpoints/tree
+
+List all endpoints organized by category.
+
+**Response:**
+```json
+{
+  "categories": [
+    {
+      "name": "job-tracker",
+      "endpoints": [
+        { "id": 1, "path": "/job-tracker/january", "slug": "january" },
+        { "id": 2, "path": "/job-tracker/february", "slug": "february" }
+      ]
+    }
+  ]
+}
+```
+
+### GET /api/endpoints/{category}/{slug}
+
+Get endpoint details with all metadata items.
+
+**Response:**
+```json
+{
+  "endpoint": {
+    "id": 1,
+    "path": "/job-tracker/january",
+    "category": "job-tracker",
+    "slug": "january"
+  },
+  "metadata": {
+    "oldMetadata": {
+      "abc12345": { "summary": "...", "entities": [...] }
+    },
+    "newMetadata": {
+      "def67890": { "summary": "...", "entities": [...] }
+    }
+  },
+  "totalItems": 2
+}
+```
+
+### POST /api/endpoints
+
+Create a new endpoint.
+
+**Request:**
+```json
+{
+  "path": "/category/slug",
+  "items": []
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "endpoint": { "id": 1, "path": "/category/slug", ... }
+}
+```
+
+### DELETE /api/endpoints/{category}/{slug}
+
+Delete an endpoint and all associated files.
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Endpoint deleted"
+}
+```
+
+## Scanning
+
+### POST /api/scan
+
+Scan files or text with AI extraction.
+
+**Request:** `multipart/form-data`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `files` | File[] | Files to scan (PDF, images, docs) |
+| `texts` | String[] | Text content to scan |
+| `prompt` | String | Category hint (e.g., "job tracker") |
+
+**Response:**
+```json
+{
+  "endpoint": {
+    "path": "/job-tracker/january-2026",
+    "category": "job-tracker",
+    "slug": "january-2026"
+  },
+  "entriesAdded": 3,
+  "metadata": {
+    "newMetadata": {
+      "abc12345": {
+        "summary": "Software Engineer position at Acme Corp",
+        "entities": [
+          { "name": "Acme Corp", "type": "company" },
+          { "name": "Software Engineer", "type": "role" }
+        ],
+        "filePath": "https://...",
+        "fileType": "application/pdf"
+      }
+    }
+  }
+}
+```
+
+## Items
+
+### DELETE /api/items/{itemId}
+
+Delete a single item from an endpoint by its 8-character ID.
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Item deleted"
+}
+```
+
+## Files
+
+### GET /api/files/{key}
+
+Get a presigned URL for a file.
+
+**Query Parameters:**
+- `format=json` - Return JSON with URL (default returns redirect)
+- `expiresIn=3600` - URL expiration in seconds (default: 3600)
+
+**Response:**
+```json
+{
+  "url": "https://s3.amazonaws.com/...",
+  "expiresIn": 3600
+}
+```
+
+## Billing
+
+### GET /api/billing/stats
+
+Get usage statistics for current billing period.
+
+**Response:**
+```json
+{
+  "tier": "pro_managed",
+  "parsesUsed": 45,
+  "parsesLimit": 300,
+  "storageUsed": 1073741824,
+  "storageLimit": 107374182400,
+  "billingPeriodStart": "2026-01-01T00:00:00Z",
+  "billingPeriodEnd": "2026-02-01T00:00:00Z"
+}
+```
+
+## Error Responses
+
+| Status | Response |
+|--------|----------|
+| 401 | `{ "error": "Unauthorized" }` |
+| 404 | `{ "error": "Endpoint not found" }` |
+| 409 | `{ "error": "Endpoint already exists" }` |
+| 429 | `{ "error": "Monthly parse limit exceeded" }` |
+| 500 | `{ "error": "Internal server error" }` |
+
+## Living JSON Structure
+
+Endpoints use the Living JSON pattern for tracking document history:
+
+```
+metadata: {
+  oldMetadata: { ... }  // Historical items (rotated from previous scans)
+  newMetadata: { ... }  // Recent items (from latest scan)
+}
+```
+
+Each item has:
+- **8-character ID** - Unique identifier (e.g., `abc12345`)
+- **summary** - AI-generated description
+- **entities** - Extracted entities (people, companies, dates, etc.)
+- **filePath** - S3 URL if file was uploaded
+- **fileType** - MIME type
+- **originalText** - Source text (if text scan)
+
+## Subscription Tiers
+
+### BYOK Tiers (Bring Your Own Key)
+| Tier | Parses | Storage | Price |
+|------|--------|---------|-------|
+| Starter BYOK | Unlimited | 25GB | $5/mo |
+| Pro BYOK | Unlimited | 100GB | $9/mo |
+| Business BYOK | Unlimited | 500GB | $35/mo |
+
+### Managed Tiers
+| Tier | Parses | Storage | Price |
+|------|--------|---------|-------|
+| Free | 25/mo | 10GB | $0 |
+| Starter | 100/mo | 25GB | $19/mo |
+| Pro | 300/mo | 100GB | $69/mo |
+| Business | 1000/mo | 500GB | $249/mo |

--- a/skills/endpoints/references/api-reference.md
+++ b/skills/endpoints/references/api-reference.md
@@ -109,7 +109,14 @@ Scan files or text with AI extraction.
 |-------|------|-------------|
 | `files` | File[] | Files to scan (PDF, images, docs) |
 | `texts` | String[] | Text content to scan |
-| `prompt` | String | Category hint (e.g., "job tracker") |
+| `prompt` | String | Controls endpoint routing (see below) |
+
+**Prompt Routing:**
+
+The `prompt` parameter determines which endpoint items are added to:
+
+- `"category name"` - Creates new endpoint with AI-generated slug (e.g., `"job tracker"` → `/job-tracker/january-2026`)
+- `"category - slug"` - Adds to existing endpoint (e.g., `"job-tracker - usds"` → `/job-tracker/usds`)
 
 **Response:**
 ```json

--- a/skills/endpoints/scripts/endpoints.sh
+++ b/skills/endpoints/scripts/endpoints.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# Endpoints API helper script
+# Requires: ENDPOINTS_API_URL, ENDPOINTS_API_KEY
+
+set -e
+
+# Validate environment
+if [[ -z "$ENDPOINTS_API_URL" ]]; then
+  echo "Error: ENDPOINTS_API_URL not set" >&2
+  echo "Set it with: export ENDPOINTS_API_URL=https://endpoints.work" >&2
+  exit 1
+fi
+
+if [[ -z "$ENDPOINTS_API_KEY" ]]; then
+  echo "Error: ENDPOINTS_API_KEY not set" >&2
+  echo "Generate an API key from your dashboard and set it with:" >&2
+  echo "  export ENDPOINTS_API_KEY=ep_your_key_here" >&2
+  exit 1
+fi
+
+AUTH="Authorization: Bearer $ENDPOINTS_API_KEY"
+
+usage() {
+  cat <<EOF
+Endpoints API Helper
+
+Usage: endpoints.sh <command> [arguments]
+
+Commands:
+  overview                      List all endpoints by category
+  inspect <path>                Get endpoint details (e.g., /category/slug)
+  scan-text <text> <prompt>     Scan text content with prompt
+  scan-file <file> <prompt>     Scan file with prompt
+  create <path>                 Create new empty endpoint
+  delete <path>                 Delete endpoint and all its data
+  delete-item <itemId>          Delete individual item by ID
+  file-url <key>                Get presigned URL for file
+  stats                         Show usage statistics
+
+Environment:
+  ENDPOINTS_API_URL             Base API URL (required)
+  ENDPOINTS_API_KEY             API key with ep_ prefix (required)
+
+Examples:
+  endpoints.sh overview
+  endpoints.sh inspect /job-tracker/january
+  endpoints.sh scan-text "Meeting notes here" "meeting tracker"
+  endpoints.sh scan-file ./invoice.pdf "invoice tracker"
+  endpoints.sh create /receipts/2026
+  endpoints.sh delete /category/slug
+  endpoints.sh delete-item abc12345
+  endpoints.sh stats
+EOF
+}
+
+case "${1:-}" in
+  overview)
+    curl -s -H "$AUTH" "$ENDPOINTS_API_URL/api/endpoints/tree"
+    ;;
+  inspect)
+    [[ -z "$2" ]] && { echo "Error: path required (e.g., /category/slug)"; exit 1; }
+    path="${2#/}"  # Remove leading slash if present
+    curl -s -H "$AUTH" "$ENDPOINTS_API_URL/api/endpoints/$path"
+    ;;
+  scan-text)
+    [[ -z "$2" || -z "$3" ]] && { echo "Error: text and prompt required"; exit 1; }
+    curl -s -X POST -H "$AUTH" \
+      -F "texts=$2" \
+      -F "prompt=$3" \
+      "$ENDPOINTS_API_URL/api/scan"
+    ;;
+  scan-file)
+    [[ -z "$2" || -z "$3" ]] && { echo "Error: file and prompt required"; exit 1; }
+    [[ ! -f "$2" ]] && { echo "Error: file not found: $2"; exit 1; }
+    curl -s -X POST -H "$AUTH" \
+      -F "files=@$2" \
+      -F "prompt=$3" \
+      "$ENDPOINTS_API_URL/api/scan"
+    ;;
+  create)
+    [[ -z "$2" ]] && { echo "Error: path required (e.g., /category/slug)"; exit 1; }
+    curl -s -X POST -H "$AUTH" -H "Content-Type: application/json" \
+      -d "{\"path\": \"$2\", \"items\": []}" \
+      "$ENDPOINTS_API_URL/api/endpoints"
+    ;;
+  delete)
+    [[ -z "$2" ]] && { echo "Error: path required (e.g., /category/slug)"; exit 1; }
+    path="${2#/}"
+    curl -s -X DELETE -H "$AUTH" "$ENDPOINTS_API_URL/api/endpoints/$path"
+    ;;
+  delete-item)
+    [[ -z "$2" ]] && { echo "Error: itemId required (e.g., abc12345)"; exit 1; }
+    curl -s -X DELETE -H "$AUTH" "$ENDPOINTS_API_URL/api/items/$2"
+    ;;
+  file-url)
+    [[ -z "$2" ]] && { echo "Error: file key required"; exit 1; }
+    curl -s -H "$AUTH" "$ENDPOINTS_API_URL/api/files/$2?format=json"
+    ;;
+  stats)
+    curl -s -H "$AUTH" "$ENDPOINTS_API_URL/api/billing/stats"
+    ;;
+  --help|-h|"")
+    usage
+    ;;
+  *)
+    echo "Unknown command: $1" >&2
+    usage
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

Adds a skill for interacting with the [Endpoints](https://endpoints.work) document management platform - a SaaS tool that uses AI to extract and organize structured data from documents.

## Features

This skill enables Claude to:
- **List endpoints** - View all endpoints organized by category
- **Inspect** - Get detailed metadata for specific endpoints
- **Scan** - Upload files/text for AI extraction
- **Create/Delete** - Manage endpoints programmatically
- **Delete items** - Remove individual metadata items by ID
- **Stats** - Check usage and billing statistics

## Files Included

- `SKILL.md` - Main skill instructions with quick reference commands
- `scripts/endpoints.sh` - Helper bash script for simplified API calls
- `references/api-reference.md` - Comprehensive API documentation

## Configuration

Requires two environment variables:
- `ENDPOINTS_API_URL` - Base API URL (e.g., `https://endpoints.work`)
- `ENDPOINTS_API_KEY` - API key with `ep_` prefix

## Example Usage

```bash
# List all endpoints
/endpoints overview

# Scan a document
/endpoints scan-file ./resume.pdf "job tracker"

# Inspect endpoint
/endpoints inspect /job-tracker/january
```

## Test plan

- [ ] Verify SKILL.md parses correctly (frontmatter + markdown)
- [ ] Test helper script with valid/invalid environment variables
- [ ] Confirm skill appears in Claude Code skill list
- [ ] Test each command (overview, inspect, scan-text, scan-file, delete, stats)

---

Generated with [Claude Code](https://claude.ai/code)