### PR TITLE
Warn about unquoted descriptions with special YAML characters

### DIFF
--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -30,6 +30,21 @@ def validate_skill(skill_path):
 
     frontmatter_text = match.group(1)
 
+    # Warn about unquoted descriptions containing YAML-special characters
+    desc_match = re.search(r'^description:\s*(.+)$', frontmatter_text, re.MULTILINE)
+    if desc_match:
+        desc_value = desc_match.group(1).strip()
+        is_quoted = (
+            (desc_value.startswith('"') and desc_value.endswith('"'))
+            or (desc_value.startswith("'") and desc_value.endswith("'"))
+        )
+        if not is_quoted and re.search(r'[:#\[\]{}]', desc_value):
+            return False, (
+                f"Description contains special YAML characters (: # [ ] {{ }}) but is not quoted. "
+                f"Wrap it in quotes to avoid silent YAML parsing issues, e.g.: "
+                f"description: \"{desc_value}\""
+            )
+
     # Parse YAML frontmatter
     try:
         frontmatter = yaml.safe_load(frontmatter_text)


### PR DESCRIPTION
## Summary
- Adds a pre-parsing check in `quick_validate.py` that detects `description` values containing YAML-special characters (`: # [ ] { }`) that aren't wrapped in quotes
- Catches the problem **before** `yaml.safe_load()` runs, preventing silent misparsing (e.g., `#` stripping text as a comment) or cryptic YAML errors
- Returns a helpful error message showing the user how to fix it by quoting the value

## Test plan
- [x] `description: Use when: gmail, inbox` → fails with clear warning
- [x] `description: "Use when: gmail, inbox"` → passes
- [x] `description: Simple description without special chars` → passes
- [x] `description: Use this tool #important for email` → fails (would silently lose `#important for email`)
- [x] Single-quoted descriptions with special chars → passes
