### PR TITLE
Add clerk-convex-expo-auth skill

### DIFF
--- a/skills/clerk-convex-expo-auth/SKILL.md
+++ b/skills/clerk-convex-expo-auth/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: clerk-convex-expo-auth
+description: Complete authentication blueprint for React Native / Expo apps using Clerk + Convex. Covers backend auth config, user schema, webhook pipeline, JWT validation, frontend providers, route protection, sign-in/sign-up flows, email verification, Apple Sign-In, onboarding, and account deletion. Use when building auth for Clerk + Convex + Expo projects, setting up webhooks, or implementing sign-in/sign-up flows.
+---
+
+# Clerk + Convex + Expo Authentication
+
+Complete authentication system for React Native / Expo apps using Clerk (identity provider) and Convex (backend). This skill provides a production-ready blueprint covering every layer from JWT validation to account deletion cascades.
+
+## When to Use
+
+- Setting up auth in a new Clerk + Convex + Expo project
+- Adding sign-in/sign-up flows (email/password, Apple Sign-In)
+- Configuring Clerk-to-Convex webhooks for user sync
+- Implementing route protection and onboarding flows
+- Adding account deletion with cascading cleanup
+
+## Tech Stack
+
+| Package | Purpose |
+|---------|---------|
+| `@clerk/clerk-expo` | Clerk SDK for React Native/Expo (client-side auth) |
+| `@clerk/backend` | Clerk backend utilities (webhook type definitions) |
+| `convex` | Backend framework (`ConvexProviderWithClerk`, `ctx.auth`) |
+| `svix` | Webhook signature verification |
+| `expo-secure-store` | Encrypted token storage on device |
+| `expo-apple-authentication` | Native Apple Sign-In (iOS) |
+| `expo-auth-session` | OAuth session handling |
+| `expo-web-browser` | Opens browser for OAuth flows |
+
+**Install:**
+```bash
+npx expo install @clerk/clerk-expo expo-secure-store expo-apple-authentication expo-auth-session expo-web-browser
+npm install @clerk/backend svix
+```
+
+## Environment Variables
+
+```env
+CLERK_JWT_ISSUER_DOMAIN=https://<your-clerk-instance>.clerk.accounts.dev
+CLERK_WEBHOOK_SECRET=whsec_<your-webhook-secret>
+EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_<your-publishable-key>
+EXPO_PUBLIC_CONVEX_URL=https://<your-convex-deployment>.convex.cloud
+```
+
+## Instructions
+
+### Architecture Overview
+
+```
+Client (Expo)                    Backend (Convex)
+─────────────                    ────────────────
+ClerkProvider                    auth.config.ts (JWT validation)
+  └─ ConvexProviderWithClerk     getUser() helper (auth enforcement)
+       └─ JWT auto-attached      Webhook handler (user sync)
+            to every request     Internal mutations (upsert/delete)
+```
+
+**Data flows:**
+1. **Auth**: Client -> Clerk JWT -> Convex validates against `CLERK_JWT_ISSUER_DOMAIN`
+2. **User sync**: Clerk event -> Webhook POST -> Convex HTTP endpoint -> Svix verifies -> Internal mutation
+3. **Per-request**: `ctx.auth.getUserIdentity()` -> lookup by `externalId` index -> return user ID
+
+### Backend Setup
+
+#### 1. Auth Config (`convex/auth.config.ts`)
+
+```typescript
+import { AuthConfig } from "convex/server";
+
+export default {
+  providers: [
+    {
+      domain: process.env.CLERK_JWT_ISSUER_DOMAIN!,
+      applicationID: "convex",
+    },
+  ],
+} satisfies AuthConfig;
+```
+
+#### 2. User Schema
+
+```typescript
+// convex/schema.ts
+users: defineTable({
+  externalId: v.string(),            // Clerk user ID (identity.subject)
+  name: v.optional(v.string()),
+  nickname: v.optional(v.string()),
+  email: v.optional(v.string()),
+  image_url: v.optional(v.string()),
+  has_image: v.optional(v.boolean()),
+  status: v.union(v.literal("online"), v.literal("offline")),
+})
+  .index("by_externalId", ["externalId"])
+```
+
+The `by_externalId` index is **critical** -- used by both the webhook handler and `getUser()`.
+
+#### 3. Auth Helper (`getUser`)
+
+Central auth enforcement function. Three usage modes:
+
+| Call | Behavior |
+|------|----------|
+| `getUser(ctx)` | Returns user ID or `null` |
+| `getUser(ctx, { required: true })` | Returns user ID or throws |
+| `getUser(ctx, { required: true, createIfMissing: true })` | Returns user ID, creating record on first access |
+
+See `references/backend.md` for full implementation.
+
+#### 4. Webhook Handler (`convex/http.ts`)
+
+Receives `user.created`, `user.updated`, `user.deleted` events from Clerk, verifies signatures with Svix, and routes to internal mutations.
+
+See `references/webhook-setup.md` for step-by-step setup and `references/backend.md` for implementation.
+
+#### 5. Auth Enforcement Patterns
+
+Every protected endpoint calls `getUser()` at the top:
+
+```typescript
+// Hard requirement (most mutations)
+const userId = await getUser(ctx, { required: true });
+
+// Auto-create (onboarding, first-time actions)
+const userId = await getUser(ctx, { required: true, createIfMissing: true });
+
+// Soft check (public queries)
+const userId = await getUser(ctx);
+if (!userId) return null;
+```
+
+### Frontend Setup
+
+#### 1. Auth Provider (`components/auth/index.tsx`)
+
+Wraps the app with `ClerkProvider` + `ConvexProviderWithClerk`. Uses `expo-secure-store` for token persistence.
+
+See `references/frontend.md` for full implementation.
+
+#### 2. Route Protection
+
+Two-layer protection:
+1. **Clerk layer**: `isSignedIn` from `useAuth()` or `<Authenticated>` / `<Unauthenticated>` from `convex/react`
+2. **App layer**: `hasCompletedOnboarding` Convex query for nickname check
+
+#### 3. Sign-In / Sign-Up
+
+Uses `useSignIn()` and `useSignUp()` from `@clerk/clerk-expo`:
+- `signIn.create({ identifier, password })` for sign-in
+- `signUp.create({ emailAddress, password })` + `prepareEmailAddressVerification()` for sign-up
+
+#### 4. Email Verification
+
+`signUp.attemptEmailAddressVerification({ code })` with 6-digit code.
+
+#### 5. Apple Sign-In (iOS)
+
+Uses `useSignInWithApple()` from `@clerk/clerk-expo` + native `expo-apple-authentication` button.
+
+#### 6. Account Deletion Cascade
+
+`clerkUser.delete()` -> Clerk fires `user.deleted` webhook -> Convex cleans up all related data.
+
+### Clerk Hook Reference
+
+| Hook | Package | Returns |
+|------|---------|---------|
+| `useAuth()` | `@clerk/clerk-expo` | `{ isLoaded, isSignedIn, signOut }` |
+| `useUser()` | `@clerk/clerk-expo` | `{ user }` |
+| `useSignIn()` | `@clerk/clerk-expo` | `{ signIn, setActive, isLoaded }` |
+| `useSignUp()` | `@clerk/clerk-expo` | `{ signUp, setActive, isLoaded }` |
+| `useSignInWithApple()` | `@clerk/clerk-expo` | `{ startAppleAuthenticationFlow }` |
+| `useConvexAuth()` | `convex/react` | `{ isAuthenticated }` |
+
+### Common Clerk Error Codes
+
+| Code | Meaning |
+|------|---------|
+| `form_password_incorrect` | Wrong password |
+| `form_identifier_not_found` | No account with this email |
+| `form_param_format_invalid` | Invalid email format |
+| `form_identifier_exists` | Email already registered |
+| `form_password_pwned` | Password in breached database |
+| `form_password_length_too_short` | Password too short |
+
+### Security Summary
+
+| Layer | Mechanism |
+|-------|-----------|
+| Client token storage | `expo-secure-store` (encrypted) |
+| Client-to-backend auth | JWT auto-attached by `ConvexProviderWithClerk` |
+| Backend JWT validation | Convex validates against `CLERK_JWT_ISSUER_DOMAIN` |
+| Webhook security | `svix` verifies signatures with `CLERK_WEBHOOK_SECRET` |
+| Per-endpoint authorization | `getUser()` at the top of every mutation/query |
+| Internal mutations | `internalMutation` prevents client access |
+| Account deletion | Cascading cleanup via webhook |
+| Token refresh | Handled automatically by Clerk SDK |
+
+### Gotchas
+
+- Webhook URL uses `.convex.site` (NOT `.convex.cloud`)
+- There's a ~1s delay between Clerk action and webhook arrival -- `createIfMissing` in `getUser()` acts as fallback
+- Clerk retries failed webhooks with exponential backoff automatically
+- `v.any() as Validator<UserJSON>` skips runtime validation but gives correct TypeScript types
+- On `user.updated`, only patch Clerk-managed fields -- never overwrite app-specific fields like `nickname`
+
+## Reference Files
+
+- `references/backend.md` - Full backend implementation (getUser, user mutations, onboarding)
+- `references/frontend.md` - Full frontend implementation (providers, forms, Apple Sign-In, modals)
+- `references/webhook-setup.md` - Step-by-step webhook configuration guide

--- a/skills/clerk-convex-expo-auth/references/backend.md
+++ b/skills/clerk-convex-expo-auth/references/backend.md
@@ -1,0 +1,253 @@
+# Backend Implementation Reference
+
+## Auth Helper (`convex/helpers/auth.ts`)
+
+```typescript
+import { Id } from "../_generated/dataModel";
+import { MutationCtx, QueryCtx } from "../_generated/server";
+
+// Overload 1: Soft lookup (returns null if not authenticated)
+export async function getUser(
+  ctx: QueryCtx | MutationCtx,
+): Promise<Id<"users"> | null>;
+
+// Overload 2: Required auth (throws if not authenticated)
+export async function getUser(
+  ctx: QueryCtx | MutationCtx,
+  options: { required: true; createIfMissing?: boolean },
+): Promise<Id<"users">>;
+
+// Implementation
+export async function getUser(
+  ctx: QueryCtx | MutationCtx,
+  options?: { required?: true; createIfMissing?: boolean },
+): Promise<Id<"users"> | null> {
+  const identity = await ctx.auth.getUserIdentity();
+
+  if (!identity) {
+    if (options?.required) {
+      throw new Error("Not authenticated");
+    }
+    return null;
+  }
+
+  const user = await ctx.db
+    .query("users")
+    .withIndex("by_externalId", (q) => q.eq("externalId", identity.subject))
+    .unique();
+
+  if (user) {
+    return user._id;
+  }
+
+  if (options?.createIfMissing) {
+    const userId = await ctx.db.insert("users", {
+      externalId: identity.subject,
+      name: identity.name ?? undefined,
+      email: identity.email ?? undefined,
+      status: "online",
+    });
+    return userId;
+  }
+
+  if (options?.required) {
+    throw new Error("Not authenticated");
+  }
+  return null;
+}
+```
+
+## User Mutations - Internal (Webhook-Triggered)
+
+**File: `convex/users.ts`**
+
+These are `internalMutation` -- only callable from the server, never from the client.
+
+```typescript
+import { UserJSON } from "@clerk/backend";
+import { v, Validator } from "convex/values";
+import {
+  internalMutation,
+  MutationCtx,
+  QueryCtx,
+} from "./_generated/server";
+
+async function userByExternalId(ctx: QueryCtx, externalId: string) {
+  return await ctx.db
+    .query("users")
+    .withIndex("by_externalId", (q) => q.eq("externalId", externalId))
+    .unique();
+}
+
+export const upsertFromClerk = internalMutation({
+  args: { data: v.any() as Validator<UserJSON> },
+  async handler(ctx, { data }) {
+    const userAttributes = {
+      name: `${data.first_name} ${data.last_name}`,
+      email: data.email_addresses[0]?.email_address || "",
+      externalId: data.id,
+      image_url: data.image_url,
+      has_image: data.has_image,
+    };
+
+    const existingUser = await userByExternalId(ctx, data.id);
+
+    if (existingUser === null) {
+      await ctx.db.insert("users", {
+        ...userAttributes,
+        status: "online",
+        nickname: undefined,
+      });
+    } else {
+      // Only update Clerk-managed fields -- never overwrite nickname, status
+      await ctx.db.patch(existingUser._id, userAttributes);
+    }
+  },
+});
+
+export const deleteFromClerk = internalMutation({
+  args: { clerkUserId: v.string() },
+  async handler(ctx, { clerkUserId }) {
+    const user = await userByExternalId(ctx, clerkUserId);
+
+    if (user !== null) {
+      await performUserDataCleanup(ctx, user._id);
+      await ctx.db.delete(user._id);
+    } else {
+      console.warn(
+        `Can't delete user, there is none for Clerk user ID: ${clerkUserId}`,
+      );
+    }
+  },
+});
+
+async function performUserDataCleanup(ctx: MutationCtx, userId: Id<"users">) {
+  // Customize: delete games, invites, queue entries, etc.
+}
+```
+
+## User Mutations - Public
+
+```typescript
+export const getCurrentUser = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await getUser(ctx);
+    if (!userId) return null;
+    const user = await ctx.db.get(userId);
+    return {
+      id: user._id,
+      nickname: user.nickname,
+      displayTag: user.displayTag,
+      status: user.status,
+    };
+  },
+});
+
+export const setUserStatus = mutation({
+  args: { status: userStatusValidator },
+  handler: async (ctx, args) => {
+    const userId = await getUser(ctx);
+    if (!userId) throw new Error("Not authenticated");
+    await ctx.db.patch(userId, { status: args.status });
+  },
+});
+```
+
+## Onboarding Mutations (`convex/onboarding.ts`)
+
+```typescript
+export const hasCompletedOnboarding = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await getUser(ctx, { required: true, createIfMissing: true });
+    const user = await ctx.db.get(userId);
+    return !!user?.nickname;
+  },
+});
+
+export const setNickname = mutation({
+  args: { nickname: v.string() },
+  handler: async (ctx, args) => {
+    const userId = await getUser(ctx, { required: true, createIfMissing: true });
+    // Validate: 3-20 chars, alphanumeric + underscore
+    // Generate unique displayTag (nickname#XXXX)
+    await ctx.db.patch(userId, { nickname, displayTag });
+  },
+});
+
+export const skipNickname = mutation({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await getUser(ctx, { required: true, createIfMissing: true });
+    // Assign random default nickname
+  },
+});
+```
+
+## HTTP Webhook Handler (`convex/http.ts`)
+
+```typescript
+import type { WebhookEvent } from "@clerk/backend";
+import { httpRouter } from "convex/server";
+import { Webhook } from "svix";
+import { internal } from "./_generated/api";
+import { httpAction } from "./_generated/server";
+
+const http = httpRouter();
+
+http.route({
+  path: "/clerk-users-webhook",
+  method: "POST",
+  handler: httpAction(async (ctx, request) => {
+    const event = await validateRequest(request);
+    if (!event) {
+      return new Response("Invalid webhook signature", { status: 400 });
+    }
+
+    switch (event.type) {
+      case "user.created":
+      case "user.updated":
+        await ctx.runMutation(internal.users.upsertFromClerk, {
+          data: event.data,
+        });
+        break;
+
+      case "user.deleted": {
+        const clerkUserId = event.data.id!;
+        await ctx.runMutation(internal.users.deleteFromClerk, {
+          clerkUserId,
+        });
+        break;
+      }
+
+      default:
+        console.log("Ignored Clerk webhook event", event.type);
+    }
+
+    return new Response(null, { status: 200 });
+  }),
+});
+
+async function validateRequest(
+  req: Request,
+): Promise<WebhookEvent | null> {
+  const payloadString = await req.text();
+
+  const svixHeaders = {
+    "svix-id": req.headers.get("svix-id")!,
+    "svix-timestamp": req.headers.get("svix-timestamp")!,
+    "svix-signature": req.headers.get("svix-signature")!,
+  };
+
+  const wh = new Webhook(process.env.CLERK_WEBHOOK_SECRET!);
+  try {
+    return wh.verify(payloadString, svixHeaders) as unknown as WebhookEvent;
+  } catch (error) {
+    console.error("Error verifying webhook event", error);
+    return null;
+  }
+}
+
+export default http;
+```

--- a/skills/clerk-convex-expo-auth/references/frontend.md
+++ b/skills/clerk-convex-expo-auth/references/frontend.md
@@ -1,0 +1,345 @@
+# Frontend Implementation Reference
+
+## Auth Provider (`components/auth/index.tsx`)
+
+```typescript
+import { ClerkProvider, useAuth } from "@clerk/clerk-expo";
+import { ConvexReactClient } from "convex/react";
+import { ConvexProviderWithClerk } from "convex/react-clerk";
+import * as SecureStore from "expo-secure-store";
+
+const convex = new ConvexReactClient(
+  process.env.EXPO_PUBLIC_CONVEX_URL as string
+);
+
+const tokenCache = {
+  async getToken(key: string) {
+    return SecureStore.getItemAsync(key);
+  },
+  async saveToken(key: string, value: string) {
+    return SecureStore.setItemAsync(key, value);
+  },
+};
+
+export default function AuthProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <ClerkProvider
+      tokenCache={tokenCache}
+      publishableKey={process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY!}
+    >
+      <ConvexProviderWithClerk client={convex} useAuth={useAuth}>
+        {children}
+      </ConvexProviderWithClerk>
+    </ClerkProvider>
+  );
+}
+```
+
+## Root Layout (`app/_layout.tsx`)
+
+```typescript
+import AuthProvider from "@/components/auth";
+
+export default function RootLayout() {
+  return (
+    <KeyboardProvider>
+      <AuthProvider>
+        <GestureHandlerRootView>
+          <Stack screenOptions={{ headerShown: false }}>
+            <Stack.Screen name="index" />
+            <Stack.Screen name="Auth/sign-in" />
+            <Stack.Screen name="Auth/verification" />
+            <Stack.Screen name="Auth/nickname" />
+          </Stack>
+        </GestureHandlerRootView>
+      </AuthProvider>
+    </KeyboardProvider>
+  );
+}
+```
+
+## Route Protection (`app/index.tsx`)
+
+### Option A: Imperative (useAuth)
+
+```typescript
+import { useAuth } from "@clerk/clerk-expo";
+import { useQuery } from "convex/react";
+import { Redirect } from "expo-router";
+import { api } from "@/convex/_generated/api";
+
+const Index = () => {
+  const { isLoaded, isSignedIn } = useAuth();
+
+  if (!isLoaded) return <LoadingScreen />;
+  if (!isSignedIn) return <UnauthenticatedMenu />;
+
+  return <AuthenticatedContent />;
+};
+
+const AuthenticatedContent = () => {
+  const hasCompletedOnboarding = useQuery(api.onboarding.hasCompletedOnboarding);
+
+  if (hasCompletedOnboarding === undefined) return <LoadingScreen />;
+  if (!hasCompletedOnboarding) return <Redirect href="/Auth/nickname" />;
+
+  return <MainApp />;
+};
+```
+
+### Option B: Declarative (Convex components)
+
+```typescript
+import { Authenticated, Unauthenticated } from "convex/react";
+
+const Index = () => (
+  <>
+    <Unauthenticated>
+      <UnauthenticatedMenu />
+    </Unauthenticated>
+    <Authenticated>
+      <AuthenticatedContent />
+    </Authenticated>
+  </>
+);
+```
+
+Both approaches are equivalent -- `ConvexProviderWithClerk` uses Clerk's `useAuth` internally.
+
+## Sign-In / Sign-Up Form
+
+```typescript
+import { useSignIn, useSignUp } from "@clerk/clerk-expo";
+
+interface SignInFormProps {
+  onSignInComplete: () => void;
+  onSignUpNeedsVerification: (email: string) => void;
+}
+
+export default function SignInForm({
+  onSignInComplete,
+  onSignUpNeedsVerification,
+}: SignInFormProps) {
+  const { signIn, setActive: setSignInActive, isLoaded: isSignInLoaded } = useSignIn();
+  const { signUp, setActive: setSignUpActive, isLoaded: isSignUpLoaded } = useSignUp();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const handleSignIn = async () => {
+    const signInAttempt = await signIn.create({
+      identifier: email.trim(),
+      password: password.trim(),
+    });
+    if (signInAttempt.status === "complete") {
+      await setSignInActive({ session: signInAttempt.createdSessionId });
+      onSignInComplete();
+    }
+  };
+
+  const handleSignUp = async () => {
+    await signUp.create({
+      emailAddress: email.trim(),
+      password: password.trim(),
+    });
+    await signUp.prepareEmailAddressVerification({ strategy: "email_code" });
+    onSignUpNeedsVerification(email.trim());
+  };
+
+  // ... render email input, password input, sign-in/sign-up buttons
+}
+```
+
+## Email Verification Form
+
+```typescript
+import { useSignUp } from "@clerk/clerk-expo";
+
+interface VerificationFormProps {
+  email: string;
+  onVerificationComplete: () => void;
+  onBack: () => void;
+}
+
+export default function VerificationForm({
+  email,
+  onVerificationComplete,
+  onBack,
+}: VerificationFormProps) {
+  const { signUp, setActive } = useSignUp();
+  const [code, setCode] = useState("");
+
+  const handleVerifyCode = async () => {
+    const signUpAttempt = await signUp.attemptEmailAddressVerification({
+      code: code.trim(),
+    });
+    if (signUpAttempt.status === "complete") {
+      await setActive({ session: signUpAttempt.createdSessionId });
+      onVerificationComplete();
+    }
+  };
+
+  const handleResendCode = async () => {
+    await signUp.prepareEmailAddressVerification({ strategy: "email_code" });
+  };
+
+  // ... render code input, verify button, resend button
+}
+```
+
+## Nickname / Onboarding Form
+
+```typescript
+import { useMutation } from "convex/react";
+import { api } from "@/convex/_generated/api";
+
+export default function NicknameForm({ onComplete }: { onComplete: () => void }) {
+  const setNickname = useMutation(api.onboarding.setNickname);
+  const skipNickname = useMutation(api.onboarding.skipNickname);
+  const [nickname, setNicknameValue] = useState("");
+
+  const handleSubmit = async () => {
+    if (!/^[a-zA-Z0-9_]+$/.test(nickname) || nickname.length < 3) return;
+    await setNickname({ nickname });
+    onComplete();
+  };
+
+  const handleSkip = async () => {
+    await skipNickname();
+    onComplete();
+  };
+
+  // ... render nickname input, submit button, skip button
+}
+```
+
+## Apple Sign-In (iOS Only)
+
+```typescript
+import { useSignInWithApple } from "@clerk/clerk-expo";
+import * as AppleAuthentication from "expo-apple-authentication";
+import { Platform } from "react-native";
+
+export function AppleSignInButton({ onSignInComplete }: { onSignInComplete?: () => void }) {
+  const { startAppleAuthenticationFlow } = useSignInWithApple();
+
+  const handleAppleSignIn = async () => {
+    try {
+      const { createdSessionId, setActive } = await startAppleAuthenticationFlow();
+      if (createdSessionId && setActive) {
+        await setActive({ session: createdSessionId });
+        onSignInComplete?.();
+      }
+    } catch (err: any) {
+      if (err.code === "ERR_REQUEST_CANCELED") return;
+      Alert.alert("Error", err.message);
+    }
+  };
+
+  if (Platform.OS !== "ios") return null;
+
+  return (
+    <AppleAuthentication.AppleAuthenticationButton
+      buttonType={AppleAuthentication.AppleAuthenticationButtonType.SIGN_IN}
+      buttonStyle={
+        colorScheme === "dark"
+          ? AppleAuthentication.AppleAuthenticationButtonStyle.WHITE
+          : AppleAuthentication.AppleAuthenticationButtonStyle.BLACK
+      }
+      cornerRadius={20}
+      style={{ width: "100%", height: 55 }}
+      onPress={handleAppleSignIn}
+    />
+  );
+}
+```
+
+## Auth Modal (Multi-Step Flow)
+
+```typescript
+export function AuthModal({ visible, onClose }: AuthModalProps) {
+  const [currentScreen, setCurrentScreen] = useState<
+    "signIn" | "verification" | "nickname"
+  >("signIn");
+  const [email, setEmail] = useState("");
+
+  return (
+    <Modal visible={visible} animationType="slide" presentationStyle="pageSheet">
+      {currentScreen === "signIn" && (
+        <SignInForm
+          onSignInComplete={onClose}
+          onSignUpNeedsVerification={(email) => {
+            setEmail(email);
+            setCurrentScreen("verification");
+          }}
+        />
+      )}
+      {currentScreen === "verification" && (
+        <VerificationForm
+          email={email}
+          onVerificationComplete={() => setCurrentScreen("nickname")}
+          onBack={() => setCurrentScreen("signIn")}
+        />
+      )}
+      {currentScreen === "nickname" && (
+        <NicknameForm onComplete={onClose} />
+      )}
+    </Modal>
+  );
+}
+```
+
+**Flow:** Sign In/Up -> Email Verification -> Nickname Setup -> Done
+
+## Sign-Out & Account Deletion
+
+```typescript
+import { useAuth, useUser } from "@clerk/clerk-expo";
+
+const { signOut } = useAuth();
+const { user: clerkUser } = useUser();
+
+// Sign out
+const handleSignOut = async () => {
+  await signOut();
+};
+
+// Delete account (triggers webhook cascade)
+const handleDeleteAccount = async () => {
+  await clerkUser?.delete();
+};
+```
+
+## User Online/Offline Status Hook
+
+```typescript
+import { useConvexAuth } from "convex/react";
+import { AppState } from "react-native";
+
+export const useUserStatus = () => {
+  const setUserStatus = useMutation(api.users.setUserStatus);
+  const { isAuthenticated } = useConvexAuth();
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      setUserStatus({ status: "online" });
+    }
+
+    const subscription = AppState.addEventListener("change", (nextAppState) => {
+      if (isAuthenticated) {
+        setUserStatus({
+          status: nextAppState === "active" ? "online" : "offline",
+        });
+      }
+    });
+
+    return () => {
+      if (isAuthenticated) setUserStatus({ status: "offline" });
+      subscription.remove();
+    };
+  }, [isAuthenticated]);
+};
+```

--- a/skills/clerk-convex-expo-auth/references/webhook-setup.md
+++ b/skills/clerk-convex-expo-auth/references/webhook-setup.md
@@ -1,0 +1,138 @@
+# Webhook Setup Guide (Step-by-Step)
+
+## Why Webhooks Are Needed
+
+Convex validates JWTs from Clerk via `ctx.auth.getUserIdentity()`, but that only gives you JWT claims (subject, email, name). It does **not** create a database record. You need a `users` table to:
+
+- Store app-specific fields (nickname, status, preferences)
+- Create relationships between users and other data
+- Query users by ID in mutations and queries
+
+**Data flow:**
+```
+User signs up -> Clerk creates user -> Clerk fires POST to webhook
+-> Convex HTTP endpoint receives it -> Svix verifies signature
+-> Internal mutation inserts/updates user in Convex DB
+```
+
+## Step 1: Install Dependencies
+
+```bash
+npm install @clerk/backend svix
+```
+
+| Package | Purpose |
+|---------|---------|
+| `@clerk/backend` | `WebhookEvent` and `UserJSON` TypeScript types |
+| `svix` | Webhook signature verification |
+
+## Step 2: Define User Schema
+
+```typescript
+// convex/schema.ts
+users: defineTable({
+  externalId: v.string(),            // Clerk user ID
+  name: v.optional(v.string()),
+  email: v.optional(v.string()),
+  image_url: v.optional(v.string()),
+  has_image: v.optional(v.boolean()),
+  nickname: v.optional(v.string()),
+  status: v.union(v.literal("online"), v.literal("offline")),
+})
+  .index("by_externalId", ["externalId"])
+```
+
+The `by_externalId` index is **critical**.
+
+## Step 3: Create Internal Mutations
+
+See `backend.md` for full `upsertFromClerk` and `deleteFromClerk` implementations.
+
+Key design decisions:
+- `upsertFromClerk` handles both `user.created` and `user.updated` (idempotent)
+- On insert, set app-specific defaults (`status: "online"`)
+- On patch, only update Clerk-managed fields -- never overwrite `nickname`, `status`
+- `deleteFromClerk` cleans up all related data before deleting user record
+- `v.any() as Validator<UserJSON>` skips runtime validation but gives TypeScript types
+
+## Step 4: Create HTTP Endpoint
+
+See `backend.md` for full `convex/http.ts` implementation.
+
+Signature verification:
+1. Clerk signs every payload using your `CLERK_WEBHOOK_SECRET` (via Svix)
+2. Three headers sent: `svix-id`, `svix-timestamp`, `svix-signature`
+3. `Webhook.verify()` re-computes signature and compares to header
+4. Mismatch (tampered payload, wrong secret, replay attack) -> throws -> return 400
+
+## Step 5: Deploy Convex
+
+```bash
+npx convex deploy
+```
+
+Note your HTTP Actions URL:
+```
+https://<your-deployment-name>.convex.site
+```
+
+**IMPORTANT:** Domain ends in `.convex.site`, NOT `.convex.cloud`. The `.cloud` domain is for queries/mutations. The `.site` domain is for HTTP actions.
+
+Full webhook endpoint:
+```
+https://<your-deployment-name>.convex.site/clerk-users-webhook
+```
+
+## Step 6: Configure Clerk Dashboard
+
+1. Go to **Clerk Dashboard** (https://dashboard.clerk.com)
+2. Navigate to **Webhooks** in the left sidebar
+3. Click **Add Endpoint**
+4. Fill in:
+   - **Endpoint URL:** `https://<your-deployment-name>.convex.site/clerk-users-webhook`
+   - **Message Filtering:** Click **"user"** to subscribe to:
+     - `user.created` -- new user signs up
+     - `user.updated` -- profile changes (name, email, avatar)
+     - `user.deleted` -- account deleted
+5. Click **Create**
+6. Copy the **Signing Secret** (starts with `whsec_`)
+
+## Step 7: Set Environment Variable
+
+In **Convex Dashboard** (https://dashboard.convex.dev):
+1. Select your project
+2. Go to **Settings** -> **Environment Variables**
+3. Add: `CLERK_WEBHOOK_SECRET` = `whsec_<your-value>`
+
+For local development, also add to `.env.local`:
+```env
+CLERK_WEBHOOK_SECRET=whsec_<your-signing-secret>
+```
+
+## Step 8: Verify It Works
+
+1. In Clerk Dashboard Webhooks, click your endpoint
+2. Go to **Testing** tab
+3. Select `user.created`, click **Send Test Webhook**
+4. Check **Logs** tab for `200` response
+5. In Convex Dashboard, check `users` table for test record
+
+End-to-end verification:
+1. Sign up a real user -> check Convex `users` table (1-2s)
+2. Update profile in Clerk Dashboard -> Convex record should update
+3. Delete user in Clerk Dashboard -> Convex record + related data removed
+
+## Troubleshooting
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| Webhook returns 400 | Wrong `CLERK_WEBHOOK_SECRET` | Re-copy from Clerk Dashboard |
+| Webhook returns 400 | Secret only in `.env.local` | Set in Convex Dashboard too |
+| Endpoint unreachable | Wrong URL domain | Use `.convex.site`, not `.convex.cloud` |
+| User not synced | Webhook not deployed | Run `npx convex deploy` first |
+| `user.deleted` user not found | User created pre-webhooks | Handle with `console.warn` |
+| Duplicate records | Missing `.unique()` | Always use `.unique()` with `by_externalId` |
+
+**Timing note:** ~1s delay between Clerk action and webhook arrival. Use `createIfMissing` in `getUser()` as fallback.
+
+**Retry behavior:** Clerk/Svix retries failed webhooks with exponential backoff automatically.


### PR DESCRIPTION
## Summary

Adds a complete authentication skill for React Native / Expo apps using Clerk + Convex.

### What it covers
- Backend: Auth config, user schema, `getUser()` helper, webhook handler, internal mutations, onboarding
- Frontend: Auth providers, route protection, sign-in/sign-up forms, email verification, Apple Sign-In, auth modal, account deletion
- Webhook setup: Step-by-step guide for Clerk-to-Convex webhook pipeline with troubleshooting

### Structure
```
skills/clerk-convex-expo-auth/
├── SKILL.md                      # Main skill (concise overview + instructions)
└── references/
    ├── backend.md                # Full backend implementation
    ├── frontend.md               # Full frontend implementation
    └── webhook-setup.md          # Step-by-step webhook guide
```

### Why this skill is useful
Setting up auth across Clerk + Convex + Expo involves many moving parts (JWT validation, webhook signatures, token caching, user sync, onboarding flows). This skill provides a production-tested blueprint that covers every layer.