### PR TITLE
Add YAML quoting requirement for skill descriptions to prevent parser errors

### DIFF
--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -311,6 +311,7 @@ Write the YAML frontmatter with `name` and `description`:
   - Include both what the Skill does and specific triggers/contexts for when to use it.
   - Include all "when to use" information here - Not in the body. The body is only loaded after triggering, so "When to Use This Skill" sections in the body are not helpful to Claude.
   - Example description for a `docx` skill: "Comprehensive document creation, editing, and analysis with support for tracked changes, comments, formatting preservation, and text extraction. Use when Claude needs to work with professional documents (.docx files) for: (1) Creating new documents, (2) Modifying or editing content, (3) Working with tracked changes, (4) Adding comments, or any other document tasks"
+  - **YAML quoting requirement**: Always wrap the `description` value in double quotes when it contains YAML special characters (colons `:`, commas `,`, brackets `[](){}`, quotes, or starts with `-`). Without quotes, YAML parsers will fail with "No valid skills found" errors. The example above correctly uses quotes because it contains colons and parentheses.
 
 Do not include any other fields in YAML frontmatter.
 


### PR DESCRIPTION
This pull request adds an important clarification to the documentation for writing YAML frontmatter in `SKILL.md`. The update emphasizes the requirement to wrap the `description` value in double quotes if it contains YAML special characters, preventing parsing errors.

Documentation improvements:

* Added a note that the `description` field in YAML frontmatter must always be wrapped in double quotes when it contains special characters (such as colons, commas, brackets, quotes, or starts with a dash) to avoid YAML parsing errors.


<img width="965" height="408" alt="image" src="https://github.com/user-attachments/assets/4c9badb1-42c0-4d77-822e-d0b241e19953" />
