### PR TITLE
Fix case sensitivity issues in pdf skill references

### DIFF
--- a/skills/pdf/SKILL.md
+++ b/skills/pdf/SKILL.md
@@ -8,7 +8,7 @@ license: Proprietary. LICENSE.txt has complete terms
 
 ## Overview
 
-This guide covers essential PDF processing operations using Python libraries and command-line tools. For advanced features, JavaScript libraries, and detailed examples, see REFERENCE.md. If you need to fill out a PDF form, read FORMS.md and follow its instructions.
+This guide covers essential PDF processing operations using Python libraries and command-line tools. For advanced features, JavaScript libraries, and detailed examples, see [reference.md](reference.md). If you need to fill out a PDF form, read [forms.md](forms.md) and follow its instructions.
 
 ## Quick Start
 
@@ -304,11 +304,11 @@ with open("encrypted.pdf", "wb") as output:
 | Create PDFs | reportlab | Canvas or Platypus |
 | Command line merge | qpdf | `qpdf --empty --pages ...` |
 | OCR scanned PDFs | pytesseract | Convert to image first |
-| Fill PDF forms | pdf-lib or pypdf (see FORMS.md) | See FORMS.md |
+| Fill PDF forms | pdf-lib or pypdf (see [forms.md](forms.md)) | See [forms.md](forms.md) |
 
 ## Next Steps
 
-- For advanced pypdfium2 usage, see REFERENCE.md
-- For JavaScript libraries (pdf-lib), see REFERENCE.md
-- If you need to fill out a PDF form, follow the instructions in FORMS.md
-- For troubleshooting guides, see REFERENCE.md
+- For advanced pypdfium2 usage, see [reference.md](reference.md)
+- For JavaScript libraries (pdf-lib), see [reference.md](reference.md)
+- If you need to fill out a PDF form, follow the instructions in [forms.md](forms.md)
+- For troubleshooting guides, see [reference.md](reference.md)


### PR DESCRIPTION
## Summary

Fixes case sensitivity mismatches in `skills/pdf/SKILL.md` where references used UPPERCASE filenames but actual files are lowercase.

Closes #375

## Changes

- ✅ `REFERENCE.md` → `reference.md` (4 occurrences)
- ✅ `FORMS.md` → `forms.md` (4 occurrences)

## Problem

The pdf skill referenced files using UPPERCASE (`FORMS.md`, `REFERENCE.md`), but actual files use lowercase (`forms.md`, `reference.md`). This breaks on case-sensitive filesystems (Linux, macOS with APFS case-sensitive).

## Root Cause

The repository follows lowercase/kebab-case convention for all files except `SKILL.md` and `LICENSE.txt` (documented in README.md line 85). The `skills/skill-creator/SKILL.md` examples use UPPERCASE references, which were incorrectly copied without adjustment.

## Validation

Created comprehensive link validation script that scans all 44 markdown files.

**Before fix:**
```
❌ Total issues: 8
⚠️  Case mismatches: 8
```

**After fix:**
```
✅ No critical issues found!
📄 Scanned files: 44
❌ Total issues: 0
```

## Impact

- **Low risk:** Only changes plain text references (not code)
- **High compatibility:** Fixes cross-platform compatibility issues
- **Tested:** Validated against all repository markdown files

## Related

- Issue #375 contains detailed analysis and recommendations
- Validation script available in issue comments if needed for CI/CD

---

**Testing:** Comprehensive markdown link validation  
**Environment:** Fedora Silverblue 43, case-sensitive filesystem