### PR TITLE
docs: Add AdaL to Partner Skills section

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,4 @@ The markdown content below contains the instructions, examples, and guidelines t
 Skills are a great way to teach Claude how to get better at using specific pieces of software. As we see awesome example skills from partners, we may highlight some of them here:
 
 - **Notion** - [Notion Skills for Claude](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0)
+- **AdaL** - [AdaL CLI](https://sylph.ai/) - A self-evolving AI coding agent compatible with Claude Code skills and plugins. [Docs](https://docs.sylph.ai/) | [GitHub](https://github.com/SylphAI-Inc/adal-cli)


### PR DESCRIPTION
## Summary

Add [AdaL](https://sylph.ai/) to the Partner Skills section.

## About AdaL

AdaL is a self-evolving AI coding agent compatible with Claude Code skills and plugins.

**Links:**
- Website: https://sylph.ai/
- Docs: https://docs.sylph.ai/
- GitHub: https://github.com/SylphAI-Inc/adal-cli
- Discord: https://discord.com/invite/ezzszrRZvT

🌸 Generated with [AdaL](https://github.com/SylphAI-Inc/adal-cli)