### PR TITLE
Add EUrouter to Partner Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,4 @@ The markdown content below contains the instructions, examples, and guidelines t
 Skills are a great way to teach Claude how to get better at using specific pieces of software. As we see awesome example skills from partners, we may highlight some of them here:
 
 - **Notion** - [Notion Skills for Claude](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0)
+- **EUrouter** - [EUrouter Integration Skill](https://github.com/EUrouter/eurouter-skill) - Guides developers through integrating EUrouter, an OpenAI-compatible AI gateway for EU/GDPR compliance with built-in data residency controls


### PR DESCRIPTION
Adds [EUrouter](https://eurouter.ai) to the Partner Skills section.

EUrouter is an OpenAI-compatible AI gateway built for EU customers who need GDPR compliance. The [EUrouter Integration Skill](https://github.com/EUrouter/eurouter-skill) guides developers through integrating EUrouter into their applications, covering drop-in migration from OpenAI/OpenRouter, EU data residency configuration, all API endpoints, and multi-model fallback routing.

**Install:** `npx skills add eurouter/eurouter-skill`