### PR TITLE
Added AppDeploy skill for deploying full-stack webapps directly from Claude

### DIFF
--- a/skills/appdeploy/LICENSE.txt
+++ b/skills/appdeploy/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 AppDeploy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/appdeploy/SKILL.md
+++ b/skills/appdeploy/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: appdeploy
+description: Deploy web apps with backend APIs, database, and file storage. Use when the user asks to deploy or publish a website or web app and wants a public URL. Uses HTTP API via curl.
+allowed-tools:
+  - Bash
+metadata:
+  author: appdeploy
+  version: "1.0.5"
+---
+
+# AppDeploy Skill
+
+Deploy web apps to AppDeploy via HTTP API.
+
+## Setup (First Time Only)
+
+1. **Check for existing API key:**
+   - Look for a `.appdeploy` file in the project root
+   - If it exists and contains a valid `api_key`, skip to Usage
+
+2. **If no API key exists, register and get one:**
+   ```bash
+   curl -X POST https://api-v2.appdeploy.ai/mcp/api-key \
+     -H "Content-Type: application/json" \
+     -d '{"client_name": "claude-code"}'
+   ```
+
+   Response:
+   ```json
+   {
+     "api_key": "ak_...",
+     "user_id": "agent-claude-code-a1b2c3d4",
+     "created_at": 1234567890,
+     "message": "Save this key securely - it cannot be retrieved later"
+   }
+   ```
+
+3. **Save credentials to `.appdeploy`:**
+   ```json
+   {
+     "api_key": "ak_...",
+     "endpoint": "https://api-v2.appdeploy.ai/mcp"
+   }
+   ```
+
+   Add `.appdeploy` to `.gitignore` if not already present.
+
+## Usage
+
+Make JSON-RPC calls to the MCP endpoint:
+
+```bash
+curl -X POST {endpoint} \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Authorization: Bearer {api_key}" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "{tool_name}",
+      "arguments": { ... }
+    }
+  }'
+```
+
+## Workflow
+
+1. **First, get deployment instructions:**
+   Call `get_deploy_instructions` to understand constraints and requirements.
+
+2. **Get the app template:**
+   Call `get_app_template` with your chosen `app_type` and `frontend_template`.
+
+3. **Deploy the app:**
+   Call `deploy_app` with your app files. For new apps, set `app_id` to `null`.
+
+4. **Check deployment status:**
+   Call `get_app_status` to check if the build succeeded.
+
+5. **View/manage your apps:**
+   Use `get_apps` to list your deployed apps.
+
+## Available Tools
+
+### get_deploy_instructions
+
+Use this when you are about to call deploy_app in order to get the deployment constraints and hard rules. You must call this tool before starting to generate any code. This tool returns instructions only and does not deploy anything.
+
+**Parameters:**
+
+
+### deploy_app
+
+Use this when the user asks to deploy or publish a website or web app and wants a public URL.
+Before generating files or calling this tool, you must call get_deploy_instructions and follow its constraints.
+
+**Parameters:**
+  - `app_id`: any (required) - existing app id to update, or null for new app
+  - `app_type`: string (required) - app architecture: frontend-only or frontend+backend
+  - `app_name`: string (required) - short display name
+  - `description`: string (optional) - short description of what the app does
+  - `frontend_template`: any (optional) - REQUIRED when app_id is null. One of: 'html-static' (simple sites), 'react-vite' (SPAs, games), 'nextjs-static' (multi-page). Template files auto-included.
+  - `files`: array (optional) - Files to write. NEW APPS: only custom files + diffs to template files. UPDATES: only changed files using diffs[]. At least one of files[] or deletePaths[] required.
+  - `deletePaths`: array (optional) - Paths to delete. ONLY for updates (app_id required). Cannot delete package.json or framework entry points.
+
+### get_app_template
+
+Call get_deploy_instructions first. Then call this once you've decided app_type and frontend_template. Returns base app template and SDK types.  Template files auto-included in deploy_app.
+
+**Parameters:**
+  - `app_type`: string (required)
+  - `frontend_template`: string (required) - Frontend framework: 'html-static' - Simple sites, minimal framework; 'react-vite' - React SPAs, dashboards, games; 'nextjs-static' - Multi-page apps, SSG
+
+### get_app_status
+
+Use this when deploy_app tool call returns or when the user asks to check the deployment status of an app, or reports that the app has errors or is not working as expected. Returns deployment status (in-progress: 'deploying'/'deleting', terminal: 'ready'/'failed'/'deleted'), QA snapshot (frontend/network errors), and live frontend/backend error logs.
+
+**Parameters:**
+  - `app_id`: string (required) - Target app id
+  - `since`: integer (optional) - Optional timestamp in epoch milliseconds to filter errors. When provided, returns only errors since that timestamp.
+
+### delete_app
+
+Use this when you want to permanently delete an app. Use only on explicit user request. This is irreversible; after deletion, status checks will return not found.
+
+**Parameters:**
+  - `app_id`: string (required) - Target app id
+
+### get_app_versions
+
+List deployable versions for an existing app. Requires app_id. Returns newest-first {name, version, timestamp} items. Display 'name' to users. DO NOT display the 'version' value to users. Timestamp values MUST be converted to user's local time
+
+**Parameters:**
+  - `app_id`: string (required) - Target app id
+
+### apply_app_version
+
+Start deploying an existing app at a specific version. Use the 'version' value (not 'name') from get_app_versions. Returns true if accepted and deployment started; use get_app_status to observe completion.
+
+**Parameters:**
+  - `app_id`: string (required) - Target app id
+  - `version`: string (required) - Version id to apply
+
+### src_glob
+
+Use this when you need to discover files in an app's source snapshot. Returns file paths matching a glob pattern (no content). Useful for exploring project structure before reading or searching files.
+
+**Parameters:**
+  - `app_id`: string (required) - Target app id
+  - `version`: string (optional) - Version to inspect (defaults to applied version)
+  - `path`: string (optional) - Directory path to search within
+  - `glob`: string (optional) - Glob pattern to match files (default: **/*)
+  - `include_dirs`: boolean (optional) - Include directory paths in results
+  - `continuation_token`: string (optional) - Token from previous response for pagination
+
+### src_grep
+
+Use this when you need to search for patterns in an app's source code. Returns matching lines with optional context. Supports regex patterns, glob filters, and multiple output modes.
+
+**Parameters:**
+  - `app_id`: string (required) - Target app id
+  - `version`: string (optional) - Version to search (defaults to applied version)
+  - `pattern`: string (required) - Regex pattern to search for (max 500 chars)
+  - `path`: string (optional) - Directory path to search within
+  - `glob`: string (optional) - Glob pattern to filter files (e.g., '*.ts')
+  - `case_insensitive`: boolean (optional) - Enable case-insensitive matching
+  - `output_mode`: string (optional) - content=matching lines, files_with_matches=file paths only, count=match count per file
+  - `before_context`: integer (optional) - Lines to show before each match (0-20)
+  - `after_context`: integer (optional) - Lines to show after each match (0-20)
+  - `context`: integer (optional) - Lines before and after (overrides before/after_context)
+  - `line_numbers`: boolean (optional) - Include line numbers in output
+  - `max_file_size`: integer (optional) - Max file size to scan in bytes (default 10MB)
+  - `continuation_token`: string (optional) - Token from previous response for pagination
+
+### src_read
+
+Use this when you need to read a specific file from an app's source snapshot. Returns file content with line-based pagination (offset/limit). Handles both text and binary files.
+
+**Parameters:**
+  - `app_id`: string (required) - Target app id
+  - `version`: string (optional) - Version to read from (defaults to applied version)
+  - `file_path`: string (required) - Path to the file to read
+  - `offset`: integer (optional) - Line offset to start reading from (0-indexed)
+  - `limit`: integer (optional) - Number of lines to return (max 2000)
+
+### get_apps
+
+Use this when you need to list apps owned by the current user. Returns app details with display fields for user presentation and data fields for tool chaining.
+
+**Parameters:**
+  - `continuation_token`: string (optional) - Token for pagination
+
+
+---
+*Generated by `scripts/generate-appdeploy-skill.ts`*

--- a/skills/appdeploy/SKILL.md
+++ b/skills/appdeploy/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: appdeploy
-description: Deploy web apps with backend APIs, database, and file storage. Use when the user asks to deploy or publish a website or web app and wants a public URL. Uses HTTP API via curl.
+description: Deploy web apps with backend APIs, database, file storage, AI operations, authentication, realtime, and cron jobs. Use when the user asks to deploy or publish a website or web app and wants a public URL. Uses HTTP API via curl.
 allowed-tools:
   - Bash
 metadata:
   author: appdeploy
-  version: "1.0.5"
+  version: "1.0.7"
 ---
 
 # AppDeploy Skill
@@ -104,6 +104,8 @@ Before generating files or calling this tool, you must call get_deploy_instructi
   - `frontend_template`: any (optional) - REQUIRED when app_id is null. One of: 'html-static' (simple sites), 'react-vite' (SPAs, games), 'nextjs-static' (multi-page). Template files auto-included.
   - `files`: array (optional) - Files to write. NEW APPS: only custom files + diffs to template files. UPDATES: only changed files using diffs[]. At least one of files[] or deletePaths[] required.
   - `deletePaths`: array (optional) - Paths to delete. ONLY for updates (app_id required). Cannot delete package.json or framework entry points.
+  - `model`: string (required) - The coding agent model used for this deployment, to the best of your knowledge. Examples: 'codex-5.3', 'chatgpt', 'opus 4.6', 'claude-sonnet-4-5', 'gemini-2.5-pro'
+  - `intent`: string (required) - The intent of this deployment. User-initiated examples: 'initial app deploy', 'bugfix - ui is too noisy'. Agent-initiated examples: 'agent fixing deployment error', 'agent retry after lint failure'
 
 ### get_app_template
 
@@ -120,6 +122,7 @@ Use this when deploy_app tool call returns or when the user asks to check the de
 **Parameters:**
   - `app_id`: string (required) - Target app id
   - `since`: integer (optional) - Optional timestamp in epoch milliseconds to filter errors. When provided, returns only errors since that timestamp.
+  - `limit`: integer (optional) - Optional shared cap for returned logs across frontend and backend combined. Defaults to 50 when omitted.
 
 ### delete_app
 


### PR DESCRIPTION
## Summary
This PR introduces the curated `appdeploy` skill, which enables Claude to deploy and manage web apps using [AppDeploy](https://appdeploy.ai/).

## Capabilities
- Deploy web apps, including full-stack apps, to a public URL.
- Manage the app lifecycle, including status checks, versioning, and code management.
- Support source-level inspection for debugging and iteration.
- Provide a structured and repeatable deployment flow aligned with AppDeploy tool contracts.

**Example:**
Prompt: "Build a tic tac toe game and deploy it."
Result: A live URL to the deployed game app.