### PR TITLE
docs: clarify SKILL.md filename is case-sensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ You can use Anthropic's pre-built skills, and upload custom skills, via the Clau
 
 Skills are simple to create - just a folder with a `SKILL.md` file containing YAML frontmatter and instructions. You can use the **template-skill** in this repository as a starting point:
 
+> **Important**: The skill definition file must be named exactly `SKILL.md` (uppercase). Using `skill.md` (lowercase) or any other capitalization will cause the skill to silently fail to load. This is case-sensitive on all platforms, including macOS and Windows which have case-insensitive filesystems by default.
+
 ```markdown
 ---
 name: my-skill-name
@@ -86,6 +88,17 @@ The frontmatter requires only two fields:
 - `description` - A complete description of what the skill does and when to use it
 
 The markdown content below contains the instructions, examples, and guidelines that Claude will follow. For more details, see [How to create custom skills](https://support.claude.com/en/articles/12512198-creating-custom-skills).
+
+## Troubleshooting
+
+### Skill Not Loading
+
+If your skill doesn't appear or load:
+
+1. **Verify the filename is exactly `SKILL.md`** (uppercase) - this is case-sensitive and the most common cause of skills not loading
+2. Check that your YAML frontmatter is valid (proper indentation, correct syntax)
+3. Ensure the skill directory is in a recognized location (`.claude/skills/` in your home directory or project)
+4. Review debug logs with `claude --debug` to see how many skills were loaded
 
 # Partner Skills
 

--- a/template/SKILL.md
+++ b/template/SKILL.md
@@ -1,4 +1,6 @@
 ---
+# NOTE: This file must be named exactly SKILL.md (uppercase) for the skill to be recognized.
+# Using skill.md (lowercase) will cause the skill to silently fail to load.
 name: template-skill
 description: Replace with description of the skill and when Claude should use it.
 ---


### PR DESCRIPTION
## Summary

Fixes #314

The skill definition file must be named exactly `SKILL.md` (uppercase). Using `skill.md` (lowercase) causes skills to silently fail to load with no error message or warning. This is a significant usability issue that causes users to waste hours debugging.

### Changes

**README.md:**
- Added prominent warning box in "Creating a Basic Skill" section
- Added new "Troubleshooting" section with "Skill Not Loading" guidance
- First troubleshooting step explicitly mentions case-sensitivity

**template/SKILL.md:**
- Added YAML comment reminding users that the filename must be uppercase

### Why This Matters

As noted in the issue:
- Users spend hours debugging non-existent issues
- Claude Code itself doesn't understand this requirement and provides incorrect guidance
- Silent failure with no error message makes this extremely difficult to diagnose
- This affects users on all platforms, especially Linux/Unix where case-sensitivity is standard

## Test plan
- [x] Manually verified README.md formatting renders correctly
- [x] Verified template SKILL.md YAML comment doesn't break parsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)