### PR TITLE
Fix skill-creator UTF-8 panic on multi-byte characters

### DIFF
--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -9,6 +9,29 @@ import re
 import yaml
 from pathlib import Path
 
+
+def _utf8_byte_len(s):
+    """Return the byte length of a string when encoded as UTF-8."""
+    return len(s.encode('utf-8'))
+
+
+def _truncate_utf8_safe(s, max_bytes):
+    """Truncate a string to fit within max_bytes of UTF-8 without splitting multi-byte characters.
+
+    Returns the truncated string by iterating over characters and accumulating
+    their UTF-8 byte lengths, stopping before exceeding the limit.
+    """
+    byte_count = 0
+    end_index = 0
+    for i, ch in enumerate(s):
+        char_bytes = len(ch.encode('utf-8'))
+        if byte_count + char_bytes > max_bytes:
+            break
+        byte_count += char_bytes
+        end_index = i + 1
+    return s[:end_index]
+
+
 def validate_skill(skill_path):
     """Basic validation of a skill"""
     skill_path = Path(skill_path)
@@ -92,9 +115,10 @@ def validate_skill(skill_path):
             return False, f"Name '{name}' should be kebab-case (lowercase letters, digits, and hyphens only)"
         if name.startswith('-') or name.endswith('-') or '--' in name:
             return False, f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens"
-        # Check name length (max 64 characters per spec)
-        if len(name) > 64:
-            return False, f"Name is too long ({len(name)} characters). Maximum is 64 characters."
+        # Check name length (max 64 bytes in UTF-8 per spec)
+        name_byte_len = _utf8_byte_len(name)
+        if name_byte_len > 64:
+            return False, f"Name is too long ({name_byte_len} bytes in UTF-8). Maximum is 64 bytes."
 
     # Extract and validate description
     description = frontmatter.get('description', '')
@@ -105,17 +129,22 @@ def validate_skill(skill_path):
         # Check for angle brackets
         if '<' in description or '>' in description:
             return False, "Description cannot contain angle brackets (< or >)"
-        # Check description length (max 1024 characters per spec)
-        if len(description) > 1024:
-            return False, f"Description is too long ({len(description)} characters). Maximum is 1024 characters."
+        # Check description length (max 1024 bytes in UTF-8 per spec)
+        # Using byte length prevents downstream Rust panics from slicing
+        # multi-byte UTF-8 characters (e.g., CJK characters, '。') at
+        # invalid byte boundaries.
+        desc_byte_len = _utf8_byte_len(description)
+        if desc_byte_len > 1024:
+            return False, f"Description is too long ({desc_byte_len} bytes in UTF-8). Maximum is 1024 bytes."
 
     # Validate compatibility field if present (optional)
     compatibility = frontmatter.get('compatibility', '')
     if compatibility:
         if not isinstance(compatibility, str):
             return False, f"Compatibility must be a string, got {type(compatibility).__name__}"
-        if len(compatibility) > 500:
-            return False, f"Compatibility is too long ({len(compatibility)} characters). Maximum is 500 characters."
+        compat_byte_len = _utf8_byte_len(compatibility)
+        if compat_byte_len > 500:
+            return False, f"Compatibility is too long ({compat_byte_len} bytes in UTF-8). Maximum is 500 bytes."
 
     return True, "Skill is valid!"
 


### PR DESCRIPTION
## Summary
- Replace character-based length checks with UTF-8 byte-length validation in quick_validate.py to prevent Rust panics when the CLI processes multi-byte characters
- Add _utf8_byte_len() and _truncate_utf8_safe() helpers for byte-aware string operations
- Switch name (64), description (1024), and compatibility (500) field validation from character counts to UTF-8 byte counts

## Problem
When a skill description contains multi-byte UTF-8 characters (such as Chinese text), Python len() counts characters rather than bytes. A 350-character Chinese description is only 350 characters but 1050 bytes in UTF-8. The previous validation accepted this since 350 < 1024. When the downstream Rust CLI then attempted to process the string at byte boundaries, it sliced in the middle of a multi-byte character, causing a panic.

## Test plan
- [x] Existing ASCII-only skills still pass validation
- [x] Chinese descriptions under 1024 bytes pass validation  
- [x] Chinese descriptions over 1024 bytes are correctly rejected
- [x] _truncate_utf8_safe() correctly avoids splitting multi-byte characters

Fixes #263