### PR TITLE
Add jolt-atlas zkML skill

### DIFF
--- a/skills/jolt-atlas/SKILL.md
+++ b/skills/jolt-atlas/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: jolt-atlas
+description: Zero-knowledge machine learning (zkML) framework for generating cryptographic proofs of ML inference from ONNX models. Activate when the user mentions zkML, zero-knowledge machine learning, jolt-atlas, SNARK proofs for ML, ONNX model verification, proof generation for neural networks, or the JOLT proving system.
+homepage: https://github.com/ICME-Lab/jolt-atlas
+user-invocable: true
+metadata: {"zkml":{"framework":"jolt-atlas","proving_system":"JOLT","curve":"BN254","commitment":"HyperKZG"}}
+---
+
+# Jolt Atlas — Zero-Knowledge Machine Learning
+
+Jolt Atlas is a zkML framework that generates cryptographic proofs of ML inference correctness from ONNX models. It extends the [JOLT](https://github.com/a16z/jolt) proving system (a16z Crypto) and replaces expensive circuit-based approaches with **lookup tables** — no quotient polynomials, no byte decomposition, no grand products, no permutation checks, no complicated circuits. Core principle: reduce commitment costs via sumcheck while committing only to small-value polynomials.
+
+**Repository:** <https://github.com/ICME-Lab/jolt-atlas>
+**Authors:** ICME Labs (Wyatt Benno, Khalil Gibran Hassam, Alberto Centelles Hidalgo, Antoine Douchet)
+
+## Prerequisites
+
+1. **Rust toolchain** (nightly recommended):
+   ```bash
+   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+   rustup default nightly
+   ```
+2. **Clone the repository:**
+   ```bash
+   git clone https://github.com/ICME-Lab/jolt-atlas.git
+   cd jolt-atlas
+   ```
+3. **Build:**
+   ```bash
+   cargo build --release
+   ```
+
+## Core Workflow
+
+Every zkML proof follows a four-step pipeline:
+
+1. **Load ONNX model** — `onnx_tracer::model(&path)` or a builder function
+2. **Create input tensor** — `Tensor::new(Some(&data), &shape)`
+3. **Preprocess + prove** — `JoltSNARK::prover_preprocess(model_fn, mem_size)` then `JoltSNARK::prove(&preprocessing, model_fn, &input)`
+4. **Verify** — `snark.verify(&verifier_preprocessing, program_io, None)`
+
+## Quick-Reference Code Pattern
+
+```rust
+use ark_bn254::Fr;
+use jolt_core::{poly::commitment::dory::DoryCommitmentScheme, transcripts::KeccakTranscript};
+use onnx_tracer::{model, tensor::Tensor};
+use std::path::PathBuf;
+use zkml_jolt_core::jolt::JoltSNARK;
+
+type PCS = DoryCommitmentScheme;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let model_fn = || model(&PathBuf::from("onnx-tracer/models/perceptron/network.onnx"));
+    let input = Tensor::new(Some(&vec![1, 2, 3, 4]), &[1, 4])?;
+
+    // Preprocess (one-time)
+    let preprocessing = JoltSNARK::<Fr, PCS, KeccakTranscript>::prover_preprocess(
+        model_fn, 1 << 14,
+    );
+
+    // Prove
+    let (snark, program_io, _dbg) = JoltSNARK::<Fr, PCS, KeccakTranscript>::prove(
+        &preprocessing, model_fn, &input,
+    );
+
+    // Verify
+    snark.verify(&(&preprocessing).into(), program_io, None)?;
+    println!("Proof verified!");
+    Ok(())
+}
+```
+
+See [templates/zkml_example.rs](templates/zkml_example.rs) for a fully commented version with config section and preprocessing helpers.
+
+## Workspace Crates
+
+| Crate | Path | Purpose |
+|---|---|---|
+| `jolt-atlas` | `/` (root) | Workspace root, top-level examples |
+| `jolt-atlas-core` | `jolt-atlas-core/` | Main proving/verification engine, examples (nanoGPT, GPT-2, transformer) |
+| `onnx-tracer` | `onnx-tracer/` | ONNX model loading, graph tracing, tensor ops |
+| `atlas-onnx-tracer` | `atlas-onnx-tracer/` | Extended ONNX tracing utilities |
+| `zkml-jolt-core` | `zkml-jolt-core/` | Core zkML SNARK logic, benchmarks, profiling CLI |
+| `joltworks` | `joltworks/` | Polynomial commitment scheme support |
+| `common` | `common/` | Shared utilities |
+
+## Available Examples
+
+### Root workspace examples (`examples/`)
+
+```bash
+cargo run --release --example article_classification
+cargo run --release --example authorization
+cargo run --release --example proof_round_trip
+```
+
+### jolt-atlas-core examples (`jolt-atlas-core/examples/`)
+
+```bash
+cargo run --release --package jolt-atlas-core --example nanoGPT
+cargo run --release --package jolt-atlas-core --example transformer
+cargo run --release --package jolt-atlas-core --example minigpt
+cargo run --release --package jolt-atlas-core --example microgpt
+cargo run --release --package jolt-atlas-core --example gpt2
+```
+
+> **GPT-2 note:** The model is not checked into the repo. Run `python scripts/download_gpt2.py` first to download and export via Hugging Face Optimum.
+
+## Pre-Trained Models
+
+Models live in `onnx-tracer/models/`:
+
+| Model | Use Case |
+|---|---|
+| `perceptron` | Simple MLP baseline |
+| `article_classification` | Text categorization (5 classes) |
+| `authorization` | Transaction approval decisions |
+| `self_attention` | Transformer attention layer |
+| `nanoGPT` | ~0.25M-param GPT (4 transformer layers) |
+| `sentiment0`, `sentiment1` | Sentiment analysis |
+| `bge-m3` | Embedding model |
+| `ffn_gelu`, `ffn_tanh` | Feed-forward networks with different activations |
+| `layernorm_*` | Layer normalization variants |
+
+GPT-2 (125M params) is downloaded separately via `scripts/download_gpt2.py` into `atlas-onnx-tracer/models/gpt2/`.
+
+## Memory Size Tuning
+
+The `max_trace_length` parameter passed to `prover_preprocess` must be a power of 2. Larger values support bigger models but use more RAM:
+
+| Value | Hex | Typical Use | Approx. RAM |
+|---|---|---|---|
+| `1 << 12` | 4,096 | Tiny models, round-trip tests | < 1 GB |
+| `1 << 14` | 16,384 | Perceptron, small MLPs | ~1 GB |
+| `1 << 16` | 65,536 | Article classification | ~2 GB |
+| `1 << 18` | 262,144 | Mid-size models | ~3 GB |
+| `1 << 20` | 1,048,576 | Self-attention, transformers | ~5 GB |
+| `1 << 21` | 2,097,152 | Large transformers, nanoGPT | ~8 GB |
+| `1 << 22`+ | 4,194,304+ | GPT-2 scale | 16+ GB |
+
+If you see memory errors or the prover panics, double the value to the next power of 2.
+
+## Performance Benchmarks
+
+Measured on MacBook Pro M3, 16 GB RAM:
+
+### nanoGPT (~0.25M params)
+
+| Stage | JOLT Atlas | ezkl (comparison) |
+|---|---|---|
+| Key generation | 0.246 s | ~404 s combined |
+| Proof time | **~14 s** | ~237 s |
+| Verify time | 0.517 s | 0.34 s |
+
+**~17× speed-up** on proof generation versus ezkl.
+
+### GPT-2 (125M params)
+
+| Stage | Wall Clock |
+|---|---|
+| Key generation | 0.872 s |
+| Witness generation | ~7.5 s |
+| Commitment time | ~3.5 s |
+| Sumcheck proving | ~16 s |
+| Reduction opening proof | ~7 s |
+| HyperKZG prove | ~3 s |
+| **End-to-end total** | **~38 s** |
+
+### Other workloads (zkml-jolt-core profiler)
+
+| Workload | Prove Time | Verify Time | Peak Memory |
+|---|---|---|---|
+| Transformer self-attention | ~20.8 s | ~143 ms | ~5.6 GB |
+| Article classification | ~0.7 s | — | — |
+| Perceptron MLP | ~800 ms | — | — |
+
+## Profiling
+
+Run from the `zkml-jolt-core/` directory:
+
+```bash
+# Terminal output
+cargo run -r -- profile --name mlp --format default
+cargo run -r -- profile --name article-classification --format default
+cargo run -r -- profile --name self-attention --format default
+
+# Chrome tracing (open chrome://tracing, load the generated JSON)
+cargo run -r -- profile --name self-attention --format chrome
+```
+
+For jolt-atlas-core examples, append `-- --trace` or `-- --trace-terminal`:
+
+```bash
+cargo run --release --package jolt-atlas-core --example nanoGPT -- --trace
+cargo run --release --package jolt-atlas-core --example nanoGPT -- --trace-terminal
+```
+
+## Key Concepts
+
+- **BN254** — Elliptic curve used as the scalar field (`ark_bn254::Fr`).
+- **HyperKZG** — Polynomial commitment scheme used by jolt-atlas-core for GPT-scale proofs. The older `DoryCommitmentScheme` is used in zkml-jolt-core examples.
+- **Keccak transcript** — Fiat-Shamir transcript implementation for non-interactivity.
+- **Sumcheck protocol** — Core proof mechanism; avoids circuit representation entirely.
+- **Lookup tables (JOLT)** — Non-linear activations (ReLU, Softmax) resolved via lookup instead of arithmetic circuits.
+- **Neural teleportation** — Model transformation that folds batch-norm layers into adjacent linear layers, reducing proof complexity. See [references/onnx-operations.md](references/onnx-operations.md).
+- **Fixed-point arithmetic** — All tensor values are `i32`; floating-point weights are quantized during ONNX tracing with configurable scale factors.
+
+## Supported Instructions
+
+Add, Sub, Mul, MatMul, Einsum, Relu, Sigmoid, Erf, Gelu, Tanh, Softmax, LayerNorm, Conv, MaxPool, AveragePool, Flatten, Reshape, Transpose, Concat, Split, Gather, Unsqueeze, Squeeze, Expand, Slice, Pad, Cast, BatchNorm, Dropout (identity at inference), Constant, ConstantOfShape, Where, Shape, Pow, Sqrt, Reciprocal, Log, Exp, Clip, ReduceMean.
+
+See [references/onnx-operations.md](references/onnx-operations.md) for detailed descriptions and limitations.
+
+## Reference Files
+
+- [references/architecture.md](references/architecture.md) — Crate architecture, key types, dependency graph, proving pipeline
+- [references/onnx-operations.md](references/onnx-operations.md) — Supported ops, teleportation, fixed-point details
+- [references/troubleshooting.md](references/troubleshooting.md) — Common errors, memory tuning, debugging
+
+## Templates
+
+- [templates/zkml_example.rs](templates/zkml_example.rs) — Full proof generation template with config section and helpers
+- [templates/proof_round_trip.rs](templates/proof_round_trip.rs) — Proof serialization and re-verification round-trip

--- a/skills/jolt-atlas/references/architecture.md
+++ b/skills/jolt-atlas/references/architecture.md
@@ -1,0 +1,244 @@
+# Jolt Atlas Architecture
+
+This document describes the crate structure, key types, dependency graph, and proving pipeline of jolt-atlas.
+
+## Crate Dependency Graph
+
+```
+jolt-atlas (workspace root)
+├── jolt-atlas-core          # Main proving engine, GPT-scale examples
+│   ├── atlas-onnx-tracer    # Extended ONNX tracing for atlas-core
+│   ├── joltworks            # Polynomial commitment schemes (HyperKZG)
+│   └── common               # Shared utilities
+├── zkml-jolt-core           # Original zkML SNARK logic (Dory PCS)
+│   └── onnx-tracer          # ONNX model loading, tensor ops, graph tracing
+└── onnx-tracer              # Also used directly by root examples
+```
+
+### External dependencies
+
+| Dependency | Source | Purpose |
+|---|---|---|
+| `jolt-core` | [a16z/jolt](https://github.com/a16z/jolt) | Base JOLT proving system, commitment schemes, transcripts |
+| `ark-bn254` | [arkworks](https://github.com/arkworks-rs) | BN254 elliptic curve field elements (`Fr`) |
+| `ark-serialize` | arkworks | Canonical serialization/deserialization for proofs |
+| `ark-ff` | arkworks | Finite field traits and arithmetic |
+
+## Workspace Crates in Detail
+
+### `jolt-atlas` (root)
+
+The workspace root. Contains top-level examples (`article_classification`, `authorization`, `proof_round_trip`) that use `zkml-jolt-core` and `onnx-tracer` with the Dory commitment scheme. These are the simplest entry points for small models.
+
+### `jolt-atlas-core`
+
+The main proving/verification engine for larger models. Uses HyperKZG commitment scheme instead of Dory. Contains examples for nanoGPT, GPT-2, transformer, minigpt, and microgpt. This is the crate to use for production-scale proofs.
+
+Key modules:
+- `src/` — Proving and verification logic
+- `examples/` — End-to-end prove/verify examples for GPT-scale models
+
+### `onnx-tracer`
+
+Handles ONNX model loading, graph tracing, and tensor operations. Core types:
+
+- `Model` — Loaded ONNX computational graph
+- `Tensor<i32>` — Fixed-point integer tensor (all values are `i32`)
+- `ProgramIO` — Input/output witness for the SNARK (serializable via serde)
+- `RunArgs` — Configuration for model execution (scale factors, etc.)
+- `builder` module — Pre-built model loader functions (e.g., `builder::simple_mlp_small_model`)
+
+Loading a model:
+```rust
+use onnx_tracer::model;
+use std::path::PathBuf;
+
+let model_instance = model(&PathBuf::from("onnx-tracer/models/perceptron/network.onnx"));
+let result = model_instance.forward(&[input_tensor])?;
+let output = &result.outputs[0];
+```
+
+### `atlas-onnx-tracer`
+
+Extended tracing utilities used by `jolt-atlas-core`. Provides model loading for larger architectures (GPT-2, nanoGPT) with additional graph optimization passes.
+
+### `zkml-jolt-core`
+
+Core zkML SNARK implementation. Contains:
+
+- `jolt` module — `JoltSNARK` type and proving/verification functions
+- `benches` module — Benchmark definitions (`BenchType` enum)
+- `main.rs` — CLI for profiling (`--name`, `--format`)
+
+### `joltworks`
+
+Polynomial commitment scheme implementations and supporting cryptographic operations. Provides the bridge between the JOLT proving system and arkworks.
+
+### `common`
+
+Shared utility types and helper functions used across crates.
+
+## Key Types
+
+### `JoltSNARK<F, PCS, FS>`
+
+The central proving/verification type. Generic over:
+
+- `F` — Scalar field (always `ark_bn254::Fr` in practice)
+- `PCS` — Polynomial commitment scheme (`DoryCommitmentScheme` for small models, HyperKZG for large)
+- `FS` — Fiat-Shamir transcript (`KeccakTranscript`)
+
+Static methods:
+
+| Method | Signature (simplified) | Description |
+|---|---|---|
+| `prover_preprocess` | `(model_fn, max_trace_length) -> JoltProverPreprocessing` | One-time setup: generates proving/verifying keys |
+| `prove` | `(&preprocessing, model_fn, &input) -> (Self, ProgramIO, DebugInfo)` | Generate SNARK proof for a given input |
+| `verify` | `(self, &verifier_preprocessing, program_io, debug) -> Result<()>` | Verify the proof |
+
+### `JoltProverPreprocessing<F, PCS>`
+
+Output of `prover_preprocess`. Contains the structured reference string (SRS), proving key, and verifying key. Expensive to compute but reusable across multiple proofs for the same model.
+
+Convertible to `JoltVerifierPreprocessing` via `Into`:
+```rust
+let verifier_preprocessing: JoltVerifierPreprocessing<Fr, PCS> = (&preprocessing).into();
+```
+
+### `JoltVerifierPreprocessing<F, PCS>`
+
+Subset of preprocessing data needed only for verification. Smaller than the full prover preprocessing. This is what a verifier needs.
+
+### `ProgramIO`
+
+The public input/output witness. Serializable via serde (`serde_json::to_string`). Contains the model inputs and outputs that are committed to in the proof.
+
+### `Model`
+
+An ONNX computational graph loaded into memory. Created via `onnx_tracer::model(&path)` or builder functions. Supports:
+
+- `forward(&[Tensor]) -> Result<RunResult>` — Execute inference
+- Graph inspection and tracing
+
+### `Tensor<i32>`
+
+Fixed-point integer tensor. Created via:
+```rust
+let tensor = Tensor::new(Some(&data), &[dim1, dim2, ...])?;
+```
+
+Supports standard tensor operations, iteration, cloning, and shape queries.
+
+## Proving Pipeline (Detailed)
+
+### Step 1: Model Loading
+
+```rust
+let model_fn = || model(&PathBuf::from("path/to/model.onnx"));
+```
+
+The model function is a closure that returns a fresh `Model` instance. It is called multiple times during proving (once for tracing, once for proof generation), so it must be repeatable.
+
+### Step 2: Preprocessing (Key Generation)
+
+```rust
+let preprocessing = JoltSNARK::<Fr, PCS, KeccakTranscript>::prover_preprocess(
+    model_fn,
+    max_trace_length,  // power of 2
+);
+```
+
+This step:
+1. Traces the model to determine the computation graph structure
+2. Generates the structured reference string (SRS)
+3. Computes the proving key and verifying key
+4. Returns `JoltProverPreprocessing` containing all material
+
+The `max_trace_length` parameter controls how much memory the prover allocates. Must be a power of 2 and large enough to hold the full execution trace.
+
+### Step 3: Proof Generation
+
+```rust
+let (snark, program_io, debug_info) = JoltSNARK::<Fr, PCS, KeccakTranscript>::prove(
+    &preprocessing,
+    model_fn,
+    &input,
+);
+```
+
+This step:
+1. Re-executes the model on the input to generate the witness
+2. Commits to the witness polynomials
+3. Runs the sumcheck protocol
+4. Produces the SNARK proof and the public `ProgramIO`
+
+### Step 4: Verification
+
+```rust
+snark.verify(&verifier_preprocessing, program_io, None)?;
+```
+
+The verifier checks:
+1. All sumcheck rounds are consistent
+2. Polynomial commitments open correctly
+3. The claimed input/output matches the committed values
+
+Verification is significantly faster than proving (~100 ms vs seconds/minutes).
+
+## Proof Serialization
+
+Proofs can be serialized for storage or transmission using arkworks' `CanonicalSerialize`:
+
+```rust
+use ark_serialize::{CanonicalSerialize, CanonicalDeserialize};
+
+// Serialize
+let mut buffer = Vec::new();
+snark.serialize_compressed(&mut buffer)?;
+
+// Deserialize
+let deserialized = JoltSNARK::<Fr, PCS, KeccakTranscript>::deserialize_compressed(&buffer[..])?;
+```
+
+`ProgramIO` is serialized via serde/JSON:
+
+```rust
+let json = serde_json::to_string(&program_io)?;
+let deserialized: ProgramIO = serde_json::from_str(&json)?;
+```
+
+See [../templates/proof_round_trip.rs](../templates/proof_round_trip.rs) for a complete working example.
+
+## DAG-Based Proof Structure
+
+The computation is represented as a directed acyclic graph (DAG) where:
+- Nodes represent operations (Add, MatMul, ReLU, etc.)
+- Edges represent tensor data flow
+- The graph is topologically sorted for execution
+- Each node's execution trace is committed to independently
+- The sumcheck protocol ties all commitments together
+
+This DAG structure enables:
+- Parallelism in witness generation
+- Incremental verification of sub-computations
+- Natural mapping from ONNX graph structure
+
+## Commitment Schemes
+
+### DoryCommitmentScheme
+
+Used in `zkml-jolt-core` and root workspace examples. Transparent (no trusted setup), based on the Dory polynomial commitment scheme. Good for smaller models and development.
+
+### HyperKZG
+
+Used in `jolt-atlas-core` for production-scale proofs (nanoGPT, GPT-2). Based on KZG commitments with hyperplonk-style multilinear extensions. Requires a structured reference string but is more efficient for large computations.
+
+Both schemes implement the same trait interface, so switching between them requires only changing the type alias:
+
+```rust
+// For small models (zkml-jolt-core style)
+type PCS = DoryCommitmentScheme;
+
+// For large models (jolt-atlas-core style)
+// type PCS = HyperKZGScheme;  // actual type depends on jolt-atlas-core imports
+```

--- a/skills/jolt-atlas/references/onnx-operations.md
+++ b/skills/jolt-atlas/references/onnx-operations.md
@@ -1,0 +1,206 @@
+# ONNX Operations & Model Format
+
+This document covers the supported ONNX operations in jolt-atlas, the fixed-point representation, neural teleportation, and model format requirements.
+
+## Supported Instructions
+
+The following ONNX operations are supported in jolt-atlas. Each is implemented as a lookup-table-based instruction in the JOLT proving system, avoiding circuit representation entirely.
+
+### Arithmetic Operations
+
+| Operation | Description | Notes |
+|---|---|---|
+| `Add` | Element-wise addition | Supports broadcasting |
+| `Sub` | Element-wise subtraction | Supports broadcasting |
+| `Mul` | Element-wise multiplication | Fixed-point scaling applied |
+| `MatMul` | Matrix multiplication | Core operation for linear layers |
+| `Einsum` | Einstein summation | Generalized tensor contraction |
+| `Pow` | Element-wise power | Integer exponents |
+| `Sqrt` | Element-wise square root | Via lookup table |
+| `Reciprocal` | Element-wise 1/x | Via lookup table |
+| `Log` | Element-wise natural logarithm | Via lookup table |
+| `Exp` | Element-wise exponential | Via lookup table |
+
+### Activation Functions
+
+| Operation | Description | Notes |
+|---|---|---|
+| `Relu` | Rectified linear unit: max(0, x) | Most common activation |
+| `Sigmoid` | Logistic function: 1/(1+e^(-x)) | Via lookup table |
+| `Erf` | Gaussian error function | Used in GELU implementation |
+| `Gelu` | Gaussian Error Linear Unit | Via Erf lookup |
+| `Tanh` | Hyperbolic tangent | Via lookup table |
+| `Softmax` | Normalized exponential | Applied along specified axis |
+| `Clip` | Clamp values to [min, max] range | Used for ReLU6, etc. |
+
+### Normalization
+
+| Operation | Description | Notes |
+|---|---|---|
+| `LayerNorm` | Layer normalization | Transformer standard |
+| `BatchNorm` | Batch normalization | Folded via teleportation when possible |
+| `ReduceMean` | Mean reduction along axes | Used in normalization implementations |
+
+### Pooling & Convolution
+
+| Operation | Description | Notes |
+|---|---|---|
+| `Conv` | N-dimensional convolution | 1D and 2D supported |
+| `MaxPool` | Max pooling | Sliding window max |
+| `AveragePool` | Average pooling | Sliding window mean |
+
+### Shape & Tensor Manipulation
+
+| Operation | Description | Notes |
+|---|---|---|
+| `Flatten` | Collapse dimensions | To 1D or specified axis |
+| `Reshape` | Change tensor shape | Total elements must match |
+| `Transpose` | Permute dimensions | Arbitrary axis ordering |
+| `Concat` | Concatenate tensors along axis | All tensors must match on other dims |
+| `Split` | Split tensor into chunks | Along specified axis |
+| `Gather` | Index-based selection | Along specified axis |
+| `Unsqueeze` | Insert dimension of size 1 | At specified axes |
+| `Squeeze` | Remove dimensions of size 1 | At specified axes |
+| `Expand` | Broadcast to larger shape | Following numpy rules |
+| `Slice` | Extract sub-tensor | With start, end, step |
+| `Pad` | Pad tensor with values | Constant padding |
+| `Cast` | Type conversion | Between supported types |
+| `Shape` | Return tensor shape | As 1D integer tensor |
+
+### Structural / Utility
+
+| Operation | Description | Notes |
+|---|---|---|
+| `Constant` | Embed constant value | Stored in graph |
+| `ConstantOfShape` | Create tensor filled with value | Given shape and fill value |
+| `Where` | Conditional selection | Element-wise ternary |
+| `Dropout` | Identity at inference | No-op (training only) |
+
+## Fixed-Point Representation
+
+All tensor values in jolt-atlas are represented as `i32` integers. Floating-point model weights and activations are quantized during ONNX tracing using configurable scale factors.
+
+### How it works
+
+1. **Weight quantization:** When the ONNX model is loaded, floating-point weights are multiplied by a scale factor and rounded to integers.
+2. **Input quantization:** User inputs must be provided as `Vec<i32>`. If your data is floating-point, multiply by the scale factor before passing.
+3. **Intermediate values:** All intermediate computations maintain fixed-point representation. Multiplication results are rescaled to prevent overflow.
+4. **Output dequantization:** The output tensor contains integer values. Divide by the appropriate scale factor to recover approximate floating-point values.
+
+### Scale factors and RunArgs
+
+The `RunArgs` configuration controls quantization behavior:
+
+```rust
+// Scale factor determines precision
+// Higher scale = more precision but larger values = bigger trace
+// Default scale is typically 2^12 = 4096
+
+// Example: converting float input to fixed-point
+let float_input: Vec<f32> = vec![0.5, -1.2, 3.7, 0.0];
+let scale = 4096;
+let fixed_input: Vec<i32> = float_input.iter()
+    .map(|&x| (x * scale as f32).round() as i32)
+    .collect();
+```
+
+### Overflow considerations
+
+- `i32` range: -2,147,483,648 to 2,147,483,647
+- With scale factor 4096 (2^12), the effective float range is roughly ±524,287
+- Matrix multiplications accumulate sums, so large models with high scale factors risk overflow
+- If you see incorrect outputs, try reducing the scale factor
+- The `onnx-tracer` crate will panic on overflow in debug mode
+
+## Neural Teleportation
+
+Neural teleportation is a model transformation technique that folds batch normalization layers into adjacent linear (fully connected or convolutional) layers. This reduces the number of operations in the computational graph, leading to smaller and faster proofs.
+
+### What it does
+
+Given a sequence `Linear -> BatchNorm`, teleportation produces a single `Linear` layer with modified weights and biases that compute the same function:
+
+```
+Original:  y = BatchNorm(W*x + b)
+           y = gamma * ((W*x + b) - mean) / sqrt(var + eps) + beta
+
+Teleported: y = W'*x + b'
+            where W' = gamma * W / sqrt(var + eps)
+                  b' = gamma * (b - mean) / sqrt(var + eps) + beta
+```
+
+### When teleportation is applied
+
+- Automatically during ONNX model loading when the tracer detects `Linear -> BatchNorm` or `Conv -> BatchNorm` patterns
+- The original model file is not modified; teleportation happens in-memory
+- Only applies when the batch norm has fixed statistics (inference mode)
+
+### Impact on proofs
+
+- Fewer operations in the DAG = fewer sumcheck rounds
+- Reduced proof size
+- Faster proving and verification times
+- No change in model accuracy (mathematically equivalent transformation)
+
+## ONNX Model Format Requirements
+
+### Supported ONNX versions
+
+jolt-atlas supports ONNX opset versions commonly exported by PyTorch (opset 11+) and ONNX Runtime. The tracer handles standard operator sets.
+
+### Exporting from PyTorch
+
+```python
+import torch
+import torch.onnx
+
+model = YourModel()
+model.eval()
+
+dummy_input = torch.randn(1, input_features)
+
+torch.onnx.export(
+    model,
+    dummy_input,
+    "model.onnx",
+    opset_version=13,
+    input_names=["input"],
+    output_names=["output"],
+    dynamic_axes=None,  # Static shapes required
+)
+```
+
+### Requirements
+
+1. **Static shapes:** All tensor shapes must be known at export time. Dynamic axes are not supported.
+2. **Single input:** The model should accept a single input tensor. Multi-input models require adapter wrappers.
+3. **Supported operations only:** All operations in the graph must be in the supported instruction set above. Unsupported ops will cause a panic during tracing.
+4. **No custom operators:** Only standard ONNX operators are supported.
+5. **File naming:** Place the ONNX file as `network.onnx` inside a model directory (e.g., `onnx-tracer/models/my_model/network.onnx`).
+
+### Model directory structure
+
+```
+onnx-tracer/models/
+└── your_model/
+    ├── network.onnx          # The ONNX model file
+    └── (optional metadata)
+```
+
+## Known Limitations
+
+The following ONNX operations are **not yet supported**:
+
+- `LSTM`, `GRU`, `RNN` — Recurrent layers
+- `ConvTranspose` — Transposed (deconvolution) layers
+- `Resize`, `Upsample` — Spatial resizing operations
+- `NonMaxSuppression` — Object detection post-processing
+- `TopK` — K-largest element selection
+- `ScatterND`, `ScatterElements` — Scatter operations
+- `QuantizeLinear`, `DequantizeLinear` — ONNX-native quantization ops (jolt-atlas uses its own fixed-point scheme)
+- Custom domain operators
+
+If your model uses unsupported operations, you will need to either:
+1. Replace them with supported equivalents in the PyTorch model before exporting
+2. Use ONNX graph surgery tools (e.g., `onnx-graphsurgeon`) to rewrite the graph
+3. Open a feature request on the jolt-atlas repository

--- a/skills/jolt-atlas/references/troubleshooting.md
+++ b/skills/jolt-atlas/references/troubleshooting.md
@@ -1,0 +1,171 @@
+# Troubleshooting
+
+Common issues when working with jolt-atlas and how to resolve them.
+
+## Memory Errors During Proving
+
+**Symptom:** Panic with "index out of bounds" or "memory allocation failed" during `prover_preprocess` or `prove`.
+
+**Cause:** The `max_trace_length` parameter is too small for the model's computation trace.
+
+**Fix:** Double the value to the next power of 2:
+
+```rust
+// Too small — causes memory errors
+let preprocessing = JoltSNARK::<Fr, PCS, KeccakTranscript>::prover_preprocess(model_fn, 1 << 14);
+
+// Try the next power of 2
+let preprocessing = JoltSNARK::<Fr, PCS, KeccakTranscript>::prover_preprocess(model_fn, 1 << 16);
+```
+
+Size guide:
+
+| Model complexity | Start with | Max reasonable |
+|---|---|---|
+| Perceptron / tiny MLP | `1 << 12` | `1 << 14` |
+| Article classification | `1 << 14` | `1 << 18` |
+| Self-attention layer | `1 << 18` | `1 << 21` |
+| nanoGPT | `1 << 20` | `1 << 22` |
+| GPT-2 | `1 << 22` | `1 << 24` |
+
+Also ensure you have sufficient system RAM. Transformer-scale models need 6+ GB, GPT-2 needs 16+ GB.
+
+## Sumcheck Verification Failures
+
+**Symptom:** `verify()` returns an error about sumcheck round mismatch or incorrect evaluation.
+
+**Known issue:** See [GitHub issue #88](https://github.com/ICME-Lab/jolt-atlas/issues/88) for tracked sumcheck verification edge cases.
+
+**Possible causes:**
+1. `max_trace_length` too small — the trace was truncated, producing an inconsistent proof. Increase the value.
+2. Numeric overflow in fixed-point arithmetic — intermediate values exceeded `i32` range. Reduce the scale factor or simplify the model.
+3. Mismatched preprocessing — the `verifier_preprocessing` was derived from a different `prover_preprocess` call or a different model. Ensure they match.
+
+**Debugging steps:**
+1. Run the model forward pass separately and check output values are reasonable
+2. Try a smaller model first to confirm the pipeline works
+3. Enable debug info: the third return value from `prove()` contains diagnostic data
+
+## Model Loading Failures
+
+**Symptom:** Panic or error when calling `model(&path)` or during `forward()`.
+
+**Possible causes:**
+
+1. **Wrong file path:** Verify the ONNX file exists at the specified path:
+   ```bash
+   ls -la onnx-tracer/models/your_model/network.onnx
+   ```
+
+2. **Unsupported ONNX operation:** The model uses an op not in the supported instruction set. The error message usually names the unsupported op. See [onnx-operations.md](onnx-operations.md) for the full list.
+
+3. **Dynamic shapes:** The ONNX model was exported with dynamic axes. Re-export with static shapes:
+   ```python
+   torch.onnx.export(model, input, "model.onnx", dynamic_axes=None)
+   ```
+
+4. **Corrupted ONNX file:** Re-export from PyTorch or validate with:
+   ```python
+   import onnx
+   model = onnx.load("model.onnx")
+   onnx.checker.check_model(model)
+   ```
+
+## Slow Compilation
+
+**Symptom:** `cargo build` takes a very long time (10+ minutes on first build).
+
+**This is expected.** jolt-atlas has heavy dependencies (arkworks, jolt-core) with extensive generic code. Subsequent incremental builds are much faster.
+
+**Tips:**
+- Always use `--release` for running examples (debug builds are extremely slow at runtime)
+- Use `cargo build --release` once, then run examples — they won't recompile unless source changes
+- If iterating on your own example code, the incremental rebuild should be fast
+- Consider using `sccache` or `mold` linker for faster link times:
+  ```bash
+  # Install mold linker
+  # Add to .cargo/config.toml:
+  # [target.x86_64-unknown-linux-gnu]
+  # linker = "clang"
+  # rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+  ```
+
+## Overflow in onnx-tracer
+
+**Symptom:** Panic with "attempt to multiply with overflow" or "attempt to add with overflow" during model tracing.
+
+**Cause:** The fixed-point integer values exceeded `i32` range during matrix multiplication or accumulation.
+
+**Fix:**
+1. Reduce the quantization scale factor in `RunArgs`
+2. Check that your input values are reasonable (not excessively large)
+3. Simplify the model (fewer layers, smaller weight magnitudes)
+4. Check for weights with very large magnitudes in the original model
+
+## Chrome Tracing / Profiling
+
+For performance analysis, generate Chrome tracing output:
+
+```bash
+# zkml-jolt-core profiler
+cd zkml-jolt-core
+cargo run -r -- profile --name self-attention --format chrome
+# Opens chrome://tracing in browser, load the generated trace-*.json
+
+# jolt-atlas-core examples
+cargo run --release --package jolt-atlas-core --example nanoGPT -- --trace
+# Terminal timing output
+cargo run --release --package jolt-atlas-core --example nanoGPT -- --trace-terminal
+```
+
+The Chrome tracing view shows:
+- Time spent in each proving stage (commitment, sumcheck, opening)
+- Witness generation breakdown
+- Memory allocation patterns
+
+## Running Tests
+
+```bash
+# All workspace tests
+cargo test --release
+
+# Specific crate tests
+cargo test --release -p onnx-tracer
+cargo test --release -p zkml-jolt-core
+cargo test --release -p jolt-atlas-core
+
+# Single test
+cargo test --release -p zkml-jolt-core -- test_name
+```
+
+Use `--release` for tests too — debug mode is orders of magnitude slower for cryptographic operations.
+
+## Common Cargo.toml Patterns
+
+When adding a new example to the jolt-atlas workspace:
+
+```toml
+[[example]]
+name = "my_example"
+path = "examples/my_example.rs"
+```
+
+Required dependencies for proof generation (root workspace):
+
+```toml
+[dependencies]
+ark-bn254 = "0.4"
+ark-serialize = { version = "0.4", features = ["derive"] }
+jolt-core = { path = "path/to/jolt-core" }
+onnx-tracer = { path = "onnx-tracer" }
+zkml-jolt-core = { path = "zkml-jolt-core" }
+serde_json = "1"
+```
+
+For jolt-atlas-core examples, dependencies are already declared in `jolt-atlas-core/Cargo.toml`.
+
+## Getting Help
+
+- **GitHub Issues:** <https://github.com/ICME-Lab/jolt-atlas/issues>
+- **JOLT Paper:** <https://eprint.iacr.org/2023/1217>
+- **a16z JOLT docs:** <https://github.com/a16z/jolt>

--- a/skills/jolt-atlas/templates/proof_round_trip.rs
+++ b/skills/jolt-atlas/templates/proof_round_trip.rs
@@ -1,0 +1,87 @@
+//! Proof Serialization Round-Trip Template
+//!
+//! Demonstrates how to serialize a JOLT Atlas SNARK proof and ProgramIO
+//! to bytes/JSON, deserialize them, and re-verify. This pattern is essential
+//! for real-world usage where proofs are stored, transmitted, or verified
+//! by a separate party.
+//!
+//! Key dependencies:
+//!   ark-serialize = { version = "0.4", features = ["derive"] }
+//!   serde_json = "1"
+//!
+//! To use:
+//! 1. Copy to `examples/your_round_trip.rs` in the jolt-atlas repo
+//! 2. Add to Cargo.toml as an [[example]]
+//! 3. Run: `cargo run --release --example your_round_trip`
+
+use ark_bn254::Fr;
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use jolt_core::{poly::commitment::dory::DoryCommitmentScheme, transcripts::KeccakTranscript};
+use onnx_tracer::{builder, tensor::Tensor, ProgramIO};
+use zkml_jolt_core::jolt::{JoltSNARK, JoltVerifierPreprocessing};
+
+#[allow(clippy::upper_case_acronyms)]
+type PCS = DoryCommitmentScheme;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("Proof serialization round-trip test");
+    println!("====================================\n");
+
+    // Create input tensor
+    let input_data = vec![1, 2, 3, 4];
+    let shape = [1, 4];
+    let input_tensor = Tensor::new(Some(&input_data), &shape)?;
+
+    // Preprocess and generate proof
+    let max_trace_length = 1 << 12;
+    let preprocessing = JoltSNARK::<Fr, PCS, KeccakTranscript>::prover_preprocess(
+        builder::simple_mlp_small_model,
+        max_trace_length,
+    );
+    let verifier_preprocessing: JoltVerifierPreprocessing<Fr, PCS> = (&preprocessing).into();
+
+    let (snark, program_io, _debug_info) = JoltSNARK::<Fr, PCS, KeccakTranscript>::prove(
+        &preprocessing,
+        builder::simple_mlp_small_model,
+        &input_tensor,
+    );
+
+    // Verify original proof
+    snark
+        .clone()
+        .verify(&verifier_preprocessing, program_io.clone(), None)
+        .expect("original proof should verify");
+    println!("✓ Original proof verified");
+
+    // Serialize proof to bytes (ark-serialize CanonicalSerialize)
+    let mut proof_buffer = Vec::new();
+    snark
+        .serialize_compressed(&mut proof_buffer)
+        .expect("proof serialization should succeed");
+    println!("✓ Proof serialized ({} bytes)", proof_buffer.len());
+
+    // Serialize ProgramIO to JSON (serde)
+    let program_io_json =
+        serde_json::to_string(&program_io).expect("program_io serialization should succeed");
+    println!("✓ ProgramIO serialized ({} bytes)", program_io_json.len());
+
+    // Deserialize proof from bytes
+    let deserialized_snark =
+        JoltSNARK::<Fr, PCS, KeccakTranscript>::deserialize_compressed(proof_buffer.as_slice())
+            .expect("proof deserialization should succeed");
+    println!("✓ Proof deserialized");
+
+    // Deserialize ProgramIO from JSON
+    let deserialized_program_io: ProgramIO =
+        serde_json::from_str(&program_io_json).expect("program_io deserialization should succeed");
+    println!("✓ ProgramIO deserialized");
+
+    // Verify deserialized proof with deserialized ProgramIO
+    deserialized_snark
+        .verify(&verifier_preprocessing, deserialized_program_io, None)
+        .expect("deserialized proof should verify");
+    println!("✓ Deserialized proof verified with deserialized ProgramIO\n");
+
+    println!("Round-trip serialization successful!");
+    Ok(())
+}

--- a/skills/jolt-atlas/templates/zkml_example.rs
+++ b/skills/jolt-atlas/templates/zkml_example.rs
@@ -1,0 +1,150 @@
+//! zkML Proof Example Template
+//!
+//! This template demonstrates how to create a zero-knowledge proof
+//! for an ONNX model inference using JOLT Atlas.
+//!
+//! To use this template:
+//! 1. Copy to `examples/your_example.rs` in the jolt-atlas repo
+//! 2. Add the example to Cargo.toml:
+//!    ```toml
+//!    [[example]]
+//!    name = "your_example"
+//!    path = "examples/your_example.rs"
+//!    ```
+//! 3. Replace MODEL_PATH with your ONNX model path
+//! 4. Adjust INPUT_SHAPE and input data generation
+//! 5. Run: `cargo run --release --example your_example`
+
+use ark_bn254::Fr;
+use jolt_core::{poly::commitment::dory::DoryCommitmentScheme, transcripts::KeccakTranscript};
+use onnx_tracer::{model, tensor::Tensor};
+use std::path::PathBuf;
+use zkml_jolt_core::jolt::JoltSNARK;
+
+// Polynomial Commitment Scheme type
+type PCS = DoryCommitmentScheme;
+
+// ============================================================================
+// CONFIGURATION - Modify these for your use case
+// ============================================================================
+
+/// Path to your ONNX model (relative to repo root)
+const MODEL_PATH: &str = "onnx-tracer/models/perceptron/network.onnx";
+
+/// Input tensor shape [batch_size, ...dimensions]
+const INPUT_SHAPE: &[usize] = &[1, 4];
+
+/// Memory size for prover (power of 2, increase if you get memory errors)
+/// Common values: 1 << 14 (small), 1 << 20 (medium), 1 << 21 (large)
+const MEMORY_SIZE: usize = 1 << 14;
+
+// ============================================================================
+// MAIN LOGIC
+// ============================================================================
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("zkML Proof Generation Example");
+    println!("==============================\n");
+
+    // Step 1: Define model loader function
+    let model_fn = || model(&PathBuf::from(MODEL_PATH));
+
+    // Step 2: Generate input data
+    // Replace this with your actual input data generation
+    let input_data = generate_input_data();
+    let input = Tensor::new(Some(&input_data), INPUT_SHAPE)?;
+
+    println!("Model: {}", MODEL_PATH);
+    println!("Input shape: {:?}", INPUT_SHAPE);
+    println!("Input data (first 10): {:?}\n", &input_data[..input_data.len().min(10)]);
+
+    // Step 3: Run model to verify output (optional but recommended)
+    println!("Running model inference...");
+    let model_instance = model_fn();
+    let result = model_instance.forward(&[input.clone()])?;
+    let output = &result.outputs[0];
+
+    println!("Output shape: {:?}", output.shape());
+    println!("Output values: {:?}\n", output.iter().collect::<Vec<_>>());
+
+    // Step 4: Preprocess for proving (one-time setup)
+    println!("Preprocessing for SNARK generation...");
+    let preprocess_start = std::time::Instant::now();
+    let preprocessing = JoltSNARK::<Fr, PCS, KeccakTranscript>::prover_preprocess(
+        model_fn,
+        MEMORY_SIZE,
+    );
+    println!("Preprocessing time: {:?}\n", preprocess_start.elapsed());
+
+    // Step 5: Generate proof
+    println!("Generating SNARK proof...");
+    let prove_start = std::time::Instant::now();
+    let (snark, program_io, _debug_info) = JoltSNARK::<Fr, PCS, KeccakTranscript>::prove(
+        &preprocessing,
+        model_fn,
+        &input,
+    );
+    let prove_time = prove_start.elapsed();
+    println!("Proving time: {:?}\n", prove_time);
+
+    // Step 6: Verify proof
+    println!("Verifying SNARK proof...");
+    let verify_start = std::time::Instant::now();
+    snark.verify(&(&preprocessing).into(), program_io, None)?;
+    let verify_time = verify_start.elapsed();
+    println!("Verification time: {:?}\n", verify_time);
+
+    // Summary
+    println!("==============================");
+    println!("Proof generation successful!");
+    println!("  Prove time:  {:?}", prove_time);
+    println!("  Verify time: {:?}", verify_time);
+    println!("==============================");
+
+    Ok(())
+}
+
+/// Generate input data for the model
+///
+/// Modify this function to generate appropriate input for your model:
+/// - For classification: feature vectors
+/// - For image models: pixel values (usually scaled to integers)
+/// - For text models: tokenized/embedded text
+fn generate_input_data() -> Vec<i32> {
+    let total_elements: usize = INPUT_SHAPE.iter().product();
+
+    // Example: simple sequential data
+    // Replace with your actual input generation logic
+    (0..total_elements as i32).collect()
+
+    // Alternative: random data
+    // use rand::{Rng, SeedableRng, rngs::StdRng};
+    // let mut rng = StdRng::seed_from_u64(42);
+    // (0..total_elements).map(|_| rng.gen_range(-100..100)).collect()
+
+    // Alternative: zeros
+    // vec![0; total_elements]
+}
+
+// ============================================================================
+// OPTIONAL: Add custom preprocessing functions below
+// ============================================================================
+
+/// Example: Text preprocessing for classification models
+#[allow(dead_code)]
+fn preprocess_text(text: &str, vocab_size: usize) -> Vec<i32> {
+    // Simple bag-of-words style encoding
+    let mut vec = vec![0; vocab_size];
+    for (i, _word) in text.split_whitespace().enumerate() {
+        if i < vocab_size {
+            vec[i] = 1;  // Presence indicator
+        }
+    }
+    vec
+}
+
+/// Example: Image preprocessing (normalize to integer range)
+#[allow(dead_code)]
+fn preprocess_image(pixels: &[f32], scale: i32) -> Vec<i32> {
+    pixels.iter().map(|&p| (p * scale as f32) as i32).collect()
+}


### PR DESCRIPTION
## Summary

- Adds a **jolt-atlas** skill for zero-knowledge machine learning (zkML) — generating cryptographic SNARK proofs of ML inference from ONNX models using the [JOLT proving system](https://github.com/a16z/jolt)
- Includes SKILL.md with YAML frontmatter, reference docs (architecture, ONNX operations, troubleshooting), and two Rust templates (proof generation, proof serialization round-trip)
- Framework produces proofs ~17x faster than circuit-based alternatives (e.g., ezkl) and scales to GPT-2 (125M params) in ~38s end-to-end

## Skill structure

```
skills/jolt-atlas/
├── SKILL.md
├── templates/
│   ├── zkml_example.rs
│   └── proof_round_trip.rs
└── references/
    ├── architecture.md
    ├── onnx-operations.md
    └── troubleshooting.md
```

## Source project

https://github.com/ICME-Lab/jolt-atlas