### PR TITLE
Add html-presentation skill

### DIFF
--- a/skills/html-presentation/LICENSE.txt
+++ b/skills/html-presentation/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/html-presentation/SKILL.md
+++ b/skills/html-presentation/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: html-presentation
+description: "Create, edit, and iterate on high-quality single-file HTML slide presentations (1280x720px, PDF-exportable). Use when the user wants to build or improve a pitch deck, hackathon presentation, demo deck, or any slideshow as a self-contained HTML file. Triggers on requests like 'make a presentation', 'create slides', 'build a pitch deck', 'add a slide about X', or iteration feedback like 'too text-heavy', 'add more visuals', 'fix the layout', 'make it look better', 'this slide is boring', 'looks like a website not a pitch deck'."
+license: Complete terms in LICENSE.txt
+---
+
+# HTML Presentation Skill
+
+Single-file HTML presentations that render at 1280×720px per slide, look great in browser, and export cleanly to PDF via Cmd+P.
+
+## Setup
+
+### Dimensions & Print
+```css
+.slide { width: 1280px; height: 720px; overflow: hidden; page-break-after: always; }
+.slide-inner { padding: 52px 72px; display: flex; flex-direction: column; position: relative; z-index: 1; }
+@page { size: 1280px 720px; margin: 0; }
+@media print { * { box-shadow: none !important; } }  /* critical — shadows cause PDF artifacts */
+@media screen { body { display: flex; flex-direction: column; align-items: center; gap: 32px; padding: 32px; } }
+```
+
+### Fonts (always load from Google Fonts)
+- **Primary:** Outfit (300, 400, 500, 600, 700, 800) — all body, headings, UI
+- **Accent:** Instrument Serif italic — one key word per major heading only
+- **Mono:** JetBrains Mono (400, 500) — eyebrow labels, code, slide numbers
+
+### Color Palette
+```css
+--bg-primary: #F7FAF8;  --bg-card: rgba(255,255,255,0.5);
+--text-primary: #0F172A;  --text-secondary: #475569;  --text-muted: #94A3B8;
+--accent-teal: #0D9488;  --accent-blue: #3B82F6;  --accent-violet: #7C3AED;
+--accent-orange: #EA580C;  --border: rgba(0,0,0,0.08);
+--critical: #DC2626;  --success: #16A34A;
+```
+
+## Quality Standards
+
+Read `references/aesthetics.md` for the full quality bar before starting any presentation.
+
+**Non-negotiable rules:**
+1. **Lead with WHY.** Every slide opens with a narrative paragraph before data or diagrams.
+2. **Stats in context.** Embed numbers in prose; don't float them as giant orphaned cards.
+3. **No over-decoration.** Cards: one subtle border (`rgba(0,0,0,0.08)`), no colored left-borders, no dot-pills, no badge stacking.
+4. **Text prominence.** Body narrative ≥ 16px. Labels/captions: 11–12px. Critical narrative never at 12px.
+5. **Diagrams beat text cards.** Pipeline/architecture/flow → inline SVG with arrows, not text boxes.
+
+## Typography Hierarchy
+
+| Role | Size | Weight | Font |
+|------|------|--------|------|
+| Title slide h1 | 48–56px | 700 | Outfit, letter-spacing -0.02em |
+| Slide heading h2 | 34px | 700 | Outfit, letter-spacing -0.015em |
+| Card heading h3 | 18px | 600 | Outfit |
+| Narrative body | 16–17px | 400 | Outfit, line-height 1.65, color: var(--text-secondary) |
+| Eyebrow label | 11px | 500 | JetBrains Mono, UPPERCASE, teal, letter-spacing 0.1em |
+| Stat number | 28–36px | 700 | Outfit, letter-spacing -0.02em |
+| Caption/muted | 11–12px | 400 | Outfit, color: var(--text-muted) |
+
+**Accent italic:** `<span style="font-family:'Instrument Serif',serif;font-style:italic;color:var(--accent-teal);">word</span>` — one emotionally resonant word per major heading.
+
+## Slide Anatomy
+
+```html
+<div class="slide">
+  <!-- z-index 0: optional decorative glows or photo accents (max 2) -->
+  <div class="slide-inner">
+    <div class="label">Section Name</div>   <!-- eyebrow -->
+    <h2>Slide <span class="accent-italic">Title</span></h2>
+    <p>Narrative WHY paragraph...</p>
+    <!-- content: cards, diagrams, tables, lists -->
+  </div>
+  <div class="brand-mark">...</div>         <!-- bottom-left: logo + product name -->
+  <div class="slide-number">04 / 15</div>  <!-- bottom-right: JetBrains Mono, 11px -->
+</div>
+```
+
+## Component Patterns
+
+### Background Decorations (max 2 per slide, always z-index 0)
+```html
+<!-- Soft radial glow blob -->
+<div style="position:absolute;border-radius:50%;filter:blur(120px);opacity:0.06;z-index:0;
+  background:var(--accent-teal);width:500px;height:500px;top:-100px;right:-100px;"></div>
+
+<!-- Edge photo accent (atmospheric only) -->
+<div style="position:absolute;right:0;top:0;width:420px;height:720px;z-index:0;overflow:hidden;">
+  <img src="[unsplash]" style="width:100%;height:100%;object-fit:cover;opacity:0.12;filter:saturate(0.4);">
+  <div style="position:absolute;inset:0;background:linear-gradient(90deg,var(--bg-primary) 0%,transparent 40%,transparent 60%,var(--bg-primary) 100%);"></div>
+</div>
+```
+
+### Cards
+```html
+<!-- Standard card -->
+<div style="background:var(--bg-card);border:1px solid var(--border);border-radius:10px;padding:22px;">
+<!-- Small card -->
+<div style="background:var(--bg-card);border:1px solid var(--border);border-radius:8px;padding:14px 16px;">
+<!-- Info/narrative card -->
+<div style="background:var(--bg-card);border:1px solid var(--border);border-radius:10px;padding:16px 18px;">
+```
+
+### Pipeline Flow (horizontal)
+```html
+<div style="display:flex;align-items:center;justify-content:center;gap:0;">
+  <div style="text-align:center;flex:1;">
+    <div style="font-size:20px;font-weight:700;color:var(--accent-teal);">6</div>
+    <div style="font-size:11px;color:var(--text-secondary);">Data Sources</div>
+  </div>
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#CBD5E1" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+  <!-- repeat for each stage -->
+</div>
+```
+
+### Architecture Diagram
+Inline `<svg viewBox="0 0 1136 380">` with `<rect>` column containers, `<text>` in JetBrains Mono, and `<line>`/`<path>` arrows in teal (`#0D9488`).
+
+### Tech Logos (CDN)
+```html
+<img src="https://cdn.simpleicons.org/{name}/{hex-without-#}" style="width:24px;height:24px;">
+<!-- Example: https://cdn.simpleicons.org/python/0D9488 -->
+```
+
+### Format/Standard Tags
+```html
+<span style="background:rgba(13,148,136,0.1);color:#0D9488;padding:3px 9px;border-radius:5px;
+  font-size:11px;font-family:'JetBrains Mono',monospace;font-weight:500;">FHIR R4</span>
+```
+
+## Slide Type Recipes
+
+**Title slide:** Left: logo + product name + large h1 + 2–3 sentence description + 4 key metrics row + team + links. Right: floating UI preview cards (absolutely positioned decorative). Background: radial teal glow + faint ECG SVG line at 6% opacity.
+
+**Problem slide:** Narrative story paragraph (pain as a real scenario), 3 stat cards, then 2-col info cards with nuanced WHY context. Edge photo accent at opacity 0.12.
+
+**Solution slide:** 2-sentence overview, then 3-column card grid (icon + h3 + narrative paragraph each). Bottom: horizontal pipeline flow with key numbers and arrows.
+
+**Architecture slide:** heading + 1-sentence description + full-width inline SVG diagram with column headers, component boxes, and directional arrows.
+
+**Tech stack slide:** 4-column grid by category (Backend, AI/ML, Frontend, Standards). Each item: CDN logo img + name + brief role. Fetch real logos — no plain text tags.
+
+**Performance/metrics slide:** Visual charts (CSS bars or inline SVG), per-class breakdowns, methodology note at bottom.
+
+**Roadmap slide:** 3 phase columns, distinct accent colors, title + timeframe + 3–4 bullets each. Vision statement at bottom, italic, large, centered.
+
+**Closing slide:** Minimal. Large product name, one italic tagline, key links. Mirror title slide background.
+
+## Iteration & Verification
+
+1. Serve: `python3 -m http.server 8765` → `http://localhost:8765/presentation.html`
+2. Screenshot every modified slide; check no overflow, readable text, images load
+3. PDF test: Cmd+P → Save as PDF → verify `@page` sizing applies
+4. Overflow fix: reduce font 1–2px, compress padding, or cut content
+
+## Anti-Patterns
+
+- Slides that read like a website (pills/badges everywhere, colorful borders)
+- Giant isolated stat cards with no surrounding narrative
+- Body narrative at 12px or smaller
+- Text-only architecture/pipeline slides — use SVG diagrams
+- `box-shadow` in `@media print` — causes PDF rendering artifacts
+- Dark backgrounds on text-heavy slides
+- More than 2 background decorations per slide
+- Slide count padding — consolidate when multiple slides cover the same concept
+- Colored dots inside pill badges

--- a/skills/html-presentation/references/aesthetics.md
+++ b/skills/html-presentation/references/aesthetics.md
@@ -1,0 +1,273 @@
+# Presentation Aesthetics & Quality Bar
+
+This reference captures the quality standards and aesthetic principles that define a high-quality HTML presentation — distilled from real iteration feedback.
+
+## Table of Contents
+1. [The Core Problem with AI-generated Slides](#1-the-core-problem)
+2. [Narrative & Story Structure](#2-narrative--story-structure)
+3. [Visual Hierarchy & Typography](#3-visual-hierarchy--typography)
+4. [Decoration vs. Information](#4-decoration-vs-information)
+5. [Diagrams & Visual Content](#5-diagrams--visual-content)
+6. [Slide-Level Feedback Patterns](#6-slide-level-feedback-patterns)
+7. [Consolidation Principles](#7-consolidation-principles)
+8. [Photo & Illustration Usage](#8-photo--illustration-usage)
+
+---
+
+## 1. The Core Problem
+
+The most common failure mode: **slides that look like a website, not a pitch deck.**
+
+Signs of this failure:
+- Every element is a card with a border
+- Colored pill badges and dot indicators scattered throughout
+- Stats displayed as giant isolated numbers with no context
+- Section labels ("Section Name") feel bureaucratic, not editorial
+- The slide shows WHAT but never WHY
+
+The fix: think of each slide as a page in a story, not a UI wireframe.
+
+---
+
+## 2. Narrative & Story Structure
+
+### Lead with WHY, not WHAT
+
+Every slide should open with a narrative paragraph that answers "Why does this matter?" before showing any data, diagram, or feature list.
+
+**Bad:**
+> *[3 stat cards: "10 min", "6+ systems", "78% adverse events"]*
+
+**Good:**
+> "Triage nurses spend 10–15 minutes manually assembling patient context from 6+ disconnected systems — ambulance reports on paper, EHRs, wearables, labs, handwritten referrals. The problem isn't a lack of data. It's a lack of interoperability."
+
+Then show the stat cards below as supporting evidence.
+
+### Tell a connected story
+
+Each slide should connect to the next. The narrative arc for a pitch deck typically follows:
+1. Problem (the pain) → 2. Solution (what we built) → 3. How it works (architecture) → 4. What it does (features) → 5. Does it work? (metrics) → 6. What's next (roadmap)
+
+Judges should feel pulled forward through the story, not confronted with isolated info dumps.
+
+### Stats inline in narrative
+
+Embed key numbers inside sentences when they support a point:
+
+**Isolated (bad):** A floating card with "87%" in 36px font.
+
+**Contextual (good):** "Our XGBoost model achieves **87% accuracy** on ESI classification — validated against Synthea-generated ground-truth data."
+
+Reserve large stat displays for emphasis on the most important 2–3 numbers per slide, and always pair them with a label that explains what they measure.
+
+---
+
+## 3. Visual Hierarchy & Typography
+
+### Font size discipline
+
+The most common mistake is inverted hierarchy: decorative text is large, informative text is small.
+
+| Right | Wrong |
+|-------|-------|
+| Body narrative at 16–17px | Body narrative at 13px |
+| Card heading at 18px | Pill badge at 16px |
+| Eyebrow label at 11px mono | Label at 14px bold |
+| Stat number at 28–36px | Everything at 14px |
+
+### The accent italic technique
+
+Use `Instrument Serif` italic for one key word per major heading. This creates editorial sophistication — the contrast between a clean sans-serif and a serif italic signals craft.
+
+```html
+<h2>Emergency triage, <span style="font-family:'Instrument Serif',serif;font-style:italic;color:#0D9488;">reimagined.</span></h2>
+```
+
+Use sparingly — only for the single most emotionally resonant word in the heading. Never more than one per slide.
+
+### JetBrains Mono for metadata, not content
+
+Mono should only appear in:
+- Eyebrow labels (UPPERCASE, 11px, teal, letter-spacing 0.1em)
+- Slide numbers
+- Code/format tags (FHIR R4, HL7 v2, etc.)
+- Technical values (port numbers, file extensions)
+
+Never use mono for body copy or card headings.
+
+### Text color intentionality
+
+- `#0F172A` (text-primary) — headings and critical information
+- `#475569` (text-secondary) — body narrative, card descriptions
+- `#94A3B8` (text-muted) — labels, captions, slide numbers
+- `#0D9488` (accent-teal) — eyebrow labels, inline stats, key highlights
+
+Never use pure black `#000000` for text. The contrast is too harsh on a light background.
+
+---
+
+## 4. Decoration vs. Information
+
+### The decoration tax
+
+Every decorative element costs context window attention. Ask: "Does this element convey information, or just fill space?"
+
+**Costs too much:**
+- Colored dots inside pill badges (decorative noise)
+- Multiple colored left-borders on adjacent cards (creates visual chaos)
+- Box shadows on every card (makes everything equally loud)
+- Badge clusters (4+ tags stacked on one slide)
+
+**Worth keeping:**
+- A single subtle glow blob at a corner (establishes spatial depth)
+- An edge photo at 0.12 opacity (adds atmosphere without competing)
+- One teal accent line/divider (marks section transitions)
+
+### Card restraint
+
+All cards should use the same neutral style:
+```css
+background: rgba(255,255,255,0.5);
+border: 1px solid rgba(0,0,0,0.08);
+border-radius: 10px;
+```
+
+Don't vary the card style within a slide (different colors, different border treatments, different shadows) — it looks undesigned. The content within cards differentiates them; the containers should be invisible infrastructure.
+
+### Pill badges
+
+Use pills for metadata only (standards compliance, version labels, hackathon category). Never use them as primary information carriers. Rules:
+- No colored dots inside pills
+- All pills should use the same neutral style (subtle border, light bg)
+- Maximum 3–4 pills on a slide
+- Only on slides where they genuinely add metadata value
+
+---
+
+## 5. Diagrams & Visual Content
+
+### Architecture and pipeline flows must be diagrams
+
+If a slide describes how data flows through a system, it must have a visual diagram — not a list of text cards arranged vertically.
+
+Use inline SVG:
+```svg
+<svg viewBox="0 0 1136 380">
+  <!-- Column containers as <rect> -->
+  <!-- Labels as <text> in JetBrains Mono -->
+  <!-- Arrows as <line> or <path> in teal -->
+</svg>
+```
+
+Column structure for pipeline diagrams:
+- Each stage = a `<rect>` box with rounded corners
+- Stage label = `<text>` in JetBrains Mono, 9px, UPPERCASE, teal
+- Component rows = `<rect>` sub-boxes within stage, `<text>` titles + descriptions
+- Arrows = `<line>` or `<path>` between stages
+
+### Tech stack slides need real logos
+
+Fetch actual SVG logos from `https://cdn.simpleicons.org/{name}/{hex}`. Never use text tags as substitutes for logos on a tech stack slide — it looks unpolished.
+
+### The Technology Stack slide as the bar
+
+The Technology Stack slide format (logos + name + brief role, grouped by category) is the gold standard for visual density without over-decoration. If judges say "that slide looks great" — replicate that visual approach for other slides.
+
+### When to use illustrations
+
+Use unDraw SVG illustrations (`https://cdn.jsdelivr.net/gh/balazser/undraw-svg-collection@main/svgs/{name}.svg`) as:
+- Background watermarks (`opacity: 0.10–0.15`, `position: absolute`, `z-index: 0`)
+- Replacements for placeholder "mockup" boxes
+
+CSS to match teal theme:
+```css
+filter: hue-rotate(160deg) saturate(0.8) brightness(0.95);
+```
+
+Never use illustrations at full opacity as primary content. They're atmospheric accents.
+
+---
+
+## 6. Slide-Level Feedback Patterns
+
+These are recurring critique patterns to watch for:
+
+### "This slide reads like a website"
+- Cause: Too many distinct card styles, colored borders, pill stacking
+- Fix: Unify all card styles, remove colored borders, reduce decoration to 2 elements per slide
+
+### "The stats are floating with no context"
+- Cause: Large stat display without narrative setup
+- Fix: Add a narrative intro paragraph; embed secondary stats inline in text
+
+### "This looks too text-heavy / boring"
+- Cause: All content is text blocks, no diagrams or visual anchors
+- Fix: Add one SVG diagram or photo accent; convert a text-only flow to a visual flow
+
+### "This slide is too late in the deck / why am I seeing this now?"
+- Cause: Content ordering doesn't follow the narrative arc
+- Fix: Ensure the deck follows: Problem → Solution → How → Performance → Future
+
+### "The text is too small / I can't read that"
+- Cause: Body copy at 13–14px to fit more content
+- Fix: Cut content before reducing font size; 16px minimum for narrative body text
+
+### "This looks like just a vibe — no real substance"
+- Cause: Lots of decorative elements, big gradients, not enough informative text
+- Fix: Every slide should have a narrative paragraph that could stand alone
+
+### "Why so many slides about the same thing?"
+- Cause: Slides padded to hit a target count
+- Fix: Consolidate. Three slides on the same topic → one slide with a proper diagram
+
+---
+
+## 7. Consolidation Principles
+
+When you have multiple slides that cover the same conceptual area, consolidate them into one slide with a proper diagram. The right slide count comes from the story, not a target number.
+
+**Consolidation signals:**
+- Two consecutive slides with the same eyebrow label
+- A slide whose entire content is a subset of the next slide's content
+- A slide with only 2–3 elements that could each be a bullet on another slide
+
+**How to consolidate:**
+1. Identify the unified concept these slides share
+2. Create a single SVG diagram or well-structured layout that covers all the content
+3. Write one narrative paragraph that introduces the full concept
+4. Use sub-sections within the single slide (not new slides) for detail
+
+Example: "Architecture", "Data Pipeline", and "Semantic Backbone" → one "System Architecture" slide with a full pipeline SVG.
+
+---
+
+## 8. Photo & Illustration Usage
+
+### Unsplash photos
+
+Use only as atmospheric edge accents. Rules:
+- `opacity: 0.10–0.15` maximum
+- `filter: saturate(0.3–0.5)` to desaturate and prevent color clash
+- Always apply a gradient overlay that fades the photo into the slide background
+- Position at the edge (right side, 30–35% width) — never center-stage
+- Never obscure text
+
+```html
+<div style="position:absolute;right:0;top:0;width:420px;height:720px;z-index:0;overflow:hidden;">
+  <img src="[url]" style="width:100%;height:100%;object-fit:cover;opacity:0.12;filter:saturate(0.4);">
+  <div style="position:absolute;inset:0;background:linear-gradient(90deg,var(--bg-primary) 0%,transparent 40%,transparent 60%,var(--bg-primary) 100%);"></div>
+</div>
+```
+
+### Photo for specific slides
+
+- **Problem slides:** Hospital corridor, ER, crowded waiting room — establishes the pain context
+- **Ambulance/transport slides:** Ambulance exterior, first responder — makes the scenario concrete
+- **Clinical slides:** Medical monitor, doctor with tablet — situates the user
+
+### When NOT to add photos
+
+- Architecture slides (diagram is the visual)
+- Tech stack slides (logos are the visual)
+- Performance slides (charts are the visual)
+- Title and closing slides (use gradient/glow instead)


### PR DESCRIPTION
## Summary

- Adds a new `html-presentation` skill for creating high-quality single-file HTML slide presentations (1280×720px, PDF-exportable)
- Covers setup, typography hierarchy, component patterns (cards, pipeline flows, SVG diagrams, tech logos, photo accents), and slide type recipes for common pitch deck slide types
- Includes a detailed `references/aesthetics.md` distilled from real iteration feedback — capturing what separates professional-looking slides from "vibe-coded" ones

## Test plan

- [x] Install skill: `unzip html-presentation.skill -d ~/.claude/skills/`
- [x] Trigger with: "make a presentation about X" or "this slide looks too text-heavy"
- [x] Verify skill loads `references/aesthetics.md` when working on visual quality issues
- [x] Verify PDF export works via Cmd+P with the print CSS rules provided


here's an example presentation we made with this skill https://patient-ly-pragyan-hackathon-2026.vercel.app/

🤖 Generated with [Claude Code](https://claude.com/claude-code)