### PR TITLE
Add portable incident, CI triage, and evidence receipt skills

### DIFF
--- a/skills/ci-failure-triage/LICENSE.txt
+++ b/skills/ci-failure-triage/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+   including, without limitation, any warranties or conditions of
+   TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/ci-failure-triage/SKILL.md
+++ b/skills/ci-failure-triage/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: ci-failure-triage
+description: Triage CI failures using artifact-first checks. Use when users need fast root-cause isolation from failing runs, integrity verification, and deterministic reruns.
+license: Apache-2.0
+---
+
+# CI Failure Triage
+
+Use this skill to isolate failing CI causes with deterministic artifact checks.
+
+## Required Inputs
+
+- `failure_target`: failing run id, runpack path, or pack path.
+- `baseline_target` (optional): known-good runpack or pack for diff.
+- `workdir`: writable directory for triage outputs.
+
+## Workflow
+
+1. Verify the failing artifact first:
+   - `gait verify <failure_target> --json`
+2. If failure came from regress grading, rerun deterministically:
+   - `gait regress run --json`
+3. If baseline evidence exists, compute deterministic diff:
+   - `gait pack diff <baseline_target> <failure_target> --json`
+4. If environment health is uncertain, run diagnostics:
+   - `gait doctor --json`
+5. Return triage summary:
+   - integrity status
+   - failing stage and reason codes
+   - diff highlights (if provided)
+   - exact next command to reproduce
+
+## Safety And Portability Rules
+
+- Never classify root cause without command output evidence.
+- Do not rely on CI provider-specific APIs when local artifacts are available.
+- Preserve stable exit-code semantics in reporting.
+- Keep recommendations reproducible with copy-pastable commands.
+
+## Usage Example
+
+```bash
+gait verify ./artifacts/runpack_failed.zip --json
+gait doctor --json
+gait regress run --json
+```
+
+Expected result:
+- verify output reports integrity status for the target artifact
+- doctor output reports actionable diagnostics
+- regress output reports stable pass/fail status and failures
+
+## Validation Example
+
+```bash
+gait verify ./artifacts/runpack_failed.zip --json > ./artifacts/verify.json
+python3 - <<'PY'
+import json
+from pathlib import Path
+p = json.loads(Path('./artifacts/verify.json').read_text(encoding='utf-8'))
+assert 'ok' in p
+assert 'manifest_digest' in p
+print('validated verify payload keys present')
+PY
+```
+
+Expected result:
+- script prints `validated verify payload keys present`
+
+## Provider Notes (Anthropic Claude)
+
+- Ask Claude to use the `ci-failure-triage` skill by name when this workflow applies.
+- Keep outputs grounded in command results and `--json` payload fields.

--- a/skills/ci-failure-triage/SKILL.md
+++ b/skills/ci-failure-triage/SKILL.md
@@ -8,6 +8,19 @@ license: Apache-2.0
 
 Use this skill to isolate failing CI causes with deterministic artifact checks.
 
+## Gait Context
+
+Gait is an offline-first runtime for AI agents that enforces tool-boundary policy, emits signed and verifiable evidence artifacts, and supports deterministic regressions.
+
+Use this skill when:
+- incident triage requires artifact-first root-cause isolation
+- CI gate failures need deterministic reruns tied to a failing artifact
+- evidence outputs must be generated from Gait artifacts
+
+Do not use this skill when:
+- Gait CLI is unavailable in the environment
+- no Gait run/pack artifact or run identifier is available as input
+
 ## Required Inputs
 
 - `failure_target`: failing run id, runpack path, or pack path.
@@ -18,13 +31,16 @@ Use this skill to isolate failing CI causes with deterministic artifact checks.
 
 1. Verify the failing artifact first:
    - `gait verify <failure_target> --json`
-2. If failure came from regress grading, rerun deterministically:
+2. Enter an isolated triage workspace:
+   - `mkdir -p <workdir> && cd <workdir>`
+3. If failure came from regress grading, bind reruns to the requested target:
+   - `gait regress init --from <failure_target> --json`
    - `gait regress run --json`
-3. If baseline evidence exists, compute deterministic diff:
+4. If baseline evidence exists, compute deterministic diff:
    - `gait pack diff <baseline_target> <failure_target> --json`
-4. If environment health is uncertain, run diagnostics:
+5. If environment health is uncertain, run diagnostics:
    - `gait doctor --json`
-5. Return triage summary:
+6. Return triage summary:
    - integrity status
    - failing stage and reason codes
    - diff highlights (if provided)
@@ -41,12 +57,15 @@ Use this skill to isolate failing CI causes with deterministic artifact checks.
 
 ```bash
 gait verify ./artifacts/runpack_failed.zip --json
-gait doctor --json
+mkdir -p ./triage && cd ./triage
+gait regress init --from ../artifacts/runpack_failed.zip --json
 gait regress run --json
+gait doctor --json
 ```
 
 Expected result:
 - verify output reports integrity status for the target artifact
+- regress init output references the requested `failure_target`
 - doctor output reports actionable diagnostics
 - regress output reports stable pass/fail status and failures
 

--- a/skills/evidence-receipt-generation/LICENSE.txt
+++ b/skills/evidence-receipt-generation/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+   including, without limitation, any warranties or conditions of
+   TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/evidence-receipt-generation/SKILL.md
+++ b/skills/evidence-receipt-generation/SKILL.md
@@ -51,8 +51,10 @@ Do not use this skill when:
 ## Usage Example
 
 ```bash
-gait verify ./artifacts/runpack.zip --json
-gait run receipt --from ./artifacts/runpack.zip --json > ./artifacts/receipt.json
+gait demo --json
+mkdir -p ./artifacts
+gait verify run_demo --json
+gait run receipt --from run_demo --json > ./artifacts/receipt.json
 ```
 
 Expected result:
@@ -62,7 +64,9 @@ Expected result:
 ## Validation Example
 
 ```bash
-gait run receipt --from ./artifacts/runpack.zip --json > ./artifacts/receipt.json
+gait demo --json
+mkdir -p ./artifacts
+gait run receipt --from run_demo --json > ./artifacts/receipt.json
 python3 - <<'PY'
 import json
 from pathlib import Path

--- a/skills/evidence-receipt-generation/SKILL.md
+++ b/skills/evidence-receipt-generation/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: evidence-receipt-generation
+description: Generate portable evidence receipts from run artifacts. Use when users ask for ticket-ready proof, receipt footers, or integrity-backed handoff metadata.
+license: Apache-2.0
+---
+
+# Evidence Receipt Generation
+
+Use this skill to generate integrity-backed receipts that are portable across CI, tickets, and audit handoff.
+
+## Required Inputs
+
+- `source`: run id, runpack path, or pack path.
+- `out_path` (optional): destination file for JSON receipt output.
+
+## Workflow
+
+1. Verify integrity before receipt generation:
+   - `gait verify <source> --json`
+2. Generate receipt from source artifact:
+   - `gait run receipt --from <source> --json`
+3. Parse receipt fields for handoff:
+   - `ok`, `run_id`, `manifest_digest`, `ticket_footer`, `bundle`
+4. Return concise evidence block containing:
+   - source identifier
+   - manifest digest
+   - ticket footer text
+   - verification status
+
+## Safety And Portability Rules
+
+- Never invent digests, run ids, or receipt text.
+- Treat failed verification as a blocking state for receipt publication.
+- Keep receipt output machine-readable and transportable.
+- Avoid environment-specific absolute paths in final handoff.
+
+## Usage Example
+
+```bash
+gait verify ./artifacts/runpack.zip --json
+gait run receipt --from ./artifacts/runpack.zip --json
+```
+
+Expected result:
+- verify returns `ok=true` for intact artifacts
+- receipt returns a non-empty `ticket_footer` suitable for issue or PR evidence
+
+## Validation Example
+
+```bash
+gait run receipt --from ./artifacts/runpack.zip --json > ./artifacts/receipt.json
+python3 - <<'PY'
+import json
+from pathlib import Path
+p = json.loads(Path('./artifacts/receipt.json').read_text(encoding='utf-8'))
+assert p.get('ok') is True
+assert str(p.get('ticket_footer', '')).strip()
+print('validated receipt footer present')
+PY
+```
+
+Expected result:
+- script prints `validated receipt footer present`
+
+## Provider Notes (Anthropic Claude)
+
+- Ask Claude to use the `evidence-receipt-generation` skill by name when this workflow applies.
+- Keep outputs grounded in command results and `--json` payload fields.

--- a/skills/evidence-receipt-generation/SKILL.md
+++ b/skills/evidence-receipt-generation/SKILL.md
@@ -8,6 +8,19 @@ license: Apache-2.0
 
 Use this skill to generate integrity-backed receipts that are portable across CI, tickets, and audit handoff.
 
+## Gait Context
+
+Gait is an offline-first runtime for AI agents that enforces tool-boundary policy, emits signed and verifiable evidence artifacts, and supports deterministic regressions.
+
+Use this skill when:
+- incident triage needs portable receipt handoff proof
+- CI gate failures require receipt/evidence attachment
+- evidence outputs must be generated from Gait artifacts
+
+Do not use this skill when:
+- Gait CLI is unavailable in the environment
+- no Gait run/pack artifact or run identifier is available as input
+
 ## Required Inputs
 
 - `source`: run id, runpack path, or pack path.
@@ -18,8 +31,9 @@ Use this skill to generate integrity-backed receipts that are portable across CI
 1. Verify integrity before receipt generation:
    - `gait verify <source> --json`
 2. Generate receipt from source artifact:
-   - `gait run receipt --from <source> --json`
-3. Parse receipt fields for handoff:
+   - when `out_path` is provided: `gait run receipt --from <source> --json > <out_path>`
+   - when `out_path` is omitted: `gait run receipt --from <source> --json`
+3. Parse receipt fields for handoff from `out_path` (if set) or stdout:
    - `ok`, `run_id`, `manifest_digest`, `ticket_footer`, `bundle`
 4. Return concise evidence block containing:
    - source identifier
@@ -38,12 +52,12 @@ Use this skill to generate integrity-backed receipts that are portable across CI
 
 ```bash
 gait verify ./artifacts/runpack.zip --json
-gait run receipt --from ./artifacts/runpack.zip --json
+gait run receipt --from ./artifacts/runpack.zip --json > ./artifacts/receipt.json
 ```
 
 Expected result:
 - verify returns `ok=true` for intact artifacts
-- receipt returns a non-empty `ticket_footer` suitable for issue or PR evidence
+- receipt file contains a non-empty `ticket_footer` suitable for issue or PR evidence
 
 ## Validation Example
 

--- a/skills/incident-to-regression/LICENSE.txt
+++ b/skills/incident-to-regression/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+   including, without limitation, any warranties or conditions of
+   TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/incident-to-regression/SKILL.md
+++ b/skills/incident-to-regression/SKILL.md
@@ -8,6 +8,19 @@ license: Apache-2.0
 
 Use this skill to transform an observed incident into deterministic regression checks.
 
+## Gait Context
+
+Gait is an offline-first runtime for AI agents that enforces tool-boundary policy, emits signed and verifiable evidence artifacts, and supports deterministic regressions.
+
+Use this skill when:
+- incident triage needs repeatable regression fixtures
+- CI gate failures need deterministic reproduction
+- evidence outputs must be generated from Gait artifacts
+
+Do not use this skill when:
+- Gait CLI is unavailable in the environment
+- no Gait run/pack artifact or run identifier is available as input
+
 ## Required Inputs
 
 - `run_source`: run id, runpack path, or equivalent source accepted by `gait regress init`.
@@ -15,15 +28,17 @@ Use this skill to transform an observed incident into deterministic regression c
 
 ## Workflow
 
-1. Initialize deterministic fixture from the incident source:
+1. Enter the declared working directory before generating artifacts:
+   - `mkdir -p <workdir> && cd <workdir>`
+2. Initialize deterministic fixture from the incident source:
    - `gait regress init --from <run_source> --json`
-2. Parse fields from init output and record them:
+3. Parse fields from init output and record them:
    - `ok`, `run_id`, `fixture_name`, `fixture_dir`, `config_path`, `next_commands`
-3. Execute regression graders:
+4. Execute regression graders:
    - `gait regress run --json`
-4. If CI evidence is needed, rerun with JUnit output:
+5. If CI evidence is needed, rerun with JUnit output:
    - `gait regress run --json --junit <junit_path>`
-5. Return a concise summary with:
+6. Return a concise summary with:
    - source identifier
    - fixture directory and config path
    - status and failed grader count
@@ -39,6 +54,7 @@ Use this skill to transform an observed incident into deterministic regression c
 ## Usage Example
 
 ```bash
+mkdir -p ./regress-workdir && cd ./regress-workdir
 gait regress init --from run_demo --json
 gait regress run --json --junit ./artifacts/junit.xml
 ```
@@ -51,6 +67,7 @@ Expected result:
 ## Validation Example
 
 ```bash
+mkdir -p ./regress-workdir && cd ./regress-workdir
 gait regress run --json > ./artifacts/regress_result.json
 python3 - <<'PY'
 import json

--- a/skills/incident-to-regression/SKILL.md
+++ b/skills/incident-to-regression/SKILL.md
@@ -28,17 +28,21 @@ Do not use this skill when:
 
 ## Workflow
 
-1. Enter the declared working directory before generating artifacts:
+1. Resolve `run_source` before changing directories:
+   - keep identifiers unchanged (for example run ids)
+   - if `run_source` is a relative file path, normalize to absolute path
+   - `run_source_ref="$(python3 -c 'import os,sys; v=sys.argv[1]; print(os.path.abspath(v) if os.path.exists(v) else v)' <run_source>)"`
+2. Enter the declared working directory before generating artifacts:
    - `mkdir -p <workdir> && cd <workdir>`
-2. Initialize deterministic fixture from the incident source:
-   - `gait regress init --from <run_source> --json`
-3. Parse fields from init output and record them:
+3. Initialize deterministic fixture from the incident source:
+   - `gait regress init --from <run_source_ref> --json`
+4. Parse fields from init output and record them:
    - `ok`, `run_id`, `fixture_name`, `fixture_dir`, `config_path`, `next_commands`
-4. Execute regression graders:
+5. Execute regression graders:
    - `gait regress run --json`
-5. If CI evidence is needed, rerun with JUnit output:
+6. If CI evidence is needed, rerun with JUnit output:
    - `gait regress run --json --junit <junit_path>`
-6. Return a concise summary with:
+7. Return a concise summary with:
    - source identifier
    - fixture directory and config path
    - status and failed grader count
@@ -54,8 +58,11 @@ Do not use this skill when:
 ## Usage Example
 
 ```bash
+run_source_ref="$(python3 -c 'import os,sys; v=sys.argv[1]; print(os.path.abspath(v) if os.path.exists(v) else v)' run_demo)"
 mkdir -p ./regress-workdir && cd ./regress-workdir
-gait regress init --from run_demo --json
+gait demo --json
+gait regress init --from "${run_source_ref}" --json
+mkdir -p ./artifacts
 gait regress run --json --junit ./artifacts/junit.xml
 ```
 
@@ -68,6 +75,9 @@ Expected result:
 
 ```bash
 mkdir -p ./regress-workdir && cd ./regress-workdir
+gait demo --json
+gait regress init --from run_demo --json
+mkdir -p ./artifacts
 gait regress run --json > ./artifacts/regress_result.json
 python3 - <<'PY'
 import json

--- a/skills/incident-to-regression/SKILL.md
+++ b/skills/incident-to-regression/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: incident-to-regression
+description: Convert incident artifacts into deterministic regression fixtures and CI-ready outputs. Use when users ask to reproduce a failure, build repeatable graders, or emit junit evidence.
+license: Apache-2.0
+---
+
+# Incident To Regression
+
+Use this skill to transform an observed incident into deterministic regression checks.
+
+## Required Inputs
+
+- `run_source`: run id, runpack path, or equivalent source accepted by `gait regress init`.
+- `workdir`: writable working directory where fixtures and outputs will be created.
+
+## Workflow
+
+1. Initialize deterministic fixture from the incident source:
+   - `gait regress init --from <run_source> --json`
+2. Parse fields from init output and record them:
+   - `ok`, `run_id`, `fixture_name`, `fixture_dir`, `config_path`, `next_commands`
+3. Execute regression graders:
+   - `gait regress run --json`
+4. If CI evidence is needed, rerun with JUnit output:
+   - `gait regress run --json --junit <junit_path>`
+5. Return a concise summary with:
+   - source identifier
+   - fixture directory and config path
+   - status and failed grader count
+   - evidence output paths
+
+## Safety And Portability Rules
+
+- Use CLI outputs only; do not infer grader results from config text.
+- Treat non-zero regress exit codes as actionable outcomes, not warnings.
+- Do not assume repository-specific fixture paths.
+- Keep paths relative to the active workspace unless the user explicitly asks for absolute paths.
+
+## Usage Example
+
+```bash
+gait regress init --from run_demo --json
+gait regress run --json --junit ./artifacts/junit.xml
+```
+
+Expected result:
+- init output includes `ok=true` and a `fixture_dir`
+- run output includes stable `status` and grader failure details
+- JUnit file exists at `./artifacts/junit.xml`
+
+## Validation Example
+
+```bash
+gait regress run --json > ./artifacts/regress_result.json
+python3 - <<'PY'
+import json
+from pathlib import Path
+p = json.loads(Path('./artifacts/regress_result.json').read_text(encoding='utf-8'))
+assert p.get('status') in {'pass', 'fail'}
+print('validated status:', p.get('status'))
+PY
+```
+
+Expected result:
+- script prints `validated status: pass` or `validated status: fail`
+
+## Provider Notes (Anthropic Claude)
+
+- Ask Claude to use the `incident-to-regression` skill by name when this workflow applies.
+- Keep outputs grounded in command results and `--json` payload fields.


### PR DESCRIPTION
## Summary
Adds three portable, CLI-first skills derived from Gait's core skill workflows:

- `incident-to-regression`
- `ci-failure-triage`
- `evidence-receipt-generation`

## Design goals
- generic and repository-agnostic instructions
- deterministic command-first workflows
- concise usage + validation examples with expected results
- no local machine paths or repo-specific assumptions

## Notes
These skills were exported from a single core source with provider-specific wording adjustments for Anthropic submission.
