### PR TITLE
Add Nyne API skills: deep-research, enrichment, search

### DIFF
--- a/skills/nyne-deep-research/SKILL.md
+++ b/skills/nyne-deep-research/SKILL.md
@@ -1,0 +1,413 @@
+---
+name: nyne-deep-research
+description: >
+  Research any person using the Nyne Deep Research API. Submit an email, phone, social URL,
+  or name and receive a comprehensive intelligence dossier with psychographic profile, social graph,
+  career analysis, conversation starters, and approach strategy. Async with 2-5 min processing.
+---
+
+# Nyne Deep Research Skill
+
+Research any person by email, phone, social URL, or name. Returns a comprehensive intelligence dossier with psychographic profile, social graph, career analysis, conversation starters, and approach strategy.
+
+**Important:** This API is async with high latency (2-5 min processing). You submit a request, get a `request_id`, then poll until complete.
+
+## Agent Instructions
+
+When presenting results to the user, show **maximum depth** — display every section of the dossier in full. Do not summarize or truncate. Walk through each section sequentially:
+
+1. **Identity Snapshot** — who they are
+2. **Career DNA** — trajectory and superpower
+3. **Psychographic Profile** — values, motivations, archetypes
+4. **Personal Life & Hobbies** — interests outside work
+5. **Social Graph Analysis** — inner circle, professional network, interest graph
+6. **Interest Cluster Deep Dive** — all 9 clusters with detail
+7. **Content & Voice Analysis** — topics, tone, opinions, quotes
+8. **Key Relationships** — full list with relationship nature and importance
+9. **Conversation Starters** — all 4 hook categories
+10. **Recommendations / How Others See Them** — reputation signals
+11. **Warnings & Landmines** — topics to avoid, sensitivities
+12. **Creepy-Good Insights** — non-obvious findings with evidence
+13. **Approach Strategy** — best angle, topics, what not to do
+
+Also include `enrichment` data (contact info, work history, education) and note whether `following` and `articles` sections have data.
+
+If `dossier` is null, present the `enrichment` data and let the user know the full dossier was not generated (this can happen with duplicate or cached requests — resubmit with a different identifier).
+
+If `following` or `articles` are null, simply note they were not available for this person.
+
+## Setup
+
+**Required environment variables:**
+- `NYNE_API_KEY` — your Nyne API key
+- `NYNE_API_SECRET` — your Nyne API secret
+
+Get credentials at [https://api.nyne.ai](https://api.nyne.ai).
+
+Set these in your shell before running any commands:
+```bash
+export NYNE_API_KEY="your-api-key"
+export NYNE_API_SECRET="your-api-secret"
+```
+
+To persist across sessions, add the exports to your shell profile (`~/.zshrc`, `~/.bashrc`, etc.) or create a `.env` file and source it:
+```bash
+# Create .env file (keep out of version control)
+echo 'export NYNE_API_KEY="your-api-key"' >> ~/.nyne_env
+echo 'export NYNE_API_SECRET="your-api-secret"' >> ~/.nyne_env
+source ~/.nyne_env
+```
+
+Verify they're set:
+```bash
+echo "Key: ${NYNE_API_KEY:0:8}... Secret: ${NYNE_API_SECRET:0:6}..."
+```
+
+## Important: JSON Handling
+
+The API response can contain control characters in JSON string values that break `jq`. All examples below use a `nyne_parse` helper that pipes through `python3` to clean and re-encode the JSON before passing to `jq`. Define it once per session:
+
+```bash
+nyne_parse() {
+  python3 -c "
+import sys, json, re
+raw = sys.stdin.read()
+clean = re.sub(r'[\x00-\x1f]+', ' ', raw)
+data = json.loads(clean)
+json.dump(data, sys.stdout)
+"
+}
+```
+
+## Quick Start
+
+Submit a research request by email and poll until complete:
+
+```bash
+# Define helper (strips control chars, re-encodes clean JSON)
+nyne_parse() {
+  python3 -c "
+import sys, json, re
+raw = sys.stdin.read()
+clean = re.sub(r'[\x00-\x1f]+', ' ', raw)
+data = json.loads(clean)
+json.dump(data, sys.stdout)
+"
+}
+
+# Submit research request
+REQUEST_ID=$(curl -s -X POST "https://api.nyne.ai/person/deep-research" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $NYNE_API_KEY" \
+  -H "X-API-Secret: $NYNE_API_SECRET" \
+  -d '{"email": "someone@example.com"}' | nyne_parse | jq -r '.data.request_id')
+
+echo "Request submitted: $REQUEST_ID"
+
+# Poll until complete (checks every 5s, times out after 10 min)
+SECONDS_WAITED=0
+while [ $SECONDS_WAITED -lt 600 ]; do
+  curl -s "https://api.nyne.ai/person/deep-research?request_id=$REQUEST_ID" \
+    -H "X-API-Key: $NYNE_API_KEY" \
+    -H "X-API-Secret: $NYNE_API_SECRET" | nyne_parse > /tmp/nyne_response.json
+  STATUS=$(jq -r '.data.status' /tmp/nyne_response.json)
+  echo "Status: $STATUS ($SECONDS_WAITED seconds elapsed)"
+  if [ "$STATUS" = "completed" ]; then
+    jq '.data.result' /tmp/nyne_response.json
+    break
+  elif [ "$STATUS" = "failed" ]; then
+    echo "Research failed."
+    jq . /tmp/nyne_response.json
+    break
+  fi
+  sleep 5
+  SECONDS_WAITED=$((SECONDS_WAITED + 5))
+done
+
+if [ $SECONDS_WAITED -ge 600 ]; then
+  echo "Timed out after 10 minutes. Try polling manually with request_id: $REQUEST_ID"
+fi
+```
+
+## Submit Research (POST)
+
+**Endpoint:** `POST https://api.nyne.ai/person/deep-research`
+
+**Headers:**
+```
+Content-Type: application/json
+X-API-Key: $NYNE_API_KEY
+X-API-Secret: $NYNE_API_SECRET
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `email` | string | Email address |
+| `phone` | string | Phone number |
+| `social_media_url` | string or array | Social profile URL(s), up to 3 |
+| `name` | string | Full name (use with `company` or `city` for disambiguation) |
+| `company` | string | Company name (helps disambiguate `name`) |
+| `city` | string | City (helps disambiguate `name`) |
+| `callback_url` | string | Webhook URL to POST results when complete |
+
+At least one identifier is required: `email`, `phone`, `social_media_url`, or `name` with `company`/`city`.
+
+### Examples
+
+**By email:**
+```bash
+curl -s -X POST "https://api.nyne.ai/person/deep-research" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $NYNE_API_KEY" \
+  -H "X-API-Secret: $NYNE_API_SECRET" \
+  -d '{"email": "someone@example.com"}' | nyne_parse | jq .
+```
+
+**By social media URL:**
+```bash
+curl -s -X POST "https://api.nyne.ai/person/deep-research" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $NYNE_API_KEY" \
+  -H "X-API-Secret: $NYNE_API_SECRET" \
+  -d '{"social_media_url": "https://twitter.com/elonmusk"}' | nyne_parse | jq .
+```
+
+**By multiple social URLs:**
+```bash
+curl -s -X POST "https://api.nyne.ai/person/deep-research" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $NYNE_API_KEY" \
+  -H "X-API-Secret: $NYNE_API_SECRET" \
+  -d '{"social_media_url": ["https://twitter.com/elonmusk", "https://linkedin.com/in/elonmusk"]}' | nyne_parse | jq .
+```
+
+**By name + company:**
+```bash
+curl -s -X POST "https://api.nyne.ai/person/deep-research" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $NYNE_API_KEY" \
+  -H "X-API-Secret: $NYNE_API_SECRET" \
+  -d '{"name": "Jane Smith", "company": "Acme Corp"}' | nyne_parse | jq .
+```
+
+**By phone:**
+```bash
+curl -s -X POST "https://api.nyne.ai/person/deep-research" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $NYNE_API_KEY" \
+  -H "X-API-Secret: $NYNE_API_SECRET" \
+  -d '{"phone": "+14155551234"}' | nyne_parse | jq .
+```
+
+**Submit response (HTTP 202):**
+```json
+{
+  "success": true,
+  "data": {
+    "request_id": "abc123-def456-...",
+    "status": "pending"
+  }
+}
+```
+
+## Poll for Results (GET)
+
+**Endpoint:** `GET https://api.nyne.ai/person/deep-research?request_id={id}`
+
+**Headers:** Same `X-API-Key` and `X-API-Secret` as above.
+
+**Status progression:** `pending` → `enriching` → `gathering` → `analyzing` → `completed` (or `failed`)
+
+This typically takes 2-3 minutes.
+
+### Check status once
+```bash
+curl -s "https://api.nyne.ai/person/deep-research?request_id=$REQUEST_ID" \
+  -H "X-API-Key: $NYNE_API_KEY" \
+  -H "X-API-Secret: $NYNE_API_SECRET" | nyne_parse | jq '{status: .data.status, completed: .data.completed}'
+```
+
+### Full polling loop
+
+```bash
+SECONDS_WAITED=0
+TIMEOUT=600  # 10 minutes
+
+while [ $SECONDS_WAITED -lt $TIMEOUT ]; do
+  curl -s "https://api.nyne.ai/person/deep-research?request_id=$REQUEST_ID" \
+    -H "X-API-Key: $NYNE_API_KEY" \
+    -H "X-API-Secret: $NYNE_API_SECRET" | nyne_parse > /tmp/nyne_response.json
+  STATUS=$(jq -r '.data.status' /tmp/nyne_response.json)
+
+  echo "[$(date +%H:%M:%S)] Status: $STATUS ($SECONDS_WAITED s)"
+
+  case "$STATUS" in
+    completed)
+      jq '.data.result' /tmp/nyne_response.json
+      break
+      ;;
+    failed)
+      echo "Research failed:"
+      jq '.data' /tmp/nyne_response.json
+      break
+      ;;
+    *)
+      sleep 5
+      SECONDS_WAITED=$((SECONDS_WAITED + 5))
+      ;;
+  esac
+done
+
+if [ "$STATUS" != "completed" ] && [ "$STATUS" != "failed" ]; then
+  echo "Timed out. Resume polling with request_id: $REQUEST_ID"
+fi
+```
+
+## Response Structure
+
+When `status` is `completed`, the response looks like:
+
+```json
+{
+  "success": true,
+  "timestamp": "2025-01-15T12:00:00Z",
+  "data": {
+    "status": "completed",
+    "completed": true,
+    "request_id": "abc123-...",
+    "created_on": "2025-01-15T11:57:00Z",
+    "completed_on": "2025-01-15T12:00:00Z",
+    "result": {
+      "enrichment": { ... },
+      "dossier": { ... },
+      "following": { ... },
+      "articles": [ ... ]
+    }
+  }
+}
+```
+
+### `result` sections
+
+| Section | Description |
+|---------|-------------|
+| `enrichment` | Contact info, social profiles, bio, schools, work history (20+ keys) |
+| `dossier` | The main intelligence output — 15 sections (see below) |
+| `following` | Twitter/Instagram following data (can be null) |
+| `articles` | Press and media mentions (can be null) |
+
+## Dossier Sections Reference
+
+The `dossier` object contains 15 sections:
+
+### `identity_snapshot`
+Top-level identity summary.
+- `full_name`, `current_role`, `company`, `location`, `age_estimate`, `emails`, `social_profiles`, `headline`, `birthday`, `self_description`
+
+### `career_dna`
+Career trajectory and strengths.
+- `trajectory`, `superpower`
+
+### `psychographic_profile`
+Values, motivations, and personality archetypes.
+- `values`, `motivations`, `archetypes`, `political_leanings`, `cluster_analysis`
+
+### `personal_life_hobbies`
+Interests and personality outside of work.
+- `life_outside_work`, `entertainment_culture`, `personal_passions`, `active_hobbies_sports`, `quirks_personality`
+
+### `social_graph_analysis`
+Network and relationship mapping.
+- `inner_circle`, `professional_network`, `personal_interest_graph`
+
+### `interest_cluster_deep_dive`
+Deep analysis across 9 interest clusters.
+- `tech`, `sports_fitness`, `music_entertainment`, `food_lifestyle`, `causes_politics`, `intellectual_interests`, `geographic_ties`, `personal_network`, `unexpected_surprising`
+
+### `content_voice_analysis`
+How they communicate and what they care about.
+- `topics`, `tone`, `humor_style`, `strong_opinions`, `frustrations`, `notable_quotes`, `recent_wins`
+
+### `content_analysis`
+Alias of `content_voice_analysis` (kept for backward compatibility).
+
+### `key_relationships`
+List of ~25 objects describing important connections.
+- Each: `name`, `handle`, `followers`, `relationship_nature`, `why_important`
+
+### `key_influencers`
+Alias of `key_relationships`.
+
+### `conversation_starters`
+Hooks to open conversation, in 4 categories.
+- `professional_hooks`, `personal_interest_hooks`, `current_events_hooks`, `shared_experience_hooks`
+
+### `recommendations_how_others_see_them`
+Public perception and reputation signals.
+- `highlighted_qualities`, `colleague_descriptions`, `patterns_in_praise`
+
+### `warnings_landmines`
+Topics and areas to avoid.
+- `topics_to_avoid`, `political_hot_buttons`, `sensitive_career_history`, `competitors_they_dislike`
+
+### `creepy_good_insights`
+Non-obvious insights derived from data.
+- List of objects: `insight`, `evidence`
+
+### `approach_strategy`
+How to approach this person.
+- `best_angle`, `topics_that_resonate`, `personal_interests_to_reference`, `shared_connections`, `what_not_to_do`
+
+## Useful jq Filters
+
+After polling completes, the clean response is at `/tmp/nyne_response.json`. Use `jq` directly on the file:
+
+```bash
+# Extract identity snapshot
+jq '.data.result.dossier.identity_snapshot' /tmp/nyne_response.json
+
+# Get all conversation starters
+jq '.data.result.dossier.conversation_starters' /tmp/nyne_response.json
+
+# List key relationships (name + why important)
+jq '.data.result.dossier.key_relationships[] | {name, why_important}' /tmp/nyne_response.json
+
+# Get approach strategy
+jq '.data.result.dossier.approach_strategy' /tmp/nyne_response.json
+
+# Extract a specific dossier section by name
+jq --arg s "psychographic_profile" '.data.result.dossier[$s]' /tmp/nyne_response.json
+
+# Get enrichment contact info
+jq '.data.result.enrichment | {emails, phones, linkedin_url, twitter_url}' /tmp/nyne_response.json
+
+# Check processing status only
+jq '{status: .data.status, completed: .data.completed, request_id: .data.request_id}' /tmp/nyne_response.json
+
+# Get warnings and landmines
+jq '.data.result.dossier.warnings_landmines' /tmp/nyne_response.json
+
+# List all creepy-good insights
+jq '.data.result.dossier.creepy_good_insights[].insight' /tmp/nyne_response.json
+```
+
+## Error Handling
+
+| HTTP Code | Error | Description |
+|-----------|-------|-------------|
+| 400 | `INVALID_PARAMETERS` | Malformed request body |
+| 400 | `MISSING_PARAMETER` | No identifier provided (need email, phone, social_media_url, or name+company/city) |
+| 401 | `AUTHENTICATION_FAILED` | Invalid or missing API key/secret |
+| 402 | `INSUFFICIENT_CREDITS` | Not enough credits (100 credits per request) |
+| 403 | `NO_ACTIVE_SUBSCRIPTION` | Subscription required |
+| 403 | `ACCESS_DENIED` | Account does not have access |
+| 429 | `RATE_LIMIT_EXCEEDED` | Too many requests |
+| 500 | `QUEUE_ERROR` | Internal processing error |
+
+## Rate Limits & Costs
+
+- **Rate limits:** 10 requests/minute, 100 requests/hour
+- **Cost:** 100 credits per research request
+- **Processing time:** Typically 2-3 minutes, up to 5 minutes

--- a/skills/nyne-enrichment/SKILL.md
+++ b/skills/nyne-enrichment/SKILL.md
@@ -1,0 +1,459 @@
+---
+name: nyne-enrichment
+description: >
+  Enrich any person by email, phone, LinkedIn URL, or name using the Nyne Enrichment API.
+  Returns contact info, social profiles, work history, education, and optional social media posts.
+  Supports lite mode (3 credits), newsfeed add-on, and AI-enhanced deep search. Async with polling.
+---
+
+# Nyne Enrichment Skill
+
+Enrich any person by email, phone, LinkedIn URL, or name. Returns contact info, social profiles, work history, education, and optional social media posts.
+
+**Important:** This API is async. You POST to submit, get a `request_id`, then poll GET until complete.
+
+## Agent Instructions
+
+When presenting results to the user, show **all available data**. Walk through each section:
+
+1. **Identity** — displayname, bio, location, gender
+2. **Contact** — emails (work + personal + alt), phones with type
+3. **Social Profiles** — LinkedIn, Twitter, GitHub, Instagram with follower counts
+4. **Work History** — all organizations with title, dates, current status
+5. **Education** — schools with degree, field, dates
+6. **Newsfeed** (if requested) — recent posts with engagement metrics
+
+If a field is missing from the response, it means no data was found — skip it silently.
+
+For lite mode responses, note that only 5 fields are returned (displayname, firstname, lastname, first organization, LinkedIn URL).
+
+## Setup
+
+**Required environment variables:**
+- `NYNE_API_KEY` — your Nyne API key
+- `NYNE_API_SECRET` — your Nyne API secret
+
+Get credentials at [https://api.nyne.ai](https://api.nyne.ai).
+
+```bash
+export NYNE_API_KEY="your-api-key"
+export NYNE_API_SECRET="your-api-secret"
+```
+
+Verify they're set:
+```bash
+echo "Key: ${NYNE_API_KEY:0:8}... Secret: ${NYNE_API_SECRET:0:6}..."
+```
+
+## Important: JSON Handling
+
+The API response can contain control characters in JSON string values that break `jq`. All examples use a `nyne_parse` helper that cleans and re-encodes JSON via `python3`. Define it once per session:
+
+```bash
+nyne_parse() {
+  python3 -c "
+import sys, json, re
+raw = sys.stdin.read()
+clean = re.sub(r'[\x00-\x1f]+', ' ', raw)
+data = json.loads(clean)
+json.dump(data, sys.stdout)
+"
+}
+```
+
+## Quick Start
+
+Submit an enrichment request by email and poll until complete:
+
+```bash
+nyne_parse() {
+  python3 -c "
+import sys, json, re
+raw = sys.stdin.read()
+clean = re.sub(r'[\x00-\x1f]+', ' ', raw)
+data = json.loads(clean)
+json.dump(data, sys.stdout)
+"
+}
+
+# Submit enrichment request
+curl -s -X POST "https://api.nyne.ai/person/enrichment" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $NYNE_API_KEY" \
+  -H "X-API-Secret: $NYNE_API_SECRET" \
+  -d '{"email": "someone@example.com"}' | nyne_parse > /tmp/nyne_enrich.json
+
+REQUEST_ID=$(jq -r '.data.request_id' /tmp/nyne_enrich.json)
+echo "Request submitted: $REQUEST_ID"
+
+# Poll until complete (checks every 3s, times out after 6 min)
+SECONDS_WAITED=0
+while [ $SECONDS_WAITED -lt 360 ]; do
+  curl -s "https://api.nyne.ai/person/enrichment?request_id=$REQUEST_ID" \
+    -H "X-API-Key: $NYNE_API_KEY" \
+    -H "X-API-Secret: $NYNE_API_SECRET" | nyne_parse > /tmp/nyne_enrich.json
+  STATUS=$(jq -r '.data.status' /tmp/nyne_enrich.json)
+  echo "Status: $STATUS ($SECONDS_WAITED seconds elapsed)"
+  if [ "$STATUS" = "completed" ]; then
+    jq '.data.result' /tmp/nyne_enrich.json
+    break
+  elif [ "$STATUS" = "failed" ]; then
+    echo "Enrichment failed."
+    jq . /tmp/nyne_enrich.json
+    break
+  fi
+  sleep 3
+  SECONDS_WAITED=$((SECONDS_WAITED + 3))
+done
+
+if [ $SECONDS_WAITED -ge 360 ]; then
+  echo "Timed out after 6 minutes. Resume polling with request_id: $REQUEST_ID"
+fi
+```
+
+## Submit Enrichment (POST)
+
+**Endpoint:** `POST https://api.nyne.ai/person/enrichment`
+
+**Headers:**
+```
+Content-Type: application/json
+X-API-Key: $NYNE_API_KEY
+X-API-Secret: $NYNE_API_SECRET
+```
+
+### Input Parameters
+
+At least one identifier is required.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `email` | string | Email address (work email preferred) |
+| `phone` | string | Phone number (e.g., "+14155551234") |
+| `social_media_url` | string | LinkedIn, Twitter, or GitHub URL |
+| `name` | string | Full name (use with `company` or `city` to disambiguate) |
+| `company` | string | Company name (helps disambiguate name lookups) |
+| `city` | string | City (accepts abbreviations: SF, NYC, LA) |
+
+**Input priority ranking:** LinkedIn URL (best) > Email (work > personal) > Phone (lowest match rate). LinkedIn + email together yields best results.
+
+### Feature Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `ai_enhanced_search` | boolean | false | AI-powered deep search for additional social profiles. Longer processing time. |
+| `lite_enrich` | boolean | false | Minimal enrichment: only 5 fields, 3 credits instead of 6 |
+| `newsfeed` | array | omit | Social posts to fetch: `["linkedin", "twitter", "instagram", "github", "facebook"]` or `["all"]`. Cannot mix `"all"` with specific sources. +6 credits when data found. |
+| `strict_email_check` | boolean | false | Strict email validation (may return no results) |
+| `callback_url` | string | omit | Webhook URL for async delivery |
+
+### Examples
+
+**By email:**
+```bash
+curl -s -X POST "https://api.nyne.ai/person/enrichment" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $NYNE_API_KEY" \
+  -H "X-API-Secret: $NYNE_API_SECRET" \
+  -d '{"email": "someone@example.com"}' | nyne_parse > /tmp/nyne_enrich.json
+
+REQUEST_ID=$(jq -r '.data.request_id' /tmp/nyne_enrich.json)
+echo "Request ID: $REQUEST_ID"
+```
+
+**By LinkedIn URL:**
+```bash
+curl -s -X POST "https://api.nyne.ai/person/enrichment" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $NYNE_API_KEY" \
+  -H "X-API-Secret: $NYNE_API_SECRET" \
+  -d '{"social_media_url": "https://linkedin.com/in/johndoe"}' | nyne_parse > /tmp/nyne_enrich.json
+
+REQUEST_ID=$(jq -r '.data.request_id' /tmp/nyne_enrich.json)
+```
+
+**By name + company:**
+```bash
+curl -s -X POST "https://api.nyne.ai/person/enrichment" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $NYNE_API_KEY" \
+  -H "X-API-Secret: $NYNE_API_SECRET" \
+  -d '{"name": "Jane Smith", "company": "Acme Corp", "city": "SF"}' | nyne_parse > /tmp/nyne_enrich.json
+
+REQUEST_ID=$(jq -r '.data.request_id' /tmp/nyne_enrich.json)
+```
+
+**With newsfeed:**
+```bash
+curl -s -X POST "https://api.nyne.ai/person/enrichment" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $NYNE_API_KEY" \
+  -H "X-API-Secret: $NYNE_API_SECRET" \
+  -d '{"email": "someone@example.com", "newsfeed": ["linkedin", "twitter"]}' | nyne_parse > /tmp/nyne_enrich.json
+
+REQUEST_ID=$(jq -r '.data.request_id' /tmp/nyne_enrich.json)
+```
+
+**Lite mode (3 credits):**
+```bash
+curl -s -X POST "https://api.nyne.ai/person/enrichment" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $NYNE_API_KEY" \
+  -H "X-API-Secret: $NYNE_API_SECRET" \
+  -d '{"email": "someone@example.com", "lite_enrich": true}' | nyne_parse > /tmp/nyne_enrich.json
+
+REQUEST_ID=$(jq -r '.data.request_id' /tmp/nyne_enrich.json)
+```
+
+**With AI-enhanced search:**
+```bash
+curl -s -X POST "https://api.nyne.ai/person/enrichment" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $NYNE_API_KEY" \
+  -H "X-API-Secret: $NYNE_API_SECRET" \
+  -d '{"email": "someone@example.com", "ai_enhanced_search": true}' | nyne_parse > /tmp/nyne_enrich.json
+
+REQUEST_ID=$(jq -r '.data.request_id' /tmp/nyne_enrich.json)
+```
+
+**Submit response:**
+```json
+{
+  "success": true,
+  "data": {
+    "request_id": "abc123-...",
+    "status": "queued",
+    "message": "Enrichment request queued. Use GET /person/enrichment?request_id=... to check status."
+  }
+}
+```
+
+## Poll for Results (GET)
+
+**Endpoint:** `GET https://api.nyne.ai/person/enrichment?request_id={id}`
+
+**Headers:** Same `X-API-Key` and `X-API-Secret` as above.
+
+### Check status once
+```bash
+curl -s "https://api.nyne.ai/person/enrichment?request_id=$REQUEST_ID" \
+  -H "X-API-Key: $NYNE_API_KEY" \
+  -H "X-API-Secret: $NYNE_API_SECRET" | nyne_parse > /tmp/nyne_enrich.json
+
+jq '{status: .data.status, completed: .data.completed}' /tmp/nyne_enrich.json
+```
+
+### Full polling loop
+
+```bash
+SECONDS_WAITED=0
+TIMEOUT=360  # 6 minutes
+
+while [ $SECONDS_WAITED -lt $TIMEOUT ]; do
+  curl -s "https://api.nyne.ai/person/enrichment?request_id=$REQUEST_ID" \
+    -H "X-API-Key: $NYNE_API_KEY" \
+    -H "X-API-Secret: $NYNE_API_SECRET" | nyne_parse > /tmp/nyne_enrich.json
+  STATUS=$(jq -r '.data.status' /tmp/nyne_enrich.json)
+
+  echo "[$(date +%H:%M:%S)] Status: $STATUS ($SECONDS_WAITED s)"
+
+  case "$STATUS" in
+    completed)
+      jq '.data.result' /tmp/nyne_enrich.json
+      break
+      ;;
+    failed)
+      echo "Enrichment failed:"
+      jq '.data' /tmp/nyne_enrich.json
+      break
+      ;;
+    *)
+      sleep 3
+      SECONDS_WAITED=$((SECONDS_WAITED + 3))
+      ;;
+  esac
+done
+
+if [ "$STATUS" != "completed" ] && [ "$STATUS" != "failed" ]; then
+  echo "Timed out. Resume polling with request_id: $REQUEST_ID"
+fi
+```
+
+## Response Structure
+
+When `status` is `completed`:
+
+```json
+{
+  "success": true,
+  "timestamp": "2025-09-05T21:45:25Z",
+  "data": {
+    "request_id": "abc123-...",
+    "status": "completed",
+    "completed": true,
+    "created_on": "2025-09-05T21:45:06",
+    "completed_on": "2025-09-05T21:45:12",
+    "result": {
+      "displayname": "...",
+      "firstname": "...",
+      "lastname": "...",
+      "bio": "...",
+      "location": "...",
+      "gender": "...",
+      "fullphone": [...],
+      "altemails": [...],
+      "best_work_email": "...",
+      "best_personal_email": "...",
+      "social_profiles": {...},
+      "organizations": [...],
+      "schools_info": [...],
+      "newsfeed": [...],
+      "probability": "high"
+    }
+  }
+}
+```
+
+**All fields are optional** — only included when data is found. No charges if person cannot be located.
+
+### Result Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `displayname` | string | Full display name |
+| `firstname` | string | First name |
+| `lastname` | string | Last name |
+| `bio` | string | Bio/headline |
+| `location` | string | Location |
+| `gender` | string | Gender |
+| `fullphone` | array | Phone numbers, each: `{fullphone, type}` |
+| `altemails` | array | Alternative email addresses |
+| `best_work_email` | string | Most probable work email |
+| `best_personal_email` | string | Most probable personal email |
+| `social_profiles` | object | LinkedIn, Twitter, GitHub, Instagram with URLs, usernames, follower counts |
+| `organizations` | array | Work history: `{name, title, startDate, endDate, is_current}` |
+| `schools_info` | array | Education: `{name, degree, title, startDate, endDate}` |
+| `newsfeed` | array | Social posts (if requested): `{source, type, content, date_posted, url, engagement}` |
+| `probability` | string | Match confidence: "high", "medium", "low" (only if `probability_score: true`) |
+
+### Social Profiles Object
+
+```json
+{
+  "linkedin": {"url": "...", "username": "...", "followers": 542, "connections": 1243},
+  "twitter": {"url": "...", "username": "...", "followers": 1234, "following": 567, "posts": 892},
+  "github": {"url": "...", "username": "...", "followers": 89, "following": 45},
+  "instagram": {"url": "...", "username": "...", "followers": 500}
+}
+```
+
+### Newsfeed Item
+
+```json
+{
+  "source": "linkedin",
+  "type": "post",
+  "content": "...",
+  "date_posted": "2025-09-01T14:30:00Z",
+  "url": "...",
+  "author": {"display_name": "...", "username": "...", "profile_url": "..."},
+  "engagement": {"likes": 42, "comments": 5, "shares": 3, "total_reactions": 50}
+}
+```
+
+### Lite Mode Response
+
+When `lite_enrich: true`, only these fields are returned:
+- `displayname`, `firstname`, `lastname`
+- First organization (name + title)
+- LinkedIn URL
+
+## Useful jq Filters
+
+After polling completes, the clean response is at `/tmp/nyne_enrich.json`:
+
+```bash
+# Full result
+jq '.data.result' /tmp/nyne_enrich.json
+
+# Identity summary
+jq '.data.result | {displayname, bio, location, gender}' /tmp/nyne_enrich.json
+
+# All emails
+jq '.data.result | {best_work_email, best_personal_email, altemails}' /tmp/nyne_enrich.json
+
+# Social profiles
+jq '.data.result.social_profiles' /tmp/nyne_enrich.json
+
+# Work history
+jq '.data.result.organizations' /tmp/nyne_enrich.json
+
+# Education
+jq '.data.result.schools_info' /tmp/nyne_enrich.json
+
+# Phone numbers
+jq '.data.result.fullphone' /tmp/nyne_enrich.json
+
+# Newsfeed posts (if requested)
+jq '.data.result.newsfeed[] | {source, date_posted, content, engagement}' /tmp/nyne_enrich.json
+
+# LinkedIn info specifically
+jq '.data.result.social_profiles.linkedin' /tmp/nyne_enrich.json
+
+# Current job
+jq '[.data.result.organizations[] | select(.endDate_formatted.is_current == true)]' /tmp/nyne_enrich.json
+```
+
+## Error Handling
+
+| HTTP Code | Error | Description |
+|-----------|-------|-------------|
+| 400 | `missing_parameters` | No identifier provided |
+| 400 | `invalid_newsfeed` | Bad newsfeed param (can't mix "all" with specific sources) |
+| 401 | `invalid_credentials` | Invalid API key/secret |
+| 403 | `subscription_required` | Plan lacks access |
+| 404 | `request_not_found` | Invalid request_id for status check |
+| 429 | `rate_limit_exceeded` | Too many requests |
+| 500 | `internal_error` | Server error |
+
+## Modes & When to Use Each
+
+### Standard Enrichment (6 credits)
+The default. Returns full contact info, social profiles, work history, and education. Use this for most lookups.
+```json
+{"email": "someone@example.com"}
+```
+
+### Lite Enrichment (3 credits)
+`lite_enrich: true` — Performs a minimal enrichment workflow. Returns only 5 essential fields: `displayname`, `firstname`, `lastname`, first organization in the `organizations` array, and LinkedIn URL in `social_profiles.linkedin.url`. When enabled, all advanced features are disabled — `ai_enhanced_search`, `newsfeed`, and `strict_email_check` parameters are ignored (emails are not returned in lite mode). Use when you only need basic profile identification at reduced cost.
+```json
+{"email": "someone@example.com", "lite_enrich": true}
+```
+
+### AI-Enhanced Search (6 credits, longer processing)
+`ai_enhanced_search: true` — Enables AI-powered deep search to discover additional social profiles and gather more comprehensive social data. Performs extensive searches and can take significantly longer to complete (up to several minutes). Only enable when comprehensive results are needed and extended processing time is acceptable. Use when standard enrichment returns sparse social profile data and you want broader coverage.
+```json
+{"email": "someone@example.com", "ai_enhanced_search": true}
+```
+
+### Newsfeed Add-on (+6 credits when data found)
+`newsfeed: [...]` — Requests social media newsfeed data from specified sources. Valid sources: `"linkedin"`, `"twitter"`, `"instagram"`, `"github"`, `"facebook"`, or `"all"`. Cannot mix `"all"` with specific sources. Additional charges apply only when newsfeed data is actually found. Stacks on top of standard or AI-enhanced enrichment. Use when you need to see what someone is posting about or gauge their activity level.
+```json
+{"email": "someone@example.com", "newsfeed": ["linkedin", "twitter"]}
+{"email": "someone@example.com", "newsfeed": ["all"]}
+```
+
+### Strict Email Check
+`strict_email_check: true` — Enables strict email validation for the best email to use. May return nothing due to its strictness. Use when email accuracy is critical and you'd rather get no result than a questionable one.
+```json
+{"email": "someone@example.com", "strict_email_check": true}
+```
+
+### No Match (0 credits)
+If the person cannot be found, you are not charged.
+
+## Rate Limits
+
+- **Per minute:** 60 requests
+- **Per hour:** 1,000 requests
+- **Monthly:** Plan-dependent

--- a/skills/nyne-search/SKILL.md
+++ b/skills/nyne-search/SKILL.md
@@ -1,0 +1,700 @@
+---
+name: nyne-search
+description: >
+  Search for people using natural language queries with the Nyne Search API. Find professionals by
+  role, company, location, industry, or any combination. Supports custom filters, AI relevance scoring,
+  contact enrichment (emails + phones), pagination, and three search tiers (light, medium, premium). Async with polling.
+---
+
+# Nyne Search Skill
+
+Search for people using natural language queries. Find professionals by role, company, location, industry, or any combination. Returns matching profiles with contact info, work history, education, and optional AI relevance scoring.
+
+**Important:** This API is async. You POST to submit, get a `request_id`, then poll GET until `status: "completed"`. Light searches complete in 3-40 seconds; premium searches take 30-300 seconds.
+
+## Agent Instructions
+
+When presenting search results to the user, show **all returned data** for each person. Walk through:
+
+1. **Result count** — total_stored, total_estimate, has_more, credits_charged
+2. **Each person** — displayname, headline, bio, location, gender, estimated_age, total_experience_years, is_decision_maker
+3. **Contact info** — best_business_email, best_personal_email, altemails, fullphone (if show_emails/show_phone_numbers were enabled)
+4. **Social profiles** — LinkedIn URL, username, connections, followers
+5. **Work history** — all organizations with title, dates, company details (industries, num_employees, funding, technologies)
+6. **Education** — schools with degree, major, dates; note is_top_universities flag
+7. **Interests** — work interests and certifications
+8. **Patents** — title, date, reference, URL (if present)
+9. **Languages** — spoken languages
+10. **Score** — AI relevance score 0-1 (if profile_scoring was enabled)
+11. **Insights** — AI-generated match reasoning (if insights were enabled)
+
+If `has_more` is true, tell the user there are more results available and offer to paginate using the `next_cursor`.
+
+If a field is missing from the response, it means no data was found — skip it silently.
+
+## Setup
+
+**Required environment variables:**
+- `NYNE_API_KEY` — your Nyne API key
+- `NYNE_API_SECRET` — your Nyne API secret
+
+Get credentials at [https://api.nyne.ai](https://api.nyne.ai).
+
+```bash
+export NYNE_API_KEY="your-api-key"
+export NYNE_API_SECRET="your-api-secret"
+```
+
+Verify they're set:
+```bash
+echo "Key: ${NYNE_API_KEY:0:8}... Secret: ${NYNE_API_SECRET:0:6}..."
+```
+
+## Important: JSON Handling
+
+The API response can contain control characters in JSON string values that break `jq`. All examples use a `nyne_parse` helper that cleans and re-encodes JSON via `python3`. Define it once per session:
+
+```bash
+nyne_parse() {
+  python3 -c "
+import sys, json, re
+raw = sys.stdin.read()
+clean = re.sub(r'[\x00-\x1f]+', ' ', raw)
+data = json.loads(clean)
+json.dump(data, sys.stdout)
+"
+}
+```
+
+## Quick Start
+
+Search for people by natural language query and poll until complete:
+
+```bash
+nyne_parse() {
+  python3 -c "
+import sys, json, re
+raw = sys.stdin.read()
+clean = re.sub(r'[\x00-\x1f]+', ' ', raw)
+data = json.loads(clean)
+json.dump(data, sys.stdout)
+"
+}
+
+# Submit search request
+curl -s -X POST "https://api.nyne.ai/person/search" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $NYNE_API_KEY" \
+  -H "X-API-Secret: $NYNE_API_SECRET" \
+  -d '{"query": "Software engineers at Google in San Francisco", "limit": 10, "type": "premium", "show_emails": true}' | nyne_parse > /tmp/nyne_search.json
+
+STATUS=$(jq -r '.data.status' /tmp/nyne_search.json)
+
+if [ "$STATUS" = "completed" ]; then
+  echo "Search completed immediately."
+  jq '.data | {total_stored, total_estimate, has_more, credits_charged}' /tmp/nyne_search.json
+  jq '.data.results[] | {displayname, headline, location}' /tmp/nyne_search.json
+else
+  REQUEST_ID=$(jq -r '.data.request_id' /tmp/nyne_search.json)
+  echo "Request submitted: $REQUEST_ID (status: $STATUS)"
+
+  # Poll until complete (checks every 5s, times out after 10 min)
+  SECONDS_WAITED=0
+  while [ $SECONDS_WAITED -lt 600 ]; do
+    curl -s "https://api.nyne.ai/person/search?request_id=$REQUEST_ID" \
+      -H "X-API-Key: $NYNE_API_KEY" \
+      -H "X-API-Secret: $NYNE_API_SECRET" | nyne_parse > /tmp/nyne_search.json
+    STATUS=$(jq -r '.data.status' /tmp/nyne_search.json)
+    echo "Status: $STATUS ($SECONDS_WAITED seconds elapsed)"
+    if [ "$STATUS" = "completed" ]; then
+      jq '.data | {total_stored, total_estimate, has_more, credits_charged}' /tmp/nyne_search.json
+      jq '.data.results[] | {displayname, headline, location}' /tmp/nyne_search.json
+      break
+    elif [ "$STATUS" = "failed" ]; then
+      echo "Search failed."
+      jq . /tmp/nyne_search.json
+      break
+    fi
+    sleep 5
+    SECONDS_WAITED=$((SECONDS_WAITED + 5))
+  done
+
+  if [ $SECONDS_WAITED -ge 600 ]; then
+    echo "Timed out after 10 minutes. Resume polling with request_id: $REQUEST_ID"
+  fi
+fi
+```
+
+## Submit Search (POST)
+
+**Endpoint:** `POST https://api.nyne.ai/person/search`
+
+**Headers:**
+```
+Content-Type: application/json
+X-API-Key: $NYNE_API_KEY
+X-API-Secret: $NYNE_API_SECRET
+```
+
+### Query Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `query` | string | *required* | Natural language search query (max 1000 chars). Examples: "Software engineers at Microsoft in Seattle", "Marketing directors at Fortune 500" |
+| `type` | string | `"premium"` | Search quality tier: `"light"` (fast, 3-40s), `"medium"` (balanced), `"premium"` (best quality, 30-300s) |
+| `limit` | integer | 10 | Results per request (max 100) |
+| `offset` | integer | 0 | Starting position, 0-indexed (max 999). `offset + limit` must be ≤ 1000 |
+| `show_emails` | boolean | false | Include email addresses in results (+2 credits). **Significantly increases latency** — search will take longer to complete as emails are enriched per result |
+| `show_phone_numbers` | boolean | false | Include phone numbers in results (+14 credits). **Significantly increases latency** — search will take longer to complete as phone numbers are enriched per result |
+| `require_emails` | boolean | false | Only return profiles that have email addresses (+1 credit) |
+| `require_phone_numbers` | boolean | false | Only return profiles that have phone numbers (+1 credit) |
+| `require_phones_or_emails` | boolean | false | Only return profiles with either phone or email (+1 credit) |
+| `insights` | boolean | false | AI-generated insights per result explaining match relevance (+1 credit per result). Not available for `light` type |
+| `profile_scoring` | boolean | false | Include AI relevance score (0-1) per result (+1 credit) |
+| `high_freshness` | boolean | false | Prioritize recently updated profiles (+2 credits). Not available for `light` type |
+| `force_new` | boolean | false | Force fresh search, ignore cached results |
+| `custom_filters` | object | omit | Structured filters for precise targeting (see Custom Filters below) |
+| `callback_url` | string | omit | Webhook URL for async results delivery |
+
+### Custom Filters
+
+Pass as a `custom_filters` object to narrow results beyond the natural language query.
+
+**Array fields** (pass as arrays of strings):
+
+| Filter | Description |
+|--------|-------------|
+| `locations` | Geographic locations (e.g., `["San Francisco", "New York"]`) |
+| `languages` | Languages spoken (e.g., `["English", "Spanish"]`) |
+| `titles` | Job titles (e.g., `["CTO", "VP Engineering"]`) |
+| `industries` | Industry sectors (e.g., `["Technology", "Healthcare"]`) |
+| `companies` | Company names, current or past (e.g., `["Google", "Meta"]`) |
+| `universities` | Universities attended (e.g., `["Stanford", "MIT"]`) |
+| `keywords` | Profile keywords (e.g., `["machine learning", "AI"]`) |
+| `degrees` | Education degrees (e.g., `["bachelor", "master", "phd"]`) |
+| `specialization_categories` | Academic specialization categories |
+
+**Numeric range fields** (pass as integers):
+
+| Filter | Description |
+|--------|-------------|
+| `min_linkedin_followers` / `max_linkedin_followers` | LinkedIn follower count range |
+| `min_total_experience_years` / `max_total_experience_years` | Total work experience range |
+| `min_current_experience_years` / `max_current_experience_years` | Current role tenure range |
+| `min_estimated_age` / `max_estimated_age` | Estimated age range |
+
+**Exact match fields**:
+
+| Filter | Type | Description |
+|--------|------|-------------|
+| `first_name` | string | Exact first name match |
+| `middle_name` | string | Exact middle name match |
+| `last_name` | string | Exact last name match |
+| `gender` | string | `"male"` or `"female"` |
+| `studied_at_top_universities` | boolean | Attended a top-ranked university |
+
+### Examples
+
+**Basic search:**
+```bash
+curl -s -X POST "https://api.nyne.ai/person/search" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $NYNE_API_KEY" \
+  -H "X-API-Secret: $NYNE_API_SECRET" \
+  -d '{"query": "Software engineers at Google in San Francisco", "limit": 10}' | nyne_parse > /tmp/nyne_search.json
+
+jq '{status: .data.status, request_id: .data.request_id}' /tmp/nyne_search.json
+```
+
+**With emails and phone numbers:**
+```bash
+curl -s -X POST "https://api.nyne.ai/person/search" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $NYNE_API_KEY" \
+  -H "X-API-Secret: $NYNE_API_SECRET" \
+  -d '{"query": "Marketing directors at tech startups in Austin", "limit": 25, "show_emails": true, "show_phone_numbers": true}' | nyne_parse > /tmp/nyne_search.json
+```
+
+**With custom filters:**
+```bash
+curl -s -X POST "https://api.nyne.ai/person/search" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $NYNE_API_KEY" \
+  -H "X-API-Secret: $NYNE_API_SECRET" \
+  -d '{
+    "query": "Engineering leaders in fintech",
+    "limit": 20,
+    "type": "premium",
+    "show_emails": true,
+    "custom_filters": {
+      "locations": ["New York", "San Francisco"],
+      "titles": ["CTO", "VP Engineering", "Head of Engineering"],
+      "min_total_experience_years": 10,
+      "industries": ["Financial Services", "Technology"]
+    }
+  }' | nyne_parse > /tmp/nyne_search.json
+```
+
+**Light search (fast, 1 credit):**
+```bash
+curl -s -X POST "https://api.nyne.ai/person/search" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $NYNE_API_KEY" \
+  -H "X-API-Secret: $NYNE_API_SECRET" \
+  -d '{"query": "Data scientists at Amazon", "type": "light", "limit": 10}' | nyne_parse > /tmp/nyne_search.json
+```
+
+**With AI scoring and insights:**
+```bash
+curl -s -X POST "https://api.nyne.ai/person/search" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $NYNE_API_KEY" \
+  -H "X-API-Secret: $NYNE_API_SECRET" \
+  -d '{"query": "AI researchers in healthcare", "type": "premium", "profile_scoring": true, "insights": true, "limit": 10}' | nyne_parse > /tmp/nyne_search.json
+```
+
+**With freshness priority:**
+```bash
+curl -s -X POST "https://api.nyne.ai/person/search" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $NYNE_API_KEY" \
+  -H "X-API-Secret: $NYNE_API_SECRET" \
+  -d '{"query": "Product managers who recently changed jobs", "type": "premium", "high_freshness": true, "show_emails": true}' | nyne_parse > /tmp/nyne_search.json
+```
+
+**Require contact info:**
+```bash
+curl -s -X POST "https://api.nyne.ai/person/search" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $NYNE_API_KEY" \
+  -H "X-API-Secret: $NYNE_API_SECRET" \
+  -d '{"query": "Sales directors at SaaS companies", "require_emails": true, "show_emails": true, "limit": 50}' | nyne_parse > /tmp/nyne_search.json
+```
+
+**Submit response:**
+```json
+{
+  "success": true,
+  "data": {
+    "request_id": "abc12345_1737123456_1234",
+    "status": "completed",
+    "results": [...],
+    "offset": 0,
+    "limit": 10,
+    "total_stored": 47,
+    "total_estimate": 2500,
+    "has_more": true,
+    "next_cursor": "eyJvIjoxMCwiciI6ImFiYzEyMzQ1XzE3MzcxMjM0NTZfMTIzNCJ9",
+    "from_cache": false,
+    "credits_charged": 7
+  },
+  "timestamp": "2026-02-19T..."
+}
+```
+
+Note: The POST may return `status: "completed"` immediately (especially for cached or light searches) or `status: "processing"` requiring polling. Always check the status.
+
+## Poll for Results (GET)
+
+**Endpoint:** `GET https://api.nyne.ai/person/search?request_id={id}`
+
+**Headers:** Same `X-API-Key` and `X-API-Secret` as above.
+
+### Check status once
+```bash
+curl -s "https://api.nyne.ai/person/search?request_id=$REQUEST_ID" \
+  -H "X-API-Key: $NYNE_API_KEY" \
+  -H "X-API-Secret: $NYNE_API_SECRET" | nyne_parse > /tmp/nyne_search.json
+
+jq '{status: .data.status, total_stored: .data.total_stored}' /tmp/nyne_search.json
+```
+
+### Full polling loop
+
+```bash
+SECONDS_WAITED=0
+TIMEOUT=600  # 10 minutes
+
+while [ $SECONDS_WAITED -lt $TIMEOUT ]; do
+  curl -s "https://api.nyne.ai/person/search?request_id=$REQUEST_ID" \
+    -H "X-API-Key: $NYNE_API_KEY" \
+    -H "X-API-Secret: $NYNE_API_SECRET" | nyne_parse > /tmp/nyne_search.json
+  STATUS=$(jq -r '.data.status' /tmp/nyne_search.json)
+
+  echo "[$(date +%H:%M:%S)] Status: $STATUS ($SECONDS_WAITED s)"
+
+  case "$STATUS" in
+    completed)
+      jq '.data | {total_stored, total_estimate, has_more, credits_charged}' /tmp/nyne_search.json
+      jq '.data.results[] | {displayname, headline, location}' /tmp/nyne_search.json
+      break
+      ;;
+    failed)
+      echo "Search failed:"
+      jq '.data' /tmp/nyne_search.json
+      break
+      ;;
+    *)
+      sleep 5
+      SECONDS_WAITED=$((SECONDS_WAITED + 5))
+      ;;
+  esac
+done
+
+if [ "$STATUS" != "completed" ] && [ "$STATUS" != "failed" ]; then
+  echo "Timed out. Resume polling with request_id: $REQUEST_ID"
+fi
+```
+
+## Pagination
+
+After the initial search completes, paginate through results for free (cached results, no additional credits).
+
+### Cursor-based pagination (recommended)
+
+Use the `next_cursor` from the previous response:
+
+```bash
+curl -s -X POST "https://api.nyne.ai/person/search" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $NYNE_API_KEY" \
+  -H "X-API-Secret: $NYNE_API_SECRET" \
+  -d '{"cursor": "eyJvIjoxMCwiciI6ImFiYzEyMzQ1XzE3MzcxMjM0NTZfMTIzNCJ9"}' | nyne_parse > /tmp/nyne_search.json
+
+jq '.data | {total_stored, offset, limit, has_more}' /tmp/nyne_search.json
+jq '.data.results[] | {displayname, headline, location}' /tmp/nyne_search.json
+```
+
+### Offset-based pagination
+
+Use `request_id` + `offset` from the original search:
+
+```bash
+curl -s -X POST "https://api.nyne.ai/person/search" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $NYNE_API_KEY" \
+  -H "X-API-Secret: $NYNE_API_SECRET" \
+  -d '{"request_id": "abc12345_1737123456_1234", "offset": 25, "limit": 25}' | nyne_parse > /tmp/nyne_search.json
+
+jq '.data | {total_stored, offset, limit, has_more}' /tmp/nyne_search.json
+jq '.data.results[] | {displayname, headline, location}' /tmp/nyne_search.json
+```
+
+**Pagination notes:**
+- Paginating through cached results is free — no additional credits charged
+- Maximum 1000 results per search (`offset + limit` ≤ 1000)
+- `has_more` indicates whether more results are available
+- `next_cursor` is only present when `has_more` is true
+- Results are cached for 30 days
+
+## Response Structure
+
+When `status` is `completed`:
+
+```json
+{
+  "success": true,
+  "timestamp": "2026-02-19T...",
+  "data": {
+    "request_id": "abc12345_1737123456_1234",
+    "status": "completed",
+    "results": [
+      {
+        "displayname": "Jane Smith",
+        "headline": "Senior Software Engineer at Google",
+        "bio": "...",
+        "location": "San Francisco, CA",
+        "gender": "female",
+        "estimated_age": 35,
+        "total_experience_years": 12,
+        "is_decision_maker": 1,
+        "is_top_universities": true,
+        "languages": ["English", "Spanish"],
+        "interests": {
+          "work": ["software engineering", "machine learning", "distributed systems"],
+          "certification": ["AWS Solutions Architect"]
+        },
+        "patents": [],
+        "best_business_email": "jane@google.com",
+        "best_personal_email": "jane@gmail.com",
+        "altemails": ["j.smith@gmail.com"],
+        "fullphone": [{"fullphone": "+14155551234", "type": "mobile"}],
+        "social_profiles": {
+          "linkedin": {
+            "url": "https://www.linkedin.com/in/janesmith",
+            "username": "janesmith",
+            "connections": 1243,
+            "followers": 542,
+            "photo_url": "..."
+          }
+        },
+        "organizations": [
+          {
+            "name": "Google",
+            "title": "Senior Software Engineer",
+            "startDate": "3-2020",
+            "location": "San Francisco",
+            "company_website": "google.com",
+            "industries": ["Technology"],
+            "num_employees": "10001+"
+          }
+        ],
+        "schools_attended": ["Stanford University"],
+        "schools_info": [
+          {
+            "name": "Stanford University",
+            "degree": "Master's",
+            "title": "Computer Science",
+            "startDate": "2012",
+            "endDate": "2014"
+          }
+        ],
+        "score": 0.92,
+        "insights": {
+          "match_reasoning": "Strong match based on..."
+        }
+      }
+    ],
+    "offset": 0,
+    "limit": 10,
+    "total_stored": 47,
+    "total_estimate": 2500,
+    "has_more": true,
+    "next_cursor": "eyJvIjoxMCwi...",
+    "from_cache": false,
+    "credits_charged": 7
+  }
+}
+```
+
+### Result Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `displayname` | string | Person's full name |
+| `headline` | string | Current job title/headline |
+| `bio` | string | Professional biography |
+| `location` | string | Geographic location |
+| `gender` | string | `"male"` or `"female"` |
+| `estimated_age` | integer | Estimated age |
+| `total_experience_years` | integer | Years of total work experience |
+| `is_decision_maker` | integer | Whether person holds decision-making authority (1 = yes) |
+| `is_top_universities` | boolean | Whether person attended a top-ranked university |
+| `languages` | array | Languages spoken (array of strings) |
+| `interests` | object | `{work: [...], certification: [...]}` — work interests and certifications |
+| `patents` | array | Patents held: `{title, description, date, reference, url}` |
+| `best_business_email` | string | Primary business email (requires `show_emails: true`) |
+| `best_personal_email` | string | Primary personal email (requires `show_emails: true`) |
+| `altemails` | array | Alternative email addresses (requires `show_emails: true`) |
+| `fullphone` | array | Phone numbers with type (requires `show_phone_numbers: true`). Each: `{fullphone, type}` |
+| `social_profiles` | object | Social profile data (see below) |
+| `organizations` | array | Work history (see below) |
+| `schools_attended` | array | University names as strings |
+| `schools_info` | array | Detailed education: `{name, degree, major, startDate, endDate}` |
+| `score` | number | AI relevance score 0-1 (requires `profile_scoring: true`) |
+| `insights` | object | AI-generated match reasoning (requires `insights: true`) |
+
+### Social Profiles Object
+
+```json
+{
+  "linkedin": {
+    "url": "https://www.linkedin.com/in/...",
+    "username": "...",
+    "connections": 1243,
+    "followers": 542,
+    "photo_url": "..."
+  }
+}
+```
+
+### Organization Object
+
+```json
+{
+  "name": "Windfall Bio",
+  "title": "Vice President of Software Engineering",
+  "startDate": "2024-08-01",
+  "endDate": null,
+  "location": "San Mateo, California, United States",
+  "company_website": "http://www.windfall.bio",
+  "company_linkedin_url": "https://www.linkedin.com/company/windfallbio",
+  "company_domain": "windfall.bio",
+  "industries": ["Manufacturing"],
+  "num_employees": 37,
+  "num_employees_range": "11-50",
+  "is_startup": true,
+  "is_b2b": true,
+  "is_b2c": false,
+  "is_saas": false,
+  "founded_in": 2022,
+  "latest_funding_round": "Series A",
+  "latest_funding_amount": 28000000,
+  "funding_total_usd": 37000000,
+  "annual_revenue": 345000,
+  "specialties": ["methane", "climate", "agtech"],
+  "technologies": ["Google Analytics", "AWS Lambda", "Webflow"],
+  "companyDesc": "...",
+  "logo_url": "..."
+}
+```
+
+Organizations include rich company intelligence: funding data, tech stack, employee counts, and B2B/B2C/SaaS flags. Not all fields are present for every organization.
+
+### Response Metadata Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `total_stored` | integer | Number of results stored from this search |
+| `total_estimate` | integer | Estimated total matching profiles |
+| `has_more` | boolean | Whether more results are available for pagination |
+| `next_cursor` | string | Opaque pagination token for next page (present when `has_more` is true) |
+| `from_cache` | boolean | Whether results came from cache (30-day TTL) |
+| `credits_charged` | integer | Total credits charged for this request |
+| `offset` | integer | Current offset in result set |
+| `limit` | integer | Results per page |
+
+## Useful jq Filters
+
+After polling completes, the clean response is at `/tmp/nyne_search.json`:
+
+```bash
+# Search metadata
+jq '.data | {total_stored, total_estimate, has_more, credits_charged, from_cache}' /tmp/nyne_search.json
+
+# List all people (name + headline + location)
+jq '.data.results[] | {displayname, headline, location}' /tmp/nyne_search.json
+
+# All emails
+jq '.data.results[] | {displayname, best_business_email, best_personal_email, altemails}' /tmp/nyne_search.json
+
+# Phone numbers
+jq '.data.results[] | {displayname, fullphone}' /tmp/nyne_search.json
+
+# LinkedIn profiles
+jq '.data.results[] | {displayname, linkedin: .social_profiles.linkedin.url}' /tmp/nyne_search.json
+
+# Work history per person
+jq '.data.results[] | {displayname, orgs: [.organizations[] | {name, title}]}' /tmp/nyne_search.json
+
+# Decision makers only
+jq '[.data.results[] | select(.is_decision_maker == true)] | length' /tmp/nyne_search.json
+jq '[.data.results[] | select(.is_decision_maker == true) | {displayname, headline}]' /tmp/nyne_search.json
+
+# Sort by relevance score (if profile_scoring enabled)
+jq '[.data.results | sort_by(-.score)[] | {displayname, headline, score}]' /tmp/nyne_search.json
+
+# Experience range
+jq '.data.results[] | {displayname, total_experience_years} | select(.total_experience_years >= 10)' /tmp/nyne_search.json
+
+# Education
+jq '.data.results[] | {displayname, schools: .schools_attended}' /tmp/nyne_search.json
+
+# Interests and certifications
+jq '.data.results[] | {displayname, work_interests: .interests.work, certifications: .interests.certification}' /tmp/nyne_search.json
+
+# Patents
+jq '.data.results[] | select(.patents | length > 0) | {displayname, patents: [.patents[] | {title, date}]}' /tmp/nyne_search.json
+
+# Company intelligence (funding, tech stack)
+jq '.data.results[] | {displayname, companies: [.organizations[] | {name, funding_total_usd, latest_funding_round, num_employees, is_startup}]}' /tmp/nyne_search.json
+
+# Get next_cursor for pagination
+jq -r '.data.next_cursor' /tmp/nyne_search.json
+
+# Count results
+jq '.data.results | length' /tmp/nyne_search.json
+```
+
+## Error Handling
+
+| HTTP Code | Error | Description |
+|-----------|-------|-------------|
+| 400 | `invalid_parameters` | Invalid parameter value or missing query |
+| 400 | `invalid_custom_filters` | Malformed custom_filters object |
+| 401 | `invalid_credentials` | Invalid API key/secret |
+| 404 | `request_not_found` | Invalid request_id for status check (GET only) |
+| 429 | `rate_limit_exceeded` | Too many requests |
+| 429 | `insufficient_credits` | Not enough credits for this search |
+| 500 | `internal_error` | Server error |
+
+## Search Tiers & When to Use Each
+
+### Fast Search — `type: "light"` (1 credit per result)
+Basic search with fast results in 3-40 seconds. Best for quick lookups when you need a broad list of names and don't need deep profile data. **AI features (`insights`, `high_freshness`) are NOT available for light type.** Profile scoring is available.
+```json
+{"query": "Software engineers at Google", "type": "light", "limit": 50}
+```
+
+### Smart Search — `type: "medium"`
+Balanced tier between speed and quality. Use when you want better matching than light but don't need the full depth of premium. Supports all AI features.
+```json
+{"query": "Engineering managers in fintech", "type": "medium", "limit": 25}
+```
+
+### Pro Search — `type: "premium"` (5 credits per result)
+Comprehensive search taking 30-300 seconds. Best quality results with deepest profile matching. Required for maximum-quality `insights` and `high_freshness` results. Use when result quality matters more than speed.
+```json
+{"query": "AI researchers at top universities", "type": "premium", "limit": 10, "insights": true, "profile_scoring": true}
+```
+
+## AI-Powered Analysis Features
+
+These features add intelligence on top of search results. **Insights and High Freshness are NOT available for `light` type searches** — use `medium` or `premium`.
+
+### Query Insights (`insights: true`, +1 credit per result)
+AI-generated analysis for each result explaining **why this person matches your search query**. Returns structured reasoning about the match relevance — how their background, role, and experience align with what you're looking for. Invaluable for qualifying leads or evaluating candidates at scale. Use when you need to understand the "why" behind each match, not just the "who".
+```json
+{"query": "AI researchers in healthcare", "type": "premium", "insights": true, "limit": 10}
+```
+
+### Profile Scoring (`profile_scoring: true`, +1 credit)
+AI relevance scoring that assigns each result a score from 0 to 1, where 1.0 is a perfect match. Use to **rank and prioritize** results by relevance. Works with all search tiers including light. Combine with insights for both a score and an explanation.
+```json
+{"query": "Senior engineers at fintech startups", "profile_scoring": true, "limit": 25}
+```
+
+### High Freshness (`high_freshness: true`, +2 credits)
+Prioritizes profiles that have been **recently updated** — people who recently changed jobs, updated their LinkedIn, or have fresh activity. Use when recency matters: hiring recently active candidates, targeting people who just moved to a new role, or finding profiles with current contact info. **Not available for `light` type.**
+```json
+{"query": "Product managers who recently changed jobs", "type": "premium", "high_freshness": true, "show_emails": true}
+```
+
+### Combining AI Features
+Stack insights + scoring + freshness for maximum intelligence:
+```json
+{
+  "query": "VP of Engineering at Series B startups in San Francisco",
+  "type": "premium",
+  "insights": true,
+  "profile_scoring": true,
+  "high_freshness": true,
+  "show_emails": true,
+  "limit": 10
+}
+```
+
+## Credit Costs
+
+Credits are charged based on features used per request. Pagination within cached results is free.
+
+| Feature | Credits | Description |
+|---------|---------|-------------|
+| Fast Search (`type: "light"`) | 1 | Basic search, fastest response (3-40 seconds) |
+| Pro Search (`type: "premium"`) | 5 | Comprehensive search, best quality (30-300 seconds) |
+| Smart Ranking (`profile_scoring`, boolean) | 1 | AI-powered relevance scoring of results |
+| Candidate Insights (`insights`, boolean) | 1 | AI-generated insights about each result |
+| Realtime Profiles (`high_freshness`, boolean) | 2 | Prioritize recently updated profiles |
+| Filter Without Contact Data | 1 | Search without email/phone enrichment |
+| Enrich Phones (`show_phone_numbers`, boolean) | 14 | Include phone numbers in results. **Significantly increases latency** |
+| Enrich Emails (`show_emails`, boolean) | 2 | Include email addresses in results. **Significantly increases latency** |
+| Require Emails (`require_emails`, boolean) | 1 | Only return profiles with email addresses |
+| Require Phones (`require_phone_numbers`, boolean) | 1 | Only return profiles with phone numbers |
+| Require Contact Info (`require_phones_or_emails`, boolean) | 1 | Only return profiles with phone OR email |
+| Pagination (cached) | 0 | Free after initial search (30-day cache) |
+
+## Rate Limits
+
+- **Per minute:** 60 requests
+- **Per hour:** 1,000 requests
+- **Monthly:** Plan-dependent


### PR DESCRIPTION
## Summary

Three community skills wrapping the [Nyne](https://api.nyne.ai) person intelligence API:

- **nyne-deep-research** — Comprehensive dossier with psychographic profile, social graph, career analysis, conversation starters, and approach strategy. 2-5 min async processing, 100 credits.
- **nyne-enrichment** — Contact info, social profiles, work history, education, and optional social media posts. 3-30s async. Supports lite mode (3 credits), standard (6 credits), AI-enhanced search, and newsfeed add-on.
- **nyne-search** — Natural language people search with custom filters (location, title, industry, experience, etc.), AI relevance scoring, candidate insights, contact enrichment, and cursor/offset pagination. 3 tiers: light (1 credit), medium, premium (5 credits).

All skills follow the same patterns:
- Async polling (POST to submit, GET to poll until completed)
- `nyne_parse` helper for JSON control character sanitization
- Temp file workflow (never store API responses in bash variables)
- Comprehensive jq filters for extracting data

## Test plan
- [x] All skills validated with `bun validate` (0 errors)
- [x] Live API testing on deep-research and enrichment endpoints
- [x] Search endpoint response structure verified against real data
- [x] All jq filters tested and working
- [x] No API credentials in any committed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)