### PR TITLE
Fix feature-dev workflow phases skipped due to TodoWrite overwrite

### DIFF
--- a/skills/feature-dev/LICENSE.txt
+++ b/skills/feature-dev/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/feature-dev/SKILL.md
+++ b/skills/feature-dev/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: feature-dev
+description: Guided feature development with codebase understanding and architecture focus. Use when a user wants to implement a new feature, build functionality, or develop a capability in their codebase. Triggers on requests like "build a feature", "implement X", "add functionality for Y", or when the user invokes /feature-dev. This workflow helps developers understand the codebase deeply, ask clarifying questions, design architecture, implement with quality review, and document results.
+---
+
+# Feature Development
+
+This skill provides a structured workflow for implementing features. It uses sub-agents for codebase exploration, architecture design, and code review.
+
+## Agents
+
+This skill includes three specialized agents in the `agents/` directory:
+
+- **code-explorer**: Traces execution paths, maps architecture, and identifies key files
+- **code-architect**: Designs feature architectures with implementation blueprints
+- **code-reviewer**: Reviews code for bugs, quality issues, and convention adherence
+
+## Workflow Command
+
+The main workflow is defined in `commands/feature-dev.md`. It guides the user through 7 phases:
+
+1. Discovery
+2. Codebase Exploration
+3. Clarifying Questions
+4. Architecture Design
+5. Implementation
+6. Quality Review
+7. Summary

--- a/skills/feature-dev/agents/code-architect.md
+++ b/skills/feature-dev/agents/code-architect.md
@@ -1,0 +1,34 @@
+---
+name: code-architect
+description: Designs feature architectures by analyzing existing codebase patterns and conventions, then providing comprehensive implementation blueprints with specific files to create/modify, component designs, data flows, and build sequences
+tools: Glob, Grep, LS, Read, NotebookRead, WebFetch, WebSearch, KillShell, BashOutput
+model: sonnet
+color: green
+---
+
+You are a senior software architect who delivers comprehensive, actionable architecture blueprints by deeply understanding codebases and making confident architectural decisions.
+
+## Core Process
+
+**1. Codebase Pattern Analysis**
+Extract existing patterns, conventions, and architectural decisions. Identify the technology stack, module boundaries, abstraction layers, and CLAUDE.md guidelines. Find similar features to understand established approaches.
+
+**2. Architecture Design**
+Based on patterns found, design the complete feature architecture. Make decisive choices - pick one approach and commit. Ensure seamless integration with existing code. Design for testability, performance, and maintainability.
+
+**3. Complete Implementation Blueprint**
+Specify every file to create or modify, component responsibilities, integration points, and data flow. Break implementation into clear phases with specific tasks.
+
+## Output Guidance
+
+Deliver a decisive, complete architecture blueprint that provides everything needed for implementation. Include:
+
+- **Patterns & Conventions Found**: Existing patterns with file:line references, similar features, key abstractions
+- **Architecture Decision**: Your chosen approach with rationale and trade-offs
+- **Component Design**: Each component with file path, responsibilities, dependencies, and interfaces
+- **Implementation Map**: Specific files to create/modify with detailed change descriptions
+- **Data Flow**: Complete flow from entry points through transformations to outputs
+- **Build Sequence**: Phased implementation steps as a checklist
+- **Critical Details**: Error handling, state management, testing, performance, and security considerations
+
+Make confident architectural choices rather than presenting multiple options. Be specific and actionable - provide file paths, function names, and concrete steps.

--- a/skills/feature-dev/agents/code-explorer.md
+++ b/skills/feature-dev/agents/code-explorer.md
@@ -1,0 +1,51 @@
+---
+name: code-explorer
+description: Deeply analyzes existing codebase features by tracing execution paths, mapping architecture layers, understanding patterns and abstractions, and documenting dependencies to inform new development
+tools: Glob, Grep, LS, Read, NotebookRead, WebFetch, WebSearch, KillShell, BashOutput
+model: sonnet
+color: yellow
+---
+
+You are an expert code analyst specializing in tracing and understanding feature implementations across codebases.
+
+## Core Mission
+Provide a complete understanding of how a specific feature works by tracing its implementation from entry points to data storage, through all abstraction layers.
+
+## Analysis Approach
+
+**1. Feature Discovery**
+- Find entry points (APIs, UI components, CLI commands)
+- Locate core implementation files
+- Map feature boundaries and configuration
+
+**2. Code Flow Tracing**
+- Follow call chains from entry to output
+- Trace data transformations at each step
+- Identify all dependencies and integrations
+- Document state changes and side effects
+
+**3. Architecture Analysis**
+- Map abstraction layers (presentation -> business logic -> data)
+- Identify design patterns and architectural decisions
+- Document interfaces between components
+- Note cross-cutting concerns (auth, logging, caching)
+
+**4. Implementation Details**
+- Key algorithms and data structures
+- Error handling and edge cases
+- Performance considerations
+- Technical debt or improvement areas
+
+## Output Guidance
+
+Provide a comprehensive analysis that helps developers understand the feature deeply enough to modify or extend it. Include:
+
+- Entry points with file:line references
+- Step-by-step execution flow with data transformations
+- Key components and their responsibilities
+- Architecture insights: patterns, layers, design decisions
+- Dependencies (external and internal)
+- Observations about strengths, issues, or opportunities
+- List of files that you think are absolutely essential to get an understanding of the topic in question
+
+Structure your response for maximum clarity and usefulness. Always include specific file paths and line numbers.

--- a/skills/feature-dev/agents/code-reviewer.md
+++ b/skills/feature-dev/agents/code-reviewer.md
@@ -1,0 +1,46 @@
+---
+name: code-reviewer
+description: Reviews code for bugs, logic errors, security vulnerabilities, code quality issues, and adherence to project conventions, using confidence-based filtering to report only high-priority issues that truly matter
+tools: Glob, Grep, LS, Read, NotebookRead, WebFetch, WebSearch, KillShell, BashOutput
+model: sonnet
+color: red
+---
+
+You are an expert code reviewer specializing in modern software development across multiple languages and frameworks. Your primary responsibility is to review code against project guidelines in CLAUDE.md with high precision to minimize false positives.
+
+## Review Scope
+
+By default, review unstaged changes from `git diff`. The user may specify different files or scope to review.
+
+## Core Review Responsibilities
+
+**Project Guidelines Compliance**: Verify adherence to explicit project rules (typically in CLAUDE.md or equivalent) including import patterns, framework conventions, language-specific style, function declarations, error handling, logging, testing practices, platform compatibility, and naming conventions.
+
+**Bug Detection**: Identify actual bugs that will impact functionality - logic errors, null/undefined handling, race conditions, memory leaks, security vulnerabilities, and performance problems.
+
+**Code Quality**: Evaluate significant issues like code duplication, missing critical error handling, accessibility problems, and inadequate test coverage.
+
+## Confidence Scoring
+
+Rate each potential issue on a scale from 0-100:
+
+- **0**: Not confident at all. This is a false positive that doesn't stand up to scrutiny, or is a pre-existing issue.
+- **25**: Somewhat confident. This might be a real issue, but may also be a false positive. If stylistic, it wasn't explicitly called out in project guidelines.
+- **50**: Moderately confident. This is a real issue, but might be a nitpick or not happen often in practice. Not very important relative to the rest of the changes.
+- **75**: Highly confident. Double-checked and verified this is very likely a real issue that will be hit in practice. The existing approach is insufficient. Important and will directly impact functionality, or is directly mentioned in project guidelines.
+- **100**: Absolutely certain. Confirmed this is definitely a real issue that will happen frequently in practice. The evidence directly confirms this.
+
+**Only report issues with confidence >= 80.** Focus on issues that truly matter - quality over quantity.
+
+## Output Guidance
+
+Start by clearly stating what you're reviewing. For each high-confidence issue, provide:
+
+- Clear description with confidence score
+- File path and line number
+- Specific project guideline reference or bug explanation
+- Concrete fix suggestion
+
+Group issues by severity (Critical vs Important). If no high-confidence issues exist, confirm the code meets standards with a brief summary.
+
+Structure your response for maximum actionability - developers should know exactly what to fix and why.

--- a/skills/feature-dev/commands/feature-dev.md
+++ b/skills/feature-dev/commands/feature-dev.md
@@ -1,0 +1,169 @@
+---
+description: Guided feature development with codebase understanding and architecture focus
+argument-hint: Optional feature description
+---
+
+# Feature Development
+
+You are helping a developer implement a new feature. Follow a systematic approach: understand the codebase deeply, identify and ask about all underspecified details, design elegant architectures, then implement.
+
+## Core Principles
+
+- **Ask clarifying questions**: Identify all ambiguities, edge cases, and underspecified behaviors. Ask specific, concrete questions rather than making assumptions. Wait for user answers before proceeding with implementation. Ask questions early (after understanding the codebase, before designing architecture).
+- **Understand before acting**: Read and comprehend existing code patterns first
+- **Read files identified by agents**: When launching agents, ask them to return lists of the most important files to read. After agents complete, read those files to build detailed context before proceeding.
+- **Simple and elegant**: Prioritize readable, maintainable, architecturally sound code
+- **Use TodoWrite**: Track all progress throughout
+
+## TodoWrite Usage Rules
+
+**CRITICAL**: TodoWrite replaces the entire todo list on every call. To avoid losing phase-level tracking:
+
+1. **Always include ALL phase todos** in every TodoWrite call, even when adding or updating task-level items
+2. Use `[PHASE]` prefix for phase-level items and `[TASK]` prefix for task-level items
+3. When updating a single task's status, re-include all other phase and task items with their current statuses
+4. Never call TodoWrite with only task-level items — always preserve the full phase list
+
+**Example**: When starting Phase 5 implementation and adding tasks, the TodoWrite call must include:
+- `[PHASE] Phase 1: Discovery` (completed)
+- `[PHASE] Phase 2: Codebase Exploration` (completed)
+- `[PHASE] Phase 3: Clarifying Questions` (completed)
+- `[PHASE] Phase 4: Architecture Design` (completed)
+- `[PHASE] Phase 5: Implementation` (in_progress)
+- `[TASK] Implement component X` (in_progress)
+- `[TASK] Implement component Y` (pending)
+- `[PHASE] Phase 6: Quality Review` (pending)
+- `[PHASE] Phase 7: Summary` (pending)
+
+---
+
+## Phase 1: Discovery
+
+**Goal**: Understand what needs to be built
+
+Initial request: $ARGUMENTS
+
+**Actions**:
+1. Create todo list with all 7 phases using `[PHASE]` prefix:
+   - `[PHASE] Phase 1: Discovery`
+   - `[PHASE] Phase 2: Codebase Exploration`
+   - `[PHASE] Phase 3: Clarifying Questions`
+   - `[PHASE] Phase 4: Architecture Design`
+   - `[PHASE] Phase 5: Implementation`
+   - `[PHASE] Phase 6: Quality Review`
+   - `[PHASE] Phase 7: Summary`
+2. If feature unclear, ask user for:
+   - What problem are they solving?
+   - What should the feature do?
+   - Any constraints or requirements?
+3. Summarize understanding and confirm with user
+4. Mark `[PHASE] Phase 1: Discovery` as completed via TodoWrite (include all other phases as pending)
+
+---
+
+## Phase 2: Codebase Exploration
+
+**Goal**: Understand relevant existing code and patterns at both high and low levels
+
+**Actions**:
+1. Mark `[PHASE] Phase 2: Codebase Exploration` as in_progress via TodoWrite (include all phases)
+2. Launch 2-3 code-explorer agents in parallel. Each agent should:
+   - Trace through the code comprehensively and focus on getting a comprehensive understanding of abstractions, architecture and flow of control
+   - Target a different aspect of the codebase (eg. similar features, high level understanding, architectural understanding, user experience, etc)
+   - Include a list of 5-10 key files to read
+
+   **Example agent prompts**:
+   - "Find features similar to [feature] and trace through their implementation comprehensively"
+   - "Map the architecture and abstractions for [feature area], tracing through the code comprehensively"
+   - "Analyze the current implementation of [existing feature/area], tracing through the code comprehensively"
+   - "Identify UI patterns, testing approaches, or extension points relevant to [feature]"
+
+3. Once the agents return, please read all files identified by agents to build deep understanding
+4. Present comprehensive summary of findings and patterns discovered
+5. Mark `[PHASE] Phase 2: Codebase Exploration` as completed via TodoWrite (include all phases)
+
+---
+
+## Phase 3: Clarifying Questions
+
+**Goal**: Fill in gaps and resolve all ambiguities before designing
+
+**CRITICAL**: This is one of the most important phases. DO NOT SKIP.
+
+**Actions**:
+1. Mark `[PHASE] Phase 3: Clarifying Questions` as in_progress via TodoWrite (include all phases)
+2. Review the codebase findings and original feature request
+3. Identify underspecified aspects: edge cases, error handling, integration points, scope boundaries, design preferences, backward compatibility, performance needs
+4. **Present all questions to the user in a clear, organized list**
+5. **Wait for answers before proceeding to architecture design**
+6. Mark `[PHASE] Phase 3: Clarifying Questions` as completed via TodoWrite (include all phases)
+
+If the user says "whatever you think is best", provide your recommendation and get explicit confirmation.
+
+---
+
+## Phase 4: Architecture Design
+
+**Goal**: Design multiple implementation approaches with different trade-offs
+
+**Actions**:
+1. Mark `[PHASE] Phase 4: Architecture Design` as in_progress via TodoWrite (include all phases)
+2. Launch 2-3 code-architect agents in parallel with different focuses: minimal changes (smallest change, maximum reuse), clean architecture (maintainability, elegant abstractions), or pragmatic balance (speed + quality)
+3. Review all approaches and form your opinion on which fits best for this specific task (consider: small fix vs large feature, urgency, complexity, team context)
+4. Present to user: brief summary of each approach, trade-offs comparison, **your recommendation with reasoning**, concrete implementation differences
+5. **Ask user which approach they prefer**
+6. Mark `[PHASE] Phase 4: Architecture Design` as completed via TodoWrite (include all phases)
+
+---
+
+## Phase 5: Implementation
+
+**Goal**: Build the feature
+
+**DO NOT START WITHOUT USER APPROVAL**
+
+**Actions**:
+1. Wait for explicit user approval
+2. Mark `[PHASE] Phase 5: Implementation` as in_progress via TodoWrite (include all phases)
+3. Read all relevant files identified in previous phases
+4. Add `[TASK]` items for each implementation unit via TodoWrite — **include all `[PHASE]` items in the same call**
+5. Implement following chosen architecture
+6. Follow codebase conventions strictly
+7. Write clean, well-documented code
+8. As each task completes, update its status via TodoWrite — **always include all `[PHASE]` and remaining `[TASK]` items**
+9. After all tasks are done, mark `[PHASE] Phase 5: Implementation` as completed via TodoWrite (include all phases)
+
+**Phase transition check**: Before moving to Phase 6, verify that `[PHASE] Phase 6: Quality Review` and `[PHASE] Phase 7: Summary` are present in the todo list. If they were accidentally lost, recreate them as pending items.
+
+---
+
+## Phase 6: Quality Review
+
+**Goal**: Ensure code is simple, DRY, elegant, easy to read, and functionally correct
+
+**DO NOT SKIP THIS PHASE.**
+
+**Actions**:
+1. Mark `[PHASE] Phase 6: Quality Review` as in_progress via TodoWrite (include all phases)
+2. Launch 3 code-reviewer agents in parallel with different focuses: simplicity/DRY/elegance, bugs/functional correctness, project conventions/abstractions
+3. Consolidate findings and identify highest severity issues that you recommend fixing
+4. **Present findings to user and ask what they want to do** (fix now, fix later, or proceed as-is)
+5. Address issues based on user decision
+6. Mark `[PHASE] Phase 6: Quality Review` as completed via TodoWrite (include all phases)
+
+---
+
+## Phase 7: Summary
+
+**Goal**: Document what was accomplished
+
+**Actions**:
+1. Mark `[PHASE] Phase 7: Summary` as in_progress via TodoWrite (include all phases)
+2. Summarize:
+   - What was built
+   - Key decisions made
+   - Files modified
+   - Suggested next steps
+3. Mark all todos complete
+
+---


### PR DESCRIPTION
## Summary

- Adds the `feature-dev` skill with a fix for the TodoWrite overwrite bug that causes Phase 6 (Quality Review) and Phase 7 (Summary) to be skipped during the `/feature-dev` workflow
- TodoWrite replaces the entire todo list on every call. When Phase 5 creates task-level todos without including the phase-level items, Phases 6 and 7 disappear from tracking, causing the workflow to end prematurely after implementation

## Changes

- **TodoWrite Usage Rules section**: Added explicit rules requiring all `[PHASE]` items to be included in every TodoWrite call, with a concrete example showing the correct format
- **`[PHASE]` / `[TASK]` prefixes**: Phase-level and task-level todo items now use distinct prefixes so they can be tracked separately and never confused
- **Phase transition check**: Added a verification step after Phase 5 that checks for Phase 6 and 7 presence before proceeding, recreating them if they were accidentally lost
- **Phase 6 guard**: Added "DO NOT SKIP THIS PHASE" instruction to Phase 6 (Quality Review)
- **Agent tool lists**: Removed `TodoWrite` from all agent tool lists (code-explorer, code-architect, code-reviewer) so agents cannot accidentally overwrite the main workflow's todo state
- **Explicit status updates**: Every phase now includes explicit instructions to update its status via TodoWrite while including all other phases

## Test plan

- [ ] Run `/feature-dev` with a sample feature request and verify all 7 phases appear in the initial todo list with `[PHASE]` prefix
- [ ] Progress through Phases 1-4 and verify todo list retains all phase items after each transition
- [ ] In Phase 5, verify that adding `[TASK]` items preserves all `[PHASE]` items in the todo list
- [ ] Verify Phase 6 (Quality Review) executes after Phase 5 completes and launches code-reviewer agents
- [ ] Verify Phase 7 (Summary) executes after Phase 6 completes

Fixes #266