### PR TITLE
feat: add 4 geepers skills — datavis, humanize, dream-swarm, readme

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# Repository Guidelines
+
+Each skill lives in `skills/<skill-name>/` and must include a `SKILL.md`. That's the minimum.
+
+Optional folders inside a skill: `scripts/` for automation, `references/` for long-form guidance, `assets/` for templates and media. Use kebab-case for skill directories (`webapp-testing`, not `webapp_testing`).
+
+- `template/SKILL.md` — starting point for new skills
+- `spec/agent-skills-spec.md` — points to the current Agent Skills spec
+- `.claude-plugin/marketplace.json` — plugin bundle definitions
+
+## Commands
+
+No repo-wide build pipeline. Validate what you changed.
+
+```bash
+# Validate a skill
+python3 skills/skill-creator/scripts/quick_validate.py skills/<skill-name>
+
+# Scaffold a new skill
+python3 skills/skill-creator/scripts/init_skill.py my-new-skill --path skills
+
+# Package for distribution
+python3 skills/skill-creator/scripts/package_skill.py skills/<skill-name> ./dist
+```
+
+Some skills have their own dependencies:
+
+```bash
+python3 -m pip install -r skills/mcp-builder/scripts/requirements.txt
+python3 -m pip install -r skills/slack-gif-creator/requirements.txt
+```
+
+## Style
+
+`SKILL.md` files start with YAML frontmatter. Required keys: `name` and `description`. Keep `name` lowercase kebab-case, max 64 characters, matching the folder name. Write concise, task-oriented sections with real examples. Python scripts follow PEP 8: 4-space indentation, clear function names.
+
+## Testing
+
+Run `quick_validate.py` on every skill you touch. If you change a script, run a basic smoke test (`python3 <script> --help` or a sample input). For packaging changes, generate a `.skill` artifact and confirm the expected files are present.
+
+## Commits and PRs
+
+Short imperative subject lines with a type prefix (`feat: ...`). Keep commits focused to one skill or one logical change.
+
+PRs need:
+- What changed and why
+- Affected paths (e.g. `skills/pdf/`, `skills/skill-creator/scripts/`)
+- Validation commands run and results
+- Screenshots or artifacts when output is visual
+
+## Security
+
+No secrets, tokens, or private keys in commits. When adding third-party content or dependencies, update `THIRD_PARTY_NOTICES.md`.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository contains skills that demonstrate what's possible with Claude's s
 
 Each skill is self-contained in its own folder with a `SKILL.md` file containing the instructions and metadata that Claude uses. Browse through these skills to get inspiration for your own skills or to understand different patterns and approaches.
 
-Many skills in this repo are open source (Apache 2.0). We've also included the document creation & editing skills that power [Claude's document capabilities](https://www.anthropic.com/news/create-files) under the hood in the [`skills/docx`](./skills/docx), [`skills/pdf`](./skills/pdf), [`skills/pptx`](./skills/pptx), and [`skills/xlsx`](./skills/xlsx) subfolders. These are source-available, not open source, but we wanted to share these with developers as a reference for more complex skills that are actively used in a production AI application.
+Many skills in this repo are open source (Apache 2.0). We've also included the document creation & editing skills that power [Claude's document capabilities](https://www.anthropic.com/news/create-files) under the hood in the [`skills/docx`](./skills/docx), [`skills/pdf`](./skills/pdf), [`skills/pptx`](./skills/pptx), and [`skills/xlsx`](./skills/xlsx) subfolders. These are source-available, not open source, but I wanted to share these with developers as a reference for more complex skills that are actively used in a production application built on Claude.
 
 ## Disclaimer
 
@@ -89,6 +89,16 @@ The markdown content below contains the instructions, examples, and guidelines t
 
 # Partner Skills
 
-Skills are a great way to teach Claude how to get better at using specific pieces of software. As we see awesome example skills from partners, we may highlight some of them here:
+Skills are a great way to teach Claude how to get better at using specific pieces of software. As I come across awesome example skills from partners, I may highlight some of them here:
 
 - **Notion** - [Notion Skills for Claude](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0)
+
+---
+
+## License
+
+Apache 2.0 for open-source skills. Source-available (not open source) for document skills.
+
+## Author
+
+**Luke Steuber** — [lukesteuber.com](https://lukesteuber.com) · [@lukesteuber.com](https://bsky.app/profile/lukesteuber.com) on Bluesky

--- a/skills/geepers-datavis/SKILL.md
+++ b/skills/geepers-datavis/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: datavis
+name: geepers-datavis
 description: Comprehensive data visualization toolkit for creating beautiful, mathematically elegant visualizations with D3.js, Chart.js, and custom SVG. Use when (1) building interactive data visualizations, (2) designing color palettes for charts, (3) choosing scales and visual encodings, (4) creating data pipelines from Census/SEC/Wikipedia APIs, (5) crafting narrative-driven data stories, (6) making perceptually accurate charts, or (7) implementing force-directed networks, timelines, or geographic maps.
 license: MIT
 ---

--- a/skills/geepers-datavis/SKILL.md
+++ b/skills/geepers-datavis/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: datavis
+description: Comprehensive data visualization toolkit for creating beautiful, mathematically elegant visualizations with D3.js, Chart.js, and custom SVG. Use when (1) building interactive data visualizations, (2) designing color palettes for charts, (3) choosing scales and visual encodings, (4) creating data pipelines from Census/SEC/Wikipedia APIs, (5) crafting narrative-driven data stories, (6) making perceptually accurate charts, or (7) implementing force-directed networks, timelines, or geographic maps.
+license: MIT
+---
+
+# Data Visualization Skill
+
+Create beautiful, mathematically elegant, emotionally resonant data visualizations.
+
+## Philosophy: "Life is Beautiful"
+
+Every visualization should:
+1. **Reveal truth** through data
+2. **Evoke wonder** through design
+3. **Respect the viewer** through accessibility
+4. **Honor complexity** through elegant simplification
+
+## Core Capabilities
+
+### 1. Visual Encoding
+
+**Scale Selection**:
+| Scale | Use When | Example |
+|-------|----------|---------|
+| Linear | Evenly distributed data | Temperature |
+| Log | Multiple orders of magnitude | Population (100 to 1B) |
+| Sqrt | Encoding area (circles) | Bubble chart radius |
+| Time | Temporal data | Dates |
+
+**Perceptual Honesty** - Area scales with square of radius, so use sqrt:
+```javascript
+// WRONG: Linear radius exaggerates large values
+const badScale = d3.scaleLinear().domain([0, max]).range([0, maxRadius]);
+
+// RIGHT: Sqrt maintains perceptual accuracy
+const goodScale = d3.scaleSqrt().domain([0, max]).range([0, maxRadius]);
+```
+
+### 2. Color Design
+
+**Palette Types**:
+- **Categorical** - Distinct hues for nominal data (max 8)
+- **Sequential** - Single hue gradient for ordered data
+- **Diverging** - Two hues meeting at meaningful midpoint
+
+**Colorblind-Safe Palette** (8 colors):
+```javascript
+const colorblindSafe = [
+  '#332288', '#117733', '#44AA99', '#88CCEE',
+  '#DDCC77', '#CC6677', '#AA4499', '#882255'
+];
+```
+
+**Always use redundant encoding** - don't rely on color alone:
+```javascript
+node.attr('fill', d => colorScale(d.category))
+    .attr('d', d => symbolScale(d.category)); // Shape too!
+```
+
+### 3. D3.js Patterns
+
+**Force Simulation**:
+```javascript
+const simulation = d3.forceSimulation(nodes)
+  .force('charge', d3.forceManyBody().strength(-300))
+  .force('link', d3.forceLink(links).id(d => d.id))
+  .force('center', d3.forceCenter(width/2, height/2))
+  .force('collision', d3.forceCollide().radius(d => d.r + 2));
+```
+
+**Responsive SVG**:
+```javascript
+const svg = d3.select('#chart')
+  .append('svg')
+  .attr('viewBox', `0 0 ${width} ${height}`)
+  .attr('preserveAspectRatio', 'xMidYMid meet');
+```
+
+**Touch-Friendly** (44x44px minimum):
+```javascript
+node.append('circle')
+  .attr('class', 'hit-area')
+  .attr('r', Math.max(actualRadius, 22))
+  .attr('fill', 'transparent');
+```
+
+### 4. Narrative Structure
+
+**Three Acts**:
+1. **Invitation** - What draws viewer in? Why should they care?
+2. **Discovery** - What patterns emerge? What surprises?
+3. **Reflection** - What should they feel/understand/do?
+
+**Progressive Disclosure**:
+```
+Level 1: Overview → Level 2: Exploration → Level 3: Detail → Level 4: Context
+```
+
+### 5. Data Pipeline
+
+**Structure**:
+```
+scripts/
+├── 01_fetch_raw.py    # API calls with caching
+├── 02_clean_data.py   # Transformation
+├── 03_validate.py     # Quality checks
+└── 04_export.py       # Final format
+```
+
+**Source Documentation** (every dataset needs):
+- URL, access date, update frequency
+- License and confidence level
+- Field descriptions and limitations
+
+## CLI Usage
+
+### 1. Scaffold Project (Manual Coding)
+Start a new visualization project with boilerplate code.
+
+```bash
+# Available templates: force-network, timeline, choropleth, radial-tree, sankey, bubble-chart, treemap
+python3 scripts/d3-scaffold.py my-viz --type radial-tree
+```
+
+### 2. Generate Visualization (Automated)
+Instantly create an HTML file from a data file.
+
+```bash
+# From JSON
+python3 scripts/viz-generator.py data.json --template sankey
+
+# From CSV
+python3 scripts/viz-generator.py data.csv --template bar-race
+```
+
+## MCP Tools
+
+### `dream_visualize_data`
+Generates a collaborative visualization artifact.
+
+**Parameters:**
+*   `data` (string/json): Data to visualize.
+*   `template` (string): One of [force-network, timeline, choropleth, radial-tree, sankey, bubble-chart, treemap].
+*   `title` (string): Title for the chart.
+
+### `dream_list_viz_templates`
+Returns descriptions of all available visualization templates.
+
+## Utility Scripts
+
+### Generate Color Palette
+```bash
+python3 scripts/color-palette.py --type sequential --hue blue --steps 9
+```
+
+### Analyze Distribution
+```bash
+python3 scripts/analyze-distribution.py data.csv --column value
+```
+
+## Quality Checklist
+
+- [ ] Scale choice justified for data distribution
+- [ ] Color palette is colorblind-safe
+- [ ] Minimum 44x44px touch targets
+- [ ] Clear entry point for viewer
+- [ ] Sources documented
+- [ ] Responsive on mobile

--- a/skills/geepers-datavis/reference/gallery.md
+++ b/skills/geepers-datavis/reference/gallery.md
@@ -1,0 +1,68 @@
+# Visualization Gallery
+
+Examples of available visualization templates and their data formats.
+
+## 1. Radial Hierarchy Tree
+**Template:** `radial-tree`
+**Description:** Circular tree layout best for deep hierarchies (3+ levels).
+**Data Format:** Hierarchical JSON (Flare format)
+```json
+{
+  "name": "Root",
+  "children": [
+    {
+      "name": "Branch A",
+      "children": [
+        {"name": "Leaf 1", "value": 100},
+        {"name": "Leaf 2", "value": 200}
+      ]
+    }
+  ]
+}
+```
+
+## 2. Sankey Flow Diagram
+**Template:** `sankey`
+**Description:** Flow diagram for tracking volume transfers between states/nodes.
+**Data Format:** Node-Link JSON
+```json
+{
+  "nodes": [{"name": "Start"}, {"name": "End"}],
+  "links": [{"source": 0, "target": 1, "value": 10}]
+}
+```
+
+## 3. Multi-Dimensional Bubble Chart
+**Template:** `bubble-chart`
+**Description:** 3-variable scatter plot (x, y, radius).
+**Data Format:** Grouped Array
+```json
+[
+  {
+    "label": "Group 1",
+    "data": [{"x": 10, "y": 20, "r": 5}]
+  }
+]
+```
+
+## 4. Force-Directed Network
+**Template:** `force-network`
+**Description:** Interconnected graph for relationship mapping.
+**Data Format:** Node-Link
+```json
+{
+  "nodes": [{"id": "A", "group": 1}],
+  "links": [{"source": "A", "target": "B", "value": 1}]
+}
+```
+
+## 5. Geographic Map (Choropleth)
+**Template:** `choropleth`
+**Description:** US State map coloring by value.
+**Data Format:** Key-Value Pairs
+```json
+[
+  ["06", 85], // California FIPS code
+  ["48", 72]  // Texas FIPS code
+]
+```

--- a/skills/geepers-datavis/scripts/analyze-distribution.py
+++ b/skills/geepers-datavis/scripts/analyze-distribution.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""
+Data Distribution Analyzer for Scale Selection
+
+Analyzes a data column and recommends appropriate D3 scale type.
+
+Usage:
+    python analyze-distribution.py data.csv --column value
+    python analyze-distribution.py data.json --column population --format json
+    cat data.csv | python analyze-distribution.py --stdin --column amount
+
+Output:
+    - Min, max, range
+    - Mean, median, standard deviation
+    - Skew ratio and distribution shape
+    - Recommended scale (linear, log, sqrt, symlog)
+    - D3.js code snippet
+
+Author: Luke Steuber
+"""
+
+import argparse
+import csv
+import json
+import math
+import sys
+from typing import List, Dict, Any, Optional
+
+
+def load_csv(filepath: str, column: str) -> List[float]:
+    """Load numeric values from CSV column."""
+    values = []
+    with open(filepath, 'r', encoding='utf-8') as f:
+        reader = csv.DictReader(f)
+        if column not in reader.fieldnames:
+            available = ', '.join(reader.fieldnames or [])
+            raise ValueError(f"Column '{column}' not found. Available: {available}")
+
+        for row in reader:
+            try:
+                val = row[column]
+                if val and val.strip():
+                    # Handle commas in numbers
+                    val = val.replace(',', '').replace('$', '').replace('%', '')
+                    values.append(float(val))
+            except (ValueError, TypeError):
+                continue
+
+    return values
+
+
+def load_json(filepath: str, column: str) -> List[float]:
+    """Load numeric values from JSON array."""
+    with open(filepath, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    if isinstance(data, list):
+        values = []
+        for item in data:
+            if isinstance(item, dict) and column in item:
+                try:
+                    values.append(float(item[column]))
+                except (ValueError, TypeError):
+                    continue
+            elif isinstance(item, (int, float)):
+                values.append(float(item))
+        return values
+
+    raise ValueError("JSON must be an array of objects or numbers")
+
+
+def load_stdin(column: str) -> List[float]:
+    """Load from stdin (CSV format)."""
+    values = []
+    reader = csv.DictReader(sys.stdin)
+    for row in reader:
+        try:
+            if column in row and row[column]:
+                val = row[column].replace(',', '').replace('$', '').replace('%', '')
+                values.append(float(val))
+        except (ValueError, TypeError):
+            continue
+    return values
+
+
+def calculate_statistics(values: List[float]) -> Dict[str, Any]:
+    """Calculate distribution statistics."""
+    if not values:
+        raise ValueError("No valid numeric values found")
+
+    n = len(values)
+    sorted_vals = sorted(values)
+
+    # Basic stats
+    min_val = min(values)
+    max_val = max(values)
+    range_val = max_val - min_val
+
+    # Mean
+    mean = sum(values) / n
+
+    # Median
+    mid = n // 2
+    if n % 2 == 0:
+        median = (sorted_vals[mid - 1] + sorted_vals[mid]) / 2
+    else:
+        median = sorted_vals[mid]
+
+    # Standard deviation
+    variance = sum((x - mean) ** 2 for x in values) / n
+    std_dev = math.sqrt(variance)
+
+    # Percentiles
+    def percentile(p):
+        k = (n - 1) * p / 100
+        f = math.floor(k)
+        c = math.ceil(k)
+        if f == c:
+            return sorted_vals[int(k)]
+        return sorted_vals[f] * (c - k) + sorted_vals[c] * (k - f)
+
+    p25 = percentile(25)
+    p75 = percentile(75)
+    p95 = percentile(95)
+    p99 = percentile(99)
+
+    # Skew indicators
+    skew_ratio = mean / median if median != 0 else float('inf')
+
+    # Range ratio (orders of magnitude)
+    if min_val > 0:
+        range_ratio = max_val / min_val
+    elif min_val == 0:
+        # Find smallest non-zero
+        non_zero = [v for v in values if v > 0]
+        range_ratio = max_val / min(non_zero) if non_zero else float('inf')
+    else:
+        range_ratio = float('inf')  # Has negatives
+
+    # Count zeros and negatives
+    zeros = sum(1 for v in values if v == 0)
+    negatives = sum(1 for v in values if v < 0)
+
+    return {
+        'count': n,
+        'min': min_val,
+        'max': max_val,
+        'range': range_val,
+        'mean': mean,
+        'median': median,
+        'std_dev': std_dev,
+        'p25': p25,
+        'p75': p75,
+        'p95': p95,
+        'p99': p99,
+        'skew_ratio': skew_ratio,
+        'range_ratio': range_ratio,
+        'zeros': zeros,
+        'negatives': negatives,
+    }
+
+
+def recommend_scale(stats: Dict[str, Any]) -> Dict[str, Any]:
+    """Recommend D3 scale based on distribution."""
+    has_negatives = stats['negatives'] > 0
+    has_zeros = stats['zeros'] > 0
+    range_ratio = stats['range_ratio']
+    skew_ratio = stats['skew_ratio']
+
+    reasons = []
+    scale_type = 'linear'
+    confidence = 'high'
+
+    # Decision tree
+    if has_negatives:
+        if range_ratio > 100:
+            scale_type = 'symlog'
+            reasons.append(f"Data has negatives ({stats['negatives']}) and large range ({range_ratio:.0f}x)")
+            reasons.append("Symlog handles zero-crossing with log-like compression")
+        else:
+            scale_type = 'linear'
+            reasons.append(f"Data has negatives but moderate range ({range_ratio:.0f}x)")
+
+    elif range_ratio > 1000:
+        scale_type = 'log'
+        reasons.append(f"Data spans {range_ratio:.0f}x (>1000x) - log scale required")
+        if has_zeros:
+            reasons.append(f"Warning: {stats['zeros']} zero values - consider symlog or offset")
+            confidence = 'medium'
+
+    elif range_ratio > 100:
+        if skew_ratio > 3:
+            scale_type = 'log'
+            reasons.append(f"Right-skewed (mean/median = {skew_ratio:.1f}) with {range_ratio:.0f}x range")
+        else:
+            scale_type = 'sqrt'
+            reasons.append(f"Moderate range ({range_ratio:.0f}x) - sqrt provides gentle compression")
+        if has_zeros:
+            reasons.append(f"Note: {stats['zeros']} zero values present")
+
+    elif skew_ratio > 2:
+        scale_type = 'sqrt'
+        reasons.append(f"Right-skewed distribution (mean/median = {skew_ratio:.1f})")
+        reasons.append("Sqrt scale compresses high values while keeping low values readable")
+
+    else:
+        scale_type = 'linear'
+        reasons.append(f"Data is relatively uniform (range {range_ratio:.0f}x, skew {skew_ratio:.2f})")
+
+    return {
+        'recommended_scale': scale_type,
+        'confidence': confidence,
+        'reasons': reasons,
+    }
+
+
+def generate_d3_code(stats: Dict, recommendation: Dict, domain_name: str = 'data') -> str:
+    """Generate D3.js scale code snippet."""
+    scale = recommendation['recommended_scale']
+    min_val = stats['min']
+    max_val = stats['max']
+
+    # Round domain for cleaner code
+    def nice_round(val, direction='up'):
+        if val == 0:
+            return 0
+        magnitude = 10 ** math.floor(math.log10(abs(val)))
+        if direction == 'up':
+            return math.ceil(val / magnitude) * magnitude
+        else:
+            return math.floor(val / magnitude) * magnitude
+
+    if scale == 'linear':
+        domain_min = nice_round(min_val, 'down') if min_val > 0 else min_val
+        domain_max = nice_round(max_val, 'up')
+        return f"""const scale = d3.scaleLinear()
+  .domain([{domain_min}, {domain_max}])
+  .range([0, width])
+  .nice();"""
+
+    elif scale == 'log':
+        domain_min = max(1, nice_round(min_val, 'down')) if min_val > 0 else 1
+        domain_max = nice_round(max_val, 'up')
+        return f"""const scale = d3.scaleLog()
+  .domain([{domain_min}, {domain_max}])
+  .range([0, width])
+  .clamp(true);
+
+// Note: Log scale requires positive domain (min > 0)
+// For zero values, consider offset: d => d + 1"""
+
+    elif scale == 'sqrt':
+        domain_max = nice_round(max_val, 'up')
+        return f"""const scale = d3.scaleSqrt()
+  .domain([0, {domain_max}])
+  .range([0, maxRadius]);
+
+// Sqrt scale is ideal for area encoding (circles, bubbles)
+// Ensures perceptually accurate size perception"""
+
+    elif scale == 'symlog':
+        domain_min = nice_round(min_val, 'down')
+        domain_max = nice_round(max_val, 'up')
+        return f"""const scale = d3.scaleSymlog()
+  .domain([{domain_min}, {domain_max}])
+  .range([0, width])
+  .constant(1);  // Adjust for transition smoothness around zero
+
+// Symlog handles negative values and zero crossing gracefully"""
+
+    return "// Unable to generate scale code"
+
+
+def format_number(val: float) -> str:
+    """Format number for display."""
+    if abs(val) >= 1_000_000_000:
+        return f"{val/1_000_000_000:.2f}B"
+    elif abs(val) >= 1_000_000:
+        return f"{val/1_000_000:.2f}M"
+    elif abs(val) >= 1_000:
+        return f"{val/1_000:.2f}K"
+    elif abs(val) < 0.01 and val != 0:
+        return f"{val:.2e}"
+    else:
+        return f"{val:.2f}"
+
+
+def print_report(stats: Dict, recommendation: Dict, column: str, output_format: str):
+    """Print analysis report."""
+    if output_format == 'json':
+        output = {
+            'column': column,
+            'statistics': stats,
+            'recommendation': recommendation,
+        }
+        print(json.dumps(output, indent=2, default=str))
+        return
+
+    # Text report
+    print("\n" + "=" * 60)
+    print(f"  DISTRIBUTION ANALYSIS: {column}")
+    print("=" * 60)
+
+    print("\n  STATISTICS")
+    print("  " + "-" * 40)
+    print(f"  Count:      {stats['count']:,}")
+    print(f"  Min:        {format_number(stats['min'])}")
+    print(f"  Max:        {format_number(stats['max'])}")
+    print(f"  Range:      {format_number(stats['range'])}")
+    print(f"  Mean:       {format_number(stats['mean'])}")
+    print(f"  Median:     {format_number(stats['median'])}")
+    print(f"  Std Dev:    {format_number(stats['std_dev'])}")
+
+    print("\n  PERCENTILES")
+    print("  " + "-" * 40)
+    print(f"  25th:       {format_number(stats['p25'])}")
+    print(f"  75th:       {format_number(stats['p75'])}")
+    print(f"  95th:       {format_number(stats['p95'])}")
+    print(f"  99th:       {format_number(stats['p99'])}")
+
+    print("\n  DISTRIBUTION SHAPE")
+    print("  " + "-" * 40)
+    print(f"  Skew Ratio: {stats['skew_ratio']:.2f} (mean/median)")
+    print(f"  Range Ratio: {stats['range_ratio']:.0f}x (max/min)")
+    print(f"  Zeros:      {stats['zeros']}")
+    print(f"  Negatives:  {stats['negatives']}")
+
+    print("\n  RECOMMENDATION")
+    print("  " + "-" * 40)
+    print(f"  Scale:      {recommendation['recommended_scale'].upper()}")
+    print(f"  Confidence: {recommendation['confidence']}")
+    print("\n  Reasons:")
+    for reason in recommendation['reasons']:
+        print(f"    - {reason}")
+
+    print("\n  D3.JS CODE")
+    print("  " + "-" * 40)
+    code = generate_d3_code(stats, recommendation, column)
+    for line in code.split('\n'):
+        print(f"  {line}")
+
+    print("\n" + "=" * 60 + "\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Analyze data distribution and recommend D3 scale',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s data.csv --column population
+  %(prog)s data.json --column value --format json
+  cat data.csv | %(prog)s --stdin --column amount
+        """
+    )
+
+    parser.add_argument('file', nargs='?',
+                        help='Input file (CSV or JSON)')
+    parser.add_argument('--column', '-c', required=True,
+                        help='Column name to analyze')
+    parser.add_argument('--stdin', action='store_true',
+                        help='Read from stdin (CSV format)')
+    parser.add_argument('--format', '-f',
+                        choices=['text', 'json'],
+                        default='text',
+                        help='Output format (default: text)')
+
+    args = parser.parse_args()
+
+    # Load data
+    try:
+        if args.stdin:
+            values = load_stdin(args.column)
+        elif args.file:
+            if args.file.endswith('.json'):
+                values = load_json(args.file, args.column)
+            else:
+                values = load_csv(args.file, args.column)
+        else:
+            parser.error("Must specify file or --stdin")
+
+        if not values:
+            print(f"Error: No valid numeric values found in column '{args.column}'",
+                  file=sys.stderr)
+            sys.exit(1)
+
+        # Analyze
+        stats = calculate_statistics(values)
+        recommendation = recommend_scale(stats)
+
+        # Output
+        print_report(stats, recommendation, args.column, args.format)
+
+    except FileNotFoundError:
+        print(f"Error: File '{args.file}' not found", file=sys.stderr)
+        sys.exit(1)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/skills/geepers-datavis/scripts/color-palette.py
+++ b/skills/geepers-datavis/scripts/color-palette.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""
+Color Palette Generator for Data Visualization
+
+Generates colorblind-safe, perceptually uniform color palettes.
+
+Usage:
+    python color-palette.py --type sequential --hue blue --steps 9
+    python color-palette.py --type categorical --count 6 --colorblind-safe
+    python color-palette.py --type diverging --low red --high blue
+    python color-palette.py --preset war-regions
+    python color-palette.py --preset corporate
+
+Author: Luke Steuber
+"""
+
+import argparse
+import json
+import sys
+from typing import List, Dict, Tuple
+
+# Colorblind-safe categorical palette (Paul Tol's scheme)
+COLORBLIND_SAFE = [
+    '#332288',  # Indigo
+    '#117733',  # Green
+    '#44AA99',  # Teal
+    '#88CCEE',  # Cyan
+    '#DDCC77',  # Sand
+    '#CC6677',  # Rose
+    '#AA4499',  # Purple
+    '#882255',  # Wine
+]
+
+# D3 categorical schemes
+D3_CATEGORY10 = [
+    '#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd',
+    '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf'
+]
+
+# Project-specific presets from existing visualizations
+PRESETS = {
+    'war-regions': {
+        'description': 'Forget Me Not war casualties by region',
+        'colors': {
+            'Europe': '#b91c1c',
+            'Asia': '#d97706',
+            'Middle East': '#1d4ed8',
+            'Africa': '#15803d',
+            'Americas': '#7e22ce',
+        }
+    },
+    'corporate': {
+        'description': 'Dow Jones corporate connections',
+        'colors': {
+            'Board': '#0077BB',
+            'Executive': '#000000',
+            'Government': '#D4AF37',
+        }
+    },
+    'sentiment': {
+        'description': 'Positive/negative sentiment diverging',
+        'colors': {
+            'Very Negative': '#b91c1c',
+            'Negative': '#dc2626',
+            'Neutral': '#6b7280',
+            'Positive': '#16a34a',
+            'Very Positive': '#15803d',
+        }
+    }
+}
+
+# Base hues for sequential palettes (HSL lightness variations)
+BASE_HUES = {
+    'blue': (210, 80),    # hue, saturation
+    'green': (140, 70),
+    'red': (0, 75),
+    'orange': (30, 85),
+    'purple': (270, 65),
+    'teal': (175, 60),
+    'gold': (45, 80),
+    'gray': (0, 0),
+}
+
+
+def hsl_to_hex(h: float, s: float, l: float) -> str:
+    """Convert HSL to hex color."""
+    s = s / 100
+    l = l / 100
+
+    c = (1 - abs(2 * l - 1)) * s
+    x = c * (1 - abs((h / 60) % 2 - 1))
+    m = l - c / 2
+
+    if 0 <= h < 60:
+        r, g, b = c, x, 0
+    elif 60 <= h < 120:
+        r, g, b = x, c, 0
+    elif 120 <= h < 180:
+        r, g, b = 0, c, x
+    elif 180 <= h < 240:
+        r, g, b = 0, x, c
+    elif 240 <= h < 300:
+        r, g, b = x, 0, c
+    else:
+        r, g, b = c, 0, x
+
+    r = int((r + m) * 255)
+    g = int((g + m) * 255)
+    b = int((b + m) * 255)
+
+    return f'#{r:02x}{g:02x}{b:02x}'
+
+
+def generate_sequential(hue: str, steps: int) -> List[str]:
+    """Generate sequential palette from light to dark."""
+    if hue not in BASE_HUES:
+        print(f"Unknown hue '{hue}'. Available: {list(BASE_HUES.keys())}", file=sys.stderr)
+        sys.exit(1)
+
+    h, s = BASE_HUES[hue]
+    colors = []
+
+    # Lightness from 95% (very light) to 25% (dark)
+    for i in range(steps):
+        l = 95 - (70 * i / (steps - 1)) if steps > 1 else 50
+        colors.append(hsl_to_hex(h, s, l))
+
+    return colors
+
+
+def generate_diverging(low_hue: str, high_hue: str, steps: int = 9) -> List[str]:
+    """Generate diverging palette with neutral midpoint."""
+    if steps % 2 == 0:
+        steps += 1  # Ensure odd number for clear midpoint
+
+    mid = steps // 2
+    colors = []
+
+    low_h, low_s = BASE_HUES.get(low_hue, (0, 75))
+    high_h, high_s = BASE_HUES.get(high_hue, (210, 80))
+
+    # Low end (dark to light)
+    for i in range(mid):
+        l = 30 + (35 * i / mid)
+        colors.append(hsl_to_hex(low_h, low_s, l))
+
+    # Midpoint (neutral gray)
+    colors.append('#f5f5f5')
+
+    # High end (light to dark)
+    for i in range(mid):
+        l = 65 - (35 * i / mid)
+        colors.append(hsl_to_hex(high_h, high_s, l))
+
+    return colors
+
+
+def generate_categorical(count: int, colorblind_safe: bool = True) -> List[str]:
+    """Generate categorical palette."""
+    if colorblind_safe:
+        if count > len(COLORBLIND_SAFE):
+            print(f"Warning: Only {len(COLORBLIND_SAFE)} colorblind-safe colors available",
+                  file=sys.stderr)
+        return COLORBLIND_SAFE[:count]
+    else:
+        return D3_CATEGORY10[:count]
+
+
+def output_palette(colors: List[str] | Dict[str, str], format: str, name: str = 'palette'):
+    """Output palette in requested format."""
+    if isinstance(colors, dict):
+        color_list = list(colors.values())
+        labels = list(colors.keys())
+    else:
+        color_list = colors
+        labels = None
+
+    if format == 'json':
+        if labels:
+            print(json.dumps(dict(zip(labels, color_list)), indent=2))
+        else:
+            print(json.dumps(color_list, indent=2))
+
+    elif format == 'js':
+        if labels:
+            print(f"const {name} = {{")
+            for label, color in zip(labels, color_list):
+                print(f"  '{label}': '{color}',")
+            print("};")
+        else:
+            print(f"const {name} = {json.dumps(color_list)};")
+
+    elif format == 'css':
+        print(":root {")
+        if labels:
+            for i, (label, color) in enumerate(zip(labels, color_list)):
+                var_name = label.lower().replace(' ', '-').replace('_', '-')
+                print(f"  --color-{var_name}: {color};")
+        else:
+            for i, color in enumerate(color_list):
+                print(f"  --color-{name}-{i}: {color};")
+        print("}")
+
+    elif format == 'd3':
+        print(f"const {name}Scale = d3.scaleOrdinal()")
+        if labels:
+            print(f"  .domain({json.dumps(labels)})")
+        print(f"  .range({json.dumps(color_list)});")
+
+    else:  # text
+        if labels:
+            for label, color in zip(labels, color_list):
+                print(f"{label}: {color}")
+        else:
+            for color in color_list:
+                print(color)
+
+
+def print_swatches(colors: List[str] | Dict[str, str]):
+    """Print color swatches using ANSI escape codes."""
+    if isinstance(colors, dict):
+        items = list(colors.items())
+    else:
+        items = [(f"Color {i+1}", c) for i, c in enumerate(colors)]
+
+    print("\nColor Swatches:")
+    print("-" * 40)
+
+    for label, hex_color in items:
+        # Convert hex to RGB for ANSI
+        r = int(hex_color[1:3], 16)
+        g = int(hex_color[3:5], 16)
+        b = int(hex_color[5:7], 16)
+
+        # ANSI true color escape sequence
+        swatch = f"\033[48;2;{r};{g};{b}m    \033[0m"
+        print(f"{swatch} {hex_color}  {label}")
+
+    print("-" * 40)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Generate colorblind-safe palettes for data visualization',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s --type sequential --hue blue --steps 9
+  %(prog)s --type categorical --count 6 --colorblind-safe
+  %(prog)s --type diverging --low red --high blue --steps 11
+  %(prog)s --preset war-regions --format css
+  %(prog)s --list-presets
+        """
+    )
+
+    parser.add_argument('--type', '-t',
+                        choices=['sequential', 'categorical', 'diverging'],
+                        help='Palette type')
+    parser.add_argument('--hue',
+                        choices=list(BASE_HUES.keys()),
+                        help='Base hue for sequential palette')
+    parser.add_argument('--low',
+                        choices=list(BASE_HUES.keys()),
+                        help='Low-end hue for diverging palette')
+    parser.add_argument('--high',
+                        choices=list(BASE_HUES.keys()),
+                        help='High-end hue for diverging palette')
+    parser.add_argument('--steps', '-s', type=int, default=9,
+                        help='Number of steps in palette (default: 9)')
+    parser.add_argument('--count', '-c', type=int, default=8,
+                        help='Number of colors for categorical (default: 8)')
+    parser.add_argument('--colorblind-safe', '-cb', action='store_true',
+                        help='Use colorblind-safe palette')
+    parser.add_argument('--preset', '-p',
+                        choices=list(PRESETS.keys()),
+                        help='Use a project preset')
+    parser.add_argument('--list-presets', action='store_true',
+                        help='List available presets')
+    parser.add_argument('--format', '-f',
+                        choices=['text', 'json', 'js', 'css', 'd3'],
+                        default='text',
+                        help='Output format (default: text)')
+    parser.add_argument('--name', '-n', default='palette',
+                        help='Variable name for js/d3 output')
+    parser.add_argument('--no-swatches', action='store_true',
+                        help='Skip printing color swatches')
+
+    args = parser.parse_args()
+
+    # List presets
+    if args.list_presets:
+        print("Available presets:")
+        for name, preset in PRESETS.items():
+            print(f"\n  {name}:")
+            print(f"    {preset['description']}")
+            for label, color in preset['colors'].items():
+                print(f"      {label}: {color}")
+        return
+
+    # Generate palette
+    colors = None
+
+    if args.preset:
+        colors = PRESETS[args.preset]['colors']
+    elif args.type == 'sequential':
+        if not args.hue:
+            parser.error("--type sequential requires --hue")
+        colors = generate_sequential(args.hue, args.steps)
+    elif args.type == 'categorical':
+        colors = generate_categorical(args.count, args.colorblind_safe)
+    elif args.type == 'diverging':
+        if not args.low or not args.high:
+            parser.error("--type diverging requires --low and --high")
+        colors = generate_diverging(args.low, args.high, args.steps)
+    else:
+        parser.error("Must specify --type or --preset")
+
+    # Output
+    output_palette(colors, args.format, args.name)
+
+    if not args.no_swatches and args.format == 'text':
+        print_swatches(colors)
+
+
+if __name__ == '__main__':
+    main()

--- a/skills/geepers-datavis/scripts/d3-scaffold.py
+++ b/skills/geepers-datavis/scripts/d3-scaffold.py
@@ -1,0 +1,1317 @@
+#!/usr/bin/env python3
+"""
+D3.js Visualization Project Scaffolder
+
+Generates boilerplate HTML/CSS/JS for common visualization types.
+
+Usage:
+    python d3-scaffold.py my-viz --type force-network
+    python d3-scaffold.py my-viz --type timeline --output ~/html/datavis/
+    python d3-scaffold.py my-viz --type choropleth --single-file
+
+Types:
+    force-network  - Force-directed node-link graph
+    timeline       - Horizontal scrolling timeline
+    choropleth     - Geographic map with color encoding
+    bar-race       - Animated bar chart race
+    treemap        - Hierarchical treemap
+    sankey         - Flow diagram
+
+Author: Luke Steuber
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import Dict
+
+# Base HTML template
+HTML_TEMPLATE = """<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{title}</title>
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="{title}">
+    <meta property="og:description" content="{description}">
+    <meta property="og:type" content="website">
+
+    <script src="https://d3js.org/d3.v7.min.js"></script>
+{extra_scripts}
+    <style>
+{css}
+    </style>
+</head>
+<body>
+    <header>
+        <h1>{title}</h1>
+        <p class="subtitle">{description}</p>
+    </header>
+
+    <main>
+        <div id="visualization"></div>
+        <p class="instructions">{instructions}</p>
+    </main>
+
+    <footer>
+        <p class="attribution">Visualization by Luke Steuber</p>
+        <p class="sources">Data sources: <a href="#">Source</a></p>
+    </footer>
+
+    <script>
+{js}
+    </script>
+</body>
+</html>
+"""
+
+# Base CSS (shared)
+BASE_CSS = """        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            font-family: 'Helvetica Neue', system-ui, sans-serif;
+            background: #fafafa;
+            color: #1a1a1a;
+            line-height: 1.6;
+        }
+
+        header {
+            text-align: center;
+            padding: 2rem 1rem;
+            background: white;
+            border-bottom: 1px solid #e0e0e0;
+        }
+
+        h1 {
+            font-size: 2rem;
+            font-weight: 600;
+            margin-bottom: 0.5rem;
+        }
+
+        .subtitle {
+            color: #666;
+            font-size: 1.1rem;
+        }
+
+        main {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 2rem 1rem;
+        }
+
+        #visualization {
+            background: white;
+            border-radius: 8px;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+            overflow: hidden;
+        }
+
+        .instructions {
+            text-align: center;
+            color: #888;
+            font-size: 0.9rem;
+            margin-top: 1rem;
+        }
+
+        footer {
+            text-align: center;
+            padding: 2rem;
+            color: #666;
+            font-size: 0.85rem;
+        }
+
+        footer a {
+            color: #0077BB;
+        }
+
+        /* Tooltip */
+        .tooltip {
+            position: absolute;
+            background: rgba(0, 0, 0, 0.85);
+            color: white;
+            padding: 8px 12px;
+            border-radius: 4px;
+            font-size: 0.85rem;
+            pointer-events: none;
+            opacity: 0;
+            transition: opacity 0.2s;
+            max-width: 250px;
+            z-index: 1000;
+        }
+
+        .tooltip.visible {
+            opacity: 1;
+        }
+
+        /* Responsive */
+        @media (max-width: 768px) {
+            h1 { font-size: 1.5rem; }
+            .subtitle { font-size: 1rem; }
+        }"""
+
+
+# Type-specific templates
+TEMPLATES: Dict[str, Dict] = {
+    'force-network': {
+        'title': 'Network Visualization',
+        'description': 'Interactive force-directed network graph',
+        'instructions': 'Drag nodes to reposition. Hover for details.',
+        'extra_scripts': '',
+        'css': BASE_CSS + """
+
+        .node {
+            cursor: grab;
+        }
+
+        .node:active {
+            cursor: grabbing;
+        }
+
+        .node circle {
+            stroke: white;
+            stroke-width: 2px;
+            transition: r 0.2s;
+        }
+
+        .node:hover circle {
+            stroke: #333;
+        }
+
+        .node text {
+            font-size: 11px;
+            fill: #333;
+            pointer-events: none;
+        }
+
+        .link {
+            fill: none;
+            stroke: #999;
+            stroke-opacity: 0.6;
+        }
+
+        .link.highlighted {
+            stroke: #0077BB;
+            stroke-opacity: 1;
+        }""",
+        'js': """
+// Sample data - replace with your data
+const data = {
+    nodes: [
+        { id: 'A', name: 'Node A', group: 1 },
+        { id: 'B', name: 'Node B', group: 1 },
+        { id: 'C', name: 'Node C', group: 2 },
+        { id: 'D', name: 'Node D', group: 2 },
+        { id: 'E', name: 'Node E', group: 3 },
+    ],
+    links: [
+        { source: 'A', target: 'B', value: 1 },
+        { source: 'A', target: 'C', value: 2 },
+        { source: 'B', target: 'D', value: 1 },
+        { source: 'C', target: 'D', value: 3 },
+        { source: 'D', target: 'E', value: 1 },
+    ]
+};
+
+// Dimensions
+const container = document.getElementById('visualization');
+const width = container.clientWidth;
+const height = 600;
+
+// Color scale
+const colorScale = d3.scaleOrdinal(d3.schemeTableau10);
+
+// Create SVG
+const svg = d3.select('#visualization')
+    .append('svg')
+    .attr('viewBox', `0 0 ${width} ${height}`)
+    .attr('preserveAspectRatio', 'xMidYMid meet');
+
+// Tooltip
+const tooltip = d3.select('body')
+    .append('div')
+    .attr('class', 'tooltip');
+
+// Force simulation
+const simulation = d3.forceSimulation(data.nodes)
+    .force('link', d3.forceLink(data.links).id(d => d.id).distance(100))
+    .force('charge', d3.forceManyBody().strength(-300))
+    .force('center', d3.forceCenter(width / 2, height / 2))
+    .force('collision', d3.forceCollide().radius(30));
+
+// Draw links
+const links = svg.append('g')
+    .selectAll('line')
+    .data(data.links)
+    .join('line')
+    .attr('class', 'link')
+    .attr('stroke-width', d => Math.sqrt(d.value) * 2);
+
+// Draw nodes
+const nodes = svg.append('g')
+    .selectAll('g')
+    .data(data.nodes)
+    .join('g')
+    .attr('class', 'node')
+    .call(drag(simulation));
+
+nodes.append('circle')
+    .attr('r', 20)
+    .attr('fill', d => colorScale(d.group));
+
+nodes.append('text')
+    .attr('dy', 4)
+    .attr('text-anchor', 'middle')
+    .text(d => d.id);
+
+// Interactions
+nodes.on('mouseover', function(event, d) {
+    tooltip
+        .html(`<strong>${d.name}</strong><br>Group: ${d.group}`)
+        .style('left', (event.pageX + 10) + 'px')
+        .style('top', (event.pageY - 10) + 'px')
+        .classed('visible', true);
+
+    // Highlight connected links
+    links.classed('highlighted', l => l.source.id === d.id || l.target.id === d.id);
+})
+.on('mouseout', function() {
+    tooltip.classed('visible', false);
+    links.classed('highlighted', false);
+});
+
+// Simulation tick
+simulation.on('tick', () => {
+    links
+        .attr('x1', d => d.source.x)
+        .attr('y1', d => d.source.y)
+        .attr('x2', d => d.target.x)
+        .attr('y2', d => d.target.y);
+
+    nodes.attr('transform', d => `translate(${d.x},${d.y})`);
+});
+
+// Drag behavior
+function drag(simulation) {
+    function dragstarted(event) {
+        if (!event.active) simulation.alphaTarget(0.3).restart();
+        event.subject.fx = event.subject.x;
+        event.subject.fy = event.subject.y;
+    }
+
+    function dragged(event) {
+        event.subject.fx = event.x;
+        event.subject.fy = event.y;
+    }
+
+    function dragended(event) {
+        if (!event.active) simulation.alphaTarget(0);
+        event.subject.fx = null;
+        event.subject.fy = null;
+    }
+
+    return d3.drag()
+        .on('start', dragstarted)
+        .on('drag', dragged)
+        .on('end', dragended);
+}"""
+    },
+
+    'timeline': {
+        'title': 'Interactive Timeline',
+        'description': 'Scroll horizontally to explore events over time',
+        'instructions': 'Scroll horizontally to explore. Click events for details.',
+        'extra_scripts': '',
+        'css': BASE_CSS + """
+
+        #visualization {
+            overflow-x: auto;
+            overflow-y: hidden;
+        }
+
+        .timeline-container {
+            min-width: 2000px;
+            height: 400px;
+            position: relative;
+        }
+
+        .axis-line {
+            stroke: #333;
+            stroke-width: 2;
+        }
+
+        .event-marker {
+            cursor: pointer;
+            transition: transform 0.2s;
+        }
+
+        .event-marker:hover {
+            transform: scale(1.2);
+        }
+
+        .event-label {
+            font-size: 11px;
+            fill: #333;
+        }
+
+        .year-label {
+            font-size: 12px;
+            fill: #666;
+        }""",
+        'js': """
+// Sample data - replace with your data
+const events = [
+    { year: 2020, month: 1, title: 'Event A', category: 'category1' },
+    { year: 2020, month: 6, title: 'Event B', category: 'category2' },
+    { year: 2021, month: 3, title: 'Event C', category: 'category1' },
+    { year: 2021, month: 9, title: 'Event D', category: 'category3' },
+    { year: 2022, month: 2, title: 'Event E', category: 'category2' },
+    { year: 2022, month: 11, title: 'Event F', category: 'category1' },
+    { year: 2023, month: 5, title: 'Event G', category: 'category3' },
+];
+
+// Dimensions
+const margin = { top: 50, right: 50, bottom: 50, left: 50 };
+const width = 2000;
+const height = 400;
+
+// Scales
+const parseDate = d => new Date(d.year, d.month - 1);
+const xScale = d3.scaleTime()
+    .domain(d3.extent(events, d => parseDate(d)))
+    .range([margin.left, width - margin.right]);
+
+const colorScale = d3.scaleOrdinal()
+    .domain(['category1', 'category2', 'category3'])
+    .range(['#0077BB', '#CC6677', '#44AA99']);
+
+// Create SVG
+const svg = d3.select('#visualization')
+    .append('div')
+    .attr('class', 'timeline-container')
+    .append('svg')
+    .attr('width', width)
+    .attr('height', height);
+
+// Tooltip
+const tooltip = d3.select('body')
+    .append('div')
+    .attr('class', 'tooltip');
+
+// Draw axis
+const axisY = height / 2;
+
+svg.append('line')
+    .attr('class', 'axis-line')
+    .attr('x1', margin.left)
+    .attr('y1', axisY)
+    .attr('x2', width - margin.right)
+    .attr('y2', axisY);
+
+// Year markers
+const years = d3.timeYear.range(
+    d3.timeYear.floor(xScale.domain()[0]),
+    d3.timeYear.ceil(xScale.domain()[1])
+);
+
+svg.selectAll('.year-marker')
+    .data(years)
+    .join('g')
+    .attr('class', 'year-marker')
+    .attr('transform', d => `translate(${xScale(d)}, ${axisY})`)
+    .call(g => {
+        g.append('line')
+            .attr('y1', -10)
+            .attr('y2', 10)
+            .attr('stroke', '#999');
+        g.append('text')
+            .attr('class', 'year-label')
+            .attr('y', 25)
+            .attr('text-anchor', 'middle')
+            .text(d => d.getFullYear());
+    });
+
+// Draw events
+const eventGroups = svg.selectAll('.event-marker')
+    .data(events)
+    .join('g')
+    .attr('class', 'event-marker')
+    .attr('transform', (d, i) => {
+        const x = xScale(parseDate(d));
+        const y = axisY + (i % 2 === 0 ? -60 : 60);
+        return `translate(${x}, ${y})`;
+    });
+
+eventGroups.append('circle')
+    .attr('r', 12)
+    .attr('fill', d => colorScale(d.category));
+
+eventGroups.append('line')
+    .attr('y1', d => events.indexOf(d) % 2 === 0 ? 12 : -12)
+    .attr('y2', d => events.indexOf(d) % 2 === 0 ? 48 : -48)
+    .attr('stroke', '#ccc')
+    .attr('stroke-dasharray', '3,3');
+
+eventGroups.append('text')
+    .attr('class', 'event-label')
+    .attr('y', d => events.indexOf(d) % 2 === 0 ? -18 : 22)
+    .attr('text-anchor', 'middle')
+    .text(d => d.title);
+
+// Interactions
+eventGroups.on('mouseover', function(event, d) {
+    tooltip
+        .html(`<strong>${d.title}</strong><br>${d.year}`)
+        .style('left', (event.pageX + 10) + 'px')
+        .style('top', (event.pageY - 10) + 'px')
+        .classed('visible', true);
+})
+.on('mouseout', () => tooltip.classed('visible', false));
+
+// Scroll to center
+document.getElementById('visualization').scrollLeft = (width - window.innerWidth) / 2;"""
+    },
+
+    'choropleth': {
+        'title': 'Geographic Data Map',
+        'description': 'Color-encoded geographic visualization',
+        'instructions': 'Hover over regions for details.',
+        'extra_scripts': '    <script src="https://d3js.org/topojson.v3.min.js"></script>',
+        'css': BASE_CSS + """
+
+        .state {
+            stroke: white;
+            stroke-width: 0.5;
+            cursor: pointer;
+            transition: opacity 0.2s;
+        }
+
+        .state:hover {
+            opacity: 0.8;
+            stroke-width: 1.5;
+        }
+
+        .legend {
+            font-size: 12px;
+        }
+
+        .legend-title {
+            font-weight: 600;
+        }""",
+        'js': """
+// Dimensions
+const width = 960;
+const height = 600;
+
+// Color scale - adjust domain based on your data
+const colorScale = d3.scaleSequential(d3.interpolateBlues)
+    .domain([0, 100]);
+
+// Create SVG
+const svg = d3.select('#visualization')
+    .append('svg')
+    .attr('viewBox', `0 0 ${width} ${height}`)
+    .attr('preserveAspectRatio', 'xMidYMid meet');
+
+// Tooltip
+const tooltip = d3.select('body')
+    .append('div')
+    .attr('class', 'tooltip');
+
+// Projection
+const projection = d3.geoAlbersUsa()
+    .scale(1200)
+    .translate([width / 2, height / 2]);
+
+const path = d3.geoPath().projection(projection);
+
+// Load US TopoJSON
+d3.json('https://cdn.jsdelivr.net/npm/us-atlas@3/states-10m.json')
+    .then(us => {
+        const states = topojson.feature(us, us.objects.states).features;
+
+        // Sample data - replace with your data
+        // Map FIPS codes to values
+        const data = new Map([
+            ['06', 85], // California
+            ['48', 72], // Texas
+            ['12', 65], // Florida
+            ['36', 90], // New York
+            // ... add more states
+        ]);
+
+        // Draw states
+        svg.selectAll('.state')
+            .data(states)
+            .join('path')
+            .attr('class', 'state')
+            .attr('d', path)
+            .attr('fill', d => {
+                const value = data.get(d.id);
+                return value ? colorScale(value) : '#eee';
+            })
+            .on('mouseover', function(event, d) {
+                const value = data.get(d.id) || 'No data';
+                tooltip
+                    .html(`<strong>${d.properties.name}</strong><br>Value: ${value}`)
+                    .style('left', (event.pageX + 10) + 'px')
+                    .style('top', (event.pageY - 10) + 'px')
+                    .classed('visible', true);
+            })
+            .on('mouseout', () => tooltip.classed('visible', false));
+
+        // Legend
+        const legendWidth = 200;
+        const legendHeight = 10;
+
+        const legend = svg.append('g')
+            .attr('class', 'legend')
+            .attr('transform', `translate(${width - legendWidth - 40}, ${height - 40})`);
+
+        // Gradient
+        const defs = svg.append('defs');
+        const gradient = defs.append('linearGradient')
+            .attr('id', 'legend-gradient');
+
+        gradient.selectAll('stop')
+            .data(d3.range(0, 1.1, 0.1))
+            .join('stop')
+            .attr('offset', d => d * 100 + '%')
+            .attr('stop-color', d => colorScale(d * 100));
+
+        legend.append('rect')
+            .attr('width', legendWidth)
+            .attr('height', legendHeight)
+            .attr('fill', 'url(#legend-gradient)');
+
+        legend.append('text')
+            .attr('class', 'legend-title')
+            .attr('y', -5)
+            .text('Value');
+
+        legend.append('text')
+            .attr('x', 0)
+            .attr('y', legendHeight + 15)
+            .text('0');
+
+        legend.append('text')
+            .attr('x', legendWidth)
+            .attr('y', legendHeight + 15)
+            .attr('text-anchor', 'end')
+            .text('100');
+    });"""
+    },
+
+    'bar-race': {
+        'title': 'Animated Bar Chart Race',
+        'description': 'Watch rankings change over time',
+        'instructions': 'Press Play to start the animation.',
+        'extra_scripts': '',
+        'css': BASE_CSS + """
+
+        .controls {
+            text-align: center;
+            margin-bottom: 1rem;
+        }
+
+        .controls button {
+            padding: 0.5rem 1.5rem;
+            font-size: 1rem;
+            background: #0077BB;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            margin: 0 0.5rem;
+        }
+
+        .controls button:hover {
+            background: #005588;
+        }
+
+        .year-display {
+            font-size: 4rem;
+            font-weight: bold;
+            fill: #ddd;
+            text-anchor: end;
+        }
+
+        .bar-label {
+            font-size: 12px;
+            fill: white;
+            font-weight: 600;
+        }
+
+        .bar-value {
+            font-size: 12px;
+            fill: #333;
+        }""",
+        'js': """
+// Sample data - replace with your data
+// Format: { name, value, year }
+const rawData = [
+    { name: 'A', value: 10, year: 2020 },
+    { name: 'B', value: 15, year: 2020 },
+    { name: 'C', value: 8, year: 2020 },
+    { name: 'A', value: 25, year: 2021 },
+    { name: 'B', value: 20, year: 2021 },
+    { name: 'C', value: 30, year: 2021 },
+    { name: 'A', value: 40, year: 2022 },
+    { name: 'B', value: 35, year: 2022 },
+    { name: 'C', value: 25, year: 2022 },
+];
+
+// Group by year
+const years = [...new Set(rawData.map(d => d.year))].sort();
+const dataByYear = new Map(
+    years.map(year => [year, rawData.filter(d => d.year === year)])
+);
+
+// Dimensions
+const margin = { top: 20, right: 100, bottom: 30, left: 100 };
+const width = 800;
+const height = 400;
+const barHeight = 40;
+const topN = 10;
+
+// Scales
+const xScale = d3.scaleLinear()
+    .range([margin.left, width - margin.right]);
+
+const yScale = d3.scaleBand()
+    .range([margin.top, margin.top + topN * barHeight])
+    .padding(0.1);
+
+const colorScale = d3.scaleOrdinal(d3.schemeTableau10);
+
+// Create SVG
+const svg = d3.select('#visualization')
+    .append('svg')
+    .attr('viewBox', `0 0 ${width} ${height}`);
+
+// Year display
+const yearText = svg.append('text')
+    .attr('class', 'year-display')
+    .attr('x', width - margin.right)
+    .attr('y', height - 30)
+    .text(years[0]);
+
+// Controls
+d3.select('#visualization')
+    .insert('div', 'svg')
+    .attr('class', 'controls')
+    .html('<button id="play">Play</button><button id="reset">Reset</button>');
+
+let currentIndex = 0;
+let interval;
+
+function update(year) {
+    const data = dataByYear.get(year)
+        .sort((a, b) => b.value - a.value)
+        .slice(0, topN);
+
+    xScale.domain([0, d3.max(data, d => d.value)]);
+    yScale.domain(data.map(d => d.name));
+
+    // Bars
+    const bars = svg.selectAll('.bar')
+        .data(data, d => d.name);
+
+    bars.enter()
+        .append('rect')
+        .attr('class', 'bar')
+        .attr('x', margin.left)
+        .attr('y', d => yScale(d.name))
+        .attr('height', yScale.bandwidth())
+        .attr('fill', d => colorScale(d.name))
+        .merge(bars)
+        .transition()
+        .duration(500)
+        .attr('y', d => yScale(d.name))
+        .attr('width', d => xScale(d.value) - margin.left);
+
+    bars.exit().remove();
+
+    // Labels
+    const labels = svg.selectAll('.bar-label')
+        .data(data, d => d.name);
+
+    labels.enter()
+        .append('text')
+        .attr('class', 'bar-label')
+        .attr('x', margin.left + 5)
+        .attr('y', d => yScale(d.name) + yScale.bandwidth() / 2 + 4)
+        .merge(labels)
+        .transition()
+        .duration(500)
+        .attr('y', d => yScale(d.name) + yScale.bandwidth() / 2 + 4)
+        .text(d => d.name);
+
+    labels.exit().remove();
+
+    // Values
+    const values = svg.selectAll('.bar-value')
+        .data(data, d => d.name);
+
+    values.enter()
+        .append('text')
+        .attr('class', 'bar-value')
+        .attr('y', d => yScale(d.name) + yScale.bandwidth() / 2 + 4)
+        .merge(values)
+        .transition()
+        .duration(500)
+        .attr('x', d => xScale(d.value) + 5)
+        .attr('y', d => yScale(d.name) + yScale.bandwidth() / 2 + 4)
+        .text(d => d.value.toLocaleString());
+
+    values.exit().remove();
+
+    // Year
+    yearText.text(year);
+}
+
+// Initialize
+update(years[0]);
+
+// Controls
+d3.select('#play').on('click', function() {
+    if (interval) {
+        clearInterval(interval);
+        interval = null;
+        this.textContent = 'Play';
+    } else {
+        this.textContent = 'Pause';
+        interval = setInterval(() => {
+            currentIndex++;
+            if (currentIndex >= years.length) {
+                clearInterval(interval);
+                interval = null;
+                d3.select('#play').text('Play');
+                return;
+            }
+            update(years[currentIndex]);
+        }, 1000);
+    }
+});
+
+d3.select('#reset').on('click', () => {
+    if (interval) {
+        clearInterval(interval);
+        interval = null;
+        d3.select('#play').text('Play');
+    }
+    currentIndex = 0;
+    update(years[0]);
+});"""
+    },
+    'bubble-chart': {
+        'title': 'Multi-Dimensional Bubble Chart',
+        'description': '3-variable analysis (x, y, size) using Chart.js',
+        'instructions': 'Hover over bubbles for detailed metrics.',
+        'extra_scripts': '    <script src="https://cdn.jsdelivr.net/npm/chart.js@3"></script>',
+        'css': BASE_CSS + """
+        .chart-container {
+            position: relative;
+            height: 600px;
+            width: 100%;
+        }
+        """,
+        'js': """
+// Sample data
+const datasets = [
+    {
+        label: 'Region A',
+        data: [
+            { x: 20, y: 30, r: 15 },
+            { x: 40, y: 10, r: 10 },
+            { x: 25, y: 20, r: 20 }
+        ]
+    },
+    {
+        label: 'Region B',
+        data: [
+            { x: 30, y: 25, r: 25 },
+            { x: 15, y: 35, r: 12 }
+        ]
+    }
+];
+
+const ctx = document.createElement('canvas');
+document.getElementById('visualization').appendChild(ctx);
+ctx.style.width = '100%';
+ctx.style.height = '100%';
+
+// Chart.js Configuration
+new Chart(ctx, {
+    type: 'bubble',
+    data: {
+        datasets: datasets.map((ds, i) => ({
+            label: ds.label,
+            data: ds.data,
+            backgroundColor: `hsla(${i * 137.5 % 360}, 70%, 50%, 0.6)`,
+            borderColor: `hsl(${i * 137.5 % 360}, 70%, 50%)`,
+            borderWidth: 1
+        }))
+    },
+    options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+            title: {
+                display: true,
+                text: 'Market Analysis (Income vs Growth vs Size)'
+            },
+            tooltip: {
+                callbacks: {
+                    label: (ctx) => {
+                        const point = ctx.raw;
+                        return `${ctx.dataset.label}: (${point.x}, ${point.y}, ${point.r})`;
+                    }
+                }
+            }
+        },
+        scales: {
+            x: { title: { display: true, text: 'Income ($k)' } },
+            y: { title: { display: true, text: 'Growth (%)' } }
+        }
+    }
+});
+"""
+    },
+
+    'radial-tree': {
+        'title': 'Radial Hierarchy Tree',
+        'description': 'Circular tree layout for deep hierarchies',
+        'instructions': 'Scroll to zoom. Drag to pan. Hover for details.',
+        'extra_scripts': '<script src="https://d3js.org/d3.v7.min.js"></script>',
+        'css': BASE_CSS + """
+        #visualization {
+            height: 800px;
+            background: #111;
+            color: #eee;
+        }
+        .node circle {
+            transition: all 0.3s;
+            cursor: pointer;
+        }
+        .node text {
+            font-family: 'Helvetica Neue', sans-serif;
+            fill: #ccc;
+            font-size: 10px;
+            pointer-events: none;
+            text-shadow: 0 1px 4px #000;
+        }
+        .link {
+            fill: none;
+            stroke: #555;
+            stroke-opacity: 0.4;
+            stroke-width: 1.5px;
+        }
+        """,
+        'js': """
+// Sample Hierarchy Data
+const data = {
+  name: "Flare",
+  children: [
+    {
+      name: "Analytics",
+      children: [
+        {name: "Cluster", value: 3938},
+        {name: "Graph", value: 3534},
+        {name: "Optimization", value: 7074}
+      ]
+    },
+    {
+      name: "Animate",
+      children: [
+        {name: "Easing", value: 17010},
+        {name: "Function", value: 5842},
+        {name: "Interpolate", value: 8746}
+      ]
+    },
+    {
+      name: "Display",
+      children: [
+        {name: "DirtySprite", value: 8833},
+        {name: "LineSprite", value: 1732},
+        {name: "RectSprite", value: 3623}
+      ]
+    }
+  ]
+};
+
+const width = 800;
+const height = 800;
+const radius = width / 2;
+
+const svg = d3.select("#visualization")
+  .append("svg")
+  .attr("viewBox", `0 0 ${width} ${height}`)
+  .style("width", "100%")
+  .style("height", "auto")
+  .style("font", "10px sans-serif");
+
+const g = svg.append("g")
+  .attr("transform", `translate(${width/2},${height/2})`);
+
+const root = d3.hierarchy(data);
+const tree = d3.tree()
+    .size([2 * Math.PI, radius - 100])
+    .separation((a, b) => (a.parent == b.parent ? 1 : 2) / a.depth);
+
+tree(root);
+
+// Links
+g.append("g")
+  .attr("fill", "none")
+  .attr("stroke", "#555")
+  .attr("stroke-opacity", 0.4)
+  .attr("stroke-width", 1.5)
+.selectAll("path")
+  .data(root.links())
+  .join("path")
+  .attr("d", d3.linkRadial()
+      .angle(d => d.x)
+      .radius(d => d.y));
+
+// Nodes
+const node = g.append("g")
+.selectAll("a")
+.data(root.descendants())
+.join("a")
+  .attr("transform", d => `rotate(${d.x * 180 / Math.PI - 90}) translate(${d.y},0)`);
+
+node.append("circle")
+  .attr("fill", d => d.children ? "#555" : "#999")
+  .attr("r", 2.5);
+
+node.append("text")
+  .attr("dy", "0.31em")
+  .attr("x", d => d.x < Math.PI === !d.children ? 6 : -6)
+  .attr("text-anchor", d => d.x < Math.PI === !d.children ? "start" : "end")
+  .attr("transform", d => d.x >= Math.PI ? "rotate(180)" : null)
+  .text(d => d.data.name)
+  .clone(true).lower()
+  .attr("stroke", "black");
+
+// Zoom
+const zoom = d3.zoom().on("zoom", e => {
+    g.attr("transform", `translate(${width/2},${height/2}) ${e.transform}`);
+});
+svg.call(zoom);
+"""
+    },
+
+    'sankey': {
+        'title': 'Sankey Flow Diagram',
+        'description': 'Visualize flows, transfers, and process steps',
+        'instructions': 'Hover links to see flow volume.',
+        'extra_scripts': """
+    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="https://unpkg.com/d3-sankey@0.12.3/dist/d3-sankey.min.js"></script>
+        """,
+        'css': BASE_CSS + """
+        .link {
+            fill: none;
+            stroke-opacity: 0.5;
+            transition: stroke-opacity 0.2s;
+        }
+        .link:hover {
+            stroke-opacity: 0.8;
+        }
+        .node rect {
+            fill-opacity: 0.9;
+            shape-rendering: crispEdges;
+        }
+        .node text {
+            text-shadow: 0 1px 0 #fff;
+            font-size: 12px;
+            font-weight: bold;
+        }
+        """,
+        'js': """
+// Sample Flow Data
+const data = {
+  nodes: [
+    {name: "Agricultural Waste"}, {name: "Bio-conversion"}, 
+    {name: "Liquid"}, {name: "Losses"}, 
+    {name: "Solid"}, {name: "Gas"},
+    {name: "Biofuel User"}, {name: "Chemical Plant"}
+  ],
+  links: [
+    {source: 0, target: 1, value: 124.729},
+    {source: 1, target: 2, value: 0.597},
+    {source: 1, target: 3, value: 26.862},
+    {source: 1, target: 4, value: 280.122},
+    {source: 1, target: 5, value: 81.144},
+    {source: 2, target: 6, value: 35.1},
+    {source: 5, target: 7, value: 12.3},
+    {source: 4, target: 7, value: 20.0}
+  ]
+};
+
+const width = 900;
+const height = 600;
+
+const svg = d3.select("#visualization").append("svg")
+    .attr("viewBox", `0 0 ${width} ${height}`)
+    .style("width", "100%")
+    .style("height", "auto");
+
+const sankey = d3.sankey()
+    .nodeWidth(15)
+    .nodePadding(10)
+    .extent([[1, 5], [width - 1, height - 5]]);
+
+const {nodes, links} = sankey(data);
+
+// Color scale
+const color = d3.scaleOrdinal(d3.schemeCategory10);
+
+// Draw nodes
+svg.append("g")
+  .selectAll("rect")
+  .data(nodes)
+  .join("rect")
+    .attr("x", d => d.x0)
+    .attr("y", d => d.y0)
+    .attr("height", d => d.y1 - d.y0)
+    .attr("width", d => d.x1 - d.x0)
+    .attr("fill", d => color(d.name))
+  .append("title")
+    .text(d => `${d.name}\\n${d.value.toLocaleString()}`);
+
+// Draw links
+const link = svg.append("g")
+    .attr("fill", "none")
+    .attr("stroke-opacity", 0.5)
+  .selectAll("g")
+  .data(links)
+  .join("g")
+    .style("mix-blend-mode", "multiply");
+
+const gradient = link.append("linearGradient")
+    .attr("id", d => (d.uid = `link-${Math.random().toString(36).substr(2, 9)}`))
+    .attr("gradientUnits", "userSpaceOnUse")
+    .attr("x1", d => d.source.x1)
+    .attr("x2", d => d.target.x0);
+
+gradient.append("stop")
+    .attr("offset", "0%")
+    .attr("stop-color", d => color(d.source.name));
+
+gradient.append("stop")
+    .attr("offset", "100%")
+    .attr("stop-color", d => color(d.target.name));
+
+link.append("path")
+    .attr("d", d3.sankeyLinkHorizontal())
+    .attr("stroke", d => `url(#${d.uid})`)
+    .attr("stroke-width", d => Math.max(1, d.width));
+
+// Text
+svg.append("g")
+    .style("font", "10px sans-serif")
+  .selectAll("text")
+  .data(nodes)
+  .join("text")
+    .attr("x", d => d.x0 < width / 2 ? d.x1 + 6 : d.x0 - 6)
+    .attr("y", d => (d.y1 + d.y0) / 2)
+    .attr("dy", "0.35em")
+    .attr("text-anchor", d => d.x0 < width / 2 ? "start" : "end")
+    .text(d => d.name);
+"""
+    }
+}
+
+
+# Add simpler templates
+TEMPLATES['treemap'] = {
+    'title': 'Hierarchical Treemap',
+    'description': 'Nested rectangles showing part-to-whole relationships',
+    'instructions': 'Click to zoom into categories. Click background to zoom out.',
+    'extra_scripts': '',
+    'css': BASE_CSS + """
+
+        .cell {
+            cursor: pointer;
+            stroke: white;
+            stroke-width: 1;
+        }
+
+        .cell:hover {
+            stroke-width: 2;
+        }
+
+        .cell-label {
+            font-size: 11px;
+            fill: white;
+            pointer-events: none;
+            text-shadow: 0 1px 2px rgba(0,0,0,0.5);
+        }""",
+    'js': """
+// Sample hierarchical data
+const data = {
+    name: 'root',
+    children: [
+        { name: 'Category A', value: 100 },
+        { name: 'Category B', children: [
+            { name: 'B1', value: 50 },
+            { name: 'B2', value: 30 },
+        ]},
+        { name: 'Category C', value: 80 },
+        { name: 'Category D', children: [
+            { name: 'D1', value: 40 },
+            { name: 'D2', value: 25 },
+            { name: 'D3', value: 35 },
+        ]},
+    ]
+};
+
+const width = 800;
+const height = 600;
+
+const colorScale = d3.scaleOrdinal(d3.schemeTableau10);
+
+const svg = d3.select('#visualization')
+    .append('svg')
+    .attr('viewBox', `0 0 ${width} ${height}`);
+
+const tooltip = d3.select('body')
+    .append('div')
+    .attr('class', 'tooltip');
+
+const root = d3.hierarchy(data)
+    .sum(d => d.value)
+    .sort((a, b) => b.value - a.value);
+
+const treemap = d3.treemap()
+    .size([width, height])
+    .padding(2);
+
+treemap(root);
+
+const cells = svg.selectAll('.cell')
+    .data(root.leaves())
+    .join('rect')
+    .attr('class', 'cell')
+    .attr('x', d => d.x0)
+    .attr('y', d => d.y0)
+    .attr('width', d => d.x1 - d.x0)
+    .attr('height', d => d.y1 - d.y0)
+    .attr('fill', d => colorScale(d.parent.data.name));
+
+const labels = svg.selectAll('.cell-label')
+    .data(root.leaves().filter(d => (d.x1 - d.x0) > 40 && (d.y1 - d.y0) > 20))
+    .join('text')
+    .attr('class', 'cell-label')
+    .attr('x', d => d.x0 + 5)
+    .attr('y', d => d.y0 + 15)
+    .text(d => d.data.name);
+
+cells.on('mouseover', function(event, d) {
+    tooltip
+        .html(`<strong>${d.data.name}</strong><br>Value: ${d.value.toLocaleString()}`)
+        .style('left', (event.pageX + 10) + 'px')
+        .style('top', (event.pageY - 10) + 'px')
+        .classed('visible', true);
+})
+.on('mouseout', () => tooltip.classed('visible', false));"""
+}
+
+
+def create_project(name: str, viz_type: str, output_dir: str, single_file: bool):
+    """Create the visualization project files."""
+    template = TEMPLATES.get(viz_type)
+    if not template:
+        print(f"Error: Unknown type '{viz_type}'", file=sys.stderr)
+        print(f"Available types: {', '.join(TEMPLATES.keys())}", file=sys.stderr)
+        sys.exit(1)
+
+    # Create directory
+    project_dir = Path(output_dir) / name
+    project_dir.mkdir(parents=True, exist_ok=True)
+
+    # Generate HTML
+    html_content = HTML_TEMPLATE.format(
+        title=template['title'],
+        description=template['description'],
+        instructions=template['instructions'],
+        extra_scripts=template['extra_scripts'],
+        css=template['css'],
+        js=template['js'],
+    )
+
+    # Write files
+    index_path = project_dir / 'index.html'
+    index_path.write_text(html_content)
+
+    print(f"\nCreated: {project_dir}")
+    print(f"  - index.html ({viz_type} template)")
+
+    if not single_file:
+        # Also create separate files for easier editing
+        (project_dir / 'data').mkdir(exist_ok=True)
+        (project_dir / 'data' / 'sample.json').write_text('[\n  {"name": "example", "value": 100}\n]')
+        print(f"  - data/sample.json")
+
+    print(f"\nNext steps:")
+    print(f"  1. cd {project_dir}")
+    print(f"  2. python3 -m http.server 8000")
+    print(f"  3. Open http://localhost:8000/")
+    print(f"  4. Replace sample data with your own")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Scaffold a D3.js visualization project',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=f"""
+Available types:
+  {chr(10).join(f'  {k:15} - {v["description"]}' for k, v in TEMPLATES.items())}
+
+Examples:
+  %(prog)s my-network --type force-network
+  %(prog)s my-map --type choropleth --output ~/html/datavis/
+  %(prog)s my-timeline --type timeline --single-file
+        """
+    )
+
+    parser.add_argument('name', nargs='?',
+                        help='Project name (will create directory)')
+    parser.add_argument('--type', '-t',
+                        choices=list(TEMPLATES.keys()),
+                        help='Visualization type')
+    parser.add_argument('--output', '-o', default='.',
+                        help='Output directory (default: current)')
+    parser.add_argument('--single-file', '-s', action='store_true',
+                        help='Create single HTML file (no separate assets)')
+    parser.add_argument('--list', '-l', action='store_true',
+                        help='List available templates')
+
+    args = parser.parse_args()
+
+    if args.list:
+        print("Available templates:")
+        for name, template in TEMPLATES.items():
+            print(f"\n  {name}:")
+            print(f"    {template['description']}")
+        return
+
+    # Validate required args when creating project
+    if not args.name:
+        parser.error("name is required (unless using --list)")
+    if not args.type:
+        parser.error("--type is required (unless using --list)")
+
+    create_project(args.name, args.type, args.output, args.single_file)
+
+
+if __name__ == '__main__':
+    main()

--- a/skills/geepers-datavis/scripts/server.py
+++ b/skills/geepers-datavis/scripts/server.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+import sys
+import json
+import logging
+import argparse
+import tempfile
+from pathlib import Path
+
+# Add script directory to path
+script_dir = Path(__file__).parent
+sys.path.append(str(script_dir))
+
+# Import logic
+try:
+    from viz_generator import generate_viz
+    from d3_scaffold import TEMPLATES
+except ImportError:
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("viz_generator", script_dir / "viz-generator.py")
+    viz_generator = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(viz_generator)
+    generate_viz = viz_generator.generate_viz
+    
+    spec_scaffold = importlib.util.spec_from_file_location("d3_scaffold", script_dir / "d3-scaffold.py")
+    d3_scaffold = importlib.util.module_from_spec(spec_scaffold)
+    spec_scaffold.loader.exec_module(d3_scaffold)
+    TEMPLATES = d3_scaffold.TEMPLATES
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("datavis-server")
+
+def list_tools():
+    return [
+        {
+            "name": "dream_visualize_data",
+            "description": "Create interactive visualizations (charts, graphs, maps) from data.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "type": "string",
+                        "description": "JSON string of data, or key-value pairs to visualize"
+                    },
+                    "template": {
+                        "type": "string",
+                        "description": f"Visualization template. Options: {', '.join(TEMPLATES.keys())}",
+                        "enum": list(TEMPLATES.keys())
+                    },
+                    "title": {
+                        "type": "string",
+                        "description": "Title for the visualization"
+                    }
+                },
+                "required": ["data", "template"]
+            }
+        },
+        {
+            "name": "dream_list_viz_templates",
+            "description": "List available visualization templates with descriptions.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {}
+            }
+        }
+    ]
+
+def handle_call_tool(name, arguments):
+    if name == "dream_visualize_data":
+        data_str = arguments.get("data")
+        template = arguments.get("template")
+        title = arguments.get("title", "Data Visualization")
+        
+        # Parse data
+        try:
+            if isinstance(data_str, str):
+                data = json.loads(data_str)
+            else:
+                data = data_str
+        except json.JSONDecodeError:
+            return {"content": [{"type": "text", "text": "Error: Data must be valid JSON."}], "isError": True}
+        
+        # Create temp file for data
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump(data, f)
+            data_path = f.name
+            
+        # Define output path
+        output_filename = f"viz_{template}_{Path(data_path).stem}.html"
+        output_dir = Path.home() / "geepers" / "visualizations"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        output_path = output_dir / output_filename
+        
+        try:
+            final_path = generate_viz(data_path, template, str(output_path))
+            return {
+                "content": [
+                    {
+                        "type": "text", 
+                        "text": f"Visualization created successfully at: {final_path}\n\nYou can open this file in a browser to view interactively."
+                    }
+                ]
+            }
+        except Exception as e:
+            return {"content": [{"type": "text", "text": f"Generation failed: {str(e)}"}], "isError": True}
+
+    elif name == "dream_list_viz_templates":
+        descriptions = [f"- **{k}**: {v['description']}" for k, v in TEMPLATES.items()]
+        return {
+            "content": [{"type": "text", "text": "Available Templates:\n\n" + "\n".join(descriptions)}]
+        }
+
+    return {"content": [{"type": "text", "text": f"Tool not found: {name}"}], "isError": True}
+
+def run_server():
+    """Run STDIO server."""
+    logging.info("Starting Datavis MCP Server...")
+    while True:
+        try:
+            line = sys.stdin.readline()
+            if not line:
+                break
+            
+            request = json.loads(line)
+            req_id = request.get("id")
+            method = request.get("method")
+            params = request.get("params", {})
+            
+            response = {
+                "jsonrpc": "2.0",
+                "id": req_id
+            }
+            
+            if method == "initialize":
+                response["result"] = {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {
+                        "tools": {}
+                    },
+                    "serverInfo": {
+                        "name": "geepers-datavis",
+                        "version": "1.0.0"
+                    }
+                }
+            elif method == "tools/list":
+                response["result"] = {
+                    "tools": list_tools()
+                }
+            elif method == "tools/call":
+                result = handle_call_tool(params.get("name"), params.get("arguments"))
+                if result.get("isError"):
+                    response["error"] = {"code": -32603, "message": result["content"][0]["text"]}
+                else:
+                    response["result"] = result
+            else:
+                # Ignore notifications or methods we don't handle
+                continue
+                
+            print(json.dumps(response), flush=True)
+            
+        except BrokenPipeError:
+            break
+        except Exception as e:
+            logger.error(f"Error handling request: {e}")
+            if 'req_id' in locals() and req_id is not None:
+                 print(json.dumps({
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "error": {"code": -32603, "message": str(e)}
+                }), flush=True)
+
+if __name__ == "__main__":
+    run_server()

--- a/skills/geepers-datavis/scripts/viz-generator.py
+++ b/skills/geepers-datavis/scripts/viz-generator.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""
+Visualization Generator
+Generates self-contained HTML visualizations from data files and templates.
+Wrapper around d3-scaffold.py logic but designed for data injection.
+"""
+import sys
+import os
+import json
+import argparse
+import csv
+from pathlib import Path
+
+# Add script directory to path to import d3-scaffold modules if needed
+# But better to just import the dict structure if possible or replicate the logic
+# For now, we will import the TEMPLATES from d3-scaffold directly
+sys.path.append(str(Path(__file__).parent))
+try:
+    from d3_scaffold import TEMPLATES, HTML_TEMPLATE
+except ImportError:
+    # If file is named d3-scaffold.py (with hyphen), direct import fails
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("d3_scaffold", Path(__file__).parent / "d3-scaffold.py")
+    d3_scaffold = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(d3_scaffold)
+    TEMPLATES = d3_scaffold.TEMPLATES
+    HTML_TEMPLATE = d3_scaffold.HTML_TEMPLATE
+
+def parse_data(file_path):
+    """Load JSON or CSV data."""
+    path = Path(file_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Data file not found: {file_path}")
+    
+    if path.suffix.lower() == '.json':
+        with open(path, 'r') as f:
+            return json.load(f)
+    elif path.suffix.lower() == '.csv':
+        data = []
+        with open(path, 'r') as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                # Type inference could go here
+                data.append(row)
+        return data
+    else:
+        raise ValueError("Unsupported format. Use .json or .csv")
+
+def generate_viz(data_file, template_name, output_file):
+    """Generate HTML visualization."""
+    
+    template = TEMPLATES.get(template_name)
+    if not template:
+        raise ValueError(f"Unknown template: {template_name}. Available: {list(TEMPLATES.keys())}")
+
+    # Load data
+    data = parse_data(data_file)
+    data_json = json.dumps(data, indent=2)
+
+    # Inject data into JS
+    # We look for "const data = ...;" or "const rawData = ...;" or "const datasets = ...;"
+    # This is a simple string replacement hack. A more robust way would be to have explicit data variable names in templates.
+    
+    js = template['js']
+    
+    # Heuristics for replacement
+    if "const data = {" in js or "const data = [" in js:
+        # Replace the first assignment
+        import re
+        js = re.sub(r'const data = [\{\[].*?;', f'const data = {data_json};', js, flags=re.DOTALL, count=1)
+    elif "const datasets =" in js:
+         js = re.sub(r'const datasets = [\[].*?;', f'const datasets = {data_json};', js, flags=re.DOTALL, count=1)
+    elif "const rawData =" in js:
+         js = re.sub(r'const rawData = [\[].*?;', f'const rawData = {data_json};', js, flags=re.DOTALL, count=1)
+    
+    html = HTML_TEMPLATE.format(
+        title=f"{template['title']} - Generated",
+        description=f"Visualization of {Path(data_file).name}",
+        instructions=template['instructions'],
+        extra_scripts=template['extra_scripts'],
+        css=template['css'],
+        js=js
+    )
+    
+    output_path = Path(output_file)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, 'w') as f:
+        f.write(html)
+    
+    print(f"Generated visualization: {output_path}")
+    return output_path
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate visualizations from data")
+    parser.add_argument("data", help="Path to JSON/CSV data file")
+    parser.add_argument("--template", "-t", required=True, choices=list(TEMPLATES.keys()), help="Visualization template")
+    parser.add_argument("--output", "-o", help="Output HTML file path")
+    
+    args = parser.parse_args()
+    
+    if not args.output:
+        args.output = f"{Path(args.data).stem}_{args.template}.html"
+        
+    try:
+        generate_viz(args.data, args.template, args.output)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/skills/geepers-dream-swarm/SKILL.md
+++ b/skills/geepers-dream-swarm/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: dream-swarm
+name: geepers-dream-swarm
 description: Launch parallel multi-domain search workflows using the Dream Swarm orchestrator. Use when (1) searching across multiple data sources simultaneously, (2) aggregating information from APIs, databases, and web sources, (3) comparing findings across domains, (4) rapid parallel data gathering. Requires the MCP server to be running.
 license: MIT
 ---

--- a/skills/geepers-dream-swarm/SKILL.md
+++ b/skills/geepers-dream-swarm/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: dream-swarm
+description: Launch parallel multi-domain search workflows using the Dream Swarm orchestrator. Use when (1) searching across multiple data sources simultaneously, (2) aggregating information from APIs, databases, and web sources, (3) comparing findings across domains, (4) rapid parallel data gathering. Requires the MCP server to be running.
+license: MIT
+---
+
+# Dream Swarm Search Skill
+
+Launch parallel multi-agent search workflows across multiple domains.
+
+## Architecture: Parallel Domain Agents
+
+```
+              ┌────────────────────────┐
+              │     SEARCH QUERY       │
+              │  "AI safety research"  │
+              └───────────┬────────────┘
+                          │
+        ┌─────────────────┼─────────────────┐
+        │                 │                 │
+   ┌────▼────┐       ┌────▼────┐       ┌────▼────┐
+   │  arXiv  │       │ GitHub  │       │  News   │
+   │  Agent  │       │  Agent  │       │  Agent  │
+   └────┬────┘       └────┬────┘       └────┬────┘
+        │                 │                 │
+        └─────────────────┼─────────────────┘
+                          │
+              ┌───────────▼───────────┐
+              │    AGGREGATOR         │
+              │  Dedupe & Synthesize  │
+              └───────────────────────┘
+```
+
+## When to Use
+
+- **Multi-source search** across different APIs
+- **Comparative analysis** from diverse sources
+- **Rapid information gathering** with parallelization
+- **Fact-checking** against multiple sources
+- **Research aggregation** from academic + news + code
+
+## Available Domains (17 sources)
+
+| Domain | Description | Example Query |
+|--------|-------------|---------------|
+| `arxiv` | Academic papers | "quantum computing" |
+| `github` | Code repositories | "react components" |
+| `news` | Recent articles | "AI regulation 2024" |
+| `wikipedia` | Encyclopedia | "machine learning" |
+| `pubmed` | Medical literature | "CRISPR therapy" |
+| `semantic_scholar` | Academic index | "transformer architectures" |
+| `census` | US demographics | "population density" |
+| `nasa` | Space/Earth data | "mars rover" |
+| `youtube` | Video content | "tutorial python" |
+| `weather` | Forecasts | "Seattle forecast" |
+| `openlibrary` | Book metadata | "science fiction" |
+| `fec` | Campaign finance | "2024 donations" |
+| `judiciary` | Court records | "antitrust case" |
+| `archive` | Wayback Machine | "historical websites" |
+| `finance` | Market data | "AAPL stock" |
+| `mal` | Anime database | "studio ghibli" |
+| `wolfram` | Computation | "integral sin(x)" |
+
+## Scripts
+
+### Start Search Workflow
+```bash
+scripts/swarm-search.py "AI safety research" --domains arxiv github news
+scripts/swarm-search.py "climate change" --agents 10 --parallel 5
+scripts/swarm-search.py "quantum computing" --all-domains
+```
+
+### Check Search Status
+```bash
+scripts/swarm-status.py workflow-xyz789
+scripts/swarm-status.py workflow-xyz789 --results
+```
+
+## Configuration Options
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `--domains` | arxiv,news | Comma-separated domain list |
+| `--agents` | 5 | Number of parallel agents (1-20) |
+| `--parallel` | 3 | Max concurrent domain searches (1-10) |
+| `--provider` | xai | LLM provider for synthesis |
+| `--max-results` | 10 | Results per domain |
+| `--stream` | false | Enable SSE streaming |
+| `--output` | stdout | Output format (stdout, json, markdown) |
+
+## Example Workflows
+
+### Academic + Code Search
+```bash
+scripts/swarm-search.py "WebAssembly optimization" \
+  --domains arxiv,github,semantic_scholar \
+  --agents 6 --parallel 3
+```
+
+### News + Social Monitoring
+```bash
+scripts/swarm-search.py "AI regulation policy" \
+  --domains news,wikipedia,youtube \
+  --agents 5 --output markdown
+```
+
+### Comprehensive Research
+```bash
+scripts/swarm-search.py "CRISPR gene therapy" \
+  --domains arxiv,pubmed,news,wikipedia \
+  --agents 8 --parallel 4 --stream
+```
+
+## Output Structure
+
+```json
+{
+  "task_id": "swarm-xyz789",
+  "status": "completed",
+  "results": {
+    "arxiv": [
+      {"title": "...", "url": "...", "abstract": "..."}
+    ],
+    "github": [
+      {"name": "...", "url": "...", "description": "..."}
+    ],
+    "news": [
+      {"title": "...", "url": "...", "source": "..."}
+    ]
+  },
+  "synthesis": {
+    "summary": "...",
+    "key_themes": [...],
+    "cross_domain_insights": [...]
+  },
+  "metadata": {
+    "domains_searched": 3,
+    "total_results": 24,
+    "execution_time": 12.5
+  }
+}
+```
+
+## Advantages over Dream Cascade
+
+| Aspect | Dream Swarm | Dream Cascade |
+|--------|-------------|---------------|
+| **Speed** | Faster (parallel) | Slower (hierarchical) |
+| **Depth** | Broad coverage | Deep analysis |
+| **Use case** | Data gathering | Research synthesis |
+| **Agent count** | Many simple agents | Fewer complex agents |
+| **Cost** | Lower | Higher |
+
+## Prerequisites
+
+- MCP server running on port 5060
+- Valid API keys for data sources
+- Python 3.10+ with requests library
+
+## Troubleshooting
+
+**"Domain not available"**: Check API key configured for that domain
+
+**"Rate limited"**: Reduce `--parallel` count
+
+**"No results"**: Try broader query or different domains
+
+## Related Skills
+
+- **dream-cascade** - Hierarchical deep research
+- **data-fetch** - Single domain direct access
+- **code-quality** - Code-specific searches

--- a/skills/geepers-dream-swarm/scripts/swarm-search.py
+++ b/skills/geepers-dream-swarm/scripts/swarm-search.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""
+Dream Swarm Multi-Domain Search Launcher
+
+Starts a parallel search workflow across multiple data domains via MCP server.
+
+Usage:
+    python swarm-search.py "AI safety research" --domains arxiv github news
+    python swarm-search.py "climate change" --agents 10 --parallel 5
+    python swarm-search.py "quantum computing" --all-domains
+
+Author: Luke Steuber
+"""
+
+import argparse
+import json
+import sys
+import requests
+from typing import List, Optional
+
+MCP_BASE_URL = "http://localhost:5060"
+
+# Available domains
+ALL_DOMAINS = [
+    "arxiv", "github", "news", "wikipedia", "pubmed", "semantic_scholar",
+    "census", "nasa", "youtube", "weather", "openlibrary", "fec",
+    "judiciary", "archive", "finance", "mal", "wolfram"
+]
+
+DEFAULT_DOMAINS = ["arxiv", "news", "wikipedia"]
+
+
+def start_search(
+    query: str,
+    domains: List[str],
+    num_agents: int = 5,
+    max_parallel: int = 3,
+    provider: str = "xai",
+    model: Optional[str] = None,
+    max_results: int = 10,
+    stream: bool = False,
+    output_format: str = "stdout"
+) -> dict:
+    """
+    Start a Dream Swarm search workflow.
+
+    Args:
+        query: Search query
+        domains: List of domains to search
+        num_agents: Number of parallel agents (1-20)
+        max_parallel: Max concurrent searches (1-10)
+        provider: LLM provider for synthesis
+        model: Specific model to use
+        max_results: Results per domain
+        stream: Enable SSE streaming
+        output_format: Output format
+
+    Returns:
+        Workflow info dict
+    """
+    # Validate domains
+    invalid = [d for d in domains if d not in ALL_DOMAINS]
+    if invalid:
+        return {"error": f"Invalid domains: {', '.join(invalid)}. Valid: {', '.join(ALL_DOMAINS)}"}
+
+    payload = {
+        "query": query,
+        "num_agents": num_agents,
+        "allowed_agent_types": domains,
+        "provider_name": provider,
+        "generate_documents": True,
+        "document_formats": ["markdown"]
+    }
+
+    if model:
+        payload["model"] = model
+
+    try:
+        response = requests.post(
+            f"{MCP_BASE_URL}/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "dream_orchestrate_search",
+                    "arguments": payload
+                }
+            },
+            timeout=30
+        )
+        response.raise_for_status()
+        result = response.json()
+
+        if "error" in result:
+            return {"error": result["error"]["message"]}
+
+        return result.get("result", result)
+
+    except requests.exceptions.ConnectionError:
+        return {"error": "Cannot connect to MCP server. Start with: sm start mcp-orchestrator"}
+    except requests.exceptions.Timeout:
+        return {"error": "Request timed out"}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+def stream_results(task_id: str):
+    """Stream SSE events for a running search."""
+    try:
+        import sseclient
+    except ImportError:
+        print("SSE streaming requires: pip install sseclient-py", file=sys.stderr)
+        return
+
+    try:
+        response = requests.get(f"{MCP_BASE_URL}/stream/{task_id}", stream=True)
+        client = sseclient.SSEClient(response)
+
+        for event in client.events():
+            if event.event == "task_completed":
+                data = json.loads(event.data)
+                print(f"\n{'='*60}")
+                print("SEARCH COMPLETED")
+                print('='*60)
+                print(json.dumps(data, indent=2))
+                break
+            elif event.event == "error":
+                print(f"Error: {event.data}", file=sys.stderr)
+                break
+            else:
+                print(f"[{event.event}] {event.data}")
+
+    except KeyboardInterrupt:
+        print("\nStreaming interrupted")
+    except Exception as e:
+        print(f"Streaming error: {e}", file=sys.stderr)
+
+
+def format_output(result: dict, output_format: str) -> str:
+    """Format the result for output."""
+    if output_format == "json":
+        return json.dumps(result, indent=2)
+    elif output_format == "markdown":
+        lines = [
+            "# Search Results",
+            "",
+            f"**Task ID**: {result.get('task_id', 'N/A')}",
+            f"**Status**: {result.get('status', 'N/A')}",
+            ""
+        ]
+        if "results" in result:
+            for domain, items in result["results"].items():
+                lines.append(f"## {domain.title()}")
+                lines.append("")
+                for item in items[:5]:  # Show top 5 per domain
+                    title = item.get("title", item.get("name", "Untitled"))
+                    url = item.get("url", "")
+                    lines.append(f"- [{title}]({url})")
+                lines.append("")
+        return "\n".join(lines)
+    else:
+        lines = [
+            f"Task ID: {result.get('task_id', 'N/A')}",
+            f"Status: {result.get('status', 'N/A')}"
+        ]
+        if "stream_url" in result:
+            lines.append(f"Stream: {MCP_BASE_URL}{result['stream_url']}")
+        if "message" in result:
+            lines.append(f"Message: {result['message']}")
+        if "error" in result:
+            lines.append(f"Error: {result['error']}")
+        return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Launch Dream Swarm parallel multi-domain search",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=f"""
+Available domains:
+  {', '.join(ALL_DOMAINS)}
+
+Examples:
+  %(prog)s "AI safety" --domains arxiv github news
+  %(prog)s "climate change" --agents 10 --parallel 5
+  %(prog)s "quantum computing" --all-domains
+  %(prog)s "market trends" --domains finance news --output json
+        """
+    )
+
+    parser.add_argument(
+        "query",
+        help="Search query"
+    )
+    parser.add_argument(
+        "--domains", "-d",
+        default=",".join(DEFAULT_DOMAINS),
+        help=f"Comma-separated domains (default: {','.join(DEFAULT_DOMAINS)})"
+    )
+    parser.add_argument(
+        "--all-domains",
+        action="store_true",
+        help="Search all available domains"
+    )
+    parser.add_argument(
+        "--agents", "-a",
+        type=int,
+        default=5,
+        help="Number of parallel agents (1-20, default: 5)"
+    )
+    parser.add_argument(
+        "--parallel", "-p",
+        type=int,
+        default=3,
+        help="Max concurrent domain searches (1-10, default: 3)"
+    )
+    parser.add_argument(
+        "--provider",
+        default="xai",
+        help="LLM provider for synthesis (default: xai)"
+    )
+    parser.add_argument(
+        "--model", "-m",
+        help="Specific model to use"
+    )
+    parser.add_argument(
+        "--max-results",
+        type=int,
+        default=10,
+        help="Max results per domain (default: 10)"
+    )
+    parser.add_argument(
+        "--stream", "-s",
+        action="store_true",
+        help="Enable SSE streaming"
+    )
+    parser.add_argument(
+        "--output", "-o",
+        choices=["stdout", "json", "markdown"],
+        default="stdout",
+        help="Output format (default: stdout)"
+    )
+    parser.add_argument(
+        "--list-domains",
+        action="store_true",
+        help="List all available domains and exit"
+    )
+
+    args = parser.parse_args()
+
+    if args.list_domains:
+        print("Available search domains:")
+        for domain in ALL_DOMAINS:
+            print(f"  - {domain}")
+        sys.exit(0)
+
+    # Parse domains
+    if args.all_domains:
+        domains = ALL_DOMAINS
+    else:
+        domains = [d.strip() for d in args.domains.split(",")]
+
+    # Validate
+    if not 1 <= args.agents <= 20:
+        print("Error: agents must be between 1 and 20", file=sys.stderr)
+        sys.exit(1)
+    if not 1 <= args.parallel <= 10:
+        print("Error: parallel must be between 1 and 10", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Starting Dream Swarm search...", file=sys.stderr)
+    print(f"Query: {args.query}", file=sys.stderr)
+    print(f"Domains: {', '.join(domains)}", file=sys.stderr)
+    print(f"Agents: {args.agents}, Parallel: {args.parallel}", file=sys.stderr)
+    print("", file=sys.stderr)
+
+    result = start_search(
+        query=args.query,
+        domains=domains,
+        num_agents=args.agents,
+        max_parallel=args.parallel,
+        provider=args.provider,
+        model=args.model,
+        max_results=args.max_results,
+        stream=args.stream,
+        output_format=args.output
+    )
+
+    print(format_output(result, args.output))
+
+    if args.stream and "task_id" in result and "error" not in result:
+        print("\nStreaming results...", file=sys.stderr)
+        stream_results(result["task_id"])
+
+    if "error" in result:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/geepers-humanize/SKILL.md
+++ b/skills/geepers-humanize/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: humanize
+name: geepers-humanize
 description: Strip out robot-sounding language from docs and code. Use when editing READMEs, prepping content for publication, or cleaning up generated docs. Also enforces the "AI" terminology ban.
 license: MIT
 ---

--- a/skills/geepers-humanize/SKILL.md
+++ b/skills/geepers-humanize/SKILL.md
@@ -1,0 +1,238 @@
+---
+name: humanize
+description: Strip out robot-sounding language from docs and code. Use when editing READMEs, prepping content for publication, or cleaning up generated docs. Also enforces the "AI" terminology ban.
+license: MIT
+---
+
+# Humanize Skill
+
+Make docs sound like a person wrote them. Kill the corporate robot voice, enforce terminology rules, and keep things casual.
+
+## Terminology Rules (MANDATORY - applies everywhere)
+
+### The "AI" Ban
+The word "AI" is **banned** from all code, docs, READMEs, package descriptions, and public content. No exceptions except third-party proper nouns.
+
+| Never Write | Write Instead |
+|-------------|---------------|
+| "AI-powered" | "uses a language model to..." or just describe the feature |
+| "AI-enhanced" | "LLM-enhanced" or describe what it actually does |
+| "AI system" | "LLM", "language model", "model" |
+| "AI capabilities" | "LLM capabilities" or be specific |
+| "AI-driven" | "LLM-driven" or "model-driven" |
+| "powered by AI" | "uses [Grok/Claude/Ollama/etc.]" - name the actual model |
+| "artificial intelligence" | "language model" or "machine learning" as appropriate |
+| "AI assistant" | just describe what it does |
+
+**Why**: "AI" is a vague marketing buzzword. LLM, language model, or the actual model name tells people what's really happening. Be specific.
+
+**Exception**: Third-party product names are fine as-is (e.g., "DigitalOcean's Gradient AI Platform").
+
+### No Co-Authored-By
+Never add `Co-Authored-By` lines to git commits. Ever. Luke is the author.
+
+### Never Reference This Skill Publicly
+Never mention "humanize" in release notes, READMEs, changelogs, package descriptions, or any public-facing content. The skill is invisible — it just makes things better silently.
+
+### Tone: Write Like a Human
+Keep it casual. If you'd feel embarrassed reading it aloud to a coworker, rewrite it.
+
+## Quick Commands
+
+```bash
+humanize file.md                    # Fix with default threshold (0.8)
+humanize file.md --preview          # Show what it'd change
+humanize file.md --confidence 0.9   # Only fix the obvious stuff
+humanize projects/wordblocks/       # Hit a whole directory
+humanize --batch file1.md file2.md  # Multiple files
+humanize README.md --yes            # Just do it, no asking
+```
+
+## What Gets Fixed
+
+### Instant Kill (confidence >0.9)
+- "In this [section/guide/tutorial]..." → just say the thing
+- "It's important to note that..." → delete, say what matters
+- "Let's explore..." → nope
+- "Please note that..." → cut the hedging
+- "AI-powered" / "AI-enhanced" → rewrite per terminology rules above
+- Walls of bullet points → paragraphs where it reads better
+- Over-structured numbered lists → flowing text
+
+### Likely Robot (confidence 0.7-0.9)
+- Overly formal transitions ("Furthermore", "Moreover")
+- Redundant clarifications nobody asked for
+- Generic placeholder examples
+- Template-looking headers
+- Passive voice where active reads better
+
+### Maybe, Maybe Not (confidence 0.6-0.7)
+- Flagged for review but not auto-fixed
+- Could be legit style choices
+
+## Detection Patterns
+
+What gives away robot writing:
+
+1. **Buzzwords**: "delve into", "leverage", "robust", "comprehensive", "streamline", "cutting-edge"
+2. **Structure**: Everything in perfectly symmetric lists, numbered everything
+3. **Meta-commentary**: "In this section we will discuss..." - just discuss it
+4. **Hedging**: "Might", "perhaps", "it's worth noting", "it should be mentioned"
+5. **Filler examples**: foo, bar, example1, myProject
+6. **Banned terms**: "AI-powered", "AI-enhanced", "AI-driven" (see terminology rules)
+
+## Confidence Levels
+
+| Level | Range | What Happens |
+|-------|-------|--------------|
+| **High** | 0.9-1.0 | Fixed automatically with `--yes` |
+| **Medium** | 0.7-0.9 | Shows suggestion, asks first |
+| **Low** | 0.6-0.7 | Just reports in preview mode |
+
+Adjust with `--confidence`:
+```bash
+humanize file.md --confidence 0.95  # Conservative - only obvious stuff
+humanize file.md --confidence 0.6   # Aggressive - catch more
+```
+
+## Safety
+
+**Preview first**: `humanize README.md --preview` shows what would change without touching anything.
+
+**Backups**: Every edit creates a `.backup` file. Undo with `mv file.md.backup file.md`.
+
+**Confirmation**: Asks before changing files unless you pass `--yes`.
+
+## Examples
+
+### Before / After
+
+```markdown
+# BEFORE (robot voice)
+In this guide, we'll explore how to install the application.
+It's important to note that you'll need Python 3.8 or higher.
+Let's dive into the AI-powered installation process.
+
+# AFTER (human voice)
+## Installation
+Needs Python 3.8+.
+```
+
+```markdown
+# BEFORE
+This AI-powered tool leverages comprehensive machine learning
+to deliver robust, cutting-edge document processing capabilities.
+
+# AFTER
+Runs your docs through an LLM to extract metadata and rename files.
+```
+
+```markdown
+# BEFORE
+Please note that this feature is currently experimental and
+might not work in all cases. It's worth mentioning that...
+
+# AFTER
+Experimental - might not work everywhere yet.
+```
+
+### Batch run
+```bash
+$ humanize projects/wordblocks/ --confidence 0.85
+# Finds .md/.html/.txt files, shows what it'd fix, asks before changing
+```
+
+## Agent Cruft Cleanup (CRITICAL)
+
+Agents leave behind `.md` files that reveal machine authorship. Hunt them down and kill them.
+
+### Known Agent Cruft Patterns
+
+Delete or gitignore any of these on sight:
+
+| Pattern | What Created It |
+|---------|-----------------|
+| `CRITIC.md` | Architecture review agent |
+| `ONBOARD.md` | Onboarding agent |
+| `SUGGESTIONS.md` | Improvement suggestion agent |
+| `REPO_AUDIT.md` | Repository audit agent |
+| `REPOSITORY_ANALYSIS.md` | Analysis agent |
+| `INTEGRATION_ANALYSIS.md` | Integration analysis agent |
+| `PROGRESS_STATUS.md` | Session tracking |
+| `IMPLEMENTATION_STATUS.md` | Status reports |
+| `SESSION_LOG.md` | Work session logs |
+| `WORK_LOG.md` | Agent work tracking |
+| `AGENT_REPORT.md` | Direct agent output |
+| `CONSOLIDATION_HISTORY.md` | Merge/consolidation reports |
+| `EXPLORATION_SUMMARY.md` | Codebase exploration output |
+| `*_IMPLEMENTATION_STATUS.md` | Prefixed status files |
+| `*_PROGRESS.md` | Progress tracking files |
+| `WORKING_SCRIPTS_TEST_REPORT.md` | Test run artifacts |
+| `.aider.chat.history.md` | Aider session history |
+| `.aider.input.history` | Aider input history |
+| `temp_*` | Temporary files from any agent |
+
+### What to Do
+
+1. **Delete**: `rm` the file if it's not tracked
+2. **Untrack**: `git rm --cached <file>` if already committed
+3. **Gitignore**: Add patterns to `.gitignore` to prevent recurrence
+4. **Never commit** files that reference agent names, skill paths, or orchestrator configs
+
+### Quick Cleanup Command
+
+```bash
+# Find agent cruft in current project
+find . -maxdepth 2 -name "CRITIC.md" -o -name "ONBOARD.md" -o -name "SUGGESTIONS.md" \
+  -o -name "REPO_AUDIT.md" -o -name "REPOSITORY_ANALYSIS.md" -o -name "INTEGRATION_ANALYSIS.md" \
+  -o -name "*_STATUS.md" -o -name "*_PROGRESS.md" -o -name "SESSION_LOG.md" \
+  -o -name "WORK_LOG.md" -o -name "AGENT_REPORT.md" -o -name "temp_*" \
+  -o -name ".aider.chat.history.md" -o -name ".aider.input.history" 2>/dev/null
+```
+
+### Pre-Push Check
+
+```bash
+# Before any git push, verify no agent cruft is staged:
+git diff --cached --name-only | grep -iE '(CRITIC|ONBOARD|PROGRESS|STATUS|LOG|REPORT|AGENT|SUGGESTIONS|ANALYSIS|AUDIT)\.md'
+# If matches found, untrack them:
+# git rm --cached <matched-files>
+```
+
+## Supported Files
+
+`.md`, `.html`, `.txt` - won't touch code blocks, inline code, links, or intentional formatting.
+
+## Workflow Integration
+
+### Pre-commit hook
+```bash
+#!/bin/bash
+for file in $(git diff --cached --name-only | grep -E '\\.md$'); do
+    humanize "$file" --yes --confidence 0.9
+    git add "$file"
+done
+```
+
+### After editing docs
+```bash
+humanize README.md --preview    # see suggestions
+humanize README.md --yes        # apply them
+```
+
+## Troubleshooting
+
+- **Too many false positives**: `--confidence 0.95`
+- **Missing obvious stuff**: `--confidence 0.6`
+- **Oops, wrong file**: `mv file.md.backup file.md`
+
+## Advanced
+
+Skip sections with markers:
+```markdown
+<!-- humanize-ignore-start -->
+This stays exactly as-is.
+<!-- humanize-ignore-end -->
+```
+
+Diff without modifying: `humanize README.md --diff-only > changes.diff`

--- a/skills/geepers-humanize/scripts/humanize.py
+++ b/skills/geepers-humanize/scripts/humanize.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""
+Humanize CLI - Remove AI writing indicators from documentation
+
+Wrapper for the DocumentHumanizer library to provide Claude Code skill interface.
+
+Author: Luke Steuber
+"""
+
+import sys
+import argparse
+from pathlib import Path
+
+# Add shared library to path
+sys.path.insert(0, '/home/coolhand/shared')
+
+try:
+    from doc_humanizer import DocumentHumanizer, format_scan_results
+except ImportError:
+    print("Error: doc_humanizer module not found in /home/coolhand/shared", file=sys.stderr)
+    print("Make sure the shared library is installed.", file=sys.stderr)
+    sys.exit(1)
+
+
+def main():
+    """CLI entry point for humanize skill."""
+    parser = argparse.ArgumentParser(
+        description='Remove AI writing indicators from documentation files',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s file.md                    # Fix with default threshold (0.8)
+  %(prog)s file.md --preview          # Show diff without applying
+  %(prog)s file.md --confidence 0.9   # Higher confidence threshold
+  %(prog)s projects/wordblocks/       # Process directory recursively
+  %(prog)s --batch file1.md file2.md  # Multiple files
+  %(prog)s README.md --yes            # Auto-apply without confirmation
+
+Exit codes:
+  0 - Success
+  1 - Error occurred
+  2 - User canceled operation
+        """
+    )
+
+    parser.add_argument(
+        'paths',
+        nargs='+',
+        help='File(s) or directory to process'
+    )
+
+    parser.add_argument(
+        '--preview',
+        action='store_true',
+        help='Show changes without applying (like --dry-run)'
+    )
+
+    parser.add_argument(
+        '--confidence',
+        type=float,
+        default=0.8,
+        metavar='LEVEL',
+        help='Confidence threshold for applying fixes (0.0-1.0, default: 0.8)'
+    )
+
+    parser.add_argument(
+        '--threshold',
+        type=float,
+        metavar='LEVEL',
+        help='Alias for --confidence (for compatibility)'
+    )
+
+    parser.add_argument(
+        '--batch',
+        action='store_true',
+        help='Process multiple files (auto-enabled if multiple paths given)'
+    )
+
+    parser.add_argument(
+        '--yes', '-y',
+        action='store_true',
+        help='Auto-apply changes without confirmation'
+    )
+
+    parser.add_argument(
+        '--parallel',
+        type=int,
+        metavar='N',
+        default=4,
+        help='Process N files in parallel (default: 4)'
+    )
+
+    parser.add_argument(
+        '--diff-only',
+        action='store_true',
+        help='Generate diff file without modifying original'
+    )
+
+    parser.add_argument(
+        '--no-backup',
+        action='store_true',
+        help='Do not create .backup files'
+    )
+
+    args = parser.parse_args()
+
+    # Use --threshold as alias for --confidence
+    if args.threshold is not None:
+        args.confidence = args.threshold
+
+    # Validate confidence
+    if not 0.0 <= args.confidence <= 1.0:
+        print("Error: Confidence must be between 0.0 and 1.0", file=sys.stderr)
+        return 1
+
+    # Collect all files to process
+    files_to_process = []
+    for path_str in args.paths:
+        path = Path(path_str)
+
+        if not path.exists():
+            print(f"Error: Path not found: {path}", file=sys.stderr)
+            return 1
+
+        if path.is_file():
+            # Check file extension
+            if path.suffix not in ['.md', '.html', '.txt']:
+                print(f"Warning: Skipping unsupported file type: {path}", file=sys.stderr)
+                continue
+            files_to_process.append(path)
+
+        elif path.is_dir():
+            # Recursively find markdown files
+            for ext in ['.md', '.html', '.txt']:
+                files_to_process.extend(path.rglob(f'*{ext}'))
+
+    if not files_to_process:
+        print("Error: No supported files found (.md, .html, .txt)", file=sys.stderr)
+        return 1
+
+    # Initialize humanizer
+    humanizer = DocumentHumanizer()
+
+    # Preview mode - just scan and show diff
+    if args.preview or args.diff_only:
+        for filepath in files_to_process:
+            print(f"\n{'='*70}")
+            print(f"Analyzing: {filepath}")
+            print('='*70)
+
+            try:
+                # Scan for indicators
+                results = humanizer.scan_file(str(filepath))
+
+                # Filter by confidence
+                filtered = {
+                    pattern: [ind for ind in indicators if ind.confidence >= args.confidence]
+                    for pattern, indicators in results.items()
+                }
+                filtered = {k: v for k, v in filtered.items() if v}
+
+                if not filtered:
+                    print("\n✓ No AI writing indicators detected above threshold")
+                    continue
+
+                print(format_scan_results(filtered))
+
+                # Generate diff
+                with open(filepath, 'r', encoding='utf-8') as f:
+                    original = f.read()
+
+                transformed = humanizer.apply_transforms(original, args.confidence)
+                diff = humanizer.generate_diff(original, transformed)
+
+                if diff:
+                    print("\n" + "─"*70)
+                    print("Preview of changes:")
+                    print("─"*70)
+                    print(diff)
+
+                    if args.diff_only:
+                        diff_path = filepath.with_suffix(filepath.suffix + '.diff')
+                        with open(diff_path, 'w', encoding='utf-8') as f:
+                            f.write(diff)
+                        print(f"\n✓ Diff saved to: {diff_path}")
+                else:
+                    print("\n✓ No changes would be made at this confidence level")
+
+            except Exception as e:
+                print(f"✗ Error processing {filepath}: {e}", file=sys.stderr)
+                continue
+
+        return 0
+
+    # Fix mode - apply transformations
+    total_fixed = 0
+    total_files = len(files_to_process)
+
+    print(f"\nProcessing {total_files} file(s) with confidence threshold {args.confidence:.1%}...")
+
+    # Ask for confirmation if not --yes
+    if not args.yes and total_files > 0:
+        print(f"\nThis will modify {total_files} file(s).")
+        if not args.no_backup:
+            print("Backups will be created with .backup extension.")
+        response = input("\nProceed? [y/N]: ").strip().lower()
+        if response not in ['y', 'yes']:
+            print("Canceled.")
+            return 2
+
+    for filepath in files_to_process:
+        try:
+            with open(filepath, 'r', encoding='utf-8') as f:
+                original = f.read()
+
+            # Apply transformations
+            transformed = humanizer.apply_transforms(original, args.confidence)
+
+            # Check if anything changed
+            if transformed == original:
+                print(f"✓ {filepath} - No changes needed")
+                continue
+
+            # Create backup
+            if not args.no_backup:
+                backup_path = Path(f"{filepath}.backup")
+                with open(backup_path, 'w', encoding='utf-8') as f:
+                    f.write(original)
+
+            # Write transformed content
+            with open(filepath, 'w', encoding='utf-8') as f:
+                f.write(transformed)
+
+            # Count changes (rough estimate from diff)
+            diff = humanizer.generate_diff(original, transformed)
+            change_count = len([line for line in diff.split('\n') if line.startswith('+') or line.startswith('-')])
+
+            total_fixed += 1
+            backup_msg = f" (backup: {filepath}.backup)" if not args.no_backup else ""
+            print(f"✓ {filepath} - Fixed (~{change_count // 2} changes){backup_msg}")
+
+        except Exception as e:
+            print(f"✗ Error processing {filepath}: {e}", file=sys.stderr)
+            continue
+
+    print(f"\n{'='*70}")
+    print(f"Summary: Fixed {total_fixed} of {total_files} file(s)")
+    print('='*70)
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/skills/geepers-readme/SKILL.md
+++ b/skills/geepers-readme/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: geepers-readme
+description: Generate polished, humanized GitHub READMEs with badges, MIT license, and Luke Steuber credit. Use when (1) creating READMEs for new projects, (2) improving existing READMEs, (3) preparing projects for public release, or (4) humanizing robotic documentation.
+license: MIT
+---
+
+# README Generator Skill
+
+Create professional, humanized GitHub READMEs.
+
+## Usage
+
+```
+/geepers-readme                          # Generate README for current directory
+/geepers-readme ~/projects/wordblocks    # Generate for specific project
+/geepers-readme --update                 # Update existing README, preserve custom sections
+```
+
+## What It Does
+
+1. Scans project files (`CLAUDE.md`, `package.json`, `setup.py`, code structure)
+2. Identifies tech stack, entry points, live URLs
+3. Generates a complete README with:
+   - Badges (language, license, live site, package registry)
+   - Screenshot/demo placeholder
+   - Features list (verb phrases, scannable)
+   - Quick start with real, working commands
+   - Usage examples from actual code
+   - Author block (Luke Steuber, dr.eamer.dev, Bluesky)
+   - MIT License reference
+
+## Humanization
+
+Automatically enforces the `/humanize` skill rules:
+- No "AI-powered", "AI-enhanced", "AI-driven"
+- No "leverages", "utilizes", "facilitates"
+- First person ("I"), not "we"
+- Natural voice, specific over vague
+
+## Routes To
+
+- **Agent**: `geepers_readme`
+- **References**: `~/.claude/skills/humanize/SKILL.md` for terminology rules
+
+## Example Output
+
+```markdown
+# Wordblocks
+
+Symbol-based communication for people who need it most.
+
+![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
+![Python](https://img.shields.io/badge/python-3.10+-blue.svg)
+![Live](https://img.shields.io/badge/live-dr.eamer.dev-cyan.svg)
+
+## Features
+- Builds sentences from pictographic symbols with text-to-speech
+- ...
+
+## Author
+**Luke Steuber**
+- Website: [dr.eamer.dev](https://dr.eamer.dev)
+- Bluesky: [@lukesteuber.com](https://bsky.app/profile/lukesteuber.com)
+```


### PR DESCRIPTION
## Summary

Adds 4 community skills from the [geepers](https://github.com/lukeslp/geepers) project:

- **geepers-datavis** — D3.js/Chart.js data visualization toolkit with color palette design, scale selection (linear/log/sqrt), narrative storytelling, and data pipeline scripts for Census, SEC, and Wikipedia APIs
- **geepers-humanize** — Strips AI-sounding corporate language from docs and READMEs; enforces plain English and terminology rules
- **geepers-dream-swarm** — Parallel multi-domain search workflows that aggregate results from multiple APIs and data sources simultaneously
- **geepers-readme** — Generates polished, humanized GitHub READMEs with badges, license blocks, and install instructions

## Details

- All skills include `license: MIT` in frontmatter
- Helper scripts are included where appropriate (Python)
- Each skill has a focused `description` trigger and clear "when to use / when not to use" sections

## Test Plan

- [ ] Install each skill and verify it loads correctly in Claude Code
- [ ] Verify frontmatter parses (name, description, license all present)
- [ ] Test trigger phrases match expected behavior