### PR TITLE
Add robot-framework-py example skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -23,7 +23,7 @@
     },
     {
       "name": "example-skills",
-      "description": "Collection of example skills demonstrating various capabilities including skill creation, MCP building, visual design, algorithmic art, internal communications, web testing, artifact building, Slack GIFs, and theme styling",
+      "description": "Collection of example skills demonstrating various capabilities including skill creation, MCP building, visual design, algorithmic art, internal communications, Robot Framework automation, web testing, artifact building, Slack GIFs, and theme styling",
       "source": "./",
       "strict": false,
       "skills": [
@@ -34,6 +34,7 @@
         "./skills/frontend-design",
         "./skills/internal-comms",
         "./skills/mcp-builder",
+        "./skills/robot-framework-py",
         "./skills/skill-creator",
         "./skills/slack-gif-creator",
         "./skills/theme-factory",

--- a/skills/robot-framework-py/LICENSE.txt
+++ b/skills/robot-framework-py/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/robot-framework-py/SKILL.md
+++ b/skills/robot-framework-py/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: robot-framework-py
+description: Guide for authoring and refactoring Robot Framework test automation with Python-based libraries. Use when Claude needs to create or modify `.robot` suites, `.resource` files, RequestsLibrary API tests, or custom Python keyword libraries for service and API testing workflows.
+license: Complete terms in LICENSE.txt
+---
+
+# Robot Framework (Python)
+
+Create deterministic, maintainable Robot Framework automation for API and service-level testing.
+
+## Use this default project layout
+
+```text
+tests/
+resources/
+libraries/
+variables/
+```
+
+- Store suite files in `tests/`.
+- Store reusable keywords in `resources/`.
+- Store custom Python keyword libraries in `libraries/`.
+- Store environment-specific variable files in `variables/`.
+
+## Generate valid Robot Framework sections
+
+For `.robot` suite files, use:
+
+- `*** Settings ***`
+- `*** Variables ***` (when needed)
+- `*** Test Cases ***`
+- `*** Keywords ***` (only when local keywords are needed)
+
+For `.resource` files, use:
+
+- `*** Settings ***`
+- `*** Variables ***` (optional)
+- `*** Keywords ***`
+
+Use BuiltIn assertions (`Should Be Equal`, `Should Contain`, `Should Be True`, `Should Not Be Empty`) instead of ad-hoc assertion logic.
+
+## Prioritize reuse and maintainability
+
+- Keep test cases short and move repeated flows into resource keywords.
+- Use `Suite Setup` and `Suite Teardown` for shared lifecycle steps.
+- Apply consistent tags (`smoke`, `api`, `regression`, domain tags).
+- Keep secrets out of suite files; load from environment variables or secure variable files.
+
+## Use libraries deliberately
+
+- Use BuiltIn for assertions, logging, and control flow.
+- Use OperatingSystem for file and environment checks.
+- Use Collections, String, Process, and XML only when required by the test flow.
+- Declare all imported libraries explicitly in `*** Settings ***`.
+
+Do not add SeleniumLibrary, Browser, Appium, or other UI automation stacks unless the user explicitly asks for them.
+
+## Follow this RequestsLibrary path for API tests
+
+- Install with `pip install robotframework-requests`.
+- Create sessions with `Create Session`.
+- Reuse sessions for related requests.
+- Build auth headers and shared request data in reusable keywords.
+- Assert both HTTP status and business-critical response fields.
+
+### Minimal RequestsLibrary example
+
+```robotframework
+*** Settings ***
+Library    RequestsLibrary
+
+*** Variables ***
+${BASE_URL}    https://api.example.com
+
+*** Test Cases ***
+Get Health Endpoint
+    Create Session    api    ${BASE_URL}
+    ${resp}=    GET On Session    api    /health
+    Should Be Equal As Integers    ${resp.status_code}    200
+```
+
+## Implement Python keyword libraries safely
+
+- Keep each keyword focused on one responsibility.
+- Return simple serializable types where possible.
+- Raise clear assertion failures for invalid state or input.
+
+### Module-style keyword library
+
+```python
+from robot.api.deco import keyword
+
+@keyword("Normalize Text")
+def normalize_text(value: str) -> str:
+    return " ".join(value.split()).strip().lower()
+```
+
+### Class-style keyword library
+
+```python
+from robot.api.deco import keyword
+
+class MathKeywords:
+    @keyword("Add Integers")
+    def add_integers(self, left: int, right: int) -> int:
+        return int(left) + int(right)
+```
+
+## Prevent hallucinations
+
+- State which library provides each non-trivial keyword pattern.
+- If a keyword or library is external and not explicitly requested, label it as optional.
+- Do not present unknown keywords as built-in Robot Framework keywords.
+
+## Execution checklist
+
+1. Identify output type (`.robot` suite, `.resource`, or Python library module).
+2. Identify required libraries (BuiltIn, OperatingSystem, RequestsLibrary, custom library).
+3. Decide variable and secret handling.
+4. Generate deterministic assertions and reusable keywords.
+5. Refactor duplicate steps into resource files.
+6. Add run commands only when requested.
+
+## References
+
+- Robot Framework User Guide: https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html
+- Standard libraries overview: https://docs.robotframework.org/docs/different_libraries/standard
+- BuiltIn library docs: https://robotframework.org/robotframework/latest/libraries/BuiltIn.html
+- OperatingSystem library docs: https://robotframework.org/robotframework/latest/libraries/OperatingSystem.html
+- Python library extension guide: https://docs.robotframework.org/docs/extending_robot_framework/custom-libraries/python_library
+- Robot Framework API docs: https://robot-framework.readthedocs.io/
+- RequestsLibrary docs: https://docs.robotframework.org/docs/different_libraries/requests


### PR DESCRIPTION
## Summary
Add a new `robot-framework-py` skill focused on Python-centric Robot Framework API and service test automation.

## What Changed
- Added `skills/robot-framework-py/SKILL.md` with:
  - valid Robot Framework section usage (`*** Settings ***`, `*** Test Cases ***`, etc.)
  - RequestsLibrary API testing workflow and example
  - guidance for Python custom keyword libraries
  - security and reuse best practices
- Added `skills/robot-framework-py/LICENSE.txt` (Apache 2.0 text)
- Updated `.claude-plugin/marketplace.json` to include `./skills/robot-framework-py` in `example-skills`

## Validation
- Parsed `.claude-plugin/marketplace.json` successfully with `JSON.parse`
- Verified skill metadata uses kebab-case name and clear trigger description
- Kept change scoped to one new skill + marketplace registration

## Notes
`anthropics/skills` currently has no `CONTRIBUTING.md` or PR template, so this follows existing repository conventions for adding new skills.