### PR TITLE
Add the-council: multi-model advisory board skill

### DIFF
--- a/skills/the-council/SKILL.md
+++ b/skills/the-council/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: the-council
+description: Multi-model advisory board using OpenAI Codex CLI and Google Gemini CLI to provide second opinions on code reviews, architecture plans, debugging, and general engineering decisions. Invoke when the user requests a "council" review, wants a second opinion from other AI models, asks for multi-model consensus, or says "ask the council". Also invoke proactively when making high-stakes architectural decisions or when a code review checkpoint is reached.
+---
+
+# The Council
+
+Convene OpenAI Codex and Google Gemini as an advisory board. Both run in parallel via their CLIs, with full project context, and return independent analyses that Claude synthesizes.
+
+## Prerequisites
+
+- Project has a `CLAUDE.md` file in the working directory
+- At least one of the following CLIs installed and authenticated:
+  - `codex` CLI (`npm i -g @openai/codex`)
+  - `gemini` CLI (`npm i -g @google/gemini-cli`)
+- Gemini experimental plan mode enabled in `~/.gemini/settings.json` (if using Gemini):
+  ```json
+  { "experimental": { "plan": true } }
+  ```
+
+## Workflow
+
+### 0. Preflight Check (First Invocation Only)
+
+On the first council invocation in a session, run the preflight script to detect available advisors:
+
+```bash
+bash <skill_dir>/scripts/council_preflight.sh
+```
+
+Parse the output (key=value lines) and determine the operating mode:
+
+| Codex Auth | Gemini Auth | Mode |
+|------------|-------------|------|
+| `true` | `true` | **Full Council** — both advisors in parallel |
+| `true` | `false` | **Codex-only** — single advisor mode |
+| `false` | `true` | **Gemini-only** — single advisor mode |
+| `false` | `false` | **Abort** — show installation instructions below |
+
+**If no advisors are available**, display this help and stop:
+
+```
+Neither Codex nor Gemini CLI is available. To use The Council, install at least one:
+
+  Codex:  npm i -g @openai/codex && codex auth
+  Gemini: npm i -g @google/gemini-cli && gemini   (authenticates via OAuth on first run)
+```
+
+**If one advisor is missing**, note which mode is active and proceed. Example:
+
+```
+Council running in Codex-only mode (Gemini CLI not found).
+```
+
+The preflight result is cached for 2 hours — subsequent invocations skip this step automatically.
+
+### 1. Sync Project Context
+
+Run the sync script to copy CLAUDE.md content into AGENTS.md (Codex) and GEMINI.md (Gemini):
+
+```bash
+bash <skill_dir>/scripts/council_sync.sh <working_directory>
+```
+
+This creates/overwrites both files with an advisory preamble + full CLAUDE.md content. Run this once per session or when CLAUDE.md changes.
+
+**Important:** After the council session, clean up the generated files:
+```bash
+rm <working_directory>/AGENTS.md <working_directory>/GEMINI.md
+```
+
+### 2. Compose the Advisory Prompt
+
+Select the appropriate template from [references/prompt-templates.md](references/prompt-templates.md) based on the use case:
+
+| Use Case | Template |
+|----------|----------|
+| Code review | Code Review |
+| Plan/architecture evaluation | Architecture / Planning |
+| Bug investigation | Debugging |
+| General question | General Advisory |
+
+Write the composed prompt to a temporary file. Include all relevant context inline (diffs, error messages, plan text) — the advisors cannot read Claude's conversation history.
+
+### 3. Invoke The Council
+
+Run the advisors based on the mode determined in Step 0:
+
+**Full Council (both available):**
+```bash
+bash <skill_dir>/scripts/council_invoke.sh <prompt_file> <working_directory>
+```
+
+**Codex-only mode:**
+```bash
+bash <skill_dir>/scripts/council_invoke.sh --codex-only <prompt_file> <working_directory>
+```
+
+**Gemini-only mode:**
+```bash
+bash <skill_dir>/scripts/council_invoke.sh --gemini-only <prompt_file> <working_directory>
+```
+
+The script outputs file paths (last lines of stdout) containing the responses. Read the response file(s).
+
+**Environment overrides:**
+- `CODEX_MODEL` — default: `gpt-5.3-codex`
+- `GEMINI_MODEL` — default: `gemini-3-pro-preview`
+- `COUNCIL_TIMEOUT` — default: `300` (seconds)
+
+### 4. Analyze and Present
+
+#### Full Council Mode (both advisors responded)
+
+**Default mode — Synthesis:** Read both responses, identify areas of agreement and disagreement, then present:
+
+```
+## Council Synthesis
+
+**Consensus:** [Points both advisors agree on]
+
+**Divergence:** [Points where they disagree, with each position]
+
+**Claude's Recommendation:** [Your assessment integrating all three perspectives — yours plus both advisors']
+```
+
+**Side-by-side mode** (when user requests "show me both" or "side by side"):
+
+```
+## Codex (gpt-5.3-codex)
+[Full Codex response]
+
+## Gemini (gemini-3-pro-preview)
+[Full Gemini response]
+
+## Claude's Take
+[Your own assessment]
+```
+
+#### Single-Advisor Mode (one advisor responded)
+
+Present the single advisor's response with your own assessment:
+
+```
+## Advisory Opinion ({Advisor Name} / {model})
+[Full response from the available advisor]
+
+## Claude's Assessment
+[Your own perspective, noting this was a single-advisor review]
+```
+
+### 5. Cleanup
+
+Remove temporary files after presenting results:
+- The prompt file
+- The response files (in the temp directory)
+- AGENTS.md and GEMINI.md from the working directory
+
+## Permissions and Safety
+
+Both advisors run in **read-only mode** — they can explore the codebase but cannot modify it:
+
+- **Codex**: `--sandbox read-only` — filesystem writes are blocked by the sandbox
+- **Gemini**: `--approval-mode plan` — strict read-only mode; only read tools (read_file, glob, search) are allowed; write tools are blocked
+
+This ensures advisors never modify project files. If either CLI updates its permission model, verify read-only enforcement before updating the scripts.
+
+## Model and Effort Configuration
+
+Both advisors run at maximum capability:
+
+- **Codex**: Model `gpt-5.3-codex` with reasoning effort `xhigh` (set via `~/.codex/config.toml` key `model_reasoning_effort = "xhigh"`)
+- **Gemini**: Model `gemini-3-pro-preview` with thinking level `HIGH` (set via `~/.gemini/settings.json` in `modelConfigs`)
+
+If the user's config doesn't have these settings, advise them to add:
+
+Codex (`~/.codex/config.toml`):
+```toml
+model_reasoning_effort = "xhigh"
+```
+
+Gemini (`~/.gemini/settings.json`):
+```json
+{
+  "modelConfigs": {
+    "customAliases": {
+      "council": {
+        "modelConfig": {
+          "model": "gemini-3-pro-preview",
+          "generateContentConfig": {
+            "thinkingConfig": { "thinkingLevel": "HIGH" }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Error Handling
+
+- If one advisor fails, present the other's response and note the failure
+- If both fail, report the errors from the log files and suggest checking CLI authentication
+- Timeout defaults to 5 minutes — suggest increasing `COUNCIL_TIMEOUT` for large reviews
+
+## When to Convene The Council
+
+- User explicitly asks for it ("ask the council", "get a second opinion", "council review")
+- High-stakes architectural decisions affecting multiple systems
+- Debugging sessions stuck after multiple failed attempts
+- Before finalizing major implementation plans
+- Code review of security-sensitive changes

--- a/skills/the-council/references/prompt-templates.md
+++ b/skills/the-council/references/prompt-templates.md
@@ -1,0 +1,88 @@
+# Council Prompt Templates
+
+Use these templates to construct the advisory prompt written to the prompt file.
+Adapt the template to the specific situation — do not use verbatim.
+
+## Code Review
+
+```
+You are an expert code reviewer. Analyze the following changes and provide:
+
+1. **Correctness**: Bugs, logic errors, edge cases
+2. **Security**: Vulnerabilities (injection, auth, data leaks)
+3. **Performance**: Inefficiencies, N+1 queries, memory issues
+4. **Maintainability**: Readability, naming, separation of concerns
+5. **Verdict**: APPROVE, REQUEST_CHANGES, or NEEDS_DISCUSSION
+
+Changes to review:
+---
+{diff or file contents}
+---
+
+Project context: You have access to the full codebase via your context file.
+Be specific — reference file names and line numbers.
+```
+
+## Architecture / Planning
+
+```
+You are a senior software architect. Evaluate this implementation plan:
+
+Plan:
+---
+{plan content}
+---
+
+Analyze:
+1. **Feasibility**: Can this be implemented as described?
+2. **Risks**: What could go wrong? What's underestimated?
+3. **Alternatives**: Are there better approaches? Trade-offs?
+4. **Dependencies**: Missing dependencies or ordering issues?
+5. **Recommendation**: Proceed as-is, modify (specify how), or rethink
+
+Project context: You have access to the full codebase via your context file.
+Ground your analysis in the actual codebase, not hypotheticals.
+```
+
+## Debugging
+
+```
+You are a debugging specialist. Help diagnose this issue:
+
+Symptoms:
+---
+{error messages, unexpected behavior, reproduction steps}
+---
+
+What's been tried:
+---
+{attempts so far}
+---
+
+Provide:
+1. **Root cause hypothesis**: Most likely cause with reasoning
+2. **Evidence to gather**: What logs/state would confirm or refute
+3. **Fix proposal**: Specific code changes with rationale
+4. **Prevention**: How to prevent recurrence
+
+Project context: You have access to the full codebase via your context file.
+Reference specific files and functions.
+```
+
+## General Advisory
+
+```
+You are a senior engineering advisor. Consider this question:
+
+---
+{question or topic}
+---
+
+Provide:
+1. **Analysis**: Key considerations and trade-offs
+2. **Recommendation**: Your advised approach with reasoning
+3. **Caveats**: Risks, assumptions, or areas needing more info
+
+Project context: You have access to the full codebase via your context file.
+Be concise and actionable.
+```

--- a/skills/the-council/scripts/council_invoke.sh
+++ b/skills/the-council/scripts/council_invoke.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# council_invoke.sh — Invoke Codex and Gemini in parallel, capture responses
+#
+# Usage: council_invoke.sh [--codex-only|--gemini-only] <prompt_file> [working_directory]
+#   --codex-only:      Only invoke Codex (skip Gemini)
+#   --gemini-only:     Only invoke Gemini (skip Codex)
+#   prompt_file:       Path to a text file containing the advisory prompt
+#   working_directory: defaults to current directory
+#
+# Outputs: Paths to response files (one per line, last lines of stdout)
+#   Full mode:   codex response path, then gemini response path
+#   Single mode: only the active advisor's response path
+#
+# Environment:
+#   CODEX_MODEL    — Override Codex model (default: gpt-5.3-codex)
+#   GEMINI_MODEL   — Override Gemini model (default: gemini-3-pro-preview)
+#   COUNCIL_TIMEOUT — Max seconds to wait per advisor (default: 300)
+
+set -euo pipefail
+
+# --- Parse flags ---
+RUN_CODEX=true
+RUN_GEMINI=true
+
+while [[ "${1:-}" == --* ]]; do
+  case "$1" in
+    --codex-only)
+      RUN_GEMINI=false
+      shift
+      ;;
+    --gemini-only)
+      RUN_CODEX=false
+      shift
+      ;;
+    *)
+      echo "ERROR: Unknown flag: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# --- Resolve timeout command (macOS compatibility) ---
+if command -v gtimeout &>/dev/null; then
+  TIMEOUT_CMD="gtimeout"
+elif command -v timeout &>/dev/null; then
+  TIMEOUT_CMD="timeout"
+else
+  # Fallback: no timeout enforcement
+  TIMEOUT_CMD=""
+fi
+
+# --- Load nvm/node environment if needed (CLIs installed via npm) ---
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+if [[ -s "$NVM_DIR/nvm.sh" ]]; then
+  source "$NVM_DIR/nvm.sh" --no-use 2>/dev/null
+  # Ensure the default node version's bin is in PATH
+  NODE_BIN="$(nvm which default 2>/dev/null | xargs dirname 2>/dev/null)" || true
+  if [[ -n "$NODE_BIN" && -d "$NODE_BIN" ]]; then
+    export PATH="$NODE_BIN:$PATH"
+  fi
+fi
+
+PROMPT_FILE="${1:?Usage: council_invoke.sh [--codex-only|--gemini-only] <prompt_file> [working_directory]}"
+WORK_DIR="${2:-.}"
+WORK_DIR="$(cd "$WORK_DIR" && pwd)"
+
+CODEX_MODEL="${CODEX_MODEL:-gpt-5.3-codex}"
+GEMINI_MODEL="${GEMINI_MODEL:-gemini-3-pro-preview}"
+TIMEOUT_SECS="${COUNCIL_TIMEOUT:-300}"
+
+if [[ ! -f "$PROMPT_FILE" ]]; then
+  echo "ERROR: Prompt file not found: $PROMPT_FILE" >&2
+  exit 1
+fi
+
+# Verify required CLIs are available
+if [[ "$RUN_CODEX" == "true" ]] && ! command -v codex &>/dev/null; then
+  echo "ERROR: 'codex' not found in PATH. Install it or check your shell environment." >&2
+  exit 1
+fi
+if [[ "$RUN_GEMINI" == "true" ]] && ! command -v gemini &>/dev/null; then
+  echo "ERROR: 'gemini' not found in PATH. Install it or check your shell environment." >&2
+  exit 1
+fi
+
+PROMPT="$(cat "$PROMPT_FILE")"
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+TMPDIR_COUNCIL="${TMPDIR:-/tmp}/council_${TIMESTAMP}"
+mkdir -p "$TMPDIR_COUNCIL"
+
+CODEX_OUT="$TMPDIR_COUNCIL/codex_response.md"
+GEMINI_OUT="$TMPDIR_COUNCIL/gemini_response.md"
+CODEX_ERR="$TMPDIR_COUNCIL/codex_error.log"
+GEMINI_ERR="$TMPDIR_COUNCIL/gemini_error.log"
+
+# Determine mode label
+if [[ "$RUN_CODEX" == "true" && "$RUN_GEMINI" == "true" ]]; then
+  MODE="Full Council"
+elif [[ "$RUN_CODEX" == "true" ]]; then
+  MODE="Codex-only"
+else
+  MODE="Gemini-only"
+fi
+
+echo "Invoking The Council ($MODE)..."
+[[ "$RUN_CODEX" == "true" ]] && echo "  Codex model:  $CODEX_MODEL"
+[[ "$RUN_GEMINI" == "true" ]] && echo "  Gemini model: $GEMINI_MODEL"
+echo "  Working dir:  $WORK_DIR"
+echo "  Timeout:      ${TIMEOUT_SECS}s (${TIMEOUT_CMD:-none})"
+echo ""
+
+# Helper: run a command with optional timeout
+run_with_timeout() {
+  if [[ -n "$TIMEOUT_CMD" ]]; then
+    "$TIMEOUT_CMD" "$TIMEOUT_SECS" "$@"
+  else
+    "$@"
+  fi
+}
+
+CODEX_PID=""
+GEMINI_PID=""
+
+# --- Invoke Codex (non-interactive, read-only sandbox) ---
+if [[ "$RUN_CODEX" == "true" ]]; then
+  (
+    cd "$WORK_DIR"
+    run_with_timeout codex exec \
+      -m "$CODEX_MODEL" \
+      --full-auto \
+      --sandbox read-only \
+      -o "$CODEX_OUT" \
+      "$PROMPT" \
+      2>"$CODEX_ERR" || {
+        echo "Codex invocation failed (exit $?). See $CODEX_ERR" >&2
+        echo "[Codex failed to respond. Check $CODEX_ERR for details.]" > "$CODEX_OUT"
+      }
+  ) &
+  CODEX_PID=$!
+fi
+
+# --- Invoke Gemini (non-interactive, plan/read-only mode) ---
+if [[ "$RUN_GEMINI" == "true" ]]; then
+  (
+    cd "$WORK_DIR"
+    run_with_timeout gemini \
+      -m "$GEMINI_MODEL" \
+      --approval-mode plan \
+      -p "$PROMPT" \
+      --output-format text \
+      > "$GEMINI_OUT" \
+      2>"$GEMINI_ERR" || {
+        echo "Gemini invocation failed (exit $?). See $GEMINI_ERR" >&2
+        echo "[Gemini failed to respond. Check $GEMINI_ERR for details.]" > "$GEMINI_OUT"
+      }
+  ) &
+  GEMINI_PID=$!
+fi
+
+# --- Wait for advisors ---
+CODEX_STATUS=0
+GEMINI_STATUS=0
+
+if [[ -n "$CODEX_PID" ]]; then
+  wait "$CODEX_PID" || CODEX_STATUS=$?
+fi
+if [[ -n "$GEMINI_PID" ]]; then
+  wait "$GEMINI_PID" || GEMINI_STATUS=$?
+fi
+
+echo ""
+echo "Council responses ready:"
+if [[ "$RUN_CODEX" == "true" ]]; then
+  echo "  Codex:  $CODEX_OUT $([ $CODEX_STATUS -eq 0 ] && echo '(success)' || echo '(failed)')"
+fi
+if [[ "$RUN_GEMINI" == "true" ]]; then
+  echo "  Gemini: $GEMINI_OUT $([ $GEMINI_STATUS -eq 0 ] && echo '(success)' || echo '(failed)')"
+fi
+echo ""
+
+# Output the paths for the caller to read
+if [[ "$RUN_CODEX" == "true" ]]; then
+  echo "$CODEX_OUT"
+fi
+if [[ "$RUN_GEMINI" == "true" ]]; then
+  echo "$GEMINI_OUT"
+fi

--- a/skills/the-council/scripts/council_preflight.sh
+++ b/skills/the-council/scripts/council_preflight.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# council_preflight.sh — Check CLI availability and authentication
+# Exit codes: 0 = at least one advisor available, 1 = none available
+# Outputs key=value status lines to stdout
+# Caches result in /tmp/council_preflight_<uid> for session reuse
+
+set -euo pipefail
+
+CACHE_FILE="/tmp/council_preflight_$(id -u)"
+
+# Return cached result if fresh (less than 2 hours old)
+if [[ -f "$CACHE_FILE" ]]; then
+  FILE_AGE=$(( $(date +%s) - $(stat -f %m "$CACHE_FILE" 2>/dev/null || stat -c %Y "$CACHE_FILE" 2>/dev/null) ))
+  if (( FILE_AGE < 7200 )); then
+    cat "$CACHE_FILE"
+    exit 0
+  fi
+fi
+
+# Load nvm/node environment if needed
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+if [[ -s "$NVM_DIR/nvm.sh" ]]; then
+  source "$NVM_DIR/nvm.sh" --no-use 2>/dev/null
+  NODE_BIN="$(nvm which default 2>/dev/null | xargs dirname 2>/dev/null)" || true
+  if [[ -n "$NODE_BIN" && -d "$NODE_BIN" ]]; then
+    export PATH="$NODE_BIN:$PATH"
+  fi
+fi
+
+CODEX_INSTALLED=false
+CODEX_AUTHENTICATED=false
+GEMINI_INSTALLED=false
+GEMINI_AUTHENTICATED=false
+
+# --- Check Codex CLI ---
+if command -v codex &>/dev/null; then
+  CODEX_INSTALLED=true
+  # Check for OpenAI API key in env or config
+  if [[ -n "${OPENAI_API_KEY:-}" ]] || [[ -f "$HOME/.codex/config.toml" ]]; then
+    CODEX_AUTHENTICATED=true
+  fi
+fi
+
+# --- Check Gemini CLI ---
+if command -v gemini &>/dev/null; then
+  GEMINI_INSTALLED=true
+  # Check for Google credentials (OAuth or API key)
+  if [[ -n "${GEMINI_API_KEY:-}" ]] || [[ -n "${GOOGLE_API_KEY:-}" ]] \
+     || [[ -d "$HOME/.gemini" && -f "$HOME/.gemini/settings.json" ]]; then
+    GEMINI_AUTHENTICATED=true
+  fi
+fi
+
+# Build result
+RESULT="CODEX_INSTALLED=$CODEX_INSTALLED
+CODEX_AUTHENTICATED=$CODEX_AUTHENTICATED
+GEMINI_INSTALLED=$GEMINI_INSTALLED
+GEMINI_AUTHENTICATED=$GEMINI_AUTHENTICATED"
+
+# Cache and output
+echo "$RESULT" > "$CACHE_FILE"
+echo "$RESULT"
+
+# At least one advisor must be ready
+if [[ "$CODEX_AUTHENTICATED" == "true" || "$GEMINI_AUTHENTICATED" == "true" ]]; then
+  exit 0
+else
+  exit 1
+fi

--- a/skills/the-council/scripts/council_sync.sh
+++ b/skills/the-council/scripts/council_sync.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# council_sync.sh — Sync project context to Codex (AGENTS.md) and Gemini (GEMINI.md)
+#
+# Usage: council_sync.sh [working_directory]
+#   working_directory: defaults to current directory
+
+set -euo pipefail
+
+WORK_DIR="${1:-.}"
+WORK_DIR="$(cd "$WORK_DIR" && pwd)"
+
+CLAUDE_MD="$WORK_DIR/CLAUDE.md"
+AGENTS_MD="$WORK_DIR/AGENTS.md"
+GEMINI_MD="$WORK_DIR/GEMINI.md"
+
+if [[ ! -f "$CLAUDE_MD" ]]; then
+  echo "ERROR: No CLAUDE.md found in $WORK_DIR" >&2
+  exit 1
+fi
+
+CLAUDE_CONTENT="$(cat "$CLAUDE_MD")"
+
+# --- Write AGENTS.md for Codex ---
+cat > "$AGENTS_MD" << 'PREAMBLE'
+# Advisory Context (synced from CLAUDE.md)
+
+You are being consulted as an external advisor on this project.
+Review the project context below and provide your expert analysis when prompted.
+Focus on correctness, potential issues, and alternative approaches.
+
+---
+
+PREAMBLE
+echo "$CLAUDE_CONTENT" >> "$AGENTS_MD"
+
+# --- Write GEMINI.md for Gemini ---
+cat > "$GEMINI_MD" << 'PREAMBLE'
+# Advisory Context (synced from CLAUDE.md)
+
+You are being consulted as an external advisor on this project.
+Review the project context below and provide your expert analysis when prompted.
+Focus on correctness, potential issues, and alternative approaches.
+
+---
+
+PREAMBLE
+echo "$CLAUDE_CONTENT" >> "$GEMINI_MD"
+
+echo "Synced context to:"
+echo "  - $AGENTS_MD ($(wc -l < "$AGENTS_MD") lines)"
+echo "  - $GEMINI_MD ($(wc -l < "$GEMINI_MD") lines)"


### PR DESCRIPTION
## Summary

Adds **the-council** — a community-contributed skill that invokes OpenAI Codex CLI and Google Gemini CLI in parallel as an advisory board. Claude synthesizes their independent analyses into a unified recommendation.

**Use cases:** Code reviews, architecture evaluation, debugging, and general engineering decisions.

**Key features:**
- Parallel CLI invocation with read-only sandboxes (Codex `--sandbox read-only`, Gemini `--approval-mode plan`)
- Startup preflight check with graceful single-advisor degradation
- Prompt templates for code review, architecture, debugging, and general advisory
- Session-cached CLI detection

**Repo:** https://github.com/DantesPeak85/the-council

## Files added
- `skills/the-council/SKILL.md` — Main skill definition
- `skills/the-council/references/prompt-templates.md` — Advisory prompt templates
- `skills/the-council/scripts/council_invoke.sh` — Parallel CLI invocation
- `skills/the-council/scripts/council_preflight.sh` — CLI availability check
- `skills/the-council/scripts/council_sync.sh` — Project context sync