### PR TITLE
 Add claude-agent-tos-guardian: TOS compliance skill for autonomous agents

### DIFF
--- a/skills/claude-agent-tos-guardian/README.md
+++ b/skills/claude-agent-tos-guardian/README.md
@@ -1,0 +1,104 @@
+# TOS Guardian — Anthropic Compliance Skill for AI Agents
+
+**Prevent account suspension. Keep your agents legal.**
+
+An [Agent Skill](https://claude.com/blog/skills) that enforces Anthropic's Consumer TOS for autonomous AI agents.
+
+🌐 [cryptopedia.ai](https://cryptopedia.ai) · 𝕏 [@cryptopedia_AI](https://x.com/cryptopedia_AI)
+
+---
+
+## What This Is
+
+TOS Guardian is a compliance skill that teaches AI agents the rules before they break them.
+
+If you run autonomous Claude-powered agents — on Hetzner, Railway, AWS, your basement server, wherever — those agents need to know what they can and can't do under Anthropic's Consumer Terms of Service. Most don't. They'll happily auto-refresh OAuth tokens, hammer the API at machine speed, or publish content without checking policy. Then your account gets suspended and you lose everything.
+
+This skill prevents that. It gives your agents a clear, machine-readable ruleset covering authentication, access methods, rate limits, content policy, data handling, and account integrity. It includes a self-check protocol agents run at startup and periodically, an audit logging system, and graceful degradation — so when something goes wrong, the agent pauses and calls you instead of digging itself deeper.
+
+## Who This Helps
+
+**Agent operators:** You get peace of mind. Your agents know the boundaries. You don't wake up to a suspended account.
+
+**Anthropic:** Compliant agents mean less abuse, fewer false positives in enforcement, and a healthier ecosystem. When agents self-police, everybody wins.
+
+**The community:** This is the first TOS compliance skill for AI agents. It's open source, cross-platform (works with Claude Code, Codex CLI, and any framework that reads Agent Skills), and sets a precedent that autonomous agents should ship with governance built in — not bolted on after something goes wrong.
+
+## Rules Covered
+
+| Rule | Summary |
+|------|---------|
+| 1. Human Auth | Tokens must come from human login — no auto-refresh |
+| 2. Sanctioned Access | Only Claude Code, API keys, or approved tools |
+| 3. Rate Respect | Human-reasonable pace, backoff on limits |
+| 4. Content Policy | All publications pass AUP checklist |
+| 5. Data Privacy | Redact secrets and PII from prompts |
+| 6. Account Integrity | One user per token, no reselling |
+| 7. Graceful Degradation | When uncertain, stop and ask |
+| 8. Audit Trail | Log every TOS-relevant decision |
+
+## How It Works
+
+1. Drop the skill into your agent's skills directory
+2. The agent loads it automatically when relevant (that's how Agent Skills work)
+3. At boot and every 4 hours, the self-check script validates token status, access methods, and environment
+4. If something's wrong — expired token, unsanctioned tool detected — the agent pauses and notifies you
+5. Every TOS-relevant decision gets logged to an audit trail you can review anytime
+
+No magic. No black boxes. Just a Markdown file with clear rules and a bash script that checks them.
+
+## Install
+
+```bash
+# Claude Code (personal)
+cp -r tos-guardian ~/.claude/skills/
+
+# Claude Code (project)
+cp -r tos-guardian .claude/skills/
+
+# OpenClaw
+cp -r tos-guardian /root/.openclaw/workspace/skills/
+
+# Any other framework
+# Load SKILL.md into your agent's system prompt at initialization
+```
+
+---
+
+## Independent Project — Not Affiliated with Anthropic
+
+This skill is an independent, community-built project. The developer is **not associated with, employed by, endorsed by, or affiliated with Anthropic in any way**.
+
+This is a good-faith effort by someone who uses Anthropic's products, appreciates them, and wants to help both sides: agent operators who want to stay compliant, and Anthropic who benefits from a community that respects the rules instead of gaming them.
+
+The rules in this skill are based on publicly available information — Anthropic's published Consumer Terms of Service, their Acceptable Use Policy, public enforcement actions, and official documentation. Nothing here is sourced from insider knowledge, private communications, or privileged access.
+
+If Anthropic has corrections, suggestions, or objections, contributions are welcome.
+
+---
+
+## Disclaimer & Terms
+
+This skill is provided **as-is**, without warranty of any kind, express or implied.
+
+By using TOS Guardian, you acknowledge and agree that:
+
+1. **No guarantees.** This skill is a best-effort guide based on publicly available information about Anthropic's Consumer Terms of Service as of February 2026. It does not guarantee compliance. Terms change. Enforcement evolves. This skill may be outdated, incomplete, or wrong.
+
+2. **Not legal advice.** Nothing in this skill constitutes legal advice. We are not lawyers. If you need a legal opinion on your specific use case, consult an actual lawyer.
+
+3. **AI-generated content.** This skill was built with the assistance of AI. AI makes mistakes. Review everything yourself before relying on it.
+
+4. **You are responsible.** The human operator is solely responsible for their agents' behavior, their account, and their compliance with any applicable terms of service. If your agent violates Anthropic's TOS (or anyone else's), that's on you — not on this skill, its authors, or its contributors.
+
+5. **No liability.** The authors and contributors of TOS Guardian shall not be held liable for any damages, account suspensions, financial losses, or consequences of any kind arising from the use or misuse of this skill.
+
+6. **You already know this.** If you're running autonomous AI agents on remote infrastructure, you presumably understand the risks. This skill helps — it doesn't babysit.
+
+This disclaimer may be updated at any time. Check the repo for the latest version.
+
+---
+
+## License
+
+Apache 2.0 — Use it, fork it, improve it. Keep agents compliant.

--- a/skills/claude-agent-tos-guardian/SKILL.md
+++ b/skills/claude-agent-tos-guardian/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: tos-guardian
+description: >
+  Enforces Anthropic Consumer Terms of Service compliance for autonomous AI agents.
+  Load this skill when agents operate persistently, handle authentication tokens,
+  publish content, interact with third-party services, or run on remote infrastructure.
+  Prevents TOS violations that could result in account suspension.
+version: 1.0.0
+author: Dorin (pygmon.com)
+license: Apache-2.0
+compatibility:
+  - claude-code
+  - claude-api
+  - claude-ai
+tags:
+  - compliance
+  - safety
+  - governance
+  - autonomous-agents
+  - tos
+---
+
+# TOS Guardian — Anthropic Compliance Skill for Autonomous Agents
+
+## Purpose
+
+This skill ensures that AI agents running on Claude infrastructure — whether locally,
+on remote servers (Hetzner, Railway, AWS, etc.), or in sandboxed environments — always
+operate within the boundaries of Anthropic's Consumer Terms of Service.
+
+It is designed for autonomous agents that run persistently, handle OAuth tokens,
+publish content, or operate with minimal human supervision.
+
+**This skill is not optional. Load it before any autonomous operation begins.**
+
+---
+
+## RULE 1: Authentication Must Involve a Human
+
+### The Law
+Anthropic's Consumer TOS prohibits accessing Services "through automated or non-human
+means, whether through a bot, script, or otherwise" — except via an Anthropic API Key
+or where Anthropic explicitly permits it.
+
+### What This Means for Agents
+
+**PERMITTED:**
+- Using an OAuth token that a human obtained by logging in via `claude /login`
+- Using an OAuth token refreshed by a human clicking an auth URL
+- Using an Anthropic API key (Commercial Terms apply instead)
+- Running Claude Code CLI on a remote server where the human authenticated
+- A human-triggered scheduled task that pushes a manually-refreshed token to servers
+
+**PROHIBITED:**
+- Programmatically calling the OAuth refresh endpoint without human interaction
+- Scripts that auto-cycle tokens on a timer with zero human involvement
+- Spoofing Claude Code's client ID or user-agent to obtain tokens
+- Using third-party harnesses that impersonate Claude Code's OAuth flow
+- Bots that complete the browser-based OAuth flow without human click
+
+### Agent Behavior
+```
+IF token_expired OR token_expiring_soon:
+  DO NOT attempt programmatic refresh
+  DO notify the human operator via configured channel
+  DO provide the auth URL if available from `claude login` headless output
+  DO pause operations gracefully until a valid token is provided
+  DO NOT crash — enter a documented sleep state with clear wake conditions
+```
+
+---
+
+## RULE 2: Use Only Sanctioned Access Methods
+
+### The Law
+Anthropic actively enforces against third-party tools that route requests through
+Consumer subscription (Free/Pro/Max) OAuth tokens while impersonating Claude Code.
+
+**SANCTIONED:** Claude Code CLI, Claude.ai, Anthropic API (with key), Claude Agent SDK, OpenClaw (wraps Claude Code)
+**NOT SANCTIONED:** OpenCode, Roo Code, Cline, Kilo, custom scripts calling internal API endpoints, tools spoofing client ID
+
+### Agent Behavior
+```
+BEFORE making any Claude API call:
+  VERIFY the access method is sanctioned
+  VERIFY you are not spoofing User-Agent or client headers
+  LOG the access method used for audit trail
+```
+
+---
+
+## RULE 3: Respect Rate Limits and Usage Patterns
+
+Consumer subscriptions are designed for human-paced interaction. Anthropic monitors
+for patterns indicating automated abuse.
+
+### Agent Behavior
+```
+IMPLEMENT natural pacing:
+  - Minimum 2-second delay between sequential API calls
+  - Exponential backoff on 429 responses
+  - Include idle periods — do not operate at 100% duty cycle
+  - If running overnight, log a human-readable activity report
+IMPLEMENT usage tracking:
+  - Count tokens consumed per session
+  - Alert human if usage exceeds reasonable thresholds
+```
+
+---
+
+## RULE 4: Content and Acceptable Use Policy
+
+**AGENTS MUST NOT generate or publish:**
+- Content that deceives about AI origin
+- Spam or bulk unsolicited communications
+- Content violating intellectual property rights
+- Harassment, threats, or violence promotion
+- Content facilitating illegal activities
+- Misinformation presented as fact
+
+**AGENTS MUST:**
+- Identify AI-generated content where required by law or platform rules
+- Respect platform-specific TOS (Twitter/X, Nostr, etc.) in addition to Anthropic's
+- Log all published content for human review
+- Implement a kill switch — published content must be retractable
+
+---
+
+## RULE 5: Data Handling and Privacy
+
+**AGENTS MUST NOT submit to Claude on Consumer plans:**
+- Credentials, API keys, passwords (except for immediate operational use)
+- Other people's PII, PHI, financial account numbers
+- Data subject to NDA or confidentiality agreements
+
+**AGENTS SHOULD:** Minimize data in prompts, strip sensitive fields, use env vars for secrets.
+
+---
+
+## RULE 6: Account Integrity
+
+**PERMITTED:** Multiple agents using one user's token (they are the user's tools)
+**PROHIBITED:** Sharing tokens with other humans, building proxy services, reselling access
+
+---
+
+## RULE 7: Graceful Degradation and Transparency
+
+```
+ON any TOS-relevant uncertainty:
+  1. STOP the potentially violating action
+  2. LOG the situation with full context
+  3. NOTIFY the human operator
+  4. ENTER safe standby mode
+  5. DOCUMENT the incident for review
+NEVER: circumvent rate limits, retry indefinitely after 403/401, switch access methods to avoid restrictions
+```
+
+---
+
+## RULE 8: Audit Trail
+
+```
+MAINTAIN an audit log at: $WORKSPACE/tos_audit.log
+LOG FORMAT: [ISO_TIMESTAMP] [RULE_N] [PASS|FAIL|WARN] description
+RETAIN logs for minimum 30 days
+MAKE logs accessible to the human operator at all times
+```
+
+---
+
+## Self-Check Protocol (run at startup + every 4 hours)
+
+```
+[ ] Am I using a sanctioned access method? (Rule 2)
+[ ] Was my token obtained via human authentication? (Rule 1)
+[ ] Is my token still valid? If not, have I notified the human? (Rule 1)
+[ ] Am I operating at human-reasonable pace? (Rule 3)
+[ ] Have I reviewed my pending publications against AUP? (Rule 4)
+[ ] Am I handling sensitive data appropriately? (Rule 5)
+[ ] Am I serving only my authorized operator? (Rule 6)
+[ ] Is my audit log current and accessible? (Rule 8)
+[ ] Time since last human check-in: ___h (target: <24h)
+```
+
+---
+
+## Integration
+
+- **Claude Code:** Place in `~/.claude/skills/tos-guardian/` or `.claude/skills/`
+- **OpenClaw:** Include in `/root/.openclaw/workspace/skills/tos-guardian/`
+- **Custom frameworks:** Load SKILL.md into system prompt at initialization
+- **Self-check script:** `scripts/self-check.sh` — run via cron every 4 hours
+
+## Environment Variables
+```bash
+TOS_GUARDIAN_NOTIFY_METHOD=nostr    # nostr|telegram|email|webhook
+TOS_GUARDIAN_NOTIFY_TARGET=npub...  # recipient for alerts
+TOS_GUARDIAN_TOKEN_WARN_HOURS=4     # hours before expiry to warn
+TOS_GUARDIAN_AUDIT_PATH=/var/log/tos_audit.log
+TOS_GUARDIAN_MAX_DAILY_TOKENS=5000000  # soft cap for usage alerts
+```
+
+---
+
+## Versioning
+
+- **v1.0.0** (2026-02-13): Initial release based on Consumer TOS as of February 2026
+- TOS enforcement precedents: January 2026 third-party harness crackdown
+
+**License:** Apache 2.0

--- a/skills/claude-agent-tos-guardian/scripts/self-check.sh
+++ b/skills/claude-agent-tos-guardian/scripts/self-check.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# TOS Guardian Self-Check Script
+# Run at agent startup and every 4 hours via cron
+# Exit codes: 0 = all clear, 1 = warnings, 2 = violations (agent should pause)
+
+set -euo pipefail
+
+AUDIT_LOG="${TOS_GUARDIAN_AUDIT_PATH:-/var/log/tos_audit.log}"
+WARN_HOURS="${TOS_GUARDIAN_TOKEN_WARN_HOURS:-4}"
+NOTIFY_METHOD="${TOS_GUARDIAN_NOTIFY_METHOD:-none}"
+NOTIFY_TARGET="${TOS_GUARDIAN_NOTIFY_TARGET:-}"
+STATUS=0
+
+timestamp() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+
+log_audit() {
+  local rule="$1" level="$2" msg="$3"
+  echo "[$(timestamp)] [RULE_${rule}] [${level}] ${msg}" >> "$AUDIT_LOG"
+}
+
+echo "================================"
+echo "TOS GUARDIAN SELF-CHECK"
+echo "$(timestamp)"
+echo "================================"
+
+# Check token validity
+CREDS_FILE="${HOME}/.claude/.credentials.json"
+if [ -f "$CREDS_FILE" ] && command -v python3 &>/dev/null; then  TOKEN_STATUS=$(python3 -c "
+import json, time
+with open('$CREDS_FILE') as f:
+    creds = json.load(f)
+oauth = creds.get('claudeAiOauth', {})
+exp = oauth.get('expiresAt', 0)
+now = int(time.time() * 1000)
+hours_left = (exp - now) / (1000*60*60)
+if hours_left <= 0: print(f'EXPIRED|{hours_left:.1f}')
+elif hours_left <= $WARN_HOURS: print(f'WARNING|{hours_left:.1f}')
+else: print(f'VALID|{hours_left:.1f}')
+" 2>/dev/null) || TOKEN_STATUS="ERROR|0"
+
+  IFS='|' read -r TOKEN_STATE HOURS_LEFT <<< "$TOKEN_STATUS"
+  case "$TOKEN_STATE" in
+    VALID)   echo "  ✅ Token valid (${HOURS_LEFT}h remaining)";;
+    WARNING) echo "  ⚠️  Token expiring (${HOURS_LEFT}h)"; STATUS=1;;
+    EXPIRED) echo "  ❌ Token EXPIRED — agent must pause"; STATUS=2;;
+    *)       echo "  ⚠️  Token check failed"; STATUS=1;;
+  esac
+  log_audit 1 "$TOKEN_STATE" "Token: ${HOURS_LEFT}h remaining"
+fi
+
+# Check sanctioned access
+CLAUDE_BIN=$(which claude 2>/dev/null || echo "")
+[ -n "$CLAUDE_BIN" ] && echo "  ✅ Claude Code CLI found" || echo "  ⚠️  Claude CLI not in PATH"
+
+# Check for unsanctioned tools
+for TOOL in opencode roo-code cline kilo; do
+  command -v "$TOOL" &>/dev/null && { echo "  ❌ UNSANCTIONED: $TOOL"; STATUS=2; }
+done
+echo ""
+echo "================================"
+case $STATUS in
+  0) echo "STATUS: ✅ ALL CLEAR — Agent may proceed" ;;
+  1) echo "STATUS: ⚠️  WARNINGS — Proceed with caution" ;;
+  2) echo "STATUS: ❌ VIOLATIONS — Agent MUST pause" ;;
+esac
+echo "================================"
+
+exit $STATUS


### PR DESCRIPTION
## What this adds

A compliance skill that teaches autonomous AI agents the rules of Anthropic's Consumer TOS before they break them.

**Problem:** Agents running on remote servers (Hetzner, Railway, AWS) don't inherently know TOS boundaries. They'll auto-refresh OAuth tokens, hammer APIs at machine speed, or publish without checking policy. Accounts get suspended.

**Solution:** 8 enforceable rules covering authentication (human-in-the-loop), sanctioned access methods, rate limiting, content policy, data privacy, account integrity, graceful degradation, and audit logging. Includes a self-check script agents run at startup and every 4 hours.

**Not affiliated with Anthropic.** Independent community project. Good-faith effort to help operators stay compliant and reduce enforcement burden on Anthropic's side.

Repo: https://github.com/cdtodosi-bit/claude-agent-tos-guardian