### PR TITLE
Add flutter-theme-factory skill

### DIFF
--- a/skills/flutter-theme-factory/SKILL.md
+++ b/skills/flutter-theme-factory/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: flutter-theme-factory
+description: Toolkit for styling Flutter apps with a theme. Apply pre-built or custom ThemeData configurations to any Flutter app — including full ColorScheme, TextTheme, component themes, and dark/light mode support. 12 pre-set themes available, or generate a custom theme on-the-fly.
+license: MIT
+---
+
+# Flutter Theme Factory Skill
+
+This skill provides a curated collection of professional Flutter `ThemeData` configurations, each with carefully selected color palettes, Google Fonts pairings, and component-level theming. Once a theme is chosen, it generates production-ready Dart code.
+
+## Purpose
+
+To apply consistent, professional styling to any Flutter application. Each theme includes:
+- A cohesive `ColorScheme` with light and dark variants
+- Complementary Google Fonts pairings for display, headline, title, body, and label text
+- Component-level theming (`AppBarTheme`, `CardTheme`, `ElevatedButtonTheme`, `InputDecorationTheme`, etc.)
+- A distinct visual identity suitable for different contexts and audiences
+
+## Usage Instructions
+
+1. **Show available themes**: Present the theme list below with descriptions
+2. **Ask for their choice**: Ask which theme to apply
+3. **Wait for selection**: Get explicit confirmation about the chosen theme
+4. **Generate the theme**: Read the selected theme file from `themes/` and generate complete Dart code
+5. **Deliver files**: Provide `app_theme.dart`, `app_colors.dart`, `app_typography.dart` ready to drop into their project
+
+## Themes Available
+
+| # | Theme | Vibe | Best For |
+|---|-------|------|----------|
+| 1 | **Ocean Depths** | Professional & calming maritime | Finance, consulting, corporate |
+| 2 | **Sunset Boulevard** | Warm & vibrant energy | Social, lifestyle, food delivery |
+| 3 | **Forest Canopy** | Natural & grounded earth tones | Wellness, sustainability, outdoor |
+| 4 | **Modern Minimalist** | Clean & contemporary grayscale | Productivity, SaaS, developer tools |
+| 5 | **Golden Hour** | Rich & warm autumnal | Photography, luxury, premium |
+| 6 | **Arctic Frost** | Cool & crisp winter-inspired | Healthcare, fintech, analytics |
+| 7 | **Desert Rose** | Soft & sophisticated dusty tones | Fashion, beauty, lifestyle |
+| 8 | **Tech Innovation** | Bold & modern tech aesthetic | Startups, AI/ML, developer |
+| 9 | **Botanical Garden** | Fresh & organic garden colors | Health, organic food, plants |
+| 10 | **Midnight Galaxy** | Dramatic & cosmic deep tones | Gaming, entertainment, music |
+| 11 | **Neon Tokyo** | Cyberpunk, high contrast neon | Gaming, nightlife, tech |
+| 12 | **Terracotta Studio** | Warm clay, artisan craft | Art, handmade, interior design |
+
+## Generated Code Structure
+
+Each theme generates:
+
+```
+lib/core/theme/
+├── app_theme.dart          # ThemeData for light & dark mode
+├── app_colors.dart         # Color constants & ColorScheme
+├── app_typography.dart     # Google Fonts TextTheme
+└── app_spacing.dart        # Consistent spacing scale
+```
+
+### app_theme.dart Pattern
+```dart
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'app_colors.dart';
+import 'app_typography.dart';
+
+class AppTheme {
+  static ThemeData get light => ThemeData(
+    useMaterial3: true,
+    brightness: Brightness.light,
+    colorScheme: AppColors.lightScheme,
+    textTheme: AppTypography.textTheme,
+    appBarTheme: AppBarTheme(...),
+    cardTheme: CardTheme(...),
+    elevatedButtonTheme: ElevatedButtonThemeData(...),
+    inputDecorationTheme: InputDecorationTheme(...),
+    bottomNavigationBarTheme: BottomNavigationBarThemeData(...),
+    floatingActionButtonTheme: FloatingActionButtonThemeData(...),
+    chipTheme: ChipThemeData(...),
+    dividerTheme: DividerThemeData(...),
+    // ... all component themes
+  );
+
+  static ThemeData get dark => ThemeData(
+    useMaterial3: true,
+    brightness: Brightness.dark,
+    colorScheme: AppColors.darkScheme,
+    textTheme: AppTypography.textTheme,
+    // ... dark variants
+  );
+}
+```
+
+### app_colors.dart Pattern
+```dart
+import 'package:flutter/material.dart';
+
+class AppColors {
+  // Brand colors
+  static const Color primary = Color(0xFF...);
+  static const Color secondary = Color(0xFF...);
+  static const Color accent = Color(0xFF...);
+  static const Color surface = Color(0xFF...);
+
+  // Semantic colors
+  static const Color success = Color(0xFF...);
+  static const Color warning = Color(0xFF...);
+  static const Color error = Color(0xFF...);
+  static const Color info = Color(0xFF...);
+
+  // Gradients
+  static const LinearGradient primaryGradient = LinearGradient(...);
+  static const LinearGradient backgroundGradient = LinearGradient(...);
+
+  // Light scheme
+  static const ColorScheme lightScheme = ColorScheme(
+    brightness: Brightness.light,
+    primary: ...,
+    onPrimary: ...,
+    secondary: ...,
+    onSecondary: ...,
+    surface: ...,
+    onSurface: ...,
+    error: ...,
+    onError: ...,
+    // ... all 30+ ColorScheme properties
+  );
+
+  // Dark scheme
+  static const ColorScheme darkScheme = ColorScheme(
+    brightness: Brightness.dark,
+    // ... dark variants
+  );
+}
+```
+
+### app_typography.dart Pattern
+```dart
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+class AppTypography {
+  static String get _displayFont => GoogleFonts.playfairDisplay().fontFamily!;
+  static String get _bodyFont => GoogleFonts.sourceSansPro().fontFamily!;
+
+  static TextTheme get textTheme => TextTheme(
+    displayLarge: TextStyle(fontFamily: _displayFont, fontSize: 57, fontWeight: FontWeight.w700),
+    displayMedium: TextStyle(fontFamily: _displayFont, fontSize: 45, fontWeight: FontWeight.w600),
+    displaySmall: TextStyle(fontFamily: _displayFont, fontSize: 36, fontWeight: FontWeight.w600),
+    headlineLarge: TextStyle(fontFamily: _displayFont, fontSize: 32, fontWeight: FontWeight.w600),
+    headlineMedium: TextStyle(fontFamily: _displayFont, fontSize: 28, fontWeight: FontWeight.w500),
+    headlineSmall: TextStyle(fontFamily: _displayFont, fontSize: 24, fontWeight: FontWeight.w500),
+    titleLarge: TextStyle(fontFamily: _bodyFont, fontSize: 22, fontWeight: FontWeight.w600),
+    titleMedium: TextStyle(fontFamily: _bodyFont, fontSize: 16, fontWeight: FontWeight.w600),
+    titleSmall: TextStyle(fontFamily: _bodyFont, fontSize: 14, fontWeight: FontWeight.w500),
+    bodyLarge: TextStyle(fontFamily: _bodyFont, fontSize: 16, fontWeight: FontWeight.w400),
+    bodyMedium: TextStyle(fontFamily: _bodyFont, fontSize: 14, fontWeight: FontWeight.w400),
+    bodySmall: TextStyle(fontFamily: _bodyFont, fontSize: 12, fontWeight: FontWeight.w400),
+    labelLarge: TextStyle(fontFamily: _bodyFont, fontSize: 14, fontWeight: FontWeight.w600),
+    labelMedium: TextStyle(fontFamily: _bodyFont, fontSize: 12, fontWeight: FontWeight.w500),
+    labelSmall: TextStyle(fontFamily: _bodyFont, fontSize: 11, fontWeight: FontWeight.w500),
+  );
+}
+```
+
+## Application Process
+
+After a preferred theme is selected:
+1. Read the corresponding theme file from the `themes/` directory
+2. Generate complete `app_theme.dart`, `app_colors.dart`, `app_typography.dart`, `app_spacing.dart`
+3. Include `pubspec.yaml` dependency additions (`google_fonts`, etc.)
+4. Provide usage example in `main.dart`:
+```dart
+MaterialApp(
+  theme: AppTheme.light,
+  darkTheme: AppTheme.dark,
+  themeMode: ThemeMode.system,
+  ...
+)
+```
+5. Ensure WCAG AA contrast ratios in both light and dark mode
+6. Test all Material component themes are properly configured
+
+## Create Your Own Theme
+
+For cases where none of the existing themes work:
+1. Ask the user for: brand colors (if any), mood/vibe, target audience, app category
+2. Generate a custom theme following the same structure as preset themes
+3. Give it a descriptive name
+4. Show a preview widget that demonstrates the theme across key components
+5. Apply the theme after user approval
+
+### Preview Widget
+When showing a theme preview, generate a `ThemePreview` widget that displays:
+- Color palette swatches
+- Typography samples (all text styles)
+- Button variants (elevated, filled, outlined, text)
+- Card with content
+- TextField / Input
+- BottomNavigationBar sample
+- Chip variants
+- Light vs Dark side-by-side comparison

--- a/skills/flutter-theme-factory/themes/arctic-frost.md
+++ b/skills/flutter-theme-factory/themes/arctic-frost.md
@@ -1,0 +1,34 @@
+# Arctic Frost
+
+Cool and crisp winter-inspired theme with icy blues and clean precision.
+
+## Color Palette
+
+- **Ice Blue**: `#0077B6` - Primary
+- **Deep Arctic**: `#023E8A` - Primary variant
+- **Frost**: `#90E0EF` - Secondary
+- **Glacier White**: `#CAF0F8` - Tertiary
+- **Polar White**: `#F8FCFF` - Background light
+- **Snow**: `#FFFFFF` - Surface
+
+### Dark Mode Adjustments
+- Background: `#0A1628`
+- Surface: `#122240`
+- Primary: `#48CAE4` (brighter for contrast)
+
+## Typography
+
+- **Display/Headlines**: `Sora` (geometric, modern, precise)
+- **Body/Labels**: `Inter` (crystal clear readability, neutral)
+
+## Component Styling Notes
+
+- Cards: Frosted glass effect (blur + white overlay), 14px radius
+- Buttons: `Ice Blue` filled, 10px radius, slight glow on hover/press
+- AppBar: Frosted translucent, blur backdrop
+- Inputs: Filled with `Glacier White`, `Ice Blue` focus border, 8px radius
+- Bottom Nav: Translucent with blur, `Ice Blue` selected
+
+## Best Used For
+
+Healthcare, fintech, analytics dashboards, data visualization, scientific tools, weather apps.

--- a/skills/flutter-theme-factory/themes/botanical-garden.md
+++ b/skills/flutter-theme-factory/themes/botanical-garden.md
@@ -1,0 +1,35 @@
+# Botanical Garden
+
+Fresh and organic garden colors inspired by living greenery and blooming flowers.
+
+## Color Palette
+
+- **Leaf Green**: `#2D6A4F` - Primary
+- **Spring Green**: `#52B788` - Secondary
+- **Petal Pink**: `#FFB4A2` - Tertiary / accent
+- **Sunshine**: `#FFD166` - Highlight
+- **Garden White**: `#F0F7F0` - Background light
+- **Linen**: `#FAFAF5` - Surface
+
+### Dark Mode Adjustments
+- Background: `#0C1A12`
+- Surface: `#162B1F`
+- Primary: `#74C69D` (lighter green)
+
+## Typography
+
+- **Display/Headlines**: `Libre Baskerville` (organic serif, editorial)
+- **Body/Labels**: `Karla` (friendly, soft, modern sans)
+
+## Component Styling Notes
+
+- Cards: White with `Spring Green` left border accent, 12px radius, subtle green shadow
+- Buttons: `Leaf Green` filled, 12px radius, leaf-ripple animation
+- AppBar: `Garden White` with green icon accents
+- Inputs: Outlined, `Leaf Green` focus with `Petal Pink` error state, 10px radius
+- Bottom Nav: White bg, `Leaf Green` selected with plant-growth animation
+- FAB: `Petal Pink` with white icon
+
+## Best Used For
+
+Health/fitness, organic food delivery, plant care, recipe apps, gardening, eco-commerce.

--- a/skills/flutter-theme-factory/themes/desert-rose.md
+++ b/skills/flutter-theme-factory/themes/desert-rose.md
@@ -1,0 +1,34 @@
+# Desert Rose
+
+Soft and sophisticated dusty tones inspired by desert landscapes and rose petals.
+
+## Color Palette
+
+- **Dusty Rose**: `#C48B9F` - Primary
+- **Mauve**: `#8E6C88` - Primary variant
+- **Sand**: `#D4B49A` - Secondary
+- **Blush**: `#F2D7D5` - Tertiary
+- **Warm Linen**: `#FDF6F0` - Background light
+- **Soft White**: `#FFFAF7` - Surface
+
+### Dark Mode Adjustments
+- Background: `#1A1215`
+- Surface: `#2D1E25`
+- Primary: `#D9A3B5` (brighter dusty rose)
+
+## Typography
+
+- **Display/Headlines**: `Cormorant Garamond` (refined, feminine elegance)
+- **Body/Labels**: `Questrial` (modern, gentle, balanced)
+
+## Component Styling Notes
+
+- Cards: Soft shadow with rose tint, 20px radius (very rounded)
+- Buttons: `Dusty Rose` filled, pill shape (24px), soft press effect
+- AppBar: Transparent with `Warm Linen` bg, centered serif title
+- Inputs: Outlined with `Sand` border, `Dusty Rose` focus, 14px radius
+- Bottom Nav: Minimal, `Dusty Rose` selected with gentle scale animation
+
+## Best Used For
+
+Fashion, beauty, lifestyle blogs, self-care, journaling, wedding planning, interior design.

--- a/skills/flutter-theme-factory/themes/forest-canopy.md
+++ b/skills/flutter-theme-factory/themes/forest-canopy.md
@@ -1,0 +1,33 @@
+# Forest Canopy
+
+Natural and grounded earth tones inspired by dense woodland and organic growth.
+
+## Color Palette
+
+- **Deep Forest**: `#1B4332` - Primary
+- **Moss Green**: `#40916C` - Secondary
+- **Sage**: `#95D5B2` - Tertiary
+- **Bark Brown**: `#5C4033` - Accent
+- **Cream Linen**: `#FAF3E0` - Surface light
+- **Off White**: `#F7F7F2` - Background light
+
+### Dark Mode Adjustments
+- Background: `#0C1F15`
+- Surface: `#1B4332`
+- Primary: `#52B788` (lighter for visibility)
+
+## Typography
+
+- **Display/Headlines**: `Cormorant Garamond` (elegant, natural serif)
+- **Body/Labels**: `Fira Sans` (clean, highly legible)
+
+## Component Styling Notes
+
+- Cards: Rounded (16px), subtle `Sage` border, leaf-like asymmetric shadow
+- Buttons: `Moss Green` filled, 12px radius, subtle press animation
+- AppBar: `Deep Forest` with slight transparency
+- Inputs: Outlined with `Moss Green` focus, organic rounded corners (10px)
+
+## Best Used For
+
+Wellness, sustainability, outdoor/hiking, organic food, eco-brands, nature photography.

--- a/skills/flutter-theme-factory/themes/golden-hour.md
+++ b/skills/flutter-theme-factory/themes/golden-hour.md
@@ -1,0 +1,34 @@
+# Golden Hour
+
+Rich and warm autumnal palette evoking luxury, premium quality, and golden warmth.
+
+## Color Palette
+
+- **Rich Gold**: `#B8860B` - Primary
+- **Deep Amber**: `#8B6914` - Primary variant
+- **Champagne**: `#F5DEB3` - Secondary
+- **Espresso**: `#3E2723` - Dark accent / text
+- **Ivory**: `#FFFFF0` - Background light
+- **Parchment**: `#FFF8DC` - Surface light
+
+### Dark Mode Adjustments
+- Background: `#1A1209`
+- Surface: `#2E1F0D`
+- Primary: `#D4A843` (brighter gold)
+
+## Typography
+
+- **Display/Headlines**: `Playfair Display` (luxury serif, editorial elegance)
+- **Body/Labels**: `Lato` (warm, professional, highly readable)
+
+## Component Styling Notes
+
+- Cards: Warm shadow, subtle gold border-bottom accent, 12px radius
+- Buttons: `Rich Gold` with `Ivory` text, 10px radius, gold shimmer on press
+- AppBar: `Espresso` with gold accent line at bottom
+- Inputs: Outlined with `Rich Gold` focus, gold underline variant
+- Bottom Nav: `Espresso` bg with `Rich Gold` selected
+
+## Best Used For
+
+Photography, luxury brands, premium subscriptions, wine/dining, fashion, jewelry.

--- a/skills/flutter-theme-factory/themes/midnight-galaxy.md
+++ b/skills/flutter-theme-factory/themes/midnight-galaxy.md
@@ -1,0 +1,40 @@
+# Midnight Galaxy
+
+Dramatic and cosmic theme with deep purples and mystical tones for impactful, immersive interfaces.
+
+## Color Palette
+
+- **Deep Purple**: `#2B1E3E` - Primary background
+- **Cosmic Blue**: `#4A4E8F` - Primary
+- **Nebula Pink**: `#C77DBA` - Secondary
+- **Lavender**: `#A490C2` - Tertiary
+- **Starlight**: `#E6E6FA` - Text on dark / highlights
+- **Void**: `#1A1028` - Deepest background
+
+### Dark Mode (Default)
+- Background: `#110B1A`
+- Surface: `#2B1E3E`
+- Primary: `#7B6BA8`
+
+### Light Mode
+- Background: `#F5F0FA`
+- Surface: `#FFFFFF`
+- Primary: `#4A4E8F`
+
+## Typography
+
+- **Display/Headlines**: `Orbitron` (futuristic, space-age geometric)
+- **Body/Labels**: `Exo 2` (sci-fi yet readable)
+
+## Component Styling Notes
+
+- Cards: `Deep Purple` with subtle `Nebula Pink` border glow, 16px radius
+- Buttons: Gradient `Cosmic Blue` → `Nebula Pink`, 12px radius, star-sparkle on press
+- AppBar: Transparent with gradient overlay, `Orbitron` title
+- Inputs: Filled `#2B1E3E`, `Lavender` focus glow ring, 10px radius
+- Bottom Nav: `Void` bg, `Nebula Pink` selected with pulse glow
+- Background: Subtle animated particle/star field using `CustomPainter`
+
+## Best Used For
+
+Gaming, entertainment, music streaming, nightlife, creative agencies, astrology, space education.

--- a/skills/flutter-theme-factory/themes/modern-minimalist.md
+++ b/skills/flutter-theme-factory/themes/modern-minimalist.md
@@ -1,0 +1,35 @@
+# Modern Minimalist
+
+Clean and contemporary grayscale with sharp typographic hierarchy and breathing space.
+
+## Color Palette
+
+- **Jet Black**: `#121212` - Primary
+- **Graphite**: `#333333` - Secondary
+- **Steel Gray**: `#6B7280` - Tertiary / muted text
+- **Light Gray**: `#E5E7EB` - Borders / dividers
+- **Snow**: `#FAFAFA` - Background light
+- **Pure White**: `#FFFFFF` - Surface / cards
+- **Accent Red**: `#EF4444` - Single accent pop (use sparingly)
+
+### Dark Mode Adjustments
+- Background: `#0A0A0A`
+- Surface: `#171717`
+- On-surface: `#E5E7EB`
+
+## Typography
+
+- **Display/Headlines**: `Space Grotesk` (geometric, modern, technical)
+- **Body/Labels**: `DM Sans` (clean, neutral, excellent readability)
+
+## Component Styling Notes
+
+- Cards: No shadow, 1px border `Light Gray`, 8px radius (sharp)
+- Buttons: Flat black filled, 6px radius, minimal. Outlined variant with 1px border
+- AppBar: Zero elevation, white/black bg, centered title
+- Inputs: Underline-only style, no background fill
+- Bottom Nav: Minimal icons, no labels, thin top border
+
+## Best Used For
+
+Productivity tools, SaaS dashboards, developer tools, note-taking, task management, portfolio apps.

--- a/skills/flutter-theme-factory/themes/neon-tokyo.md
+++ b/skills/flutter-theme-factory/themes/neon-tokyo.md
@@ -1,0 +1,40 @@
+# Neon Tokyo
+
+Cyberpunk-inspired high contrast neon theme with electric energy and urban edge.
+
+## Color Palette
+
+- **Neon Magenta**: `#FF006E` - Primary
+- **Electric Cyan**: `#00F5D4` - Secondary
+- **Hot Yellow**: `#FEE440` - Tertiary / highlights
+- **Deep Black**: `#0A0A0A` - Background
+- **Dark Surface**: `#161616` - Surface / cards
+- **Smoke**: `#2A2A2A` - Elevated surface
+- **Ghost White**: `#F0F0F0` - Text
+
+### Dark Mode (Default, this theme is dark-first)
+- Background: `#0A0A0A`
+- Surface: `#161616`
+
+### Light Mode
+- Background: `#F5F5F5`
+- Surface: `#FFFFFF`
+- Primary: `#D4005A` (darker magenta for light bg)
+
+## Typography
+
+- **Display/Headlines**: `Bebas Neue` (bold, condensed, impactful)
+- **Body/Labels**: `Barlow` (semi-condensed, technical, modern)
+
+## Component Styling Notes
+
+- Cards: `Dark Surface` with neon border on hover/active, 8px radius
+- Buttons: Outlined with `Neon Magenta` border + glow, transparent fill. Filled variant with gradient
+- AppBar: `Deep Black`, `Neon Magenta` accent strip, `Bebas Neue` title
+- Inputs: `Smoke` filled, `Electric Cyan` focus border with glow, 6px radius
+- Bottom Nav: `Deep Black`, neon dot indicators, `Electric Cyan` selected
+- Special: Neon glow `BoxShadow` effect on focused/active elements
+
+## Best Used For
+
+Gaming apps, nightlife/club events, cyberpunk-themed, music production, social platforms, crypto.

--- a/skills/flutter-theme-factory/themes/ocean-depths.md
+++ b/skills/flutter-theme-factory/themes/ocean-depths.md
@@ -1,0 +1,34 @@
+# Ocean Depths
+
+A professional and calming maritime theme that evokes the serenity of deep ocean waters.
+
+## Color Palette
+
+- **Deep Navy**: `#1A2332` - Primary / dark backgrounds
+- **Ocean Blue**: `#1B4965` - Primary container
+- **Teal**: `#2D8B8B` - Secondary / accent highlights
+- **Seafoam**: `#A8DADC` - Tertiary / light accents
+- **Cream**: `#F1FAEE` - Surface light / text on dark
+- **White Smoke**: `#F8F9FA` - Background light
+
+### Dark Mode Adjustments
+- Background: `#0D1620`
+- Surface: `#1A2332`
+- On-surface: `#E8F0F2`
+
+## Typography
+
+- **Display/Headlines**: `Merriweather` (serif, authoritative, trustworthy)
+- **Body/Labels**: `Source Sans Pro` (clean, highly readable)
+
+## Component Styling Notes
+
+- Cards: Subtle border with `Seafoam` at 20% opacity, 12px radius
+- Buttons: Rounded (20px radius), `Teal` primary
+- AppBar: `Deep Navy` with no elevation, `Cream` text
+- Inputs: Outlined with `Teal` focus border, 8px radius
+- Bottom Nav: `Deep Navy` background, `Teal` selected icon
+
+## Best Used For
+
+Corporate apps, financial dashboards, professional consulting tools, healthcare, trust-building interfaces.

--- a/skills/flutter-theme-factory/themes/sunset-boulevard.md
+++ b/skills/flutter-theme-factory/themes/sunset-boulevard.md
@@ -1,0 +1,35 @@
+# Sunset Boulevard
+
+Warm and vibrant sunset colors that evoke energy, warmth, and social connection.
+
+## Color Palette
+
+- **Burnt Orange**: `#E85D04` - Primary
+- **Warm Red**: `#DC2F02` - Primary variant
+- **Golden Yellow**: `#FAA307` - Secondary
+- **Peach**: `#FFBA08` - Tertiary
+- **Dark Charcoal**: `#1A1A2E` - Background dark
+- **Warm White**: `#FFF8F0` - Background light
+- **Soft Cream**: `#FEF3E2` - Surface light
+
+### Dark Mode Adjustments
+- Background: `#1A1110`
+- Surface: `#2D1F1E`
+- Primary: `#FF8A4C` (lighter for dark bg)
+
+## Typography
+
+- **Display/Headlines**: `Raleway` (modern, geometric, energetic)
+- **Body/Labels**: `Nunito` (friendly, rounded, warm)
+
+## Component Styling Notes
+
+- Cards: Warm shadow with orange tint, 16px radius
+- Buttons: Pill shape (24px radius), gradient from `Burnt Orange` to `Golden Yellow`
+- AppBar: Transparent with gradient background
+- Inputs: Filled style with `Peach` at 15% opacity, 12px radius
+- Bottom Nav: Floating with rounded container, shadow
+
+## Best Used For
+
+Social media, food delivery, lifestyle apps, travel, event booking, community platforms.

--- a/skills/flutter-theme-factory/themes/tech-innovation.md
+++ b/skills/flutter-theme-factory/themes/tech-innovation.md
@@ -1,0 +1,41 @@
+# Tech Innovation
+
+Bold and modern tech aesthetic with electric accents and dark-first design.
+
+## Color Palette
+
+- **Electric Blue**: `#3B82F6` - Primary
+- **Vivid Violet**: `#7C3AED` - Secondary
+- **Cyber Green**: `#10B981` - Tertiary / success
+- **Dark Slate**: `#0F172A` - Background dark (default)
+- **Charcoal**: `#1E293B` - Surface dark
+- **Cool Gray**: `#94A3B8` - Muted text
+- **Off White**: `#F1F5F9` - Background light
+
+### Dark Mode (Default)
+- Background: `#0F172A`
+- Surface: `#1E293B`
+- Primary: `#60A5FA` (brighter blue)
+
+### Light Mode
+- Background: `#F8FAFC`
+- Surface: `#FFFFFF`
+- Primary: `#3B82F6`
+
+## Typography
+
+- **Display/Headlines**: `JetBrains Mono` (monospace, developer aesthetic)
+- **Body/Labels**: `Inter` (clean, geometric, readable)
+
+## Component Styling Notes
+
+- Cards: `Charcoal` with 1px border `#334155`, 12px radius, subtle glow on primary cards
+- Buttons: Gradient `Electric Blue` → `Vivid Violet`, 8px radius, neon glow shadow
+- AppBar: `Dark Slate` with no elevation, monospace title
+- Inputs: Filled `#1E293B`, `Electric Blue` focus ring, 8px radius
+- Bottom Nav: `Dark Slate`, `Electric Blue` selected with glow dot indicator
+- Code blocks: `JetBrains Mono` with syntax-highlighted background
+
+## Best Used For
+
+Developer tools, AI/ML apps, startup dashboards, tech platforms, coding apps, crypto/web3.

--- a/skills/flutter-theme-factory/themes/terracotta-studio.md
+++ b/skills/flutter-theme-factory/themes/terracotta-studio.md
@@ -1,0 +1,36 @@
+# Terracotta Studio
+
+Warm clay tones and artisan craft aesthetic, inspired by handmade pottery and natural materials.
+
+## Color Palette
+
+- **Terracotta**: `#C75B39` - Primary
+- **Clay**: `#A0522D` - Primary variant
+- **Warm Sand**: `#DEB887` - Secondary
+- **Sage Cream**: `#C4B59D` - Tertiary
+- **Raw Linen**: `#FAF0E6` - Background light
+- **Cotton**: `#FFF5EB` - Surface
+- **Charcoal Earth**: `#3C3024` - Dark text
+
+### Dark Mode Adjustments
+- Background: `#1E1610`
+- Surface: `#2E2218`
+- Primary: `#D97B5C` (warmer, lighter terracotta)
+
+## Typography
+
+- **Display/Headlines**: `Cardo` (classic, artisan serif with character)
+- **Body/Labels**: `Work Sans` (friendly, approachable, clean)
+
+## Component Styling Notes
+
+- Cards: `Cotton` with warm shadow, 14px radius, optional top border `Terracotta`
+- Buttons: `Terracotta` filled, 10px radius, earthy press animation
+- AppBar: `Raw Linen` with `Charcoal Earth` text, no elevation, craft feel
+- Inputs: Outlined with `Warm Sand` border, `Terracotta` focus, 10px radius
+- Bottom Nav: `Raw Linen` bg, `Terracotta` selected with organic indicator shape
+- Decorative: Subtle paper/canvas texture overlay via `CustomPainter`
+
+## Best Used For
+
+Art portfolios, handmade marketplaces, interior design, cafe/bakery, ceramics, home decor.


### PR DESCRIPTION
## Add: Flutter Theme Factory Skill

Adds a skill for styling Flutter apps with professional themes. Includes **12 pre-built themes** (Ocean Depths, Sunset Boulevard, Neon Tokyo, etc.) with full `ColorScheme`, Google Fonts pairings, component theming, and light/dark mode support.

Claude reads the theme spec and generates production-ready Dart files (`app_theme.dart`, `app_colors.dart`, `app_typography.dart`, `app_spacing.dart`) — ready to drop into any Flutter project. Also supports custom theme generation based on brand colors and audience.

Material 3 compliant. WCAG AA accessible. MIT Licensed.