### PR TITLE
feat: add Specl specification language skill

### DIFF
--- a/skills/specl/LICENSE.txt
+++ b/skills/specl/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/specl/SKILL.md
+++ b/skills/specl/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: specl
+description: >
+  Write, debug, and verify Specl specifications for concurrent and distributed systems.
+  Specl is a modern TLA+ replacement with clean syntax, implicit frame semantics, and a fast
+  Rust model checker. Use when: writing Specl specs (.specl files), modelling distributed
+  protocols (Raft, Paxos, 2PC, etc.), debugging invariant violations or deadlocks, translating
+  TLA+ to Specl, reviewing formal specifications, or when the user mentions Specl, model checking,
+  formal verification, or state space exploration. Keywords: specl, model checking, formal
+  verification, TLA+, distributed systems, consensus, invariant, safety, specification language.
+license: Complete terms in LICENSE.txt
+---
+
+# Specl — Specification Language & Model Checker
+
+Specl is an exhaustive model checker for concurrent and distributed systems. Write a spec (state machine), and the checker explores every reachable state to verify invariants or produce minimal counterexample traces.
+
+GitHub: https://github.com/danwt/specl
+
+## Installation & CLI
+
+```bash
+cargo install --path crates/specl-cli    # `specl` binary
+cargo install --path crates/specl-lsp    # language server (optional)
+```
+
+Key commands:
+```bash
+specl check spec.specl -c N=3 -c MAX=10    # check with constants
+specl check spec.specl --no-deadlock        # skip deadlock check (use for protocols)
+specl check spec.specl --fast               # fingerprint-only (10x less memory, no traces)
+specl check spec.specl --por                # partial order reduction
+specl check spec.specl --symmetry           # symmetry reduction
+specl format spec.specl --write             # auto-format
+specl watch spec.specl -c N=3              # re-check on save
+specl translate spec.tla -o spec.specl     # TLA+ to Specl
+```
+
+## Minimal Example
+
+```specl
+module Counter
+const MAX: 0..10
+var count: 0..10
+init { count = 0 }
+action Inc() { require count < MAX; count = count + 1 }
+action Dec() { require count > 0; count = count - 1 }
+invariant Bounded { count >= 0 and count <= MAX }
+```
+
+`specl check Counter.specl -c MAX=3` explores all 4 states and verifies the invariant.
+
+## Critical Rules
+
+- **`=`** assigns next-state. **`==`** compares. Mixing these up is the #1 mistake.
+- Variables not mentioned in an action stay unchanged (implicit frame).
+- Use `and` to update multiple variables in one action.
+- `require` is a guard. If false, the action is skipped (checker tries other actions).
+- The checker explores ALL actions x ALL parameter combinations x ALL reachable states.
+
+## Full Language Reference
+
+For complete syntax, types, operators, dict patterns, quantifiers, functions, modelling patterns,
+and common pitfalls, read [references/language.md](references/language.md).
+
+## Modelling Approach
+
+1. **Identify state.** What variables describe the system? For N processes, use `Dict[Int, ...]`.
+2. **Identify actions.** What transitions can happen? Use parameters for nondeterminism.
+3. **Write guards.** `require` restricts when actions fire.
+4. **Write invariants.** Safety properties that must always hold.
+5. **Start small.** N=2, small bounds. State spaces grow exponentially.
+
+Common patterns:
+- **Process ensemble:** `var state: Dict[Int, Int]` + `action Act(p: 0..N) { state = state | {p: newVal} }`
+- **Messages:** `var msgs: Set[Seq[Int]]` — add with `union`, check with `in`
+- **Quorum:** `len({i in 0..N if votes[i]}) * 2 > N + 1`
+- **Nested dict update:** `votesGranted = votesGranted | {i: votesGranted[i] | {j: true}}`
+
+## Analysing Results
+
+**OK:** All states satisfy all invariants.
+
+**INVARIANT VIOLATION:** Trace shows shortest path — each step is one action firing with resulting state.
+
+**DEADLOCK:** A state where no action is enabled. Use `--no-deadlock` for protocols.
+
+**Tips:** `--fast` for large state spaces. `--por` for loosely coupled processes. `--no-deadlock` for most protocols.

--- a/skills/specl/references/language.md
+++ b/skills/specl/references/language.md
@@ -1,0 +1,186 @@
+# Specl Language Reference
+
+## Module Structure
+
+```specl
+module Name
+const C: Int              // set at check time: -c C=5
+var x: 0..10              // state variable with type bound
+init { x = 0 }            // initial state (one block)
+action Step() { ... }     // state transition
+func Helper(a) { ... }    // pure function (no state modification)
+invariant Safe { ... }    // must hold in every reachable state
+```
+
+## Types
+
+| Type | Example | Notes |
+|------|---------|-------|
+| `Bool` | `true`, `false` | |
+| `Int` | `42`, `-7` | Unbounded |
+| `Nat` | `0`, `100` | Non-negative int |
+| `0..10` | | Inclusive range of ints |
+| `Set[T]` | `{1, 2, 3}` | Finite set |
+| `Seq[T]` | `[a, b, c]` | Ordered list (0-indexed) |
+| `Dict[K, V]` | `{k: 0 for k in 0..N}` | Map from keys to values |
+| `String` | `"red"` | String literal |
+
+## Operators
+
+| Category | Operators |
+|----------|-----------|
+| Logical | `and`, `or`, `not`, `implies`, `iff` |
+| Comparison | `==`, `!=`, `<`, `<=`, `>`, `>=` |
+| Arithmetic | `+`, `-`, `*`, `/`, `%` |
+| Set | `in`, `not in`, `union`, `intersect`, `diff`, `subset_of` |
+| Sequence | `++` (concat), `head(s)`, `tail(s)`, `len(s)`, `s[i]` (index) |
+| Conditional | `if ... then ... else ...` (expression — always requires else) |
+
+## Dicts
+
+Create with comprehension:
+```specl
+var role: Dict[Int, Int]
+init { role = {p: 0 for p in 0..N} }
+```
+
+Update with `|` (merge):
+```specl
+role = role | {i: 2}                                               // one key
+balance = balance | { from: balance[from] - amt, to: balance[to] + amt }  // multiple keys
+votesGranted = votesGranted | {i: votesGranted[i] | {j: true}}     // nested dict
+```
+
+Access: `role[i]`, `votesGranted[i][j]`
+
+## Parameterized Actions
+
+Checker tries ALL valid parameter combinations in every reachable state:
+
+```specl
+action Transfer(from: 0..N, to: 0..N, amount: 1..MAX) {
+    require from != to
+    require balance[from] >= amount
+    balance = balance | { from: balance[from] - amount, to: balance[to] + amount }
+}
+```
+
+## Guards
+
+`require` is a precondition. If false, the action is skipped (not an error):
+
+```specl
+action Eat(p: 0..2) {
+    require philState[p] == 1
+    require fork[p] == true and fork[(p + 2) % 3] == true
+    philState = philState | { p: 2 }
+    and fork = fork | { p: false, (p + 2) % 3: false }
+}
+```
+
+## Quantifiers
+
+```specl
+all x in 0..N: P(x)       // universal: true if P holds for ALL x
+any x in 0..N: P(x)       // existential: true if P holds for SOME x
+```
+
+Work in invariants, guards, and any expression.
+
+## Set Comprehensions
+
+```specl
+{p in 0..N if state[p] == 1}                    // filter
+len({v in 0..N if votedFor[v] == i})             // count matching
+len({v in 0..N if voted[v]}) * 2 > N + 1         // quorum check
+```
+
+## Functions
+
+Pure, no state modification, used for reusable logic:
+
+```specl
+func LastLogTerm(l) { if len(l) == 0 then 0 else l[len(l) - 1] }
+func Quorum(n) { (n / 2) + 1 }
+func Max(a, b) { if a > b then a else b }
+```
+
+## Multiple Variable Updates
+
+Use `and` to update multiple variables atomically:
+
+```specl
+action Reset() {
+    x = 0
+    and y = 0
+    and z = 0
+}
+```
+
+## TLA+ Comparison
+
+| TLA+ | Specl |
+|------|-------|
+| `x' = x + 1` | `x = x + 1` |
+| `x = y` (equality) | `x == y` |
+| `UNCHANGED <<y, z>>` | *(implicit)* |
+| `/\`, `\/`, `~` | `and`, `or`, `not` |
+| `\in`, `\notin` | `in`, `not in` |
+| `\A x \in S: P(x)` | `all x in S: P(x)` |
+| `\E x \in S: P(x)` | `any x in S: P(x)` |
+| `[f EXCEPT ![k] = v]` | `f \| { k: v }` |
+| `Init == ...` | `init { ... }` |
+| `Next == A \/ B` | *(implicit — all actions OR'd)* |
+
+## Common Pitfalls
+
+- **`=` vs `==`**: `=` assigns, `==` compares. Inside actions, `x = 5` sets x. In invariants, use `x == 5`.
+- **No `let` bindings**: Use inline expressions or extract to a `func`.
+- **`any` is boolean only**: `any x in S: P(x)` returns Bool. Cannot use `x` outside.
+- **Range params no arithmetic**: `action A(i: 0..N+1)` is invalid. Define `const MaxI: Int` and use `0..MaxI`.
+- **`implies` precedence in nested quantifiers**: Flatten: `all c: all k: (A and B) implies C` instead of nesting.
+- **State spaces are exponential**: N=2 ~ 100K-2M states, N=3 ~ 10M-100M. Always start small.
+- **Use `--no-deadlock` for protocols**: Most distributed protocols have quiescent states where no action fires.
+
+## Message Passing Pattern
+
+Encode messages as sequences (tuples), store in a set:
+
+```specl
+var msgs: Set[Seq[Int]]
+init { msgs = {} }
+
+action Send(src: 0..N, dest: 0..N) {
+    require role[src] == 2
+    msgs = msgs union {[1, src, dest, currentTerm[src]]}
+}
+
+action Receive(src: 0..N, dest: 0..N) {
+    require [1, src, dest, currentTerm[src]] in msgs
+    // handle message...
+}
+```
+
+## Encoding Enums
+
+Use integer constants with comments:
+
+```specl
+// Roles: 0=Follower, 1=Candidate, 2=Leader
+var role: Dict[Int, 0..2]
+action BecomeCandidate(i: 0..N) { require role[i] == 0; role = role | {i: 1} }
+```
+
+## CLI Flags Reference
+
+| Flag | Effect |
+|------|--------|
+| `-c KEY=VAL` | Set constant value |
+| `--no-deadlock` | Don't report deadlocks |
+| `--no-parallel` | Single-threaded |
+| `--threads N` | Set thread count |
+| `--max-states N` | Stop after N states |
+| `--fast` | Fingerprint-only (no traces, 8 bytes/state) |
+| `--por` | Partial order reduction |
+| `--symmetry` | Symmetry reduction |
+| `--write` | (format) Write in place |


### PR DESCRIPTION
## Summary

Adds a skill for [Specl](https://github.com/danwt/specl), a modern specification language and model checker for concurrent and distributed systems (TLA+/TLC replacement).

- **SKILL.md** — installation, CLI, minimal example, critical syntax rules, modelling approach, result analysis
- **references/language.md** — full language reference: types, operators, dicts, quantifiers, functions, common patterns, pitfalls, TLA+ comparison, CLI flags

## Use cases

- Writing new Specl specifications (.specl files)
- Modelling distributed protocols (Raft, Paxos, 2PC, Percolator, etc.)
- Debugging invariant violations and deadlocks from model checker traces
- Translating TLA+ specifications to Specl
- Reviewing formal specifications for correctness

## Structure

```
skills/specl/
├── SKILL.md                  # Core instructions + modelling guide
├── references/language.md    # Full syntax/type/operator reference
└── LICENSE.txt               # Apache 2.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)