### PR TITLE
Add cursor-usage-analysis skill

### DIFF
--- a/skills/cursor-usage-analysis/SKILL.md
+++ b/skills/cursor-usage-analysis/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: cursor-usage-analysis
+description: Interpret Cursor Enterprise API data correctly. Use when analyzing team AI spending, usage patterns, model adoption, or answering questions about Cursor usage metrics. Knows the gotchas and nuances that raw API numbers don't reveal.
+license: MIT
+metadata:
+  author: ofershap
+  version: "1.0"
+---
+
+# Cursor Usage Analysis
+
+Guide for correctly interpreting data from the Cursor Enterprise Admin and Analytics APIs. The API returns raw numbers, but understanding what they mean requires context that is not in the official docs.
+
+## When to Use This Skill
+
+Use this when working with Cursor Enterprise API data, whether through:
+- The `cursor-usage-mcp` MCP server (`npx cursor-usage-mcp`)
+- Direct API calls to `https://api.cursor.com`
+- Exported data from the Cursor admin dashboard
+
+## Critical Data Interpretation Rules
+
+### Spending
+
+- `spendCents` is the **total** spend including the subscription-included amount. To get overage (extra cost beyond the plan), subtract `includedSpendCents`.
+- A user with `spendCents: 5000` and `includedSpendCents: 4000` has $10 in overage, not $50 in total extra cost.
+- `fastPremiumRequests` counts requests to premium/expensive models (Opus, GPT-5) that consume the fast request quota faster.
+- Spend limits (`hardLimitOverrideDollars`) only cap overage spend, not included spend. A limit of $0 means "no overage allowed," not "no usage allowed."
+
+### Lines of Code Metrics
+
+- `totalLinesAdded` includes ALL lines: agent-suggested, tab-completed, and manually typed. It is NOT a measure of AI productivity.
+- `acceptedLinesAdded` is the real AI productivity metric, counting lines the user explicitly accepted from AI suggestions.
+- The acceptance rate (`acceptedLinesAdded / totalLinesAdded`) is misleading because the denominator includes manual edits. Use `totalAccepts / totalApplies` for the true AI acceptance rate.
+- Agent mode lines are counted in `totalLinesAdded` but may not appear in `acceptedLinesAdded` because agent mode auto-applies changes.
+
+### Request Types
+
+- `composerRequests`: Inline edit requests (Cmd+K / Ctrl+K)
+- `chatRequests`: Chat panel conversations
+- `agentRequests`: Agent mode (autonomous multi-step tasks)
+- `usageBasedReqs`: Requests that count against usage-based billing (overage)
+- `cmdkUsages`: Legacy name for composer/inline edit usage
+- `bugbotUsages`: Automated bug detection runs
+
+### Model Usage
+
+Model names in the API don't always match marketing names. Common mappings:
+- `claude-sonnet-4.5` = Claude 4.5 Sonnet (mid-tier, good balance)
+- `claude-opus-4.5` / `claude-opus-4.6` = Claude Opus (expensive, highest quality)
+- `gpt-4o` = GPT-4o (OpenAI mid-tier)
+- `gpt-5.2` / `gpt-5.3-codex` = GPT-5 variants (expensive)
+- `gemini-3-flash` = Gemini Flash (fast, cheap)
+- `gemini-3-pro` = Gemini Pro (mid-tier)
+
+Cost tiers (approximate per request):
+- **Budget**: Gemini Flash, smaller models ($0.001-0.01)
+- **Standard**: Sonnet, GPT-4o ($0.01-0.05)
+- **Premium**: Opus, GPT-5 ($0.10-0.50+)
+
+A single user switching from Sonnet to Opus can 10x their daily spend.
+
+### Analytics Data
+
+- Analytics data is aggregated and may lag up to 1 hour behind real-time.
+- `dau` counts anyone who made at least one request that day.
+- `cli_dau` counts users of the Cursor CLI (terminal-based usage).
+- `cloud_agent_dau` counts users of cloud-hosted agent sessions.
+- Model breakdown `users` is the peak concurrent users for that model on that day, not unique users over the period.
+
+### Usage Events
+
+- Each event represents a single API request to an AI model.
+- `isChargeable: false` means the request was covered by the subscription.
+- `isChargeable: true` means it counted against overage/usage-based billing.
+- `isHeadless: true` means the request came from background processing (Bugbot, indexing), not direct user action.
+- `tokenUsage` may be null for non-token-based requests.
+- `kind` values include: `chat`, `composer`, `agent`, `tab`, `cmd-k`, `bugbot`.
+
+## Analysis Patterns
+
+### "Who is spending the most?"
+1. Get spending data for all members
+2. Sort by `spendCents` descending
+3. Flag anyone whose spend is >3x the team median
+4. Check their model usage since premium model users will dominate
+
+### "Are we getting value from AI?"
+1. Get agent edit metrics for acceptance rates
+2. Get tab completion metrics for autocomplete effectiveness
+3. Compare `total_accepted_diffs / total_suggested_diffs` (healthy teams see 40-70% acceptance)
+4. Low acceptance + high spend = the team is not finding AI suggestions useful
+
+### "Which models should we standardize on?"
+1. Get model usage for the last 30 days
+2. Calculate cost-per-message for each model (cross-reference with spending data)
+3. Models with high usage AND high acceptance rates are the best value
+4. Models with high usage but low acceptance rates are wasting money
+
+## MCP Server
+
+For programmatic access to all these metrics, install the `cursor-usage-mcp` MCP server:
+
+```json
+{
+  "mcpServers": {
+    "cursor-usage": {
+      "command": "npx",
+      "args": ["-y", "cursor-usage-mcp"],
+      "env": {
+        "CURSOR_API_KEY": "your-api-key"
+      }
+    }
+  }
+}
+```
+
+For historical trends, anomaly detection, alerting, and a web dashboard, see [cursor-usage-tracker](https://github.com/ofershap/cursor-usage-tracker).

--- a/skills/cursor-usage-analysis/references/API-REFERENCE.md
+++ b/skills/cursor-usage-analysis/references/API-REFERENCE.md
@@ -1,0 +1,66 @@
+# Cursor Enterprise API Reference
+
+Base URL: `https://api.cursor.com`
+Auth: **Basic Auth** with `Authorization: Basic {base64(API_KEY + ':')}`
+
+Two separate API keys may be required: Admin API key and Analytics API key (generated from team settings).
+
+## Rate Limits (per team, per minute)
+
+| API | Endpoint Type | Limit |
+|-----|---------------|-------|
+| Admin API | Most endpoints | 20 req/min |
+| Admin API | `/teams/user-spend-limit` | 250 req/min |
+| Analytics API | Team-level (`/analytics/team/*`) | 100 req/min |
+| Analytics API | By-user (`/analytics/by-user/*`) | 50 req/min |
+
+304 responses from ETag caching do NOT count against rate limits.
+
+## Admin API Endpoints
+
+### GET /teams/members
+Returns `{ teamMembers: [{ name, email, id, role, isRemoved }] }`
+
+### POST /teams/daily-usage-data
+Body: `{ page, pageSize, startDate?: number (ms), endDate?: number (ms) }`
+Returns paginated daily usage per user. Poll at most once per hour.
+
+### POST /teams/spend
+Body: `{ page, pageSize }`
+Returns `{ teamMemberSpend: [...], subscriptionCycleStart, totalPages, totalMembers }`
+
+### POST /teams/filtered-usage-events
+Body: `{ email?, startDate?, endDate?, page, pageSize }`
+Returns per-request events with model, tokens, cost. Max 30 days per request.
+
+### POST /teams/user-spend-limit
+Body: `{ email, hardLimitDollars }`
+
+### GET /teams/groups
+Returns billing groups with member lists, spend, and daily spend breakdown.
+
+## Analytics API Endpoints
+
+All use `startDate`/`endDate` query params. Formats: `YYYY-MM-DD`, `7d`, `30d`, `today`, `yesterday`. Max 30 days.
+Optional `users` param: comma-separated emails.
+
+### Team-Level
+- `GET /analytics/team/dau` - daily active users
+- `GET /analytics/team/models` - model usage with breakdown per day
+- `GET /analytics/team/agent-edits` - suggested/accepted/rejected diffs and lines
+- `GET /analytics/team/tabs` - tab autocomplete usage
+- `GET /analytics/team/mcp` - MCP tool adoption
+- `GET /analytics/team/commands` - command usage
+- `GET /analytics/team/plans` - plan mode adoption
+- `GET /analytics/team/client-versions` - version distribution
+- `GET /analytics/team/top-file-extensions` - most edited file types
+- `GET /analytics/team/leaderboard` - ranked by AI usage
+- `GET /analytics/team/ask-mode` - ask mode adoption
+
+### By-User (paginated)
+Pattern: `GET /analytics/by-user/{metric}?page&pageSize` (max 500)
+Available: agent-edits, tabs, models, mcp, commands, plans, ask-mode, client-versions, top-file-extensions
+
+## Caching
+
+Analytics APIs support ETags. Use `If-None-Match` header for 304 responses (15-minute cache).


### PR DESCRIPTION
Adds a skill for interpreting Cursor Enterprise API data correctly.

If you manage a Cursor Enterprise team, the Admin and Analytics APIs give you raw usage numbers -- but those numbers are easy to misread. This skill teaches agents the gotchas:

- `spendCents` includes subscription-included spend, not just overage
- `totalLinesAdded` includes manual edits, not just AI-generated code
- Agent mode lines don't show up in `acceptedLinesAdded` because they auto-apply
- Model names in the API don't match marketing names
- Premium models cost 10-50x more than standard ones per request

Also covers common analysis patterns (finding top spenders, measuring AI effectiveness, model selection optimization) and includes a full API reference.

Works standalone as a knowledge skill, or pairs with the [cursor-usage-mcp](https://www.npmjs.com/package/cursor-usage-mcp) MCP server for live data access.

Made with [Cursor](https://cursor.com)