### PR TITLE
add api testing automation skill

### DIFF
--- a/skills/api-testing/SKILL.md
+++ b/skills/api-testing/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: api-testing
+description: Generate integration tests for REST and GraphQL APIs from API docs (OpenAPI/Swagger/Postman),
+  covering HTTP methods, status codes, auth, and parameter validation.
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob
+---
+
+# API Testing Skill
+
+## Purpose
+
+This skill generates integration tests for APIs, covering all HTTP methods, success/error status codes, auth and auth failure, request/response validation, and error handling.
+
+## Use Cases
+
+- **Generate tests from API docs**: Generate tests for REST APIs; supports OpenAPI 2.0/3.x (Swagger), Postman Collection — use scripts in this directory's `scripts/` to obtain endpoint inventory first
+- Generate tests for GraphQL queries and mutations
+- Validate request/response contracts
+- Validate auth, auth failure, and status codes
+
+## Test Coverage
+
+Each endpoint should cover:
+
+- ✅ **Success scenarios** (200, 201, 204)
+- ✅ **Parameter/validation errors** (400, 422)
+- ✅ **Unauthenticated** (401)
+- ✅ **Forbidden** (403)
+- ✅ **Not Found** (404)
+- ✅ **Conflict** (409)
+- ✅ **Server error** (500)
+- ✅ **Request body/query parameter validation**
+- ✅ **Response structure validation**
+
+---
+
+## Real-World Scenarios and Test Data
+
+To let tests **catch API behavior issues** (e.g. returning 200 when 400 is expected), design for real scenarios and use **strict assertions**.
+
+### Test Data Setup
+
+- **Endpoints that depend on resources** (e.g. "get/update/delete a pipeline"): In fixture or class/session-level setup, **call the create endpoint first** to obtain real `id` (e.g. `pipeline_id`, `file_id`), then use that ID in subsequent tests.
+- **Example**: Create pipeline via `POST /studio/pipelines` → use returned `pipeline_id` to test `GET /studio/pipelines/{pipeline_id}`, `POST .../run`, `DELETE .../files/{file_id}`, etc.
+- Optional: Delete created resources in teardown, or use a dedicated test account/project to avoid polluting the environment.
+
+### Assertion Strictness
+
+- **Assert exactly one expected status code per scenario** (e.g. success → `assert response.status_code == 200`, invalid params → `assert response.status_code == 400`, not found → `assert response.status_code == 404`).
+- **Do not write loose assertions like "accept 200 or 400"**: they hide bugs such as "should return 400 but returned 200", making it hard for QA to find issues.
+- Response structure: besides status code in success scenarios, validate fields defined in the docs (e.g. `code`, `data`, `meta`, `pipeline_id`).
+
+### Two Test Modes
+
+| Mode | When to use | Assertion | Purpose |
+|------|-------------|-----------|---------|
+| **Contract/real scenario** | Controllable data or Mock | One expected status code + response structure per scenario | Catch API behavior bugs; suitable for QA |
+| **Smoke/connectivity** | No data, direct external API | May accept multiple status codes (e.g. 200/404/401) | Quick reachability check; no strict validation |
+
+Prefer generating **contract/real scenario** tests; if data cannot be set up yet, mark as smoke tests (e.g. `@pytest.mark.smoke`) and document accordingly.
+
+### Mock Files (Multiple Formats)
+
+For **upload and file-related endpoints** that need file bodies, use **mock files** to provide in-memory content in multiple formats — **no mock server**, no real disk files — suitable for CI and environments without file dependencies.
+
+- **Use**: Upload endpoints (e.g. `POST .../upload`), endpoints that depend on `file_id` (upload mock file first to get `file_id`, then test).
+- **Design**:
+  - Provide a shared module in the test project (e.g. `tests/mock_files.py`) with minimal valid or placeholder bytes per format (e.g. minimal PDF, 1×1 PNG, JPEG header, txt/csv/json).
+  - Provide `get_mock_file_bytes(format)` returning `bytes`, and `get_mock_upload_tuple(format [, filename])` returning `(filename, BytesIO(bytes), content_type)` for use with `requests`'s `files=`.
+  - Supported formats example: `pdf`, `png`, `jpg`/`jpeg`, `gif`, `txt`, `csv`, `json`, `xml`; extend per API docs.
+- **In conftest**: Provide `mock_upload_file(format)` factory or fixtures like `mock_pdf_file`, `mock_png_file` for test injection.
+- **Test strategy**: Prefer **mock files** for upload-success and delete-success tests; if the server only accepts real files (e.g. magic bytes validation), fall back to real project files (if any) or skip with a note.
+
+Example (upload mock PNG):
+
+```python
+from tests.mock_files import get_mock_upload_tuple
+
+file_tuple = get_mock_upload_tuple("png")  # ("mock.png", BytesIO(...), "image/png")
+payload = {"files": file_tuple, "pipeline_id": (None, pipeline_id)}
+resp = api_client("POST", f"/studio/pipelines/{pipeline_id}/upload", files=payload)
+```
+
+---
+
+## Supported API Doc Formats
+
+When APIs are defined by **API docs**, use these formats and the scripts in this skill's `scripts/` to get endpoint inventory:
+
+| Format | Description | Script |
+|--------|-------------|--------|
+| **OpenAPI 3.x** | OpenAPI 3.0/3.1 JSON or YAML | `scripts/parse_openapi.py <doc path>` |
+| **OpenAPI 2.0 (Swagger)** | Swagger 2.0 JSON or YAML | `scripts/parse_openapi.py <doc path>` |
+| **Postman Collection 2.x** | Postman-exported JSON | `scripts/parse_postman.py <doc path>` |
+
+- **OpenAPI/Swagger**: From project root run `python .cursor/skills/api-testing/scripts/parse_openapi.py path/to/openapi.json` (or `.yaml`). Optional: `--output inventory.txt`, `--base-url https://api.example.com`. YAML requires `pyyaml`.
+- **Postman**: Run `python .cursor/skills/api-testing/scripts/parse_postman.py path/to/collection.json`. Optional: `--output inventory.txt`, `--base-url https://api.example.com`.
+
+Output is a "method path - summary" text inventory, i.e. the **deliverable** for workflow step 1. See this directory's `scripts/README.md` for script usage.
+
+---
+
+## Workflow
+
+### 1. Get Endpoint Inventory from API Docs
+
+Use scripts in this directory's `scripts/` to extract endpoints from OpenAPI / Swagger / Postman docs:
+
+```bash
+# OpenAPI 3.x or Swagger 2.0 (JSON/YAML)
+python .cursor/skills/api-testing/scripts/parse_openapi.py path/to/openapi.json --output inventory.txt
+
+# Postman Collection 2.x
+python .cursor/skills/api-testing/scripts/parse_postman.py path/to/collection.json --output inventory.txt
+```
+
+From the generated inventory and doc content, organize per endpoint: path, method, parameters, request body, response, auth requirements. Base URL comes from `--base-url` or OpenAPI `servers` / Postman variables.
+
+**Endpoint inventory example:**
+
+```
+GET    /api/users              - User list (public)
+GET    /api/users/:id          - User detail (public)
+POST   /api/users              - Create user (admin only)
+PUT    /api/users/:id          - Update user (login required, self or admin)
+DELETE /api/users/:id          - Delete user (login required, self or admin)
+```
+
+**Deliverable:** API endpoint inventory (script output).
+
+**Test environment:** If the target is an **external HTTP service** (described by OpenAPI/Postman, called via HTTP), tests typically use `requests` with a configurable base_url (and optional auth headers), not an in-process TestClient and database. Provide `api_client`, `base_url` etc. in `conftest.py`; do not provide DB fixtures when there is no local app/DB. For **real scenario** tests, create data via create endpoints in fixtures (e.g. create pipeline), then write tests with real IDs and strict status assertions (see "Real-World Scenarios and Test Data" above).
+
+---
+
+### 2. Generate REST API Tests
+
+- **Structure**: One class per endpoint (e.g. `TestGetUsers`, `TestCreateUser`), with `test_xxx` per scenario; use Arrange-Act-Assert; include both positive (success codes) and negative (400/401/403/404/409) cases.
+- **Assertions**: **Assert exactly one expected status code per scenario** (e.g. success 200, invalid params 400, not found 404), aligned with doc `responses`; do not write loose "accept 200 or 400" assertions, or QA cannot reliably find API bugs.
+- **Data**: For resource-dependent endpoints, create resources in fixture/setup first (see "Real-World Scenarios and Test Data"), then write tests with real IDs.
+- **Example code**: See `examples/rest_api_test_example.py` in this directory.
+- **Status code examples**: See `examples/http_status_codes_example.py`.
+
+**Deliverable:** Full REST API test file (e.g. `tests/test_xxx_api.py`).
+
+---
+
+### 3. Generate GraphQL API Tests
+
+- **Structure**: Separate tests for queries and mutations; assert `response.status_code == 200` and `response.json()["data"]` structure.
+- **Example code**: See `examples/graphql_test_example.py` in this directory.
+
+**Deliverable:** GraphQL API test file.
+
+---
+
+## HTTP Status Codes
+
+Status codes to cover are illustrated in `examples/http_status_codes_example.py`, including:
+
+- 200 (GET/PUT/PATCH success), 201 (POST create), 204 (DELETE success)
+- 400 (parameter/validation error), 401 (unauthorized), 403 (forbidden), 404 (not found), 409 (conflict), 422 (unprocessable), 500 (server error)
+
+---
+
+## Best Practices
+
+1. Cover all endpoints and HTTP methods
+2. Test both success and error status codes; **assert exactly one expected status code per scenario** (no "or" over multiple codes)
+3. For resource-dependent endpoints: **create data first, then test** (create in fixture/setup, then use real ID)
+4. For upload/file endpoints: **prefer mock files** (in-memory multi-format content, no real files, no mock server); fall back or skip if server only accepts real files
+5. Validate request body: required fields, format, constraints
+6. Validate response body: structure, fields, types (match API doc schemas/examples)
+7. Test auth: with/without token, expired token
+8. Test authorization: different roles and permissions
+9. Test boundaries: empty list, null, max limits
+10. When DB exists, validate persistence; when testing external APIs with created data, validate behavior accordingly
+11. Clear test names; one scenario per test
+12. Organize by endpoint; tests are independent
+
+---
+
+## Quality Checklist
+
+Before finishing tests, confirm:
+
+- [ ] All endpoints covered (inventory from API docs)
+- [ ] All HTTP methods covered
+- [ ] Success scenarios (200, 201, 204) covered, **with exactly one expected status code per scenario** (no loose 200 or 400)
+- [ ] Error scenarios (400, 401, 403, 404, 409) covered, **with exactly one expected status code per scenario**
+- [ ] Resource-dependent endpoints **create data first** in fixture/setup, then test with real ID (real scenario)
+- [ ] Request validation tested
+- [ ] Response structure validated (matches docs)
+- [ ] Auth tested (if required)
+- [ ] Authorization tested (if required)
+- [ ] Edge cases covered
+- [ ] Persistence validated when DB exists; when testing external API with created data, assert real scenario
+- [ ] Tests run independently and all pass
+
+---
+
+## Integration with Test Process
+
+**Input:** API doc files (OpenAPI/Swagger/Postman).  
+**Process:** Analyze (optionally with this directory's `scripts/`) → generate tests → run and fix.  
+**Output:** Complete API test suite.  
+**Next:** Integrate with CI, docs, or deployment.
+
+---
+
+## Remember
+
+- Cover all endpoints and HTTP methods
+- Test both success and error scenarios; **assert exactly one expected status code per scenario** (so QA can catch API bugs)
+- Resource-dependent endpoints: **create data first, then test**, use real IDs, no loose "accept multiple status codes" assertions
+- Upload/file endpoints: **prefer mock files** (in-memory multi-format), no real files, no mock server
+- Validate request and response structure (match API docs)
+- Test auth and authorization
+- Validate persistence when DB exists
+- One scenario per test
+- Tests as documentation; keep them readable

--- a/skills/api-testing/examples/README.md
+++ b/skills/api-testing/examples/README.md
@@ -1,0 +1,11 @@
+# Examples
+
+This directory contains test code examples for the **api-testing** skill, for reference when generating test cases.
+
+| File | Description |
+|------|-------------|
+| `rest_api_test_example.py` | REST API test structure: one class per endpoint, positive/negative cases, Arrange-Act-Assert |
+| `graphql_test_example.py` | GraphQL query/mutation test examples |
+| `http_status_codes_example.py` | Assertion examples for HTTP status codes (200/201/204/400/401/403/404/409/422/500) |
+
+Usage: Based on endpoint inventory and business logic, use the above structure to write or generate `tests/test_xxx_api.py`, and provide `client`, `db`, `admin_headers` etc. via project `conftest.py`.

--- a/skills/api-testing/examples/graphql_test_example.py
+++ b/skills/api-testing/examples/graphql_test_example.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+"""
+GraphQL API test example: queries and mutations, asserting status 200 and data structure.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+
+class TestGraphQLQueries:
+    """GraphQL query example."""
+
+    def test_query_users_returns_list(self, client: TestClient, db: Session):
+        # create_test_users(db, count=3)
+        query = """
+        query {
+            users {
+                id
+                name
+                email
+            }
+        }
+        """
+        response = client.post("/graphql", json={"query": query})
+        assert response.status_code == 200
+        data = response.json().get("data", {})
+        assert "users" in data
+
+    def test_query_user_by_id_returns_user(self, client: TestClient, test_user):
+        query = """
+        query {{
+            user(id: {}) {{
+                id
+                name
+                email
+            }}
+        }}
+        """.format(test_user.id)
+        response = client.post("/graphql", json={"query": query})
+        assert response.status_code == 200
+        data = response.json().get("data", {}).get("user")
+        assert data is not None
+
+
+class TestGraphQLMutations:
+    """GraphQL mutation example."""
+
+    def test_create_user_mutation_creates_user(self, client: TestClient, db: Session, admin_headers: dict):
+        mutation = """
+        mutation {
+            createUser(input: {
+                name: "New User",
+                email: "newuser@example.com",
+                password: "SecurePass123"
+            }) {
+                user {
+                    id
+                    name
+                    email
+                }
+            }
+        }
+        """
+        response = client.post("/graphql", json={"query": mutation}, headers=admin_headers)
+        assert response.status_code == 200
+        data = response.json().get("data", {}).get("createUser", {}).get("user")
+        assert data is not None
+        assert data.get("email") == "newuser@example.com"

--- a/skills/api-testing/examples/http_status_codes_example.py
+++ b/skills/api-testing/examples/http_status_codes_example.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+"""
+HTTP status code test example: success and error codes to cover per endpoint.
+"""
+
+# 200 OK - GET/PUT/PATCH success
+def test_returns_200_on_success(client):
+    response = client.get("/api/resource")
+    assert response.status_code == 200
+
+# 201 Created - POST create success
+def test_returns_201_on_create(client):
+    response = client.post("/api/resource", json={})
+    assert response.status_code == 201
+
+# 204 No Content - DELETE success
+def test_returns_204_on_delete(client):
+    response = client.delete("/api/resource/1")
+    assert response.status_code == 204
+
+# 400 Bad Request - parameter/validation error
+def test_returns_400_on_invalid_input(client):
+    response = client.post("/api/resource", json={"invalid": True})
+    assert response.status_code == 400
+
+# 401 Unauthorized - unauthenticated
+def test_returns_401_without_auth(client):
+    response = client.get("/api/protected")
+    assert response.status_code == 401
+
+# 403 Forbidden - no permission
+def test_returns_403_without_permission(client, user_token):
+    response = client.delete("/api/admin/resource", headers=user_token)
+    assert response.status_code == 403
+
+# 404 Not Found - resource does not exist
+def test_returns_404_for_nonexistent(client):
+    response = client.get("/api/resource/99999")
+    assert response.status_code == 404
+
+# 409 Conflict - duplicate/conflict
+def test_returns_409_on_duplicate(client):
+    response = client.post("/api/resource", json={"duplicate": "key"})
+    assert response.status_code == 409
+
+# 422 Unprocessable Entity - semantic error
+def test_returns_422_on_semantic_error(client):
+    response = client.post("/api/resource", json={"bad_semantic": True})
+    assert response.status_code == 422
+
+# 500 Internal Server Error - typically triggered via mock
+def test_returns_500_on_server_error(client, mock_error):
+    response = client.get("/api/resource")
+    assert response.status_code == 500

--- a/skills/api-testing/examples/rest_api_test_example.py
+++ b/skills/api-testing/examples/rest_api_test_example.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+"""
+REST API integration test example (full version in SKILL history or expand as needed).
+
+Use with: FastAPI TestClient + local DB; or for external HTTP API use requests + base_url, with fixture providing api_client/base_url.
+One class per endpoint, one test_xxx per scenario; cover both positive (success codes) and negative (400/401/403/404/409).
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+# from src.models import User
+
+
+# ============================================================================
+# GET /api/users - List
+# ============================================================================
+
+class TestGetUsers:
+    """GET /api/users example: empty list, pagination, invalid params."""
+
+    def test_get_users_empty_returns_empty_list(self, client: TestClient):
+        response = client.get("/api/users")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_get_users_with_pagination(self, client: TestClient, db: Session):
+        # Arrange: create data then request
+        # response = client.get("/api/users?limit=5&offset=0")
+        # assert response.status_code == 200
+        # assert len(response.json()) == 5
+        pass
+
+    def test_get_users_invalid_limit_returns_400(self, client: TestClient):
+        response = client.get("/api/users?limit=-1")
+        assert response.status_code == 400
+
+
+# ============================================================================
+# GET /api/users/:id - Detail
+# ============================================================================
+
+class TestGetUserById:
+    """GET /api/users/:id: success, 404, invalid ID."""
+
+    def test_get_user_nonexistent_id_returns_404(self, client: TestClient):
+        response = client.get("/api/users/99999")
+        assert response.status_code == 404
+
+    def test_get_user_invalid_id_format_returns_400(self, client: TestClient):
+        response = client.get("/api/users/invalid-id")
+        assert response.status_code == 400
+
+
+# ============================================================================
+# POST /api/users - Create
+# ============================================================================
+
+class TestCreateUser:
+    """POST /api/users: 201, missing required 400, duplicate 409, no auth 401, non-admin 403."""
+
+    def test_create_user_missing_required_field_returns_400(self, client: TestClient, admin_headers: dict):
+        invalid_data = {"name": "User", "password": "password"}  # missing email
+        response = client.post("/api/users", json=invalid_data, headers=admin_headers)
+        assert response.status_code == 400
+
+    def test_create_user_without_auth_returns_401(self, client: TestClient):
+        response = client.post("/api/users", json={"name": "x", "email": "x@x.com", "password": "x"})
+        assert response.status_code == 401
+
+
+# ============================================================================
+# PUT /api/users/:id, PATCH, DELETE: same pattern - success codes + 404/403/401 negative cases
+# ============================================================================
+
+class TestDeleteUser:
+    """DELETE /api/users/:id: 204, 404, 401, 403."""
+
+    def test_delete_user_nonexistent_returns_404(self, client: TestClient, admin_headers: dict):
+        response = client.delete("/api/users/99999", headers=admin_headers)
+        assert response.status_code == 404

--- a/skills/api-testing/scripts/README.md
+++ b/skills/api-testing/scripts/README.md
@@ -1,0 +1,55 @@
+# Scripts
+
+This directory contains helper scripts for the **api-testing** skill. They extract endpoint inventory from API docs for use in the SKILL workflow step "Get endpoint inventory from API docs".
+
+## Dependencies
+
+- Python 3.7+
+- For YAML OpenAPI: `pip install pyyaml`
+
+## Paths
+
+Scripts live under the skill directory: `.cursor/skills/api-test-generator/scripts/`. When run from the **project root**, doc paths are relative to the project root.
+
+## Usage
+
+### OpenAPI / Swagger
+
+Supports **OpenAPI 2.0 (Swagger)** and **OpenAPI 3.x**, and `.json` / `.yaml` / `.yml`.
+
+```bash
+# Output to terminal
+python .cursor/skills/api-test-generator/scripts/parse_openapi.py path/to/openapi.json
+python .cursor/skills/api-test-generator/scripts/parse_openapi.py path/to/openapi.yaml
+
+# Output to file
+python .cursor/skills/api-test-generator/scripts/parse_openapi.py path/to/openapi.json --output inventory.txt
+python .cursor/skills/api-test-generator/scripts/parse_openapi.py path/to/openapi.json --base-url https://api.example.com
+```
+
+### Postman Collection
+
+Supports **Postman Collection 2.x** JSON export.
+
+```bash
+# Output to terminal
+python .cursor/skills/api-test-generator/scripts/parse_postman.py path/to/collection.json
+
+# Output to file
+python .cursor/skills/api-test-generator/scripts/parse_postman.py path/to/collection.json --output inventory.txt --base-url https://api.example.com
+```
+
+## Output Example
+
+```
+# API Name (version 1.0)
+# Base URL: https://api.example.com
+
+GET    /api/users              - Get user list
+GET    /api/users/{id}         - Get user detail
+POST   /api/users              - Create user
+PUT    /api/users/{id}         - Update user
+DELETE /api/users/{id}         - Delete user
+```
+
+Use this inventory as the **API endpoint inventory** input in the workflow, then generate positive/negative test cases per endpoint.

--- a/skills/api-testing/scripts/parse_openapi.py
+++ b/skills/api-testing/scripts/parse_openapi.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Extract endpoint inventory from OpenAPI 2.0 (Swagger) or OpenAPI 3.x docs for API test case design.
+
+Usage (when run from project root where this skill lives, path is relative to project root):
+  python .cursor/skills/api-test-generator/scripts/parse_openapi.py path/to/openapi.json
+  python .cursor/skills/api-test-generator/scripts/parse_openapi.py path/to/openapi.yaml --output inventory.txt
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def load_spec(path):
+    """Load OpenAPI/Swagger doc from disk: supports .json and .yaml/.yml, parsed by extension."""
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(path)
+    text = path.read_text(encoding="utf-8")
+    # YAML requires pyyaml
+    if path.suffix.lower() in (".yaml", ".yml"):
+        try:
+            import yaml
+            return yaml.safe_load(text)
+        except ImportError:
+            raise RuntimeError("YAML requires PyYAML: pip install pyyaml")
+    return json.loads(text)
+
+
+def is_openapi3(spec):
+    """Check if doc is OpenAPI 3.x (openapi field starts with 3)."""
+    return "openapi" in spec and str(spec.get("openapi", "")).startswith("3")
+
+
+def is_swagger2(spec):
+    """Check if doc is Swagger 2.0."""
+    return "swagger" in spec and spec.get("swagger") == "2.0"
+
+
+def get_paths(spec):
+    """Get paths object from doc (compatible with different field names)."""
+    return spec.get("paths") or spec.get("path") or {}
+
+
+def get_servers(spec):
+    """Only OpenAPI 3.x has servers; return first server url list."""
+    if is_openapi3(spec):
+        servers = spec.get("servers") or []
+        return [s.get("url", "") for s in servers if isinstance(s, dict)]
+    return []
+
+
+def collect_endpoints(spec):
+    """
+    Walk paths and collect each path's HTTP method operations.
+    Returns list of items with path, method, summary, parameters, requestBody, security, etc.
+    """
+    paths = get_paths(spec)
+    endpoints = []
+    for path, path_item in paths.items():
+        if not isinstance(path_item, dict):
+            continue
+        # Standard HTTP methods
+        for method in ("get", "post", "put", "patch", "delete", "head", "options"):
+            op = path_item.get(method)
+            if not isinstance(op, dict):
+                continue
+            operation_id = op.get("operationId") or op.get("operation_id") or ""
+            summary = op.get("summary") or op.get("description") or ""
+            tags = op.get("tags") or []
+            security = op.get("security") or path_item.get("security") or []
+            # Collect parameters (query/path/header etc.)
+            params = []
+            for p in op.get("parameters") or path_item.get("parameters") or []:
+                if isinstance(p, dict):
+                    params.append({
+                        "in": p.get("in"),
+                        "name": p.get("name"),
+                        "required": p.get("required", False),
+                    })
+            # OpenAPI 3 uses requestBody, Swagger 2 uses parameters.in=body
+            body = None
+            if "requestBody" in op:
+                body = "requestBody"
+            elif any(p.get("in") == "body" for p in (op.get("parameters") or [])):
+                body = "body"
+            endpoints.append({
+                "path": path,
+                "method": method.upper(),
+                "operationId": operation_id,
+                "summary": summary,
+                "tags": tags,
+                "parameters": params,
+                "requestBody": body,
+                "security": security,
+            })
+    return endpoints
+
+
+def format_inventory(spec, endpoints, base_url=""):
+    """Format endpoint list as "method path - summary" text inventory with API title, version, and Base URL."""
+    lines = []
+    title = spec.get("info", {}).get("title") or "API"
+    version = spec.get("info", {}).get("version") or ""
+    lines.append("# {} (version {})".format(title, version))
+    if base_url:
+        lines.append("# Base URL: {}".format(base_url))
+    lines.append("")
+    for e in endpoints:
+        line = "{:6} {}".format(e["method"], e["path"])
+        if e["summary"]:
+            line += "  - {}".format(e["summary"])
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def main():
+    """CLI entry: parse args, load doc, extract endpoints, output to stdout or file."""
+    parser = argparse.ArgumentParser(description="Extract endpoint inventory from OpenAPI/Swagger doc")
+    parser.add_argument("spec_path", help="Path to openapi.json or openapi.yaml")
+    parser.add_argument("--output", "-o", help="Write to file (default: stdout)")
+    parser.add_argument("--base-url", help="Base URL to write in inventory header")
+    args = parser.parse_args()
+
+    try:
+        spec = load_spec(args.spec_path)
+    except Exception as e:
+        print("Failed to load doc: {}".format(e), file=sys.stderr)
+        sys.exit(1)
+
+    if not is_openapi3(spec) and not is_swagger2(spec):
+        print("Unsupported doc format; need openapi 3.x or swagger 2.0", file=sys.stderr)
+        sys.exit(1)
+
+    # Prefer CLI --base-url, else first OpenAPI 3 servers URL
+    base_url = args.base_url or (get_servers(spec) and get_servers(spec)[0]) or ""
+    endpoints = collect_endpoints(spec)
+    out = format_inventory(spec, endpoints, base_url)
+
+    if args.output:
+        Path(args.output).write_text(out, encoding="utf-8")
+        print("Wrote {} endpoints to {}".format(len(endpoints), args.output), file=sys.stderr)
+    else:
+        print(out)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/api-testing/scripts/parse_postman.py
+++ b/skills/api-testing/scripts/parse_postman.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Extract endpoint inventory from Postman Collection 2.x JSON for API test case design.
+
+Usage (when run from project root where this skill lives, path is relative to project root):
+  python .cursor/skills/api-test-generator/scripts/parse_postman.py path/to/collection.json
+  python .cursor/skills/api-test-generator/scripts/parse_postman.py path/to/collection.json --output inventory.txt
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def load_collection(path):
+    """Load Postman Collection JSON file from disk."""
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(path)
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def is_v2(collection):
+    """Determine if collection is Postman Collection 2.x format via info.schema etc."""
+    info = collection.get("info") or {}
+    schema = (info.get("schema") or "").lower()
+    return "2." in schema or "v2" in schema or "postman" in str(collection.get("info", {}))
+
+
+def walk_requests(item, base_path="", results=None):
+    """
+    Recursively walk Collection item tree: if a node has request, treat as one request and add to results,
+    then recurse into child items; child nodes inherit current folder path.
+    """
+    if results is None:
+        results = []
+    name = item.get("name", "")
+    # Leaf node: items with request are actual requests
+    if "request" in item:
+        req = item["request"]
+        if isinstance(req, dict):
+            method = (req.get("method") or "GET").upper()
+            url = req.get("url")
+            # url may be string or object (path/raw etc.)
+            if isinstance(url, str):
+                path = url
+            elif isinstance(url, dict):
+                path = url.get("path") or ""
+                if isinstance(path, list):
+                    path = "/" + "/".join(str(p) for p in path)
+                raw = url.get("raw", "")
+                if raw and path and not path.startswith("/"):
+                    path = raw
+            else:
+                path = ""
+            results.append({
+                "method": method,
+                "path": path,
+                "name": name,
+                "folder": base_path,
+            })
+    # Recurse into children (folders or nested requests)
+    for child in item.get("item") or []:
+        if isinstance(child, dict):
+            folder = "{}/{}".format(base_path, name).strip("/") if name else base_path
+            walk_requests(child, folder, results)
+    return results
+
+
+def collect_endpoints(collection):
+    """Starting from Collection root item, recursively collect all requests into endpoint list."""
+    results = []
+    for item in collection.get("item") or []:
+        if isinstance(item, dict):
+            walk_requests(item, "", results)
+    return results
+
+
+def format_inventory(collection, endpoints, base_url=""):
+    """Format endpoint list as "method path - name" text inventory with Collection name and Base URL."""
+    info = collection.get("info") or {}
+    name = info.get("name") or "Postman Collection"
+    lines = ["# {}".format(name), ""]
+    if base_url:
+        lines.append("# Base URL: {}".format(base_url))
+        lines.append("")
+    for e in endpoints:
+        path = e["path"]
+        line = "{:6} {}".format(e["method"], path)
+        if e.get("name"):
+            line += "  - {}".format(e["name"])
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def main():
+    """CLI entry: parse args, load Collection, extract endpoints, output to stdout or file."""
+    parser = argparse.ArgumentParser(description="Extract endpoint inventory from Postman Collection")
+    parser.add_argument("collection_path", help="Path to Postman-exported collection JSON")
+    parser.add_argument("--output", "-o", help="Write to file (default: stdout)")
+    parser.add_argument("--base-url", help="Base URL to write in inventory header")
+    args = parser.parse_args()
+
+    try:
+        collection = load_collection(args.collection_path)
+    except Exception as e:
+        print("Failed to load Collection: {}".format(e), file=sys.stderr)
+        sys.exit(1)
+
+    if not is_v2(collection):
+        print("Warning: may not be v2 format; continuing.", file=sys.stderr)
+
+    base_url = args.base_url or ""
+    endpoints = collect_endpoints(collection)
+    out = format_inventory(collection, endpoints, base_url)
+
+    if args.output:
+        Path(args.output).write_text(out, encoding="utf-8")
+        print("Wrote {} endpoints to {}".format(len(endpoints), args.output), file=sys.stderr)
+    else:
+        print(out)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
# Add API Testing Skill

## Summary
Adds a new api-testing skill that guides generation of integration tests for REST and GraphQL APIs from API documentation (OpenAPI/Swagger/Postman). The skill covers HTTP methods, status codes, auth, and request/response validation, with a focus on real-world scenarios and strict assertions.

## Purpose
- Generate integration tests from API docs with consistent structure and coverage.
- Support REST (by endpoint, success/error status codes) and GraphQL (queries and mutations).
- Enforce one expected status code per scenario and response-structure checks so tests can catch API behavior bugs (e.g. returning 200 when 400 is expected).

## What's included
| Area      | Description                                                                 |
|-----------|-----------------------------------------------------------------------------|
| SKILL.md  | Skill definition: purpose, use cases, test coverage, real-world data setup, assertion strictness, contract vs smoke mode, mock files, supported doc formats, 3-step workflow, best practices, quality checklist. |
| scripts/  | Helper scripts to build endpoint inventory from API docs: parse_openapi.py (OpenAPI 2.0/3.x JSON or YAML), parse_postman.py (Postman Collection 2.x). Optional --output and --base-url. scripts/README.md documents usage and paths. |
| examples/ | Reference test examples: rest_api_test_example.py (REST by endpoint with Arrange–Act–Assert), graphql_test_example.py (query/mutation), http_status_codes_example.py (200/201/204/400/401/403/404/409/422/500). examples/README.md describes each file. |

## Workflow (in SKILL)
1. Get endpoint inventory — Run scripts on OpenAPI/Swagger or Postman docs → text inventory (method, path, summary).
2. Generate REST API tests — One class per endpoint, positive + negative cases, strict status and response assertions; use fixtures to create data where needed.
3. Generate GraphQL API tests — Tests for queries and mutations with status 200 and data structure checks.

## Highlights
- Supported doc formats: OpenAPI 3.x, OpenAPI 2.0 (Swagger), Postman Collection 2.x.
- Test modes: Contract/real-scenario (strict, one status per scenario) and smoke/connectivity (looser, for reachability).
- Mock files: Guidance for in-memory mock files (e.g. tests/mock_files.py, get_mock_upload_tuple) for upload/file endpoints without a mock server or real disk files.
- Data setup: Create resources via create endpoints in fixtures/setup, then use real IDs in tests.

## File structure

```
skills/api-testing/
├── SKILL.md
├── scripts/
│   ├── README.md
│   ├── parse_openapi.py
│   └── parse_postman.py
└── examples/
    ├── README.md
    ├── rest_api_test_example.py
    ├── graphql_test_example.py
    └── http_status_codes_example.py
```

## Notes
- All descriptions, comments, and user-facing text in the skill are in English.
- Scripts assume Python 3.7+; YAML OpenAPI support requires `pip install pyyaml`.
- Paths in script README refer to `.claude/skills/api-test-generator/scripts/`; when the skill is installed as api-testing, adjust paths to the actual skill location (e.g. api-testing/scripts/).