### PR TITLE
Add character-board project files and skill template

### DIFF
--- a/character-board/README.md
+++ b/character-board/README.md
@@ -1,0 +1,102 @@
+# Character Board — Political Satire Animation Project
+
+## Premise
+
+A viewer watches the news. Each episode cuts to an "inside look" at what actually happened, told from a specific character's distorted point of view.
+
+The Anchor delivers the sanitized official version. Then we cut inside — same event, five different realities, each one shaped entirely by the character's archetype.
+
+---
+
+## Style
+
+US-centered political satire. Core cast of 5 recurring archetypes. Global characters appear as episode-specific guests.
+
+Two animation modes:
+
+| Mode | Used For |
+|---|---|
+| South Park flat cutout | Characters with rigid, symbolic worldviews |
+| Boondocks anime-fluid | Characters with emotional complexity or physical expressiveness |
+
+---
+
+## Core Cast
+
+| Character | File | Animation Style |
+|---|---|---|
+| The Anchor *(frame)* | `frame/the-anchor.md` | South Park flat |
+| The MAGA Cultist | `core-cast/maga-cultist.md` | South Park flat |
+| The Typical Leftist | `core-cast/typical-leftist.md` | South Park flat |
+| The Informed Person | `core-cast/informed-person.md` | Boondocks fluid |
+| The Opportunist | `core-cast/opportunist.md` | Boondocks fluid |
+| The Talking Head | `core-cast/talking-head.md` | South Park flat |
+
+---
+
+## Style Assignment Rationale
+
+| Character | Style | Reason |
+|---|---|---|
+| The Anchor | Flat | Symbolic, institutional, no inner life |
+| The MAGA Cultist | Flat | Rigid worldview — symbolic not expressive |
+| The Typical Leftist | Flat | Performative — the flatness mirrors the performance |
+| The Informed Person | Fluid | Emotional complexity, internal life visible |
+| The Opportunist | Fluid | Calculation requires readable microexpressions |
+| The Talking Head | Flat | Pure surface — flat is the point |
+
+---
+
+## Directory Structure
+
+```
+character-board/
+├── README.md                          ← this file
+├── frame/
+│   └── the-anchor.md                  ← frame character / viewer entry point
+├── core-cast/
+│   ├── maga-cultist.md
+│   ├── typical-leftist.md
+│   ├── informed-person.md
+│   ├── opportunist.md
+│   └── talking-head.md
+├── assets/
+│   ├── color-palettes/                ← per-character color data
+│   │   ├── the-anchor.md
+│   │   ├── maga-cultist.md
+│   │   ├── typical-leftist.md
+│   │   ├── informed-person.md
+│   │   ├── opportunist.md
+│   │   └── talking-head.md
+│   └── svg-maps/
+│       └── README.md                  ← SVG asset map index (populated per episode)
+└── storyboard/
+    └── episode-template.md            ← standard episode structure
+```
+
+---
+
+## Global Guest Characters
+
+Global characters appear in specific episodes only. Introduced through The Anchor's desk before their POV cut. Animation style assigned per episode based on narrative role — flat if serving a symbolic function, fluid if carrying dramatic weight.
+
+Placeholder archetypes for future episodes:
+
+| Archetype | Style |
+|---|---|
+| The Nationalist Strongman | Boondocks fluid |
+| The Technocrat | South Park flat |
+| The Revolutionary | Boondocks fluid |
+| The Multilateral Bureaucrat | South Park flat |
+
+---
+
+## Episode Format
+
+See `storyboard/episode-template.md`.
+
+---
+
+*Version 1.0 — Character Board*
+*Branch: feature/character-board*
+*Next: Storyboard template → feature/storyboard branch*

--- a/character-board/assets/color-palettes/informed-person.md
+++ b/character-board/assets/color-palettes/informed-person.md
@@ -1,0 +1,92 @@
+# Color Palette — The Informed Person
+
+**Animation style:** Boondocks anime-fluid
+**Character archetype:** The Huey Freeman function — accurate, exhausted, marginal
+
+---
+
+## Palette
+
+| Element | Name | Hex | RGB | Usage |
+|---|---|---|---|---|
+| Primary | Charcoal gray | `#3D3D3D` | 61, 61, 61 | Primary clothing — jacket, outer layer |
+| Secondary | Warm brown | `#5C4A32` | 92, 74, 50 | Secondary clothing — pants, inner layer |
+| Tertiary | Dark forest green | `#2D4A2D` | 45, 74, 45 | Occasional accent layer — sweater, alternate top |
+| Skin | Medium brown | `#8B6340` | 139, 99, 64 | Skin base |
+| Glasses | Matte gold | `#8A7340` | 138, 115, 64 | Wire-frame glasses |
+
+---
+
+## Extended Palette (Boondocks Cel-Shade)
+
+| Element | Base | Shadow | Highlight | Notes |
+|---|---|---|---|---|
+| Outer clothing | `#3D3D3D` | `#252525` | `#555555` | Charcoal — 1-stop cel shadow |
+| Inner clothing | `#5C4A32` | `#3C2E1A` | `#7A6448` | Warm brown — 1-stop cel shadow |
+| Tertiary layer | `#2D4A2D` | `#1A2E1A` | `#3E6040` | Dark forest green |
+| Skin | `#8B6340` | `#6A4828` | `#A87A54` | Medium brown — Boondocks skin group |
+| Skin line | `#5C3A20` | — | — | Interior skin detail lines |
+| Glasses frame | `#8A7340` | `#6A5828` | — | Matte — no highlight on glasses |
+| Glasses lens | `#B8C8C0` | — | `#D8E8E0` | Subtle cool tint — slight glare in key moments |
+| Outline | `#1A1A1A` | — | — | 4px contour |
+| Interior line | `#2A2A2A` | — | — | 2px interior — folds, anatomy |
+
+---
+
+## Hair
+
+| Element | Hex | Notes |
+|---|---|---|
+| Hair base | `#1A1210` | Near black — natural, low maintenance |
+| Hair shadow | `#0D0A08` | Very dark — minimal differentiation |
+
+**Hair design note:** No sheen, no highlight pass. The hair reads as practical. It is the absence of grooming as a statement — specifically, the absence of grooming as a signal. He is not signaling anything through his hair, which is the only person in the cast not doing that.
+
+---
+
+## Glasses Design Note
+
+The glasses are the most important accessory in the character's visual system. They serve two functions:
+
+1. **In rest state:** They are practical wire-frame rounds — slightly worn, no particular style
+2. **In recognition moments:** The lens catches light — a single glare pass that appears when something just registered
+
+The glare animation is a Boondocks fluid feature: it is the visual tell for the specific moment of "I knew it" that the character experiences multiple times per episode. Matte gold frame, no highlight. Lens: slight cool tint (`#B8C8C0`), glare highlight (`#D8E8E0`) in key frames.
+
+---
+
+## Book / Newspaper Prop
+
+| Element | Hex | Notes |
+|---|---|---|
+| Book cover | `#3D3D3D` | Matches outer clothing — it disappears against his lap |
+| Book pages | `#F0EDE0` | Warm paper white |
+| Book spine detail | `#2A2A2A` | Minimal — this is not a decorative prop |
+| Newspaper | `#E8E0D0` | Newsprint gray-white |
+| Newspaper ink | `#1A1A1A` | Text block — readable as text, not readable as text |
+
+**Prop note:** The book/newspaper is set down, never thrown down. The animation is deliberate. The color matches his outer clothing closely enough that it reads as an extension of him, which communicates that the act of putting it down costs something.
+
+---
+
+## Palette Design Intent
+
+This palette is the anti-palette of the rest of the cast. Where others signal through color, he signals through the absence of it. Charcoal and warm brown are the colors of someone who selected clothing once, found something that worked, and stopped thinking about it.
+
+**The forest green tertiary** exists because even the Informed Person occasionally wears something slightly different — but it is still a dark, low-saturation green. It is not expressive. It is a different shade of not trying.
+
+**The skin tone** (`#8B6340`) is the warmest color in the palette, and it belongs to the person, not the outfit. The character's humanity is in his face. The clothing is armor — or camouflage. The palette communicates both.
+
+**The matte gold glasses** are the only element that suggests any prior decision-making. At some point he chose those frames. They are good frames. He stopped noticing them years ago.
+
+---
+
+## Application Rules (Boondocks Fluid)
+
+- Cel-shade: base + 1-stop shadow layer (multiply blend)
+- Outline: `#1A1A1A` at 4px contour, `#2A2A2A` at 2px interior
+- Glasses frame: no highlight pass — matte
+- Glasses lens: subtle tint, glare highlight only in recognition moments (not continuous)
+- Book/newspaper: present in establishing shots, set down in action sequences
+- Skin detail lines: `#5C3A20` for face interior — nose, jaw, expression lines
+- Sigh animation: full-body — shoulders, chest, eyes — this is a featured Boondocks fluid moment

--- a/character-board/assets/color-palettes/maga-cultist.md
+++ b/character-board/assets/color-palettes/maga-cultist.md
@@ -1,0 +1,82 @@
+# Color Palette — The MAGA Cultist
+
+**Animation style:** South Park flat cutout
+**Character archetype:** True believer / grievance identity
+
+---
+
+## Palette
+
+| Element | Name | Hex | RGB | Usage |
+|---|---|---|---|---|
+| Primary | Flag red | `#B22234` | 178, 34, 52 | Flannel shirt base, dominant body color |
+| Secondary | Faded denim blue | `#4A6741` | 74, 103, 65 | Jeans, secondary body color |
+| Tertiary | Off-white | `#EDE8D0` | 237, 232, 208 | Shirt underlayer, undershirt if visible |
+| Accent | Earth brown | `#6B4C2A` | 107, 76, 42 | Boots, belt |
+| Cap | Bright red | `#CC0000` | 204, 0, 0 | The cap — brighter than the shirt red |
+
+---
+
+## Extended Palette
+
+| Element | Hex | Notes |
+|---|---|---|
+| Flannel shadow | `#8A1A24` | Shadow pass on primary — darker, cooler |
+| Denim shadow | `#344A30` | Shadow pass on jeans |
+| Boot shadow | `#4A3018` | Shadow pass on boots / belt |
+| Skin | `#D4A870` | Medium-light, slightly weathered |
+| Skin shadow | `#A8784A` | Single shadow stop |
+| Outline | `#1A1A1A` | Standard South Park black |
+| Flag pin/patch | `#B22234` + `#FFFFFF` + `#3C3B6E` | American flag — red/white/navy triad |
+| Phone | `#222222` | Dark device body |
+| Phone screen | `#3A7ABF` | Social media blue — the feed color |
+| Hair | `#3D2A18` | Dark brown, slightly unkempt — no sheen |
+
+---
+
+## Flag Color Reference
+
+For the American flag pin, patch, or shirt print:
+
+| Element | Hex |
+|---|---|
+| Flag red | `#B22234` |
+| Flag white | `#FFFFFF` |
+| Flag navy | `#3C3B6E` |
+
+Flag elements should be visually identifiable but do not require pixel-accurate stripe count. The read should be immediate.
+
+---
+
+## Palette Design Intent
+
+The palette is the palette of the American flag plus earth. The reds are sincere — no irony in the color, no subversion of the expected reads. The flag red is the flag red. The bright red of the cap is brighter, more saturated than the shirt — because the cap is the most important garment, and it should read as such.
+
+**The denim blue** (`#4A6741`) is notable: it is slightly muted toward olive-gray, not the clean classic denim blue. This communicates the faded quality — worn, not new. This is not fresh-off-the-shelf patriotism. It has been worn for years.
+
+**The earth brown** of the boots grounds the palette literally and figuratively. He is a man of the earth, by which he means the land that he believes is being taken from him.
+
+**The off-white** is not clean white. Clean white would suggest freshness. Off-white suggests accumulated use — the shirt worn under things, the background to a body of work.
+
+---
+
+## Phone Screen Design Note
+
+The phone screen should show a recognizable social media feed layout (no actual platform branding). Key visual elements:
+- Bright notification indicator
+- Image posts with high-saturation thumbnails — flag imagery, text memes
+- Continuous downward scroll in animation
+- No specific text readable — general pattern only
+
+Screen color: `#3A7ABF` — the specific blue of platforms designed to produce engagement.
+
+---
+
+## Application Rules (South Park Flat)
+
+- Flat fills only — no gradients
+- Outline: `#1A1A1A` at 3px
+- Cap sits low on the head — brim defined at geometry level
+- Flag element must be visible in all orientations (front, 3/4, side)
+- Boots and belt share earth brown — same fill, different geometry
+- Phone in dominant hand in all shots where character is stationary

--- a/character-board/assets/color-palettes/opportunist.md
+++ b/character-board/assets/color-palettes/opportunist.md
@@ -1,0 +1,95 @@
+# Color Palette — The Opportunist
+
+**Animation style:** Boondocks anime-fluid
+**Character archetype:** Unprincipled centrist — self-interest as pragmatism
+
+---
+
+## Palette
+
+| Element | Name | Hex | RGB | Usage |
+|---|---|---|---|---|
+| Primary | Beige | `#C8B89A` | 200, 184, 154 | Shirt, base skin-adjacent clothing |
+| Secondary | Slate | `#7A8A96` | 122, 138, 150 | Tie if worn, secondary accessories |
+| Tertiary | Tan | `#B09070` | 176, 144, 112 | Pants, transitional elements |
+| Blazer | Medium gray | `#888888` | 136, 136, 136 | Blazer — the most visible garment |
+| Accent | Muted gold | `#B8A060` | 184, 160, 96 | Pocket square, watch, subtle accent |
+
+---
+
+## Extended Palette (Boondocks Cel-Shade)
+
+| Element | Base | Shadow | Highlight | Notes |
+|---|---|---|---|---|
+| Blazer | `#888888` | `#606060` | `#A8A8A8` | Medium gray — 1-stop each direction |
+| Blazer shadow region | `#606060` | — | — | Shadow side of blazer |
+| Shirt | `#C8B89A` | `#A89878` | `#E0D0B8` | Beige — warm, unmemorable |
+| Pants | `#B09070` | `#886848` | `#C8A888` | Tan — functional |
+| Pocket square | `#B8A060` | `#907A40` | — | Muted gold — no highlight, present not declarative |
+| Outline | `#1A1A1A` | — | — | 4px contour |
+| Interior line | `#2A2A2A` | — | — | 2px interior |
+| Skin | `#C8A882` | `#A08060` | `#E0C09A` | Light — well-groomed, slightly soft |
+| Skin line | `#8A6040` | — | — | Interior face detail |
+| Hair | `#5A4830` | `#3A3020` | `#7A6848` | Warm brown — perfectly maintained |
+| Hair product sheen | `#8A7858` | — | — | Single highlight line — the product-assist |
+
+---
+
+## Hair Design Note
+
+The hair is the most carefully maintained element of the character's appearance, which means it requires the most deliberately unnatural highlight in the cel-shade system. A single slightly too-perfect highlight line communicates the product without being decorative. It should look like someone else noticed it and he pretends not to have.
+
+| Element | Hex | Notes |
+|---|---|---|
+| Hair base | `#5A4830` | Warm brown — forgettable |
+| Hair shadow | `#3A3020` | Shadow pass |
+| Product sheen | `#8A7858` | One deliberate highlight — this is the tell |
+
+---
+
+## Business Card Prop
+
+| Element | Hex | Notes |
+|---|---|---|
+| Card body | `#F5F2EC` | Off-white — quality stock |
+| Card text area | `#1A1A1A` | Dark — minimal |
+| Card accent line | `#B8A060` | Muted gold — matches pocket square |
+
+**Prop note:** The business card should be its own small prop asset with the gold accent line visible. It appears in hand naturally — it was always there.
+
+---
+
+## Phone Prop
+
+| Element | Hex | Notes |
+|---|---|---|
+| Device | `#2A2A2A` | Dark |
+| Screen active | `#3A4A58` | Multiple apps visible — no single dominant color |
+| News app icons | Varied grid | 4–6 icons in a 2×3 grid — readable as multiple news apps, not branded |
+
+**Prop note:** Multiple news apps visible simultaneously — this communicates real-time position tracking. The screen is always on. No single app is dominant, which communicates that no single position is dominant.
+
+---
+
+## Palette Design Intent
+
+The Opportunist's palette is the hardest to remember. This is the design goal. Every color is reasonable. None of them declare anything. The blazer is gray because gray doesn't pick sides. The beige is beige because beige is the color of deferring a decision.
+
+**The muted gold** is the only element of ambition — pocket square, watch, the business card accent line. It is the only color that has decided something. It has decided to signal quality without declaring it. This is the most honest color in his palette.
+
+**The skin** is light and well-maintained — slightly too smooth. The Boondocks fluid system allows the calculation behind the face to be visible to the viewer, and the cel-shade on the skin must be clean enough to let that animation register. No rough edges. No character in the skin tone.
+
+**The hair sheen** is the tell — it's one step too deliberate. Everything else in the palette says "I am not trying." The hair says "I absolutely tried."
+
+---
+
+## Application Rules (Boondocks Fluid)
+
+- Cel-shade: base + 1-stop shadow + 1-stop highlight on blazer only
+- All other garments: base + shadow only (no highlight)
+- Hair: base + shadow + one deliberate sheen line
+- Outline: `#1A1A1A` at 4px contour, `#2A2A2A` at 2px interior
+- Pocket square: present but not highlighted — it is noticed, not featured
+- Business card: in hand in any scene where he is meeting someone or could meet someone (most scenes)
+- Phone: in hand or on surface — multiple apps visible, no single dominant
+- The head tilt animation must be preceded by a slight pause — the Boondocks fluid microexpression window for the calculation

--- a/character-board/assets/color-palettes/talking-head.md
+++ b/character-board/assets/color-palettes/talking-head.md
@@ -1,0 +1,110 @@
+# Color Palette — The Talking Head
+
+**Animation style:** South Park flat cutout
+**Character archetype:** Corporate media amplifier — everything is a crisis, nothing is explained
+
+---
+
+## Palette
+
+| Element | Name | Hex | RGB | Usage |
+|---|---|---|---|---|
+| Primary | Network red | `#CC2222` | 204, 34, 34 | Power garment — dominant suit or equivalent |
+| Secondary | Corporate navy | `#1A2A5E` | 26, 42, 94 | Alternate suit — rotates with primary |
+| Tertiary | Broadcast gold | `#C8A830` | 200, 168, 48 | Accent — tie, brooch, button detail |
+| Skin | Overlit warm | `#D4A882` | 212, 168, 130 | Skin base — overlit from years of studio lighting |
+| Accent | White hot | `#FFFFFF` | 255, 255, 255 | Collar, teeth, peak broadcast luminosity |
+
+---
+
+## Extended Palette
+
+| Element | Hex | Notes |
+|---|---|---|
+| Suit shadow (red) | `#961A1A` | Shadow pass on network red suit |
+| Suit shadow (navy) | `#0E1A3E` | Shadow pass on corporate navy suit |
+| Gold shadow | `#9A7C20` | Shadow pass on broadcast gold accent |
+| Skin shadow | `#A87850` | Single shadow stop — overlit, so shadow is limited |
+| Skin highlight | `#E8C8A0` | Overlit — highlight is pronounced |
+| Outline | `#1A1A1A` | Standard South Park black |
+| Makeup highlight | `#EED0B0` | Slightly brighter than skin — makeup layer |
+| Hair | `#1A1A1A` + solid fill | Perfect, single-shape, does not move |
+| Tablet | `#222222` | Device body |
+| Tablet screen | `#2A3A6A` | Screen on — implies content, delivers nothing |
+| Teeth | `#FFFFFF` | White hot — the smile is a broadcast element |
+
+---
+
+## Hair Design Note
+
+The hair is a single solid shape. In South Park flat, it does not move, separate, or vary between shots. It is correct in every orientation, which is only possible if it is not real hair — it is a hair-adjacent structure.
+
+| Element | Hex | Notes |
+|---|---|---|
+| Hair body | `#1A1A1A` | Single fill — no sheen, no variation |
+| Hair shape | Solid geometric | No individual strands implied |
+
+**Hair note:** In a sense, the hair being `#1A1A1A` — the same as the outline — is appropriate. There is no boundary between the person and the performance at the level of the hair. It is part of the character's outline.
+
+---
+
+## Skin: "Overlit Warm"
+
+The skin tone `#D4A882` is described as "overlit warm" — the specific quality of someone who has spent a disproportionate percentage of their life under studio lighting. It is warmer and slightly more saturated than natural skin at this tone would appear in standard light.
+
+| Element | Hex | Notes |
+|---|---|---|
+| Skin base | `#D4A882` | Overlit — warmer than natural |
+| Skin shadow | `#A87850` | Shadow limited — overlit environments suppress shadow |
+| Skin highlight | `#E8C8A0` | Pronounced — the studio lighting is aggressive |
+| Makeup layer | `#EED0B0` | Slightly lighter, applied — visible in South Park flat as a slightly different value |
+
+**South Park flat note:** The makeup being visible at the geometry level — a slightly brighter fill on the face area — communicates the studio-prepared quality without requiring a separate pass.
+
+---
+
+## Network Color Variants
+
+The Talking Head wears a different network color in different episodes, cycling through:
+
+| Variant | Primary | Accent |
+|---|---|---|
+| Network red (default) | `#CC2222` | `#C8A830` gold |
+| Corporate navy | `#1A2A5E` | `#CC2222` red accent |
+| Broadcast gold | `#C8A830` | `#1A2A5E` navy accent |
+
+**The broadcast gold variant** is reserved for high-stakes episodes — it reads as more expensive, which communicates more urgency.
+
+---
+
+## Tablet Prop
+
+| Element | Hex | Notes |
+|---|---|---|
+| Device body | `#222222` | Dark, thin — current |
+| Screen active | `#2A3A6A` | Navy-tinted — implies graphics, content |
+| Screen glance indicator | `#4A6AAA` | Slightly lighter — the screen is being looked at (not read) |
+
+**Prop note:** The tablet glance-and-away animation is one of the most important recurring beats. The screen color suggests information. The glance duration is insufficient for information to transfer. These two things together are the prop's entire function.
+
+---
+
+## Palette Design Intent
+
+The Talking Head's palette is the palette of broadcast television — the specific palette designed to communicate importance through color before any content is delivered. Network red is the color of urgency. Corporate navy is the color of authority. Broadcast gold is the color of premium tier.
+
+**The white hot accent** (`#FFFFFF`) appears at the collar and the teeth — the two most luminous points in a broadcast close-up. Both are performance elements. The collar announces formality. The teeth announce delivery. Neither communicates content.
+
+**The overlit skin** completes the broadcast signal: this person exists in studio light. They are a broadcast entity. They are appropriately lit for a screen. The fact that they appear in non-broadcast environments with the same lighting effect communicates that the performance never stops.
+
+---
+
+## Application Rules (South Park Flat)
+
+- Flat fills only — no gradients
+- Outline: `#1A1A1A` at 3px
+- Hair: single solid shape — same fill as outline — does not move
+- Eyebrow geometry: raised 3mm above standard position — this is a construction parameter, not an expression
+- Makeup: skin fill is slightly lighter than standard skin tone — `#EED0B0` face area vs `#D4A882` neck/hands
+- Tablet in hand in all shots — glance animation consistent and insufficient
+- Teeth visible when mouth is open — `#FFFFFF` white hot

--- a/character-board/assets/color-palettes/the-anchor.md
+++ b/character-board/assets/color-palettes/the-anchor.md
@@ -1,0 +1,66 @@
+# Color Palette — The Anchor
+
+**Animation style:** South Park flat cutout
+**Character role:** Frame character / news desk host
+
+---
+
+## Palette
+
+| Element | Name | Hex | RGB | Usage |
+|---|---|---|---|---|
+| Primary | Institutional blue | `#1A3A5C` | 26, 58, 92 | Blazer, authority elements |
+| Secondary | Cool gray | `#8A9BB0` | 138, 155, 176 | Desk surface, secondary props |
+| Accent | White | `#F5F5F5` | 245, 245, 245 | Shirt/collar, papers, earpiece |
+| Studio BG | Dark gradient blue | `#0D1F33` | 13, 31, 51 | Background — anchor desk environment |
+
+---
+
+## Extended Palette
+
+| Element | Hex | Notes |
+|---|---|---|
+| Blazer shadow | `#0F2440` | Shadow pass on blazer at South Park flat stroke weight |
+| Skin (neutral) | `#D4B896` | Generic — The Anchor reads as demographic-neutral by design |
+| Skin shadow | `#B09070` | Single shadow stop |
+| Outline | `#1A1A1A` | Standard South Park black |
+| Papers | `#F0EDE0` | Slightly warm white — present, never referenced |
+| Earpiece | `#CCCCCC` | Light gray — the cord should catch eye without demanding it |
+| Lower-third bar | `#1A3A5C` | Matches primary — institutional continuity |
+| Lower-third text | `#F5F5F5` | Matches accent — readable, authority-adjacent |
+
+---
+
+## Studio Background
+
+The anchor desk environment uses a dark-to-midtone blue gradient:
+
+| Position | Hex | Description |
+|---|---|---|
+| Far background | `#0D1F33` | Deep authority blue |
+| Mid background | `#1A3A5C` | Primary institutional blue |
+| Backlight bloom | `#2A5A8C` | Cooler, lighter — implied studio lighting behind desk |
+| Desk surface | `#8A9BB0` | Secondary gray — elevated, reflective |
+
+**Gradient note for South Park flat:** Gradient is rendered as 2–3 discrete banded zones, not continuous. Flat style; no smooth transitions.
+
+---
+
+## Palette Design Intent
+
+The Anchor's palette is the color of institutional authority — the specific blue that appears on government websites, news network backgrounds, and official presentations. It is not the blue of sky or water. It is the blue of approved information.
+
+**Nothing in this palette is warm.** Warmth implies personality. The Anchor has no personality to express — only position to perform. The single warm element is the skin tone, and even that is rendered as neutral as possible within the character's visual range.
+
+**The white accent** (`#F5F5F5`) appears at the collar, the papers, and the earpiece — the three points that communicate: this person is clean, prepared, and receiving. All three are props.
+
+---
+
+## Application Rules (South Park Flat)
+
+- Flat fills only — no gradients within character elements
+- Outline: `#1A1A1A` at 3px
+- Shadow pass: single darker value per color zone — no multi-stop shading
+- Background gradient rendered as 2–3 discrete bands
+- Papers always visible, always white, never in motion
+- Earpiece cord: `#CCCCCC`, thin line, visible in all orientations

--- a/character-board/assets/color-palettes/typical-leftist.md
+++ b/character-board/assets/color-palettes/typical-leftist.md
@@ -1,0 +1,110 @@
+# Color Palette — The Typical Leftist
+
+**Animation style:** South Park flat cutout
+**Character archetype:** Performative progressive / activism as identity accessory
+
+---
+
+## Palette
+
+| Element | Name | Hex | RGB | Usage |
+|---|---|---|---|---|
+| Primary | Muted olive | `#7A7A52` | 122, 122, 82 | Primary clothing layer — jacket, overshirt |
+| Secondary | Dusty rose | `#C4967A` | 196, 150, 122 | Secondary clothing layer — inner shirt, skirt |
+| Accent | Hair color (teal) | `#3DBCB0` | 61, 188, 176 | Hair — primary distinguishing feature |
+| Bag | Worn tan | `#B8956A` | 184, 149, 106 | Tote bag body |
+| Pin accent | Bright contrast yellow | `#F2C94C` | 242, 201, 76 | Pin/patch highlight — cause signaling |
+
+---
+
+## Extended Palette
+
+| Element | Hex | Notes |
+|---|---|---|
+| Olive shadow | `#5A5A38` | Shadow pass on primary clothing |
+| Dusty rose shadow | `#9A7058` | Shadow pass on secondary layer |
+| Hair shadow | `#2A8C82` | Teal shadow — darker, cooler |
+| Bag shadow | `#8A6A48` | Worn tan shadow |
+| Outline | `#1A1A1A` | Standard South Park black |
+| Skin | `#E0C0A0` | Light, warm — not notable |
+| Skin shadow | `#BCA080` | Single shadow stop |
+| Coffee cup | `#8A6A48` | The cup is from a chain — this is the chain's paper cup color |
+| Cup sleeve | `#6A5030` | Slightly darker — branded but unbranded |
+| Cup logo area | `#C04040` | Generic chain red — readable as chain without being one |
+| Phone | `#2A2A2A` | Dark device |
+| Pin cluster (vary) | `#F2C94C`, `#E04040`, `#4A9A4A`, `#4A70CC` | Multiple causes — varied bright accents |
+
+---
+
+## Hair Color Variants
+
+The hair color is episode-specific within the teal/lavender/pink range. Core palette is teal. Alternates:
+
+| Variant | Hex | Notes |
+|---|---|---|
+| Teal (default) | `#3DBCB0` | Primary — most readable at distance |
+| Teal shadow | `#2A8C82` | Shadow pass for default |
+| Lavender (alt) | `#A090CC` | Episodes requiring a softer visual read |
+| Lavender shadow | `#7868A0` | Shadow pass for lavender |
+| Pink (alt) | `#E080A0` | Episodes requiring more warmth or contrast |
+| Pink shadow | `#B86080` | Shadow pass for pink |
+
+**Not blue.** Blue reads as too direct a shorthand. The teal, lavender, and pink are adjacent to the obvious choice without landing on it — which is exactly the character's relationship to everything.
+
+---
+
+## Tote Bag Design Note
+
+The tote bag should carry at least one visible cause indicator — a word, symbol, or print. It should be:
+- Present in all shots
+- Slightly overfull (implies accumulation)
+- At least one cause marker legible in freeze-frame
+- Not individually distracting in motion
+
+The bag is the external hard drive of her self-image.
+
+---
+
+## Coffee Cup Design Note
+
+The cup is from a chain. This must be visually legible without being literally branded. Suggested approach:
+- Generic paper cup shape (not a reusable-looking vessel)
+- A color band or logo area in a recognizable chain-adjacent red
+- A sleeve in dark paper
+- The cup should immediately read to the viewer as "a chain" before they can identify which one
+
+This is the primary visual irony prop. It should never be absent.
+
+---
+
+## Pin Color System
+
+Pins use high-contrast accent colors against the muted olive/rose base palette. Suggested cluster approach:
+
+| Pin function | Color | Notes |
+|---|---|---|
+| Primary cause | `#F2C94C` | Yellow — most legible against olive |
+| Secondary cause | `#E04040` | Red — bright, readable |
+| Band / cultural ref | `#4A70CC` | Blue — slightly ironic cool |
+| Symbol pin | `#4A9A4A` | Green — environmental implication |
+
+No pin should be legible enough to commit to a specific real-world cause. Readable enough to register as cause-signaling, not specific enough to be about any particular one.
+
+---
+
+## Palette Design Intent
+
+The palette is deliberately anti-palette — muted, layered, accumulated. The muted olive is the color of thrift-store finds that were chosen for their anti-mainstream quality. The dusty rose is adjacent to feminine without committing to it. The combination reads as deliberately artless, which is the joke: this is a very deliberate palette.
+
+The teal hair is the only saturated element — it is the statement, surrounded by muted supporting clothing. This is also accurate: there is one visible declaration and everything else around it is complicated.
+
+---
+
+## Application Rules (South Park Flat)
+
+- Flat fills only — no gradients
+- Outline: `#1A1A1A` at 3px
+- Layered clothing reads at geometry level — multiple rectangular shapes at slightly different values
+- Tote bag always in frame — visible in front, 3/4, and side views
+- Coffee cup in dominant hand — nearly as present as the face
+- Pin cluster on bag: 3–5 colored dots at minimum in all shots

--- a/character-board/assets/svg-maps/README.md
+++ b/character-board/assets/svg-maps/README.md
@@ -1,0 +1,152 @@
+# SVG Maps — Asset Index
+
+This directory contains SVG asset maps for each character: per-character rig breakdowns with named groups, pivot points, and z-layer ordering.
+
+SVG maps are generated from the character board specifications and the skill template at `skills/character-board/templates/`.
+
+---
+
+## Status
+
+| Character | Style | SVG Map | Status |
+|---|---|---|---|
+| The Anchor | South Park flat | `the-anchor.svg` | Pending |
+| The MAGA Cultist | South Park flat | `maga-cultist.svg` | Pending |
+| The Typical Leftist | South Park flat | `typical-leftist.svg` | Pending |
+| The Informed Person | Boondocks fluid | `informed-person.svg` | Pending |
+| The Opportunist | Boondocks fluid | `opportunist.svg` | Pending |
+| The Talking Head | South Park flat | `talking-head.svg` | Pending |
+
+---
+
+## South Park Flat — Standard Part List
+
+South Park flat characters use an 8-part rig. All parts in a single SVG file, each in a named `<g>` group.
+
+```
+head
+body
+left-arm
+right-arm
+left-leg
+right-leg
+accessory-1        ← character-specific (cap, tote bag, tablet, etc.)
+accessory-2        ← character-specific (phone, earpiece, book, etc.)
+```
+
+Registration point per part:
+
+| Part | Pivot |
+|---|---|
+| `head` | Geometric center of head circle |
+| `body` | Torso center |
+| `left-arm` | Shoulder joint (top of arm shape) |
+| `right-arm` | Shoulder joint |
+| `left-leg` | Hip joint (top of leg shape) |
+| `right-leg` | Hip joint |
+| `accessory-1` | Geometric center |
+| `accessory-2` | Geometric center |
+
+---
+
+## Boondocks Fluid — Standard Part List
+
+Boondocks fluid characters use a 22-part rig. All parts in a single SVG, each in a named `<g>` group with `transform-origin` set at the pivot point.
+
+```
+hair-back
+head
+hair-front
+face
+left-eye
+right-eye
+mouth
+neck
+torso
+left-upper-arm
+left-forearm
+left-hand
+right-upper-arm
+right-forearm
+right-hand
+pelvis
+left-thigh
+left-shin
+left-foot
+right-thigh
+right-shin
+right-foot
+outfit-overlay     ← clothing detail layer over body segments
+accessory-1        ← character-specific
+accessory-2        ← character-specific
+```
+
+Registration point per part:
+
+| Part | Pivot |
+|---|---|
+| `head` | Neck connection point |
+| `hair-front` / `hair-back` | Top of head |
+| `left-upper-arm` / `right-upper-arm` | Shoulder joint |
+| `left-forearm` / `right-forearm` | Elbow joint |
+| `left-hand` / `right-hand` | Wrist joint |
+| `left-thigh` / `right-thigh` | Hip joint |
+| `left-shin` / `right-shin` | Knee joint |
+| `left-foot` / `right-foot` | Ankle joint |
+| `torso` | Waist center |
+| `accessory-*` | Geometric center |
+
+---
+
+## SVG Group Convention
+
+```svg
+<g id="[part-name]" style="transform-origin: [px] [py]px;">
+  <!-- shapes for this part -->
+</g>
+```
+
+All `transform-origin` values are set in the coordinate space of the full SVG viewBox, not relative to the group's own bounding box.
+
+---
+
+## Character-Specific Accessories
+
+| Character | accessory-1 | accessory-2 |
+|---|---|---|
+| The Anchor | Earpiece + cord | Papers on desk |
+| The MAGA Cultist | Red cap | Phone (mid-scroll) |
+| The Typical Leftist | Tote bag | Reusable coffee cup |
+| The Informed Person | Glasses (separate layer) | Book / newspaper |
+| The Opportunist | Business card | Phone (multi-app) |
+| The Talking Head | Tablet | — |
+
+---
+
+## Generation Notes
+
+SVG maps are produced using the skill template at:
+
+```
+skills/character-board/templates/south-park/svg-assets/asset-map.svg
+skills/character-board/templates/boondocks/svg-assets/asset-map.svg
+```
+
+When generating a character's SVG map:
+1. Start from the appropriate style template
+2. Apply the character's color palette (from `assets/color-palettes/`)
+3. Adjust geometry for the character's specific build
+4. Rename `accessory-1` and `accessory-2` groups to match the character's props
+5. Set all `transform-origin` values at joint centers
+
+---
+
+## File Format Requirements
+
+- Format: SVG 1.1
+- ViewBox: `0 0 400 600` (South Park) or `0 0 400 700` (Boondocks)
+- All fills: flat color attributes (no inline gradients) for South Park
+- All fills: flat base + shadow layer group for Boondocks
+- Outline: `stroke-width="3"` (South Park), `stroke-width="4"` contour + `stroke-width="2"` interior (Boondocks)
+- No embedded raster images
+- No external font dependencies

--- a/character-board/core-cast/informed-person.md
+++ b/character-board/core-cast/informed-person.md
@@ -1,0 +1,98 @@
+# Character 3 — The Informed Person
+
+## Archetype
+
+The Huey Freeman function. Sees everything clearly. Exhausted by it. Frustrated narrator-adjacent observer.
+
+**Animation style:** Boondocks anime-fluid
+
+---
+
+## Visual Spec
+
+| Attribute | Description |
+|---|---|
+| Gender | Male |
+| Age | Late 30s–40s |
+| Build | Lean, slightly tired posture |
+| Hair | Natural, low maintenance |
+| Expression | Default is tired disappointment |
+| Expression shift | Sharp focus when something confirms what he already knew |
+| Face shape | Angular, expressive eyes behind glasses |
+
+**Expression design note:** The face requires Boondocks fluid animation because the comedy and the pathos live in the same expression simultaneously. The tired disappointment has layers — resignation over prior certainty, the specific weariness of being right and unable to make it matter. The shift to sharp focus is important: it's not surprise, it's recognition. The eyes change before the posture does.
+
+---
+
+## Wardrobe
+
+| Item | Detail |
+|---|---|
+| Glasses | Round wire-frame, slightly worn |
+| Clothing | Plain, practical — nothing expressive, deliberately invisible |
+| Logos | None |
+| Signals | None — no allegiance markers of any kind |
+| Overall read | Someone who stopped trying to communicate through their outfit |
+
+**Wardrobe design note:** The absence of signals is itself a signal, but he's not performing it — he genuinely stopped caring. The clothes are functional. The glasses are the only distinctive element, and even they look chosen for practicality rather than aesthetics. He does not want to be read. This makes him legible in a different way.
+
+---
+
+## Color Palette
+
+See `assets/color-palettes/informed-person.md` for full data.
+
+| Element | Color | Hex |
+|---|---|---|
+| Primary | Charcoal gray | `#3D3D3D` |
+| Secondary | Warm brown | `#5C4A32` |
+| Tertiary | Dark forest green | `#2D4A2D` |
+| Skin | Medium brown | `#8B6340` |
+| Glasses | Matte gold | `#8A7340` |
+
+---
+
+## Behavioral Trait
+
+The only character who accurately perceives events. This makes him the least powerful person in every scene.
+
+POV cuts are the straightest — closest to what actually happened — which makes them the most unsettling to watch. There is no distortion. The thing that happened is the thing that happened, and it is bad.
+
+He frequently sighs. He is never surprised.
+
+**The key comedic and dramatic mechanism:** He has the information everyone else lacks, and it does nothing. His accuracy is not power. Watching someone be completely right and completely ineffective is the tension the character carries.
+
+---
+
+## Signature Props
+
+| Prop | Function |
+|---|---|
+| Book or newspaper | Set down when forced to engage with the world again |
+| The act of setting it down | This is the animation note — the book going down is the tell |
+
+**Prop note:** He had been reading. He was at peace. Something happened. He put the book down. This sequence should be recurring, recognizable, and slightly exhausting to watch by episode 4 — because it always leads to the same place.
+
+---
+
+## POV Distortion Rules
+
+When cutting to the Informed Person's POV:
+
+1. **No distortion.** The event is depicted as it actually occurred.
+2. **The straightness is the distortion.** After three other POV sequences, undistorted reality reads as deeply unsettling.
+3. **His position in the scene is marginal.** He sees everything and is seen by no one who matters.
+4. **He does not intervene.** He knows exactly what would happen if he did, and he's been through it.
+5. **The sigh is mandatory.** It is the punctuation mark on every POV sequence. It is the most information-dense moment.
+
+---
+
+## Animation Notes (Boondocks Fluid)
+
+- The tired posture is the rest state — lean, slightly forward, the weight of knowing distributed across the shoulders
+- Eye animation is the primary emotional instrument: the shift to sharp focus happens through the eyes before the body catches up
+- The book/newspaper set-down must be animated deliberately — not slammed, not dropped, placed with the resignation of someone who knows this will happen again
+- Glasses catch light in moments of key recognition — a subtle visual cue that something just registered
+- The sigh is a full-body animation: slight exhale, shoulders down, eyes briefly closed, then open to face it
+- Microexpressions are essential — Boondocks fluid allows the specific combination of "correct" and "tired about it" to coexist in the same frame
+- He should look older at the end of every POV sequence than at the beginning

--- a/character-board/core-cast/maga-cultist.md
+++ b/character-board/core-cast/maga-cultist.md
@@ -1,0 +1,96 @@
+# Character 1 — The MAGA Cultist
+
+## Archetype
+
+True believer. Grievance identity. Reality is whatever the leader says it is.
+
+**Animation style:** South Park flat cutout
+
+---
+
+## Visual Spec
+
+| Attribute | Description |
+|---|---|
+| Gender | Male |
+| Age | Middle-aged (45–55) |
+| Build | Stocky, solid |
+| Hair | Short, slightly unkempt |
+| Expression | Squared jaw, rigid posture, slightly clenched at rest |
+| Emotional register | Anger is the default — not volatility, certainty |
+| Face shape | Round to square, thick neck |
+
+**Expression design note:** The face should communicate a man who has been told he is owed something and has not received it. The anger is not hot — it is calcified. At rest he looks like he is waiting for confirmation of something he already knows. When confirmed, the expression doesn't change much. He was right. He is always right.
+
+---
+
+## Wardrobe
+
+| Item | Detail |
+|---|---|
+| Cap | Red, unbranded — legally clean, visually unmistakable |
+| Flag | American flag somewhere on body — pin, patch, or shirt print |
+| Shirt | Flannel or work jacket |
+| Pants | Jeans |
+| Shoes | Boots |
+| Irony | None. Everything is completely sincere. |
+
+**Wardrobe design note:** The outfit is not a costume to him. Every element is a declaration. The cap is the crown. The flag is the oath. The boots are the stance. Nothing is worn for aesthetics — everything is worn for allegiance.
+
+---
+
+## Color Palette
+
+See `assets/color-palettes/maga-cultist.md` for full data.
+
+| Element | Color | Hex |
+|---|---|---|
+| Primary | Flag red | `#B22234` |
+| Secondary | Faded denim blue | `#4A6741` |
+| Tertiary | Off-white | `#EDE8D0` |
+| Accent | Earth brown | `#6B4C2A` |
+| Cap | Bright red | `#CC0000` |
+
+---
+
+## Behavioral Trait
+
+Absolute certainty. Zero self-awareness.
+
+In POV sequences, he is always the hero of a story where everyone else is either a traitor or an enemy. Events that directly contradict his worldview are instantly, automatically reframed as proof of the conspiracy. The contradiction doesn't register as a contradiction — it registers as evidence.
+
+**The key comedic mechanism:** His internal logic is internally consistent. Every new piece of information slots into the existing structure without friction. The structure is closed. Nothing can enter it that doesn't become part of it.
+
+---
+
+## Signature Props
+
+| Prop | Function |
+|---|---|
+| Phone | Showing social media feed — always mid-scroll |
+| Phone content | Memes, headlines, shares — the loop that sustains the worldview |
+
+The phone is an extension of the worldview. It does not introduce information — it confirms what is already known.
+
+---
+
+## POV Distortion Rules
+
+When cutting to the MAGA Cultist's POV:
+
+1. **He is the protagonist.** Everyone in the scene is reacting to him, with him, or against him.
+2. **Enemies are visible and identifiable.** No ambiguity — their allegiance reads in their design.
+3. **The leader is the offscreen authority.** Referenced but never fully depicted — voice, silhouette, or on-screen image only.
+4. **Any contradicting fact becomes conspiracy evidence.** The reframe is instantaneous.
+5. **His certainty is the camera's certainty.** In his POV, the framing is stable, confident, unquestioning. The instability is in the content.
+
+---
+
+## Animation Notes (South Park Flat)
+
+- Jaw slightly wider than standard head proportions — the geometry of certainty
+- Clenched expression is the rest state; smile is the exception and slightly unsettling
+- Cap fits flush and low — brim defined
+- Body moves in blocks — he turns the whole torso, not just the head
+- Phone animation: continuous downward scroll on screen, occasional aggressive tap
+- Flag pin or patch visible in all orientations (front, 3/4, side)

--- a/character-board/core-cast/opportunist.md
+++ b/character-board/core-cast/opportunist.md
@@ -1,0 +1,100 @@
+# Character 4 — The Opportunist
+
+## Archetype
+
+Unprincipled centrist. Positions track personal advantage in real time. Mistakes self-interest for pragmatism every single time.
+
+**Animation style:** Boondocks anime-fluid
+
+---
+
+## Visual Spec
+
+| Attribute | Description |
+|---|---|
+| Gender | Male |
+| Age | 40s–50s |
+| Build | Well-groomed, slightly soft |
+| Hair | Perfectly maintained, faintly product-assisted |
+| Expression | Neutral smile that never reaches the eyes |
+| Expression tic | Tilts head to appear thoughtful |
+| Face shape | Smooth, forgettable in the best possible way |
+
+**Expression design note:** The face requires Boondocks fluid animation because the comedy lives in the gap between the displayed expression and the visible calculation behind it. The neutral smile is the mask. Boondocks fluid allows the mask and the machinery behind it to coexist in the same face — the audience can see both, the other characters in the scene cannot. The head tilt is the tell: it is performed thoughtfulness, and it recurs every time a position shift is being prepared.
+
+**Face shape note:** Forgettable is a design goal, not a failure. He should be difficult to describe afterward. Medium everything. This is how he survives.
+
+---
+
+## Wardrobe
+
+| Item | Detail |
+|---|---|
+| Jacket | Blazer without a tie — business casual, always |
+| Overall read | Just came from a meeting, heading to a different meeting |
+| Colors | Coordinated but never memorable |
+| Pocket square | Optional — present when present, immediately forgettable |
+| Shoes | Good shoes. The kind that signal without declaring. |
+
+**Wardrobe design note:** Nothing in his wardrobe is accidental, and nothing is personal. It has been selected to not select a side. The blazer-without-tie is the political position made textile: formal enough to be taken seriously, casual enough to not be held to a standard.
+
+---
+
+## Color Palette
+
+See `assets/color-palettes/opportunist.md` for full data.
+
+| Element | Color | Hex |
+|---|---|---|
+| Primary | Beige | `#C8B89A` |
+| Secondary | Slate | `#7A8A96` |
+| Tertiary | Tan | `#B09070` |
+| Blazer | Medium gray | `#888888` |
+| Accent | Muted gold | `#B8A060` |
+
+---
+
+## Behavioral Trait
+
+Never commits. Always frames self-interest as pragmatism.
+
+In POV sequences, he is the only adult in the room making the impossible sacrifice of "finding common ground." The audience can see the personal benefit calculation running behind his eyes. The tragedy — and the joke — is that he believes his own framing. The self-deception is complete.
+
+**The key comedic mechanism:** He is not cynical. He is sincere. He sincerely believes that what is good for him is good for everyone, and this belief is genuinely held, which makes it worse. The cynical opportunist is easier to condemn. The sincere opportunist is the more accurate portrait.
+
+---
+
+## Signature Props
+
+| Prop | Function |
+|---|---|
+| Business card | In hand — readiness to network is always at maximum |
+| Phone | Multiple news apps open simultaneously — position tracking |
+
+**Prop note:** The business card and the phone together communicate his relationship to information: it is currency, not knowledge. He is always either receiving contacts or checking what the current consensus is so he can align with it.
+
+---
+
+## POV Distortion Rules
+
+When cutting to the Opportunist's POV:
+
+1. **He is the moderate hero.** Everyone else is an extremist — on both sides, symmetrically.
+2. **His position is not stated clearly in his own POV.** It is always described relative to what others are doing wrong.
+3. **The personal benefit is visible to the viewer, invisible to him.** The framing actively conceals it.
+4. **The head tilt recurs before every position statement.** It is a reliable tell.
+5. **His POV is the most comfortable to watch in the moment and the most unsettling on reflection.** It sounds reasonable. That's the problem.
+6. **He is always in motion.** Standing still is committing to a location. He moves between conversations, between positions, between rooms.
+
+---
+
+## Animation Notes (Boondocks Fluid)
+
+- The neutral smile is the primary expression — it must be held with consistency while the eyes do something different
+- The head tilt is a key recurring animation — slight, measured, performed — and should precede every significant position shift
+- Boondocks fluid allows the calculation to be visible: a specific look behind the eyes that the viewer reads and the scene's other characters don't
+- Posture is upright and composed — he always looks like he's presenting
+- Movement is smooth and purposeful — there is no hesitation, because hesitation would look like weakness, and he has processed that
+- Business card appears in hand naturally, without being drawn — it was always there
+- Phone screen should be visible enough to show multiple app icons but not readable
+- The moment the viewer sees the benefit calculation register on his face — before the speech about finding common ground — is the comedic peak of every POV sequence

--- a/character-board/core-cast/talking-head.md
+++ b/character-board/core-cast/talking-head.md
@@ -1,0 +1,107 @@
+# Character 5 — The Talking Head
+
+## Archetype
+
+Corporate media amplifier. Not left, not right — just loud. Manufactures urgency without delivering information.
+
+**Animation style:** South Park flat cutout
+
+---
+
+## Visual Spec
+
+| Attribute | Description |
+|---|---|
+| Gender | Either |
+| Age | 30s–50s |
+| Build | Camera-ready, overdressed for the content |
+| Hair | Perfect. Alarmingly perfect. |
+| Expression | Permanently slightly alarmed — eyebrows 3mm too high at rest |
+| Face shape | Symmetrical, telegenic, hollow |
+
+**Expression design note:** The eyebrows are the key. They are raised at rest — not dramatically, not comically, but just enough. The alarm is constant and mild, which means it communicates urgency about everything and information about nothing. The face is South Park flat because there is nothing behind it — the performance of alarm has entirely replaced the experience of alarm. Flat is the appropriate mode. There is no inner life to render.
+
+**Hair note:** "Alarmingly perfect" should be a design decision that is visible even in simplified South Park geometry. The hair reads as a single solid shape with no movement — it would not shift if the character turned their head quickly. This is intentional.
+
+---
+
+## Wardrobe
+
+| Item | Detail |
+|---|---|
+| Makeup | Full TV makeup — visible even in casual settings |
+| Suit | Expensive — equivalent for female-presenting variant |
+| Color | Power color: network red, broadcast gold, or corporate navy |
+| Formality | Overdressed for every environment they appear in |
+| Overall read | This person believes they are in a very important room at all times |
+
+**Wardrobe design note:** The Talking Head is always on camera, even when not on camera. The makeup is visible in scenes where no cameras are present. The suit is correct for a formal broadcast environment and therefore wrong for every other context they appear in. The overdressing is the visual argument: they inhabit a performance of importance at all times.
+
+---
+
+## Color Palette
+
+See `assets/color-palettes/talking-head.md` for full data.
+
+| Element | Color | Hex |
+|---|---|---|
+| Primary | Network red | `#CC2222` |
+| Secondary | Corporate navy | `#1A2A5E` |
+| Tertiary | Broadcast gold | `#C8A830` |
+| Skin | Overlit warm | `#D4A882` |
+| Accent | White hot | `#FFFFFF` |
+
+**Palette note:** The skin tone is described as "overlit warm" — it should read as someone who has been under studio lighting for so long their baseline has shifted. The white hot accent communicates the teeth, the collar, the highlight — the points of maximum broadcast luminosity.
+
+---
+
+## Behavioral Trait
+
+Everything is a crisis. Nothing is explained.
+
+In POV sequences, they are performing the most important work in the world and the audience should be simultaneously grateful and terrified. Facts are props, not information — they are referenced, displayed, gestured toward, and not engaged with.
+
+**The key comedic mechanism:** The performance of urgency is completely sincere. They are not lying. They genuinely believe that manufacturing urgency is the same as communicating urgency. The crisis is real, somehow, because they are this alarmed about it. The circularity is the joke.
+
+---
+
+## Signature Props
+
+| Prop | Function |
+|---|---|
+| Tablet | Glanced at — never read from — always in hand |
+| The glance | The prop use IS the prop — the look at the tablet is the gesture, not the information |
+
+**Prop note:** The tablet communicates: I have information. What is never shown is that the information on the tablet is not being processed. The glance is performed. This is the Talking Head equivalent of the Anchor's papers.
+
+---
+
+## Relationship to The Anchor
+
+The Talking Head is the escalated version of The Anchor. Where The Anchor performs credibility through restraint, the Talking Head performs credibility through urgency. They are the same function at different volumes.
+
+The Anchor would never hire the Talking Head. The Talking Head would never respect the Anchor's restraint. Both are manufacturing the same product.
+
+---
+
+## POV Distortion Rules
+
+When cutting to the Talking Head's POV:
+
+1. **Everything is unprecedented.** Every event is the most important thing that has ever happened.
+2. **Facts appear and disappear.** They are referenced but not integrated. The specific number, the specific name — they flash and vanish.
+3. **The frame is always the same.** Crisis-sized everything. The camera is always slightly too close.
+4. **The audience is necessary.** In their POV, the audience must be watching this right now. The urgency depends on it.
+5. **No resolution is ever gestured toward.** Resolution would end the urgency. The crisis must remain productive.
+6. **The tablet glance punctuates every major statement.** Information confirmed. No information delivered.
+
+---
+
+## Animation Notes (South Park Flat)
+
+- Eyebrows are a slightly separate component from the face — raised by 3mm at all times, slight upward animation on key statements
+- Hair is a single solid shape — does not move, does not separate, is essentially a helmet
+- The eyebrow raise for emphasis should go up from already-up — there is nowhere to come from neutral because neutral is already alarmed
+- Tablet in hand in nearly all shots — the glance-down animation should be quick, unconvincing, and consistent
+- South Park flat is the correct choice: there is no face behind this face, and flat geometry communicates that truthfully
+- The makeup should read at the geometry level — slightly more defined features, slightly brighter skin value — so it is visible even in the simplified visual register

--- a/character-board/core-cast/typical-leftist.md
+++ b/character-board/core-cast/typical-leftist.md
@@ -1,0 +1,96 @@
+# Character 2 — The Typical Leftist
+
+## Archetype
+
+Performative progressive. Correct positions, contradictory behavior. Activism as identity accessory.
+
+**Animation style:** South Park flat cutout
+
+---
+
+## Visual Spec
+
+| Attribute | Description |
+|---|---|
+| Gender | Female-presenting |
+| Age | Late 20s |
+| Build | Average, slightly slouched |
+| Hair | Dyed — single unnatural color: teal, lavender, or pink (not blue — too on-the-nose) |
+| Expression | Perpetual mild indignation at rest; escalates to full outrage quickly |
+| Face shape | Soft, expressive |
+
+**Expression design note:** The face is doing more work than the MAGA Cultist's — there is more visible processing happening. But the processing has a predetermined output. She arrives at indignation because indignation is where she begins. The escalation is fast and readable, which is part of the comedic engine: she's not wrong about what she's indignant about, but she's indignant about it from a coffee shop.
+
+**Hair color note:** Teal is the default. Lavender and pink are alternates by episode or mood. Not blue — that reads as too obvious a shorthand and flattens the character into a simpler version of the joke.
+
+---
+
+## Wardrobe
+
+| Item | Detail |
+|---|---|
+| Clothing | Layered, thrift-style — purchased deliberately to look non-deliberate |
+| Bag | Tote bag, always present |
+| Coffee | Reusable cup from a chain she publicly criticizes |
+| Pins and patches | Multiple on bag or jacket — causes, bands, slogans |
+| Aesthetic | Anti-aesthetic — the look is deliberate, not accidental |
+| Irony | Present in the outfit, absent from her awareness of the outfit |
+
+**Wardrobe design note:** The layering should look effortless but isn't. Every pin was a decision. The tote bag has at least two causes on it that are technically in tension with each other. The reusable cup is the central visual irony — it should be immediately readable as being from a large chain, but she holds it with conviction.
+
+---
+
+## Color Palette
+
+See `assets/color-palettes/typical-leftist.md` for full data.
+
+| Element | Color | Hex |
+|---|---|---|
+| Primary | Muted olive | `#7A7A52` |
+| Secondary | Dusty rose | `#C4967A` |
+| Accent | Hair color (teal) | `#3DBCB0` |
+| Bag | Worn tan | `#B8956A` |
+| Pin accent | Varied — bright contrast | `#F2C94C` |
+
+---
+
+## Behavioral Trait
+
+Performative outrage followed immediately by personal convenience.
+
+In POV sequences, she is the most morally advanced person in every room, constantly let down by everyone else's inadequacy. She never notices her own contradictions because she processes them as nuance — the specific kind of nuance that always resolves in her favor.
+
+**The key comedic mechanism:** She is often correct about the problem. The joke is never that she's wrong — it's that her response is self-oriented, the personal sacrifice is minimal, and she believes the tweet constitutes action.
+
+---
+
+## Signature Props
+
+| Prop | Function |
+|---|---|
+| Reusable coffee cup | Irony prop — from a chain she publicly criticizes |
+| Phone | Mid-post about a cause as the cup sits beside it |
+| Tote bag | Visible cause signaling — always in frame |
+
+---
+
+## POV Distortion Rules
+
+When cutting to the Typical Leftist's POV:
+
+1. **She is the most aware person in the scene.** Everyone else reads as less evolved, less informed, or less sensitive.
+2. **Contradictions are invisible.** The coffee cup is not a contradiction in her POV — it is a necessary compromise, obviously.
+3. **Outrage is proportional to the offense's effect on her identity.** Events that don't affect her identity register as abstract. Events that touch her self-image as a progressive are the crisis.
+4. **The phone is always mid-post.** She is documenting, not acting — but in her frame, documenting is acting.
+5. **She is disappointed in everyone she agrees with, too.** The left is never left enough. This is important — she's not a partisan hack, she's a standards problem.
+
+---
+
+## Animation Notes (South Park Flat)
+
+- Slightly slouched posture as the rest state — not defeated, just carrying the weight of being the most aware person in the room
+- Expression shifts are fast: mild indignation → full outrage → back to mild indignation (never full calm)
+- Hair color provides the brightest accent in any scene — teal reads against the muted olive clothing palette
+- Tote bag is always present and slightly overfull — one cause visible at minimum
+- Cup held in dominant hand in almost all shots — it's nearly as present as the character's face
+- Pins should be legible enough to catch in freeze-frame but not individually distracting in motion

--- a/character-board/frame/the-anchor.md
+++ b/character-board/frame/the-anchor.md
@@ -1,0 +1,104 @@
+# The Anchor — Frame Character
+
+## Role
+
+News desk host. Viewer entry point. Delivers the sanitized official version of events before cutting to each character's POV.
+
+The Anchor is not a POV character — they are the frame. Every episode opens and closes at the desk. The satire lives in what they don't say, in the gap between their intonation and the content they're delivering.
+
+**Animation style:** South Park flat cutout
+
+---
+
+## Visual Spec
+
+| Attribute | Description |
+|---|---|
+| Build | Neutral, presentable, professionally generic |
+| Hair | Short and clean (male) or straight, shoulder-length (female) |
+| Expression range | Minimal — neutral to slightly concerned, never fully alarmed |
+| Posture | Upright, slightly stiff, performance of authority |
+| Setting | Elevated anchor desk, backlit studio gradient |
+
+**Expression design note:** The face should read as authoritative at distance and hollow up close. Expressions are approved, not felt. The range is approximately: `[neutral] → [mildly concerned] → [neutral]`. Alarm is never permitted.
+
+---
+
+## Wardrobe
+
+| Item | Detail |
+|---|---|
+| Blazer | Monochrome — navy, charcoal, or burgundy |
+| Accessories | Minimal |
+| Earpiece | Always visible — the cord to something offscreen |
+| Desk papers | Present, never consulted |
+| Tie / collar | Gender-appropriate, conservative |
+
+**Wardrobe design note:** Nothing on The Anchor is accidental, and nothing is personal. Every item is institutional. The earpiece is the most important prop — it signals that The Anchor is receiving, not originating.
+
+---
+
+## Setting
+
+**The Anchor Desk:**
+- Elevated above the viewer sightline
+- Backlit with a cool blue studio gradient — color palette `#0D1F33`
+- Papers on desk, never referenced
+- Lower-third graphics frame implied
+- No windows, no exterior references — this is a sealed environment
+
+The desk should read as a kind of altar. The colors are authority colors. The lighting erases shadows.
+
+---
+
+## Color Palette
+
+See `assets/color-palettes/the-anchor.md` for full data.
+
+| Element | Color | Hex |
+|---|---|---|
+| Primary | Institutional blue | `#1A3A5C` |
+| Secondary | Cool gray | `#8A9BB0` |
+| Accent | White | `#F5F5F5` |
+| Studio BG | Dark gradient blue | `#0D1F33` |
+
+---
+
+## Behavioral Trait
+
+Regurgitates. Never questions. Projects absolute credibility with zero substance.
+
+Segues between horror and sports scores with identical intonation. The satire is structural — the horror of the blank transition is the joke.
+
+**POV note:** The Anchor has no POV sequence. They are the frame — the point the show always returns to, unchanged, regardless of what just happened in the character cuts. Their consistency is the punchline.
+
+---
+
+## Signature Props
+
+| Prop | Function |
+|---|---|
+| Earpiece | Signals receipt of approved content from offscreen authority |
+| Papers on desk | Authority prop — never read from, always present |
+
+---
+
+## Script Function
+
+The Anchor's lines follow a fixed pattern:
+
+1. **Cold open:** Deliver the event in 1–2 sentences. Authoritative. Completely inadequate.
+2. **POV intro:** "For a closer look, we turn to..." (transition to character POV)
+3. **Button:** Return after POV sequence. Move on without acknowledgment. "In other news..."
+
+The Anchor should never react to the content of a POV sequence. The absence of reaction is the point.
+
+---
+
+## Animation Notes (South Park Flat)
+
+- Face constructed from standard flat primitives — perfect circle, minimal features
+- Expressions change as discrete swaps, not continuous animation
+- Posture is fixed — the desk does the framing
+- The earpiece cord should animate occasionally (implying incoming signal) even when the mouth is not moving
+- Blink rate is slightly too low — just enough to be noticed on rewatch

--- a/character-board/storyboard/episode-template.md
+++ b/character-board/storyboard/episode-template.md
@@ -1,0 +1,185 @@
+# Episode Template
+
+## Standard Episode Structure
+
+---
+
+### [COLD OPEN — NEWS DESK]
+
+**The Anchor** delivers the sanitized official version of the event.
+
+- Tone: Authoritative. Bland. Completely inadequate.
+- Duration: 30–45 seconds
+- Animation style: South Park flat
+- Setting: Anchor desk, full studio environment
+
+**Script format:**
+
+> "Tonight — [EVENT IN ONE CLAUSE]. [SECOND CLAUSE THAT DOESN'T EXPLAIN THE FIRST ONE]. We have a closer look."
+
+The cold open establishes the official version. The entire rest of the episode is about how that version fails.
+
+---
+
+### [TITLE CARD]
+
+> **"What actually happened — according to [CHARACTER NAME]"**
+
+- Full-screen card
+- Character's name in the title should be their archetype label, not a personal name
+- Brief pause before cut
+
+---
+
+### [CHARACTER POV SEQUENCE]
+
+The same event, filtered through the character's worldview.
+
+Reality is distorted in the specific direction of their archetype. The distortion is internally consistent — the character is not lying, they are perceiving.
+
+**Style:** Character's assigned animation mode (flat or fluid).
+
+---
+
+#### POV Sequence Structure
+
+**Beat 1 — Establishing shot (character in their environment)**
+
+The character's home context. This is where they receive the news, or where the event touches their world. The environment should communicate the archetype before the character speaks.
+
+| Character | Home Environment |
+|---|---|
+| The MAGA Cultist | Living room, TV, phone in hand |
+| The Typical Leftist | Coffee shop, laptop open, tote bag on chair |
+| The Informed Person | Home or library — book or paper nearby |
+| The Opportunist | Office or conference room — always mid-meeting-adjacent |
+| The Talking Head | Studio — or a setting that reads as studio |
+
+---
+
+**Beat 2 — The event, filtered**
+
+The same event the Anchor just described — but now through this character's perceptual system.
+
+Apply the character's POV distortion rules (documented in their character file under **POV Distortion Rules**):
+
+| Character | POV Distortion Direction |
+|---|---|
+| The MAGA Cultist | He is the hero; contradiction becomes conspiracy evidence |
+| The Typical Leftist | She is the most aware; her contradictions are invisible |
+| The Informed Person | No distortion — which is the most unsettling version |
+| The Opportunist | He is the moderate adult; benefit calculation runs visibly |
+| The Talking Head | Everything is unprecedented; facts appear and vanish |
+
+---
+
+**Beat 3 — The signature prop moment**
+
+Each character has a signature prop that appears in a key-action moment during the POV sequence.
+
+| Character | Prop | Moment |
+|---|---|---|
+| The MAGA Cultist | Phone, mid-scroll | Finds confirmation — the scroll stops, the share happens |
+| The Typical Leftist | Reusable cup + phone | Posts about the cause while holding the irony |
+| The Informed Person | Book, set down | The moment he stops being able to not engage |
+| The Opportunist | Business card + head tilt | The calculation completes — the card appears |
+| The Talking Head | Tablet glance | The glance-and-away — the gesture of information without transfer |
+
+---
+
+**Beat 4 — Climax of distortion**
+
+The moment where the character's worldview reaches its most extreme expression in relation to the event.
+
+This is the comedic or dramatic peak. It should be the most concentrated expression of the archetype — the thing that would make someone watching say: *yes, that is exactly what that person would do.*
+
+---
+
+**Beat 5 — Return signal**
+
+A brief moment that signals the POV sequence is ending. The character's expression or action returns them to their stable state — because nothing that just happened will change them.
+
+| Character | Return State |
+|---|---|
+| The MAGA Cultist | Returns to scroll — already looking for the next confirmation |
+| The Typical Leftist | Returns to mild indignation — the crisis absorbed, filed, and accessorized |
+| The Informed Person | Picks the book back up (or tries to) |
+| The Opportunist | Business card goes back, phone comes out — position still tracking |
+| The Talking Head | New crisis already beginning — this one is already over |
+
+---
+
+### [BUTTON]
+
+Brief return to news desk. **The Anchor** moves on without acknowledgment.
+
+> **"In other news..."**
+
+- Duration: 5–10 seconds
+- The Anchor's expression: identical to the cold open. Unchanged.
+- The transition from POV content to "In other news" is the punchline.
+- Do not editorialize. Do not linger. Do not let The Anchor acknowledge what just happened.
+
+---
+
+## Multi-Character Episodes
+
+In episodes featuring multiple POV sequences:
+
+- Each POV sequence follows the 5-beat structure above
+- The Anchor returns between each POV with a brief transition line
+- The same event is rendered 2–4 times through different archetypes
+- The Informed Person's POV, if included, should be last — the undistorted version lands differently after several distorted ones
+
+**Transition between POV sequences:**
+
+> **"For another perspective..."**
+
+Brief Anchor moment — same desk, same expression, identical intonation to the cold open.
+
+---
+
+## Global Guest Character Episodes
+
+When a global character appears:
+
+1. The Anchor introduces them with a geographic/political identifier — no personal name
+2. The guest character receives their own title card variant:
+   > **"What actually happened — according to [ARCHETYPE], [LOCATION/CONTEXT]"**
+3. The guest's POV follows the same 5-beat structure
+4. Animation style is determined by narrative role (see `README.md` → Global Guest Characters)
+5. The button returns to The Anchor — same transition, same non-acknowledgment
+
+---
+
+## Running Time Guidelines
+
+| Segment | Duration |
+|---|---|
+| Cold open (Anchor) | 30–45 sec |
+| Title card | 3–5 sec |
+| POV sequence (single character) | 90–180 sec |
+| Button | 5–10 sec |
+| **Single-character episode total** | ~3–4 min |
+| **Multi-character episode (3 POVs)** | ~8–10 min |
+
+---
+
+## Visual Continuity Notes
+
+- The Anchor desk environment is **identical in every episode** — same colors, same framing, same papers
+- The POV environment changes per character but is consistent within a character's appearances
+- The cut between Anchor and POV should feel like a channel change — a visual register shift
+- The cut back from POV to Anchor should feel like a reset — the POV didn't happen, officially
+
+---
+
+## What This Template Is Not
+
+This template does not include:
+- Specific dialogue (episode-specific)
+- B-roll or cutaway descriptions (episode-specific)
+- Character voice direction (see individual character files)
+- Specific event content (news-cycle dependent)
+
+For episode-specific breakdowns, create a new file in `storyboard/` following the naming convention: `ep-[number]-[slug].md`

--- a/skills/character-board/LICENSE.txt
+++ b/skills/character-board/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/character-board/SKILL.md
+++ b/skills/character-board/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: character-board
+description: Build production-ready character boards for 2D animation targeting South Park flat-cutout style and Boondocks anime style. Use this when the user requests character sheets, model sheets, SVG asset maps, animation rigs, color palettes, or geometry reference guides for animated characters.
+license: Complete terms in LICENSE.txt
+---
+
+# Character Board Skill
+
+Create structured character board packages for 2D animation. Output SVG files organized into four domains: **specs**, **color-palettes**, **geometry**, and **svg-assets**. All output must respect the target style's visual language.
+
+## Supported Styles
+
+| Style | Key Traits |
+|---|---|
+| `south-park` | Flat cutout, bold fills, minimal outlines, simple geometry, zero shading |
+| `boondocks` | Anime-influenced, angular lines, strong outlines, 6–7 head heights, cel shading |
+
+---
+
+## Workflow
+
+Complete the board in four sequential phases. For each phase, produce SVG files saved to the correct subdirectory under `templates/<style>/`.
+
+---
+
+### Phase 1 — Character Specs (`specs/`)
+
+Create a **model sheet** SVG containing:
+- Three orthographic views: **front · ¾ turn · side profile**
+- A **height scale bar** in "heads" (1 head = head height unit)
+- An **expression strip** of 4–6 keyframe faces (neutral, happy, angry, surprised, sad, determined)
+- Text labels for character name, version, and date
+
+**South Park rules:**
+- Head is a near-perfect circle (~⅓ total body height)
+- Body is a trapezoid or oval; arms/legs are stubby pill shapes
+- Eyes are two simple dots; mouth is a thin arc
+- No perspective distortion — pure flat orthographic
+
+**Boondocks rules:**
+- Head is ≈1/6 to 1/7 of total height
+- Angular jaw; large eyes placed at vertical midpoint of head
+- Facial thirds: forehead / brow-to-nose / nose-to-chin each ≈1/3 of face height
+- 3/4 view shows clear nose bridge and far-eye foreshortening
+
+Output: `character-spec.svg`
+
+---
+
+### Phase 2 — Color Palettes (`color-palettes/`)
+
+Create a **swatch board** SVG containing named, hex-coded color groups.
+
+**Required groups (both styles):**
+
+| Group | Swatches |
+|---|---|
+| Skin | base, shadow, highlight |
+| Hair | base, shadow, accent |
+| Outfit Primary | base, shadow, highlight |
+| Outfit Secondary | base, shadow |
+| Eyes | iris, pupil, white, reflection |
+| Outline | main, secondary |
+
+**South Park rules:**
+- Flat fills only — shadow = same hue, 20% darker; no gradients
+- Palette max 12 total colors
+- Outline is always solid black `#1a1a1a`
+
+**Boondocks rules:**
+- Cel-shade approach: base + one shadow stop (multiply blend)
+- Highlight can be a separate lighter tone or rim-light color
+- Allow up to 20 total colors
+- Outline varies by plane: thick contour, thin interior
+
+Output: `palette.svg`
+
+---
+
+### Phase 3 — Geometry References (`geometry/`)
+
+Create a **construction guide** SVG with:
+- Underlying shape primitives (circles, ellipses, rectangles, polygons)
+- Centerline axis (vertical + horizontal cross)
+- Proportion ruler with labeled head-unit tick marks
+- Annotations for key measurements
+
+**South Park rules:**
+- Primary shapes: 1 large circle (head), 1 oval/trapezoid (body), 4 pill shapes (limbs)
+- Head ≈ 33% of total height; body ≈ 42%; legs ≈ 25%
+- Show snap-to-grid: 16px grid
+
+**Boondocks rules:**
+- Head = circle + flattened chin polygon
+- Facial cross: horizontal line at eye level, vertical centerline
+- Facial thirds lines: hairline / brow / nose-base / chin
+- Body = tapered torso box, pelvis box; limbs segmented (upper arm / forearm / hand)
+- Show 7-heads-tall proportion ruler
+
+Output: `construction-guide.svg`
+
+---
+
+### Phase 4 — SVG Asset Maps (`svg-assets/`)
+
+Create an **asset map** SVG that breaks the character into independently transformable parts for rigging. Each part must be:
+- A named `<g id="part-name">` group
+- Drawn with a distinct bounding box label
+- Annotated with its layer order (z-index)
+
+**South Park parts (simple rig):**
+
+```
+head · body · left-arm · right-arm · left-leg · right-leg · accessory-1 · accessory-2
+```
+
+Registration point for each part: joint center or geometric center.
+
+**Boondocks parts (detailed rig):**
+
+```
+hair-back · head · hair-front · face · left-eye · right-eye · mouth
+neck · torso · left-upper-arm · left-forearm · left-hand
+right-upper-arm · right-forearm · right-hand
+pelvis · left-thigh · left-shin · left-foot
+right-thigh · right-shin · right-foot
+outfit-overlay · accessory-1 · accessory-2
+```
+
+Output: `asset-map.svg`
+
+---
+
+## Shared Assets
+
+Reusable assets across both styles live in `templates/shared/`:
+
+- `color-palettes/skin-tones.svg` — universal skin tone reference chart
+- `geometry/base-grid.svg` — 16px snap grid overlay (import into other SVGs)
+
+---
+
+## Output Checklist
+
+For each character, produce:
+
+- [ ] `templates/<style>/specs/character-spec.svg`
+- [ ] `templates/<style>/color-palettes/palette.svg`
+- [ ] `templates/<style>/geometry/construction-guide.svg`
+- [ ] `templates/<style>/svg-assets/asset-map.svg`
+
+Name additional characters by prefixing: `<character-name>-spec.svg`, `<character-name>-palette.svg`, etc.
+
+---
+
+## Style Quick-Reference
+
+### South Park Visual Language
+- Stroke: `stroke-width="3"` solid black only
+- Fill: flat `fill` attribute — no gradients, no filters
+- Font: Bold sans-serif, all-caps labels
+- Shapes: prefer `<circle>`, `<ellipse>`, `<rect>`, `<path>` with rounded corners
+
+### Boondocks Visual Language
+- Stroke: `stroke-width="4"` contour, `stroke-width="2"` interior
+- Fill: base color layer + `<feColorMatrix>` or multiply overlay for cel shadow
+- Font: Medium-weight sans-serif, title-case labels
+- Shapes: angular `<polygon>` and `<path>` with sharp corners for face/jaw; curved paths for hair

--- a/skills/character-board/templates/boondocks/color-palettes/palette.svg
+++ b/skills/character-board/templates/boondocks/color-palettes/palette.svg
@@ -1,0 +1,127 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 940 560" width="940" height="560" font-family="Arial, sans-serif">
+  <rect width="940" height="560" fill="#f2f0ec"/>
+
+  <!-- Title bar -->
+  <rect x="0" y="0" width="940" height="44" fill="#1a1a1a"/>
+  <text x="16" y="29" fill="#ffffff" font-size="16" font-weight="bold" letter-spacing="2">COLOR PALETTE — BOONDOCKS ANIME</text>
+  <text x="660" y="29" fill="#666" font-size="11">CEL-SHADE · BASE + SHADOW + HIGHLIGHT</text>
+
+  <!-- SKIN GROUP -->
+  <text x="20" y="68" fill="#1a1a1a" font-size="11" font-weight="bold" letter-spacing="1">SKIN</text>
+  <line x1="20" y1="72" x2="360" y2="72" stroke="#1a1a1a" stroke-width="1"/>
+  <rect x="20"  y="78" width="90" height="90" fill="#c8915a" stroke="#1a1a1a" stroke-width="2" rx="3"/>
+  <text x="65"  y="180" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">BASE</text>
+  <text x="65"  y="192" fill="#555" font-size="9" text-anchor="middle">#C8915A</text>
+  <rect x="120" y="78" width="90" height="90" fill="#9e6838" stroke="#1a1a1a" stroke-width="2" rx="3"/>
+  <text x="165" y="180" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">SHADOW</text>
+  <text x="165" y="192" fill="#555" font-size="9" text-anchor="middle">#9E6838</text>
+  <rect x="220" y="78" width="90" height="90" fill="#e4b988" stroke="#1a1a1a" stroke-width="2" rx="3"/>
+  <text x="265" y="180" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">HIGHLIGHT</text>
+  <text x="265" y="192" fill="#555" font-size="9" text-anchor="middle">#E4B988</text>
+
+  <!-- HAIR GROUP -->
+  <text x="380" y="68" fill="#1a1a1a" font-size="11" font-weight="bold" letter-spacing="1">HAIR</text>
+  <line x1="380" y1="72" x2="620" y2="72" stroke="#1a1a1a" stroke-width="1"/>
+  <rect x="380" y="78" width="70" height="90" fill="#1a1a1a" stroke="#555" stroke-width="2" rx="3"/>
+  <text x="415" y="180" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">BASE</text>
+  <text x="415" y="192" fill="#555" font-size="9" text-anchor="middle">#1A1A1A</text>
+  <rect x="460" y="78" width="70" height="90" fill="#0d0d0d" stroke="#555" stroke-width="2" rx="3"/>
+  <text x="495" y="180" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">SHADOW</text>
+  <text x="495" y="192" fill="#555" font-size="9" text-anchor="middle">#0D0D0D</text>
+  <rect x="540" y="78" width="70" height="90" fill="#3d3020" stroke="#1a1a1a" stroke-width="2" rx="3"/>
+  <text x="575" y="180" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">ACCENT</text>
+  <text x="575" y="192" fill="#555" font-size="9" text-anchor="middle">#3D3020</text>
+
+  <!-- OUTLINE GROUP -->
+  <text x="650" y="68" fill="#1a1a1a" font-size="11" font-weight="bold" letter-spacing="1">OUTLINE</text>
+  <line x1="650" y1="72" x2="920" y2="72" stroke="#1a1a1a" stroke-width="1"/>
+  <rect x="650" y="78" width="80" height="90" fill="#1a1a1a" stroke="#555" stroke-width="2" rx="3"/>
+  <text x="690" y="180" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">CONTOUR</text>
+  <text x="690" y="192" fill="#555" font-size="9" text-anchor="middle">#1A1A1A · 4px</text>
+  <rect x="740" y="78" width="80" height="90" fill="#2a2a2a" stroke="#1a1a1a" stroke-width="2" rx="3"/>
+  <text x="780" y="180" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">INTERIOR</text>
+  <text x="780" y="192" fill="#555" font-size="9" text-anchor="middle">#2A2A2A · 2px</text>
+  <rect x="830" y="78" width="80" height="90" fill="#4a3818" stroke="#1a1a1a" stroke-width="2" rx="3"/>
+  <text x="870" y="180" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">SKIN LINE</text>
+  <text x="870" y="192" fill="#555" font-size="9" text-anchor="middle">#4A3818 · 2.5px</text>
+
+  <!-- OUTFIT PRIMARY GROUP -->
+  <text x="20" y="222" fill="#1a1a1a" font-size="11" font-weight="bold" letter-spacing="1">OUTFIT PRIMARY</text>
+  <line x1="20" y1="226" x2="360" y2="226" stroke="#1a1a1a" stroke-width="1"/>
+  <rect x="20"  y="232" width="90" height="90" fill="#2d4a6b" stroke="#1a1a1a" stroke-width="2" rx="3"/>
+  <text x="65"  y="334" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">BASE</text>
+  <text x="65"  y="346" fill="#555" font-size="9" text-anchor="middle">#2D4A6B</text>
+  <rect x="120" y="232" width="90" height="90" fill="#1c3050" stroke="#1a1a1a" stroke-width="2" rx="3"/>
+  <text x="165" y="334" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">SHADOW</text>
+  <text x="165" y="346" fill="#555" font-size="9" text-anchor="middle">#1C3050</text>
+  <rect x="220" y="232" width="90" height="90" fill="#3f6590" stroke="#1a1a1a" stroke-width="2" rx="3"/>
+  <text x="265" y="334" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">HIGHLIGHT</text>
+  <text x="265" y="346" fill="#555" font-size="9" text-anchor="middle">#3F6590</text>
+
+  <!-- OUTFIT SECONDARY GROUP -->
+  <text x="380" y="222" fill="#1a1a1a" font-size="11" font-weight="bold" letter-spacing="1">OUTFIT SECONDARY</text>
+  <line x1="380" y1="226" x2="640" y2="226" stroke="#1a1a1a" stroke-width="1"/>
+  <rect x="380" y="232" width="80" height="90" fill="#1a4488" stroke="#1a1a1a" stroke-width="2" rx="3"/>
+  <text x="420" y="334" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">BASE</text>
+  <text x="420" y="346" fill="#555" font-size="9" text-anchor="middle">#1A4488</text>
+  <rect x="470" y="232" width="80" height="90" fill="#0e2f66" stroke="#1a1a1a" stroke-width="2" rx="3"/>
+  <text x="510" y="334" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">SHADOW</text>
+  <text x="510" y="346" fill="#555" font-size="9" text-anchor="middle">#0E2F66</text>
+
+  <!-- EYES GROUP -->
+  <text x="660" y="222" fill="#1a1a1a" font-size="11" font-weight="bold" letter-spacing="1">EYES</text>
+  <line x1="660" y1="226" x2="920" y2="226" stroke="#1a1a1a" stroke-width="1"/>
+  <rect x="660" y="232" width="58" height="68" fill="#553300" stroke="#1a1a1a" stroke-width="2" rx="3"/>
+  <text x="689" y="312" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">IRIS</text>
+  <text x="689" y="324" fill="#555" font-size="9" text-anchor="middle">#553300</text>
+  <rect x="728" y="232" width="58" height="68" fill="#111111" stroke="#555" stroke-width="2" rx="3"/>
+  <text x="757" y="312" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">PUPIL</text>
+  <text x="757" y="324" fill="#555" font-size="9" text-anchor="middle">#111111</text>
+  <rect x="796" y="232" width="58" height="68" fill="#f0ede0" stroke="#1a1a1a" stroke-width="2" rx="3"/>
+  <text x="825" y="312" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">WHITE</text>
+  <text x="825" y="324" fill="#555" font-size="9" text-anchor="middle">#F0EDE0</text>
+  <rect x="864" y="232" width="56" height="68" fill="#ffffff" stroke="#1a1a1a" stroke-width="2" rx="3"/>
+  <text x="892" y="312" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">REFLECT</text>
+  <text x="892" y="324" fill="#555" font-size="9" text-anchor="middle">#FFFFFF</text>
+
+  <!-- ACCENT / ACCESSORY GROUP -->
+  <text x="20" y="376" fill="#1a1a1a" font-size="11" font-weight="bold" letter-spacing="1">ACCENT / ACCESSORY</text>
+  <line x1="20" y1="380" x2="400" y2="380" stroke="#1a1a1a" stroke-width="1"/>
+  <rect x="20"  y="386" width="80" height="80" fill="#ccaa00" stroke="#1a1a1a" stroke-width="2" rx="3"/>
+  <text x="60"  y="478" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">BELT BUCKLE</text>
+  <text x="60"  y="490" fill="#555" font-size="9" text-anchor="middle">#CCAA00</text>
+  <rect x="110" y="386" width="80" height="80" fill="#996600" stroke="#1a1a1a" stroke-width="2" rx="3"/>
+  <text x="150" y="478" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">BELT SHADOW</text>
+  <text x="150" y="490" fill="#555" font-size="9" text-anchor="middle">#996600</text>
+  <rect x="200" y="386" width="80" height="80" fill="#8b0000" stroke="#1a1a1a" stroke-width="2" rx="3"/>
+  <text x="240" y="478" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">ACCENT RED</text>
+  <text x="240" y="490" fill="#555" font-size="9" text-anchor="middle">#8B0000</text>
+  <rect x="290" y="386" width="80" height="80" fill="#5d4e37" stroke="#1a1a1a" stroke-width="2" rx="3"/>
+  <text x="330" y="478" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">NEUTRAL WARM</text>
+  <text x="330" y="490" fill="#555" font-size="9" text-anchor="middle">#5D4E37</text>
+
+  <!-- CEL-SHADE DIAGRAM -->
+  <rect x="440" y="376" width="480" height="168" fill="#ffffff" stroke="#1a1a1a" stroke-width="1.5" rx="4"/>
+  <rect x="440" y="376" width="480" height="26" fill="#1a1a1a" rx="4"/>
+  <text x="680" y="394" fill="#ffffff" font-size="11" font-weight="bold" text-anchor="middle" letter-spacing="1">CEL-SHADE METHOD</text>
+  <!-- Base -->
+  <rect x="456" y="414" width="120" height="40" fill="#c8915a" rx="3"/>
+  <text x="516" y="438" fill="#ffffff" font-size="10" font-weight="bold" text-anchor="middle">BASE</text>
+  <!-- Arrow -->
+  <text x="596" y="438" fill="#1a1a1a" font-size="18" text-anchor="middle">+</text>
+  <!-- Shadow layer -->
+  <rect x="616" y="414" width="120" height="40" fill="#9e6838" rx="3" opacity="0.85"/>
+  <text x="676" y="425" fill="#ffffff" font-size="8" text-anchor="middle" font-weight="bold">SHADOW LAYER</text>
+  <text x="676" y="440" fill="#ffffff" font-size="8" text-anchor="middle">(multiply blend)</text>
+  <!-- Arrow -->
+  <text x="756" y="438" fill="#1a1a1a" font-size="18" text-anchor="middle">=</text>
+  <!-- Result -->
+  <rect x="766" y="414" width="140" height="40" rx="3" fill="#c8915a"/>
+  <rect x="810" y="414" width="96" height="40" rx="3" fill="#9e6838" opacity="0.7"/>
+  <text x="838" y="438" fill="#ffffff" font-size="10" font-weight="bold" text-anchor="middle">RESULT</text>
+  <!-- Note -->
+  <text x="456" y="480" fill="#555" font-size="9">Skin line color: #4A3818 (2.5px) for interior face/hand detail</text>
+  <text x="456" y="496" fill="#555" font-size="9">Contour outline: #1A1A1A (4px) — Boondocks signature thick border</text>
+  <text x="456" y="512" fill="#555" font-size="9">Interior lines: #2A2A2A (2px) for cloth folds, anatomy definition</text>
+  <text x="456" y="528" fill="#555" font-size="9">Max 20 colors total · Rim light optional: #E4B988 applied on lit edges</text>
+</svg>

--- a/skills/character-board/templates/boondocks/geometry/construction-guide.svg
+++ b/skills/character-board/templates/boondocks/geometry/construction-guide.svg
@@ -1,0 +1,221 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 840 600" width="840" height="600" font-family="Arial, sans-serif">
+  <defs>
+    <pattern id="g20" width="20" height="20" patternUnits="userSpaceOnUse">
+      <path d="M 20 0 L 0 0 0 20" fill="none" stroke="#e8e4dc" stroke-width="0.5"/>
+    </pattern>
+  </defs>
+  <rect width="840" height="600" fill="#f2f0ec"/>
+  <rect width="840" height="600" fill="url(#g20)"/>
+
+  <!-- Title bar -->
+  <rect x="0" y="0" width="840" height="40" fill="#1a1a1a"/>
+  <text x="14" y="26" fill="#ffffff" font-size="15" font-weight="bold" letter-spacing="2">GEOMETRY CONSTRUCTION GUIDE — BOONDOCKS ANIME</text>
+
+  <!-- ────────────────────────────────────────
+       LEFT: HEAD CONSTRUCTION DETAIL
+  ──────────────────────────────────────── -->
+  <text x="56" y="62" fill="#1a1a1a" font-size="11" font-weight="bold" letter-spacing="1">HEAD CONSTRUCTION</text>
+
+  <!-- Head base circle -->
+  <circle cx="150" cy="138" r="66" fill="none" stroke="#aaaaaa" stroke-width="1" stroke-dasharray="4,3"/>
+  <circle cx="150" cy="138" r="66" fill="#c8915a" stroke="#1a1a1a" stroke-width="3" opacity="0.7"/>
+  <!-- Chin extension (angular jaw) -->
+  <path d="M 84 145 L 92 182 L 150 194 L 208 182 L 216 145" fill="#c8915a" stroke="#1a1a1a" stroke-width="3" opacity="0.7"/>
+
+  <!-- Vertical centerline -->
+  <line x1="150" y1="68" x2="150" y2="210" stroke="#2266cc" stroke-width="1.5" stroke-dasharray="8,4" opacity="0.7"/>
+  <!-- Horizontal eye line (midpoint of circle) -->
+  <line x1="72"  y1="138" x2="228" y2="138" stroke="#cc2200" stroke-width="1.5" stroke-dasharray="6,4" opacity="0.7"/>
+
+  <!-- Facial thirds markers -->
+  <!-- Top of head → hairline: 68 to 96  (28px) -->
+  <!-- Hairline → brow:       96 to 116  (20px) -->
+  <!-- Brow → nose:          116 to 160  (44px) -->
+  <!-- Nose → chin:          160 to 194  (34px) -->
+  <line x1="60" y1="96"  x2="240" y2="96"  stroke="#228822" stroke-width="1" stroke-dasharray="5,4" opacity="0.6"/>
+  <line x1="60" y1="116" x2="240" y2="116" stroke="#228822" stroke-width="1" stroke-dasharray="5,4" opacity="0.6"/>
+  <line x1="60" y1="160" x2="240" y2="160" stroke="#228822" stroke-width="1" stroke-dasharray="5,4" opacity="0.6"/>
+
+  <!-- Labels for thirds -->
+  <text x="244" y="82"  fill="#228822" font-size="9">hair zone</text>
+  <text x="244" y="108" fill="#228822" font-size="9">forehead</text>
+  <text x="244" y="130" fill="#228822" font-size="9">brow line</text>
+  <text x="244" y="152" fill="#cc2200" font-size="9">EYE LINE ← midpoint</text>
+  <text x="244" y="172" fill="#228822" font-size="9">nose</text>
+  <text x="244" y="190" fill="#228822" font-size="9">mouth / chin</text>
+
+  <!-- Eye placeholders (large) -->
+  <ellipse cx="119" cy="138" rx="20" ry="22" fill="#1a1a1a" opacity="0.85"/>
+  <ellipse cx="181" cy="138" rx="20" ry="22" fill="#1a1a1a" opacity="0.85"/>
+  <ellipse cx="119" cy="138" rx="14" ry="15" fill="#553300"/>
+  <ellipse cx="181" cy="138" rx="14" ry="15" fill="#553300"/>
+  <circle  cx="123" cy="133" r="4" fill="#ffffff"/>
+  <circle  cx="185" cy="133" r="4" fill="#ffffff"/>
+
+  <!-- Eyebrow guides (angular) -->
+  <path d="M 98 120 L 140 124" stroke="#1a1a1a" stroke-width="3" stroke-linecap="round" opacity="0.85"/>
+  <path d="M 162 124 L 204 119" stroke="#1a1a1a" stroke-width="3" stroke-linecap="round" opacity="0.85"/>
+
+  <!-- Nose (small, angular) -->
+  <path d="M 150 158 L 154 174 L 148 174" fill="none" stroke="#4a3818" stroke-width="2.5" stroke-linecap="round"/>
+  <!-- Mouth -->
+  <path d="M 132 182 L 150 188 L 168 182" fill="none" stroke="#1a1a1a" stroke-width="2.5" stroke-linecap="round"/>
+
+  <!-- ────────────────────────────────────────
+       CENTER: FULL BODY PROPORTION (7H)
+  ──────────────────────────────────────── -->
+  <text x="340" y="62" fill="#1a1a1a" font-size="11" font-weight="bold" letter-spacing="1">7-HEAD PROPORTION</text>
+
+  <!-- Proportion ruler: 58 to 478, 420px = 7H, each H = 60px -->
+  <line x1="336" y1="68" x2="336" y2="488" stroke="#1a1a1a" stroke-width="2"/>
+  <line x1="330" y1="68"  x2="342" y2="68"  stroke="#1a1a1a" stroke-width="2"/>
+  <line x1="330" y1="128" x2="342" y2="128" stroke="#cc2200" stroke-width="1.5" stroke-dasharray="4,2"/>
+  <line x1="330" y1="188" x2="342" y2="188" stroke="#cc2200" stroke-width="1.5" stroke-dasharray="4,2"/>
+  <line x1="330" y1="248" x2="342" y2="248" stroke="#cc2200" stroke-width="1.5" stroke-dasharray="4,2"/>
+  <line x1="330" y1="308" x2="342" y2="308" stroke="#cc2200" stroke-width="1.5" stroke-dasharray="4,2"/>
+  <line x1="330" y1="368" x2="342" y2="368" stroke="#cc2200" stroke-width="1.5" stroke-dasharray="4,2"/>
+  <line x1="330" y1="428" x2="342" y2="428" stroke="#cc2200" stroke-width="1.5" stroke-dasharray="4,2"/>
+  <line x1="330" y1="488" x2="342" y2="488" stroke="#1a1a1a" stroke-width="2"/>
+  <text x="326" y="71"  fill="#1a1a1a" font-size="9" text-anchor="end">1H</text>
+  <text x="326" y="131" fill="#cc2200" font-size="9" text-anchor="end">2H</text>
+  <text x="326" y="191" fill="#cc2200" font-size="9" text-anchor="end">3H</text>
+  <text x="326" y="251" fill="#cc2200" font-size="9" text-anchor="end">4H</text>
+  <text x="326" y="311" fill="#cc2200" font-size="9" text-anchor="end">5H</text>
+  <text x="326" y="371" fill="#cc2200" font-size="9" text-anchor="end">6H</text>
+  <text x="326" y="431" fill="#cc2200" font-size="9" text-anchor="end">7H</text>
+
+  <!-- Horizontal proportion lines -->
+  <line x1="350" y1="128" x2="690" y2="128" stroke="#cc2200" stroke-width="1" stroke-dasharray="6,5" opacity="0.3"/>
+  <line x1="350" y1="188" x2="690" y2="188" stroke="#cc2200" stroke-width="1" stroke-dasharray="6,5" opacity="0.3"/>
+  <line x1="350" y1="248" x2="690" y2="248" stroke="#cc2200" stroke-width="1" stroke-dasharray="6,5" opacity="0.3"/>
+  <line x1="350" y1="308" x2="690" y2="308" stroke="#cc2200" stroke-width="1" stroke-dasharray="6,5" opacity="0.3"/>
+  <line x1="350" y1="368" x2="690" y2="368" stroke="#cc2200" stroke-width="1" stroke-dasharray="6,5" opacity="0.3"/>
+  <line x1="350" y1="428" x2="690" y2="428" stroke="#cc2200" stroke-width="1" stroke-dasharray="6,5" opacity="0.3"/>
+
+  <!-- Body centerline -->
+  <line x1="470" y1="60" x2="470" y2="500" stroke="#2266cc" stroke-width="1.5" stroke-dasharray="8,5" opacity="0.5"/>
+
+  <!-- Head zone label -->
+  <rect x="350" y="68" width="24" height="14" fill="#ccaa00" opacity="0.8" rx="2"/>
+  <text x="362" y="79" fill="#1a1a1a" font-size="7" text-anchor="middle" font-weight="bold">HEAD</text>
+
+  <!-- Body construction (simplified) -->
+  <!-- Head ellipse (1H = 68 to 128) -->
+  <ellipse cx="470" cy="98" rx="44" ry="30" fill="#c8915a" stroke="#1a1a1a" stroke-width="2.5" opacity="0.8"/>
+  <!-- Jaw -->
+  <path d="M 428 106 L 434 128 L 470 134 L 506 128 L 512 106" fill="#c8915a" stroke="#1a1a1a" stroke-width="2.5" opacity="0.8"/>
+  <!-- Neck (128 to 148) -->
+  <rect x="462" y="128" width="16" height="24" fill="#c8915a" stroke="#1a1a1a" stroke-width="2" opacity="0.8"/>
+  <!-- Shoulders / chest label band (2H = 128 to 188) -->
+  <rect x="350" y="128" width="24" height="14" fill="#2d4a6b" opacity="0.8" rx="2"/>
+  <text x="362" y="139" fill="#ffffff" font-size="7" text-anchor="middle" font-weight="bold">TORSO</text>
+  <!-- Torso (148 to 248) — trapezoid -->
+  <path d="M 420 148 L 408 248 L 432 248 L 470 252 L 508 248 L 532 248 L 520 148 Z"
+        fill="#2d4a6b" stroke="#1a1a1a" stroke-width="2.5" opacity="0.8"/>
+  <!-- Left upper arm (148 to 248) -->
+  <path d="M 420 152 L 398 156 L 386 250 L 408 256 L 420 196 Z"
+        fill="#2d4a6b" stroke="#1a1a1a" stroke-width="2" opacity="0.8"/>
+  <!-- Right upper arm -->
+  <path d="M 520 152 L 542 156 L 554 250 L 532 256 L 520 196 Z"
+        fill="#2d4a6b" stroke="#1a1a1a" stroke-width="2" opacity="0.8"/>
+  <!-- Forearms (248 to 338, 3H to ~4.7H) -->
+  <path d="M 386 250 L 378 320 L 396 326 L 408 256 Z" fill="#c8915a" stroke="#1a1a1a" stroke-width="2" opacity="0.8"/>
+  <path d="M 554 250 L 562 320 L 544 326 L 532 256 Z" fill="#c8915a" stroke="#1a1a1a" stroke-width="2" opacity="0.8"/>
+  <!-- Pelvis/waist label -->
+  <rect x="350" y="248" width="24" height="14" fill="#1a1a1a" opacity="0.7" rx="2"/>
+  <text x="362" y="259" fill="#ffffff" font-size="7" text-anchor="middle" font-weight="bold">BELT</text>
+  <!-- Pelvis (248 to 308) -->
+  <path d="M 432 248 L 428 308 L 512 308 L 508 248 Z" fill="#1a1a4a" stroke="#1a1a1a" stroke-width="2" opacity="0.8"/>
+  <!-- Thighs (5H–6H, 308–368) label -->
+  <rect x="350" y="308" width="24" height="14" fill="#1a4488" opacity="0.8" rx="2"/>
+  <text x="362" y="319" fill="#ffffff" font-size="7" text-anchor="middle">THI</text>
+  <!-- Thighs -->
+  <path d="M 430 308 L 422 368 L 456 372 L 468 312 Z" fill="#1a4488" stroke="#1a1a1a" stroke-width="2" opacity="0.8"/>
+  <path d="M 510 308 L 518 368 L 484 372 L 472 312 Z" fill="#1a4488" stroke="#1a1a1a" stroke-width="2" opacity="0.8"/>
+  <!-- Shins (6H–7H, 368–428) -->
+  <rect x="350" y="368" width="24" height="14" fill="#163980" opacity="0.8" rx="2"/>
+  <text x="362" y="379" fill="#ffffff" font-size="7" text-anchor="middle">SHIN</text>
+  <path d="M 422 368 L 414 432 L 448 436 L 456 372 Z" fill="#163980" stroke="#1a1a1a" stroke-width="2" opacity="0.8"/>
+  <path d="M 518 368 L 526 432 L 492 436 L 484 372 Z" fill="#163980" stroke="#1a1a1a" stroke-width="2" opacity="0.8"/>
+  <!-- Feet -->
+  <path d="M 408 432 L 406 452 L 452 454 L 452 438 Z" fill="#1a1a1a" opacity="0.85"/>
+  <path d="M 488 438 L 488 454 L 534 452 L 532 432 Z" fill="#1a1a1a" opacity="0.85"/>
+
+  <!-- Hands -->
+  <ellipse cx="386" cy="334" rx="15" ry="12" fill="#c8915a" stroke="#1a1a1a" stroke-width="2" opacity="0.8"/>
+  <ellipse cx="554" cy="334" rx="15" ry="12" fill="#c8915a" stroke="#1a1a1a" stroke-width="2" opacity="0.8"/>
+
+  <!-- ── RIGHT PANEL: Proportion summary ── -->
+  <rect x="704" y="52" width="126" height="430" fill="#ffffff" stroke="#1a1a1a" stroke-width="1.5" rx="3"/>
+  <rect x="704" y="52" width="126" height="28" fill="#1a1a1a" rx="3"/>
+  <text x="767" y="71" fill="#ffffff" font-size="10" font-weight="bold" text-anchor="middle" letter-spacing="1">PROPORTIONS</text>
+
+  <text x="712" y="96"  fill="#1a1a1a" font-size="9" font-weight="bold">Total height:</text>
+  <text x="823" y="96"  fill="#555" font-size="9" text-anchor="end">7H</text>
+  <line x1="710" y1="101" x2="824" y2="101" stroke="#eee" stroke-width="1"/>
+  <text x="712" y="116" fill="#1a1a1a" font-size="9" font-weight="bold">Head:</text>
+  <text x="823" y="116" fill="#555" font-size="9" text-anchor="end">1H (60px)</text>
+  <line x1="710" y1="121" x2="824" y2="121" stroke="#eee" stroke-width="1"/>
+  <text x="712" y="136" fill="#1a1a1a" font-size="9" font-weight="bold">Neck:</text>
+  <text x="823" y="136" fill="#555" font-size="9" text-anchor="end">0.3H</text>
+  <line x1="710" y1="141" x2="824" y2="141" stroke="#eee" stroke-width="1"/>
+  <text x="712" y="156" fill="#1a1a1a" font-size="9" font-weight="bold">Torso:</text>
+  <text x="823" y="156" fill="#555" font-size="9" text-anchor="end">2H</text>
+  <line x1="710" y1="161" x2="824" y2="161" stroke="#eee" stroke-width="1"/>
+  <text x="712" y="176" fill="#1a1a1a" font-size="9" font-weight="bold">Pelvis:</text>
+  <text x="823" y="176" fill="#555" font-size="9" text-anchor="end">1H</text>
+  <line x1="710" y1="181" x2="824" y2="181" stroke="#eee" stroke-width="1"/>
+  <text x="712" y="196" fill="#1a1a1a" font-size="9" font-weight="bold">Thighs:</text>
+  <text x="823" y="196" fill="#555" font-size="9" text-anchor="end">1H</text>
+  <line x1="710" y1="201" x2="824" y2="201" stroke="#eee" stroke-width="1"/>
+  <text x="712" y="216" fill="#1a1a1a" font-size="9" font-weight="bold">Shins:</text>
+  <text x="823" y="216" fill="#555" font-size="9" text-anchor="end">1H</text>
+  <line x1="710" y1="221" x2="824" y2="221" stroke="#eee" stroke-width="1"/>
+  <text x="712" y="236" fill="#1a1a1a" font-size="9" font-weight="bold">Feet:</text>
+  <text x="823" y="236" fill="#555" font-size="9" text-anchor="end">0.3H</text>
+  <line x1="710" y1="241" x2="824" y2="241" stroke="#cccccc" stroke-width="1.5"/>
+  <text x="712" y="258" fill="#1a1a1a" font-size="9" font-weight="bold">Eye position:</text>
+  <text x="823" y="258" fill="#555" font-size="9" text-anchor="end">½ head height</text>
+  <line x1="710" y1="263" x2="824" y2="263" stroke="#eee" stroke-width="1"/>
+  <text x="712" y="278" fill="#1a1a1a" font-size="9" font-weight="bold">Eye size:</text>
+  <text x="823" y="278" fill="#555" font-size="9" text-anchor="end">large (anime)</text>
+  <line x1="710" y1="283" x2="824" y2="283" stroke="#eee" stroke-width="1"/>
+  <text x="712" y="298" fill="#1a1a1a" font-size="9" font-weight="bold">Jaw style:</text>
+  <text x="823" y="298" fill="#555" font-size="9" text-anchor="end">angular</text>
+  <line x1="710" y1="303" x2="824" y2="303" stroke="#eee" stroke-width="1"/>
+  <text x="712" y="318" fill="#1a1a1a" font-size="9" font-weight="bold">Contour:</text>
+  <text x="823" y="318" fill="#555" font-size="9" text-anchor="end">4px</text>
+  <line x1="710" y1="323" x2="824" y2="323" stroke="#eee" stroke-width="1"/>
+  <text x="712" y="338" fill="#1a1a1a" font-size="9" font-weight="bold">Interior:</text>
+  <text x="823" y="338" fill="#555" font-size="9" text-anchor="end">2px</text>
+  <line x1="710" y1="343" x2="824" y2="343" stroke="#eee" stroke-width="1"/>
+  <text x="712" y="358" fill="#1a1a1a" font-size="9" font-weight="bold">Shading:</text>
+  <text x="823" y="358" fill="#555" font-size="9" text-anchor="end">cel (1 stop)</text>
+  <line x1="710" y1="363" x2="824" y2="363" stroke="#eee" stroke-width="1"/>
+  <text x="712" y="378" fill="#1a1a1a" font-size="9" font-weight="bold">Facial thirds:</text>
+  <text x="823" y="378" fill="#555" font-size="9" text-anchor="end">3 equal zones</text>
+  <line x1="710" y1="383" x2="824" y2="383" stroke="#eee" stroke-width="1"/>
+  <text x="712" y="398" fill="#1a1a1a" font-size="9" font-weight="bold">Grid snap:</text>
+  <text x="823" y="398" fill="#555" font-size="9" text-anchor="end">20px</text>
+  <line x1="710" y1="403" x2="824" y2="403" stroke="#eee" stroke-width="1"/>
+  <text x="712" y="418" fill="#1a1a1a" font-size="9" font-weight="bold">Perspective:</text>
+  <text x="823" y="418" fill="#555" font-size="9" text-anchor="end">slight 3/4</text>
+  <line x1="710" y1="423" x2="824" y2="423" stroke="#eee" stroke-width="1"/>
+  <text x="712" y="438" fill="#1a1a1a" font-size="9" font-weight="bold">Primary shapes:</text>
+  <text x="823" y="438" fill="#555" font-size="9" text-anchor="end">20+ segments</text>
+  <text x="712" y="454" fill="#555" font-size="9">ellipse head · polygon</text>
+  <text x="712" y="468" fill="#555" font-size="9">jaw · angular paths</text>
+
+  <!-- Color legend for proportion zones -->
+  <rect x="56" y="224" width="260" height="108" fill="#ffffff" stroke="#cccccc" stroke-width="1" rx="3" opacity="0.9"/>
+  <text x="186" y="242" fill="#1a1a1a" font-size="10" font-weight="bold" text-anchor="middle">GUIDE COLOR KEY</text>
+  <line x1="64" y1="248" x2="308" y2="248" stroke="#eee" stroke-width="1"/>
+  <line x1="64" y1="265" x2="84" y2="265" stroke="#2266cc" stroke-width="2" stroke-dasharray="6,3"/>
+  <text x="90" y="269" fill="#1a1a1a" font-size="9">Vertical centerline</text>
+  <line x1="64" y1="283" x2="84" y2="283" stroke="#cc2200" stroke-width="2" stroke-dasharray="5,3"/>
+  <text x="90" y="287" fill="#1a1a1a" font-size="9">Eye line / head-unit markers</text>
+  <line x1="64" y1="301" x2="84" y2="301" stroke="#228822" stroke-width="2" stroke-dasharray="4,3"/>
+  <text x="90" y="305" fill="#1a1a1a" font-size="9">Facial thirds</text>
+  <line x1="64" y1="319" x2="84" y2="319" stroke="#aaaaaa" stroke-width="1.5" stroke-dasharray="3,3"/>
+  <text x="90" y="323" fill="#1a1a1a" font-size="9">Construction ghost</text>
+</svg>

--- a/skills/character-board/templates/boondocks/specs/character-spec.svg
+++ b/skills/character-board/templates/boondocks/specs/character-spec.svg
@@ -1,0 +1,281 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 620" width="960" height="620" font-family="Arial, sans-serif">
+  <!-- Background -->
+  <rect width="960" height="620" fill="#f2f0ec"/>
+
+  <!-- Subtle grid -->
+  <defs>
+    <pattern id="bg-grid" width="20" height="20" patternUnits="userSpaceOnUse">
+      <path d="M 20 0 L 0 0 0 20" fill="none" stroke="#e4e0da" stroke-width="0.5"/>
+    </pattern>
+  </defs>
+  <rect width="960" height="620" fill="url(#bg-grid)"/>
+
+  <!-- Title bar -->
+  <rect x="0" y="0" width="960" height="44" fill="#1a1a1a"/>
+  <text x="16" y="29" fill="#ffffff" font-size="17" font-weight="bold" letter-spacing="2">CHARACTER SPEC — BOONDOCKS ANIME STYLE</text>
+  <text x="780" y="29" fill="#888" font-size="11">v1.0 · DATE</text>
+
+  <!-- Section labels -->
+  <text x="138" y="72" fill="#1a1a1a" font-size="11" font-weight="bold" text-anchor="middle" letter-spacing="1">FRONT</text>
+  <text x="390" y="72" fill="#1a1a1a" font-size="11" font-weight="bold" text-anchor="middle" letter-spacing="1">¾ TURN</text>
+  <text x="636" y="72" fill="#1a1a1a" font-size="11" font-weight="bold" text-anchor="middle" letter-spacing="1">SIDE PROFILE</text>
+
+  <!-- Dividers -->
+  <line x1="270" y1="58" x2="270" y2="510" stroke="#cccccc" stroke-width="1" stroke-dasharray="4,4"/>
+  <line x1="510" y1="58" x2="510" y2="510" stroke="#cccccc" stroke-width="1" stroke-dasharray="4,4"/>
+  <line x1="760" y1="58" x2="760" y2="510" stroke="#cccccc" stroke-width="1" stroke-dasharray="4,4"/>
+
+  <!-- Height ruler (7 heads) -->
+  <line x1="30" y1="82" x2="30" y2="502" stroke="#1a1a1a" stroke-width="2"/>
+  <!-- Each head = 60px. 7H = 420px. Range 82 to 502 = 420px. -->
+  <line x1="24" y1="82"  x2="36" y2="82"  stroke="#1a1a1a" stroke-width="2"/>
+  <line x1="24" y1="142" x2="36" y2="142" stroke="#cc2200" stroke-width="1.5" stroke-dasharray="4,2"/>
+  <line x1="24" y1="202" x2="36" y2="202" stroke="#cc2200" stroke-width="1.5" stroke-dasharray="4,2"/>
+  <line x1="24" y1="262" x2="36" y2="262" stroke="#cc2200" stroke-width="1.5" stroke-dasharray="4,2"/>
+  <line x1="24" y1="322" x2="36" y2="322" stroke="#cc2200" stroke-width="1.5" stroke-dasharray="4,2"/>
+  <line x1="24" y1="382" x2="36" y2="382" stroke="#cc2200" stroke-width="1.5" stroke-dasharray="4,2"/>
+  <line x1="24" y1="442" x2="36" y2="442" stroke="#cc2200" stroke-width="1.5" stroke-dasharray="4,2"/>
+  <line x1="24" y1="502" x2="36" y2="502" stroke="#1a1a1a" stroke-width="2"/>
+  <text x="20" y="85"  fill="#1a1a1a" font-size="9" text-anchor="end" font-weight="bold">1H</text>
+  <text x="20" y="145" fill="#cc2200" font-size="9" text-anchor="end">2H</text>
+  <text x="20" y="205" fill="#cc2200" font-size="9" text-anchor="end">3H</text>
+  <text x="20" y="265" fill="#cc2200" font-size="9" text-anchor="end">4H</text>
+  <text x="20" y="325" fill="#cc2200" font-size="9" text-anchor="end">5H</text>
+  <text x="20" y="385" fill="#cc2200" font-size="9" text-anchor="end">6H</text>
+  <text x="20" y="445" fill="#cc2200" font-size="9" text-anchor="end">7H</text>
+
+  <!-- Proportion lines across -->
+  <line x1="50" y1="142" x2="760" y2="142" stroke="#cc2200" stroke-width="1" stroke-dasharray="6,5" opacity="0.35"/>
+  <line x1="50" y1="202" x2="760" y2="202" stroke="#cc2200" stroke-width="1" stroke-dasharray="6,5" opacity="0.35"/>
+  <line x1="50" y1="262" x2="760" y2="262" stroke="#cc2200" stroke-width="1" stroke-dasharray="6,5" opacity="0.35"/>
+  <line x1="50" y1="322" x2="760" y2="322" stroke="#cc2200" stroke-width="1" stroke-dasharray="6,5" opacity="0.35"/>
+  <line x1="50" y1="382" x2="760" y2="382" stroke="#cc2200" stroke-width="1" stroke-dasharray="6,5" opacity="0.35"/>
+  <line x1="50" y1="442" x2="760" y2="442" stroke="#cc2200" stroke-width="1" stroke-dasharray="6,5" opacity="0.35"/>
+
+  <!-- ── FRONT VIEW ── -->
+  <!-- Vertical centerline -->
+  <line x1="138" y1="78" x2="138" y2="508" stroke="#2266cc" stroke-width="1" stroke-dasharray="8,5" opacity="0.4"/>
+  <!-- Head (circle + angular jaw) -->
+  <ellipse cx="138" cy="110" rx="42" ry="44" fill="#c8915a" stroke="#1a1a1a" stroke-width="3"/>
+  <!-- Jaw definition (angular) -->
+  <path d="M 98 118 L 108 142 L 138 148 L 168 142 L 178 118" fill="none" stroke="#1a1a1a" stroke-width="3"/>
+  <!-- Hair -->
+  <path d="M 96 100 Q 94 78 110 72 Q 138 62 166 72 Q 182 78 180 100 Q 174 86 138 84 Q 102 86 96 100 Z"
+        fill="#1a1a1a" stroke="#1a1a1a" stroke-width="2"/>
+  <!-- Eyes (large anime, at midpoint) -->
+  <ellipse cx="118" cy="108" rx="13" ry="15" fill="#1a1a1a" stroke="#1a1a1a" stroke-width="1"/>
+  <ellipse cx="158" cy="108" rx="13" ry="15" fill="#1a1a1a" stroke="#1a1a1a" stroke-width="1"/>
+  <ellipse cx="118" cy="108" rx="9" ry="10" fill="#553300"/>
+  <ellipse cx="158" cy="108" rx="9" ry="10" fill="#553300"/>
+  <ellipse cx="118" cy="108" rx="5" ry="6" fill="#111111"/>
+  <ellipse cx="158" cy="108" rx="5" ry="6" fill="#111111"/>
+  <circle cx="121" cy="104" r="2.5" fill="#ffffff"/>
+  <circle cx="161" cy="104" r="2.5" fill="#ffffff"/>
+  <!-- Eyebrows (angular) -->
+  <path d="M 105 93 L 132 96" stroke="#1a1a1a" stroke-width="3" stroke-linecap="round"/>
+  <path d="M 145 96 L 172 93" stroke="#1a1a1a" stroke-width="3" stroke-linecap="round"/>
+  <!-- Nose (small, angular) -->
+  <path d="M 138 114 L 140 128 L 136 128" fill="none" stroke="#8b5e3c" stroke-width="2" stroke-linecap="round"/>
+  <!-- Mouth -->
+  <path d="M 126 136 L 138 140 L 150 136" fill="none" stroke="#1a1a1a" stroke-width="2.5" stroke-linecap="round"/>
+  <!-- Neck -->
+  <rect x="128" y="148" width="20" height="24" fill="#c8915a" stroke="#1a1a1a" stroke-width="2.5"/>
+  <!-- Shoulders & body (angular torso) -->
+  <path d="M 80 172 L 68 282 L 108 290 L 138 294 L 168 290 L 208 282 L 196 172 L 158 166 L 118 166 Z"
+        fill="#2d4a6b" stroke="#1a1a1a" stroke-width="3"/>
+  <!-- Upper arms -->
+  <path d="M 80 172 L 58 176 L 46 266 L 72 272 L 80 200 Z" fill="#2d4a6b" stroke="#1a1a1a" stroke-width="2.5"/>
+  <path d="M 196 172 L 218 176 L 230 266 L 204 272 L 196 200 Z" fill="#2d4a6b" stroke="#1a1a1a" stroke-width="2.5"/>
+  <!-- Forearms -->
+  <path d="M 46 266 L 38 330 L 60 334 L 72 272 Z" fill="#c8915a" stroke="#1a1a1a" stroke-width="2.5"/>
+  <path d="M 230 266 L 238 330 L 216 334 L 204 272 Z" fill="#c8915a" stroke="#1a1a1a" stroke-width="2.5"/>
+  <!-- Hands -->
+  <ellipse cx="50"  cy="340" rx="14" ry="10" fill="#c8915a" stroke="#1a1a1a" stroke-width="2.5"/>
+  <ellipse cx="226" cy="340" rx="14" ry="10" fill="#c8915a" stroke="#1a1a1a" stroke-width="2.5"/>
+  <!-- Belt/waist -->
+  <rect x="100" y="290" width="76" height="16" rx="2" fill="#1a1a1a"/>
+  <rect x="130" y="292" width="16" height="12" rx="1" fill="#ccaa00"/>
+  <!-- Legs (thighs) -->
+  <path d="M 108 306 L 96 382 L 128 388 L 138 310 Z" fill="#1a4488" stroke="#1a1a1a" stroke-width="2.5"/>
+  <path d="M 168 306 L 180 382 L 148 388 L 138 310 Z" fill="#1a4488" stroke="#1a1a1a" stroke-width="2.5"/>
+  <!-- Shins -->
+  <path d="M 96 382 L 88 450 L 116 454 L 128 388 Z" fill="#1a4488" stroke="#1a1a1a" stroke-width="2.5"/>
+  <path d="M 180 382 L 188 450 L 160 454 L 148 388 Z" fill="#1a4488" stroke="#1a1a1a" stroke-width="2.5"/>
+  <!-- Feet -->
+  <path d="M 82 450 L 80 468 L 118 470 L 120 456 Z" fill="#1a1a1a" stroke="#1a1a1a" stroke-width="2"/>
+  <path d="M 156 456 L 158 470 L 196 468 L 194 450 Z" fill="#1a1a1a" stroke="#1a1a1a" stroke-width="2"/>
+
+  <!-- ── ¾ TURN VIEW (simplified, shifted) ── -->
+  <line x1="390" y1="78" x2="390" y2="508" stroke="#2266cc" stroke-width="1" stroke-dasharray="8,5" opacity="0.3"/>
+  <!-- Head -->
+  <ellipse cx="388" cy="110" rx="40" ry="44" fill="#c8915a" stroke="#1a1a1a" stroke-width="3"/>
+  <path d="M 350 118 L 360 142 L 388 148 L 422 140 L 428 116" fill="none" stroke="#1a1a1a" stroke-width="3"/>
+  <!-- Hair (3/4) -->
+  <path d="M 348 100 Q 346 78 360 72 Q 388 62 416 72 Q 430 78 428 100 Q 422 86 388 84 Q 354 86 348 100 Z"
+        fill="#1a1a1a" stroke="#1a1a1a" stroke-width="2"/>
+  <!-- Far eye (small) -->
+  <ellipse cx="368" cy="108" rx="10" ry="12" fill="#1a1a1a"/>
+  <ellipse cx="368" cy="108" rx="6"  ry="7"  fill="#553300"/>
+  <ellipse cx="368" cy="108" rx="3"  ry="4"  fill="#111"/>
+  <circle  cx="370" cy="104" r="2"   fill="#ffffff"/>
+  <!-- Near eye (larger) -->
+  <ellipse cx="402" cy="108" rx="14" ry="15" fill="#1a1a1a"/>
+  <ellipse cx="402" cy="108" rx="10" ry="11" fill="#553300"/>
+  <ellipse cx="402" cy="108" rx="5"  ry="6"  fill="#111"/>
+  <circle  cx="405" cy="104" r="2.5" fill="#ffffff"/>
+  <!-- Nose (visible from 3/4) -->
+  <path d="M 414 118 L 422 128 L 416 132" fill="none" stroke="#8b5e3c" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Brows -->
+  <path d="M 356 93 L 380 96" stroke="#1a1a1a" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M 392 95 L 418 91" stroke="#1a1a1a" stroke-width="2.5" stroke-linecap="round"/>
+  <!-- Mouth -->
+  <path d="M 372 136 L 385 140 L 400 136" fill="none" stroke="#1a1a1a" stroke-width="2.5" stroke-linecap="round"/>
+  <!-- Neck -->
+  <rect x="378" y="148" width="18" height="24" fill="#c8915a" stroke="#1a1a1a" stroke-width="2.5"/>
+  <!-- Torso (3/4 — slightly rotated) -->
+  <path d="M 334 172 L 322 282 L 360 290 L 388 294 L 428 290 L 444 282 L 440 172 L 404 166 L 372 166 Z"
+        fill="#2d4a6b" stroke="#1a1a1a" stroke-width="3"/>
+  <!-- Near arm -->
+  <path d="M 440 172 L 462 178 L 474 268 L 452 274 L 444 200 Z" fill="#2d4a6b" stroke="#1a1a1a" stroke-width="2.5"/>
+  <path d="M 462 268 L 470 332 L 448 336 L 452 274 Z" fill="#c8915a" stroke="#1a1a1a" stroke-width="2.5"/>
+  <ellipse cx="462" cy="342" rx="14" ry="10" fill="#c8915a" stroke="#1a1a1a" stroke-width="2.5"/>
+  <!-- Far arm (partially visible) -->
+  <path d="M 334 172 L 316 178 L 306 240 L 326 246 Z" fill="#22395a" stroke="#1a1a1a" stroke-width="2"/>
+  <!-- Belt -->
+  <rect x="354" y="290" width="76" height="16" rx="2" fill="#1a1a1a"/>
+  <rect x="384" y="292" width="16" height="12" rx="1" fill="#ccaa00"/>
+  <!-- Legs (3/4) -->
+  <path d="M 360 306 L 350 382 L 378 388 L 388 310 Z" fill="#1a4488" stroke="#1a1a1a" stroke-width="2.5"/>
+  <path d="M 418 306 L 426 382 L 400 388 L 390 310 Z" fill="#163980" stroke="#1a1a1a" stroke-width="2.5"/>
+  <path d="M 350 382 L 342 450 L 370 454 L 378 388 Z" fill="#1a4488" stroke="#1a1a1a" stroke-width="2.5"/>
+  <path d="M 426 382 L 434 450 L 406 454 L 400 388 Z" fill="#163980" stroke="#1a1a1a" stroke-width="2.5"/>
+  <!-- Feet -->
+  <path d="M 336 450 L 334 468 L 372 470 L 374 456 Z" fill="#1a1a1a" stroke="#1a1a1a" stroke-width="2"/>
+  <path d="M 402 456 L 404 470 L 442 468 L 440 450 Z" fill="#111" stroke="#1a1a1a" stroke-width="2"/>
+
+  <!-- ── SIDE PROFILE ── -->
+  <!-- Head -->
+  <ellipse cx="636" cy="110" rx="36" ry="44" fill="#c8915a" stroke="#1a1a1a" stroke-width="3"/>
+  <path d="M 604 118 L 612 142 L 636 148 L 660 140 L 666 118" fill="none" stroke="#1a1a1a" stroke-width="3"/>
+  <!-- Hair (side) -->
+  <path d="M 600 98 Q 598 75 615 68 Q 636 60 660 68 Q 674 76 672 98 Q 666 84 636 82 Q 606 84 600 98 Z"
+        fill="#1a1a1a" stroke="#1a1a1a" stroke-width="2"/>
+  <!-- Side eye -->
+  <ellipse cx="626" cy="108" rx="12" ry="14" fill="#1a1a1a"/>
+  <ellipse cx="626" cy="108" rx="8"  ry="9"  fill="#553300"/>
+  <ellipse cx="626" cy="108" rx="4"  ry="5"  fill="#111"/>
+  <circle  cx="628" cy="104" r="2"   fill="#ffffff"/>
+  <!-- Side brow -->
+  <path d="M 614 92 L 638 95" stroke="#1a1a1a" stroke-width="2.5" stroke-linecap="round"/>
+  <!-- Nose (clear from side) -->
+  <path d="M 668 118 L 680 130 L 672 138" fill="none" stroke="#1a1a1a" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Mouth (side) -->
+  <path d="M 620 136 L 632 140 L 648 136" fill="none" stroke="#1a1a1a" stroke-width="2.5" stroke-linecap="round"/>
+  <!-- Neck -->
+  <rect x="626" y="148" width="16" height="24" fill="#c8915a" stroke="#1a1a1a" stroke-width="2.5"/>
+  <!-- Torso (side — narrow) -->
+  <path d="M 598 172 L 590 282 L 622 290 L 650 288 L 674 280 L 672 172 L 648 166 L 620 166 Z"
+        fill="#2d4a6b" stroke="#1a1a1a" stroke-width="3"/>
+  <!-- Visible arm -->
+  <path d="M 672 172 L 690 178 L 700 268 L 680 274 L 672 198 Z" fill="#2d4a6b" stroke="#1a1a1a" stroke-width="2.5"/>
+  <path d="M 690 268 L 698 330 L 678 334 L 680 274 Z" fill="#c8915a" stroke="#1a1a1a" stroke-width="2.5"/>
+  <ellipse cx="690" cy="340" rx="14" ry="10" fill="#c8915a" stroke="#1a1a1a" stroke-width="2.5"/>
+  <!-- Belt -->
+  <rect x="580" y="288" width="76" height="16" rx="2" fill="#1a1a1a"/>
+  <!-- Legs (side) -->
+  <path d="M 590 306 L 580 388 L 612 392 L 618 310 Z" fill="#163980" stroke="#1a1a1a" stroke-width="2.5"/>
+  <path d="M 636 306 L 648 388 L 680 382 L 660 308 Z" fill="#1a4488" stroke="#1a1a1a" stroke-width="2.5"/>
+  <path d="M 580 388 L 572 458 L 604 460 L 612 392 Z" fill="#163980" stroke="#1a1a1a" stroke-width="2.5"/>
+  <path d="M 648 388 L 656 458 L 688 452 L 680 382 Z" fill="#1a4488" stroke="#1a1a1a" stroke-width="2.5"/>
+  <!-- Feet -->
+  <path d="M 562 456 L 558 472 L 606 474 L 608 462 Z" fill="#111" stroke="#1a1a1a" stroke-width="2"/>
+  <path d="M 650 462 L 652 476 L 700 474 L 698 458 Z" fill="#1a1a1a" stroke="#1a1a1a" stroke-width="2"/>
+
+  <!-- ── EXPRESSION STRIP ── -->
+  <rect x="20" y="518" width="920" height="90" fill="#e8e4dc" rx="4"/>
+  <text x="36" y="534" fill="#1a1a1a" font-size="10" font-weight="bold" letter-spacing="1">EXPRESSIONS</text>
+
+  <!-- Neutral -->
+  <ellipse cx="90" cy="565" rx="30" ry="34" fill="#c8915a" stroke="#1a1a1a" stroke-width="2.5"/>
+  <path d="M 64 565 L 70 578 L 90 582 L 110 578 L 116 565" fill="none" stroke="#1a1a1a" stroke-width="2"/>
+  <ellipse cx="80"  cy="560" rx="8" ry="9" fill="#1a1a1a"/>
+  <ellipse cx="100" cy="560" rx="8" ry="9" fill="#1a1a1a"/>
+  <ellipse cx="80"  cy="560" rx="5" ry="6" fill="#553300"/>
+  <ellipse cx="100" cy="560" rx="5" ry="6" fill="#553300"/>
+  <circle  cx="82"  cy="557" r="2" fill="#ffffff"/>
+  <circle  cx="102" cy="557" r="2" fill="#ffffff"/>
+  <path d="M 80 575 L 100 575" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="90" y="600" fill="#444" font-size="8" text-anchor="middle">NEUTRAL</text>
+
+  <!-- Happy -->
+  <ellipse cx="196" cy="565" rx="30" ry="34" fill="#c8915a" stroke="#1a1a1a" stroke-width="2.5"/>
+  <path d="M 170 565 L 176 578 L 196 582 L 216 578 L 222 565" fill="none" stroke="#1a1a1a" stroke-width="2"/>
+  <ellipse cx="186" cy="558" rx="9" ry="10" fill="#1a1a1a"/>
+  <ellipse cx="206" cy="558" rx="9" ry="10" fill="#1a1a1a"/>
+  <ellipse cx="186" cy="560" rx="6" ry="5" fill="#553300"/>
+  <ellipse cx="206" cy="560" rx="6" ry="5" fill="#553300"/>
+  <circle  cx="188" cy="556" r="2" fill="#ffffff"/>
+  <circle  cx="208" cy="556" r="2" fill="#ffffff"/>
+  <path d="M 182 571 Q 196 582 210 571" fill="none" stroke="#1a1a1a" stroke-width="2" stroke-linecap="round"/>
+  <text x="196" y="600" fill="#444" font-size="8" text-anchor="middle">HAPPY</text>
+
+  <!-- Angry -->
+  <ellipse cx="302" cy="565" rx="30" ry="34" fill="#c8915a" stroke="#1a1a1a" stroke-width="2.5"/>
+  <path d="M 276 565 L 282 578 L 302 582 L 322 578 L 328 565" fill="none" stroke="#1a1a1a" stroke-width="2"/>
+  <path d="M 280 548 L 292 555" stroke="#1a1a1a" stroke-width="3" stroke-linecap="round"/>
+  <path d="M 316 555 L 328 548" stroke="#1a1a1a" stroke-width="3" stroke-linecap="round"/>
+  <ellipse cx="289" cy="560" rx="8" ry="9" fill="#1a1a1a"/>
+  <ellipse cx="315" cy="560" rx="8" ry="9" fill="#1a1a1a"/>
+  <ellipse cx="289" cy="560" rx="5" ry="6" fill="#553300"/>
+  <ellipse cx="315" cy="560" rx="5" ry="6" fill="#553300"/>
+  <path d="M 288 574 L 318 574" stroke="#1a1a1a" stroke-width="1.5"/>
+  <text x="302" y="600" fill="#444" font-size="8" text-anchor="middle">ANGRY</text>
+
+  <!-- Surprised -->
+  <ellipse cx="408" cy="565" rx="30" ry="34" fill="#c8915a" stroke="#1a1a1a" stroke-width="2.5"/>
+  <path d="M 382 565 L 388 578 L 408 582 L 428 578 L 434 565" fill="none" stroke="#1a1a1a" stroke-width="2"/>
+  <ellipse cx="396" cy="557" rx="10" ry="12" fill="#1a1a1a"/>
+  <ellipse cx="420" cy="557" rx="10" ry="12" fill="#1a1a1a"/>
+  <ellipse cx="396" cy="557" rx="7" ry="8" fill="#553300"/>
+  <ellipse cx="420" cy="557" rx="7" ry="8" fill="#553300"/>
+  <circle  cx="398" cy="553" r="2.5" fill="#ffffff"/>
+  <circle  cx="422" cy="553" r="2.5" fill="#ffffff"/>
+  <ellipse cx="408" cy="576" rx="7" ry="5" fill="#1a1a1a"/>
+  <text x="408" y="600" fill="#444" font-size="8" text-anchor="middle">SURPRISED</text>
+
+  <!-- Determined -->
+  <ellipse cx="514" cy="565" rx="30" ry="34" fill="#c8915a" stroke="#1a1a1a" stroke-width="2.5"/>
+  <path d="M 488 565 L 494 578 L 514 582 L 534 578 L 540 565" fill="none" stroke="#1a1a1a" stroke-width="2"/>
+  <path d="M 490 550 L 506 556" stroke="#1a1a1a" stroke-width="3" stroke-linecap="round"/>
+  <path d="M 524 556 L 540 549" stroke="#1a1a1a" stroke-width="3" stroke-linecap="round"/>
+  <ellipse cx="502" cy="562" rx="9" ry="10" fill="#1a1a1a"/>
+  <ellipse cx="526" cy="562" rx="9" ry="10" fill="#1a1a1a"/>
+  <ellipse cx="502" cy="562" rx="6" ry="7" fill="#553300"/>
+  <ellipse cx="526" cy="562" rx="6" ry="7" fill="#553300"/>
+  <circle  cx="504" cy="558" r="2" fill="#ffffff"/>
+  <circle  cx="528" cy="558" r="2" fill="#ffffff"/>
+  <path d="M 500 575 Q 514 580 528 575" fill="none" stroke="#1a1a1a" stroke-width="2" stroke-linecap="round"/>
+  <text x="514" y="600" fill="#444" font-size="8" text-anchor="middle">DETERMINED</text>
+
+  <!-- Sad -->
+  <ellipse cx="620" cy="565" rx="30" ry="34" fill="#c8915a" stroke="#1a1a1a" stroke-width="2.5"/>
+  <path d="M 594 565 L 600 578 L 620 582 L 640 578 L 646 565" fill="none" stroke="#1a1a1a" stroke-width="2"/>
+  <path d="M 596 554 L 608 558" stroke="#1a1a1a" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M 634 558 L 646 553" stroke="#1a1a1a" stroke-width="2.5" stroke-linecap="round"/>
+  <ellipse cx="606" cy="562" rx="8" ry="10" fill="#1a1a1a"/>
+  <ellipse cx="632" cy="562" rx="8" ry="10" fill="#1a1a1a"/>
+  <ellipse cx="606" cy="563" rx="5" ry="7" fill="#553300"/>
+  <ellipse cx="632" cy="563" rx="5" ry="7" fill="#553300"/>
+  <!-- Teardrops -->
+  <ellipse cx="600" cy="573" rx="3" ry="4" fill="#88aadd" opacity="0.8"/>
+  <ellipse cx="636" cy="573" rx="3" ry="4" fill="#88aadd" opacity="0.8"/>
+  <path d="M 604 576 Q 620 584 636 576" fill="none" stroke="#1a1a1a" stroke-width="2" stroke-linecap="round"/>
+  <text x="620" y="600" fill="#444" font-size="8" text-anchor="middle">SAD</text>
+
+  <!-- Character name plate -->
+  <rect x="820" y="518" width="120" height="90" fill="#1a1a1a" rx="4"/>
+  <text x="880" y="540" fill="#ffffff" font-size="9" font-weight="bold" text-anchor="middle" letter-spacing="1">CHARACTER</text>
+  <text x="880" y="558" fill="#d4a855" font-size="14" font-weight="bold" text-anchor="middle">NAME</text>
+  <text x="880" y="576" fill="#888888" font-size="8" text-anchor="middle">Boondocks Style</text>
+  <text x="880" y="592" fill="#666666" font-size="8" text-anchor="middle">7H · Anime</text>
+</svg>

--- a/skills/character-board/templates/boondocks/svg-assets/asset-map.svg
+++ b/skills/character-board/templates/boondocks/svg-assets/asset-map.svg
@@ -1,0 +1,283 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 580" width="980" height="580" font-family="monospace, Arial, sans-serif">
+  <rect width="980" height="580" fill="#f2f0ec"/>
+
+  <!-- Title bar -->
+  <rect x="0" y="0" width="980" height="40" fill="#1a1a1a"/>
+  <text x="14" y="26" fill="#ffffff" font-size="15" font-weight="bold" letter-spacing="2">SVG ASSET MAP — BOONDOCKS RIG</text>
+  <text x="680" y="26" fill="#888" font-size="10">CEL-SHADE ANIME · 22 PARTS</text>
+
+  <!-- ── LEGEND (right) ── -->
+  <rect x="720" y="50" width="246" height="486" fill="#ffffff" stroke="#1a1a1a" stroke-width="1.5" rx="3"/>
+  <rect x="720" y="50" width="246" height="28" fill="#1a1a1a" rx="3"/>
+  <text x="843" y="69" fill="#ffffff" font-size="11" font-weight="bold" text-anchor="middle" letter-spacing="1">LAYER ORDER (z-index)</text>
+  <text x="730" y="93" fill="#1a1a1a" font-size="9" font-weight="bold">Z   ID                    Group</text>
+  <line x1="726" y1="98" x2="960" y2="98" stroke="#ddd" stroke-width="1"/>
+
+  <!-- Layer list -->
+  <text x="730" y="113" fill="#cc2200" font-size="9" font-weight="bold">22</text><text x="752" y="113" fill="#1a1a1a" font-size="9">accessory-2</text>
+  <text x="730" y="127" fill="#cc2200" font-size="9" font-weight="bold">21</text><text x="752" y="127" fill="#1a1a1a" font-size="9">accessory-1</text>
+  <text x="730" y="141" fill="#cc2200" font-size="9" font-weight="bold">20</text><text x="752" y="141" fill="#1a1a1a" font-size="9">outfit-overlay</text>
+  <text x="730" y="155" fill="#cc2200" font-size="9" font-weight="bold">19</text><text x="752" y="155" fill="#1a1a1a" font-size="9">hair-front</text>
+  <text x="730" y="169" fill="#cc2200" font-size="9" font-weight="bold">18</text><text x="752" y="169" fill="#1a1a1a" font-size="9">face (eyes/mouth)</text>
+  <text x="730" y="183" fill="#cc2200" font-size="9" font-weight="bold">17</text><text x="752" y="183" fill="#1a1a1a" font-size="9">right-eye</text>
+  <text x="730" y="197" fill="#cc2200" font-size="9" font-weight="bold">16</text><text x="752" y="197" fill="#1a1a1a" font-size="9">left-eye</text>
+  <text x="730" y="211" fill="#cc2200" font-size="9" font-weight="bold">15</text><text x="752" y="211" fill="#1a1a1a" font-size="9">head</text>
+  <text x="730" y="225" fill="#cc2200" font-size="9" font-weight="bold">14</text><text x="752" y="225" fill="#1a1a1a" font-size="9">neck</text>
+  <text x="730" y="239" fill="#cc2200" font-size="9" font-weight="bold">13</text><text x="752" y="239" fill="#1a1a1a" font-size="9">right-hand</text>
+  <text x="730" y="253" fill="#cc2200" font-size="9" font-weight="bold">12</text><text x="752" y="253" fill="#1a1a1a" font-size="9">right-forearm</text>
+  <text x="730" y="267" fill="#cc2200" font-size="9" font-weight="bold">11</text><text x="752" y="267" fill="#1a1a1a" font-size="9">right-upper-arm</text>
+  <text x="730" y="281" fill="#cc2200" font-size="9" font-weight="bold">10</text><text x="752" y="281" fill="#1a1a1a" font-size="9">torso</text>
+  <text x="730" y="295" fill="#cc2200" font-size="9" font-weight="bold"> 9</text><text x="752" y="295" fill="#1a1a1a" font-size="9">left-upper-arm</text>
+  <text x="730" y="309" fill="#cc2200" font-size="9" font-weight="bold"> 8</text><text x="752" y="309" fill="#1a1a1a" font-size="9">left-forearm</text>
+  <text x="730" y="323" fill="#cc2200" font-size="9" font-weight="bold"> 7</text><text x="752" y="323" fill="#1a1a1a" font-size="9">left-hand</text>
+  <text x="730" y="337" fill="#cc2200" font-size="9" font-weight="bold"> 6</text><text x="752" y="337" fill="#1a1a1a" font-size="9">right-foot</text>
+  <text x="730" y="351" fill="#cc2200" font-size="9" font-weight="bold"> 5</text><text x="752" y="351" fill="#1a1a1a" font-size="9">right-shin</text>
+  <text x="730" y="365" fill="#cc2200" font-size="9" font-weight="bold"> 4</text><text x="752" y="365" fill="#1a1a1a" font-size="9">right-thigh</text>
+  <text x="730" y="379" fill="#cc2200" font-size="9" font-weight="bold"> 3</text><text x="752" y="379" fill="#1a1a1a" font-size="9">left-foot</text>
+  <text x="730" y="393" fill="#cc2200" font-size="9" font-weight="bold"> 2</text><text x="752" y="393" fill="#1a1a1a" font-size="9">left-shin</text>
+  <text x="730" y="407" fill="#cc2200" font-size="9" font-weight="bold"> 1</text><text x="752" y="407" fill="#1a1a1a" font-size="9">left-thigh</text>
+  <line x1="726" y1="415" x2="960" y2="415" stroke="#ddd" stroke-width="1"/>
+  <text x="730" y="432" fill="#555" font-size="9" font-weight="bold">Registration points:</text>
+  <text x="730" y="447" fill="#555" font-size="9">● head/eyes → center of part</text>
+  <text x="730" y="461" fill="#555" font-size="9">● upper-arms → shoulder joint</text>
+  <text x="730" y="475" fill="#555" font-size="9">● forearms   → elbow joint</text>
+  <text x="730" y="489" fill="#555" font-size="9">● thighs     → hip joint</text>
+  <text x="730" y="503" fill="#555" font-size="9">● shins      → knee joint</text>
+  <text x="730" y="517" fill="#555" font-size="9">● torso      → waist center</text>
+  <text x="730" y="531" fill="#555" font-size="9">● accessory  → geometric center</text>
+
+  <!-- ── EXPLODED CHARACTER VIEW ── -->
+
+  <!-- left-thigh (z=1) -->
+  <g id="left-thigh">
+    <path d="M 84 296 L 76 356 L 108 360 L 116 300 Z" fill="#1a4488" stroke="#1a1a1a" stroke-width="2"/>
+  </g>
+  <rect x="70" y="290" width="52" height="76" fill="none" stroke="#22aa44" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="96" y="378" fill="#22aa44" font-size="7" text-anchor="middle">left-thigh</text>
+  <circle cx="96" cy="296" r="3" fill="#22aa44"/>
+
+  <!-- left-shin (z=2) -->
+  <g id="left-shin">
+    <path d="M 76 356 L 68 420 L 100 424 L 108 360 Z" fill="#163980" stroke="#1a1a1a" stroke-width="2"/>
+  </g>
+  <rect x="60" y="350" width="54" height="80" fill="none" stroke="#44cc66" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="87" y="442" fill="#44cc66" font-size="7" text-anchor="middle">left-shin</text>
+  <circle cx="87" cy="356" r="3" fill="#44cc66"/>
+
+  <!-- left-foot (z=3) -->
+  <g id="left-foot">
+    <path d="M 58 420 L 56 444 L 104 446 L 104 428 Z" fill="#1a1a1a" stroke="#1a1a1a" stroke-width="1.5"/>
+  </g>
+  <rect x="52" y="416" width="56" height="36" fill="none" stroke="#66dd88" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="80" y="464" fill="#66dd88" font-size="7" text-anchor="middle">left-foot</text>
+
+  <!-- right-thigh (z=4) -->
+  <g id="right-thigh">
+    <path d="M 164 296 L 172 356 L 140 360 L 132 300 Z" fill="#163980" stroke="#1a1a1a" stroke-width="2"/>
+  </g>
+  <rect x="126" y="290" width="52" height="76" fill="none" stroke="#2299cc" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="152" y="378" fill="#2299cc" font-size="7" text-anchor="middle">right-thigh</text>
+  <circle cx="152" cy="296" r="3" fill="#2299cc"/>
+
+  <!-- right-shin (z=5) -->
+  <g id="right-shin">
+    <path d="M 172 356 L 180 420 L 148 424 L 140 360 Z" fill="#1a4488" stroke="#1a1a1a" stroke-width="2"/>
+  </g>
+  <rect x="134" y="350" width="52" height="80" fill="none" stroke="#44aadd" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="160" y="442" fill="#44aadd" font-size="7" text-anchor="middle">right-shin</text>
+  <circle cx="156" cy="356" r="3" fill="#44aadd"/>
+
+  <!-- right-foot (z=6) -->
+  <g id="right-foot">
+    <path d="M 136 428 L 136 446 L 184 444 L 182 420 Z" fill="#111" stroke="#1a1a1a" stroke-width="1.5"/>
+  </g>
+  <rect x="130" y="416" width="58" height="36" fill="none" stroke="#66ccee" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="159" y="464" fill="#66ccee" font-size="7" text-anchor="middle">right-foot</text>
+
+  <!-- left-hand (z=7) -->
+  <g id="left-hand">
+    <ellipse cx="36" cy="318" rx="16" ry="12" fill="#c8915a" stroke="#1a1a1a" stroke-width="2"/>
+  </g>
+  <rect x="16" y="308" width="40" height="24" fill="none" stroke="#cc8800" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="36" y="344" fill="#cc8800" font-size="7" text-anchor="middle">left-hand</text>
+
+  <!-- left-forearm (z=8) -->
+  <g id="left-forearm">
+    <path d="M 38 226 L 30 310 L 48 316 L 56 232 Z" fill="#c8915a" stroke="#1a1a1a" stroke-width="2"/>
+  </g>
+  <rect x="24" y="220" width="38" height="100" fill="none" stroke="#dd9900" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="43" y="332" fill="#dd9900" font-size="7" text-anchor="middle">left-forearm</text>
+  <circle cx="47" cy="226" r="3" fill="#dd9900"/>
+
+  <!-- left-upper-arm (z=9) -->
+  <g id="left-upper-arm">
+    <path d="M 78 166 L 56 170 L 44 224 L 64 230 L 76 190 Z" fill="#2d4a6b" stroke="#1a1a1a" stroke-width="2"/>
+  </g>
+  <rect x="40" y="160" width="44" height="76" fill="none" stroke="#cc6600" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="62" y="248" fill="#cc6600" font-size="7" text-anchor="middle">left-upper-arm</text>
+  <circle cx="78" cy="166" r="3" fill="#cc6600"/>
+
+  <!-- torso (z=10) -->
+  <g id="torso">
+    <path d="M 82 156 L 70 248 L 94 256 L 124 260 L 154 260 L 184 256 L 208 248 L 196 156 L 158 148 L 120 148 Z"
+          fill="#2d4a6b" stroke="#1a1a1a" stroke-width="2.5"/>
+    <!-- Belt -->
+    <rect x="86" y="256" width="76" height="14" rx="2" fill="#1a1a1a"/>
+    <rect x="115" y="258" width="14" height="10" rx="1" fill="#ccaa00"/>
+  </g>
+  <rect x="64" y="140" width="150" height="136" fill="none" stroke="#9922cc" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="139" y="288" fill="#9922cc" font-size="7" text-anchor="middle">torso</text>
+  <circle cx="139" cy="204" r="3" fill="#9922cc"/>
+
+  <!-- right-upper-arm (z=11) -->
+  <g id="right-upper-arm">
+    <path d="M 196 166 L 218 170 L 230 224 L 210 230 L 202 190 Z" fill="#2d4a6b" stroke="#1a1a1a" stroke-width="2"/>
+  </g>
+  <rect x="194" y="160" width="42" height="76" fill="none" stroke="#cc4400" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="215" y="248" fill="#cc4400" font-size="7" text-anchor="middle">right-upper-arm</text>
+  <circle cx="196" cy="166" r="3" fill="#cc4400"/>
+
+  <!-- right-forearm (z=12) -->
+  <g id="right-forearm">
+    <path d="M 222 226 L 230 310 L 248 314 L 240 232 Z" fill="#c8915a" stroke="#1a1a1a" stroke-width="2"/>
+  </g>
+  <rect x="216" y="220" width="38" height="100" fill="none" stroke="#dd4422" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="235" y="332" fill="#dd4422" font-size="7" text-anchor="middle">right-forearm</text>
+  <circle cx="228" cy="226" r="3" fill="#dd4422"/>
+
+  <!-- right-hand (z=13) -->
+  <g id="right-hand">
+    <ellipse cx="242" cy="320" rx="16" ry="12" fill="#c8915a" stroke="#1a1a1a" stroke-width="2"/>
+  </g>
+  <rect x="222" y="308" width="40" height="24" fill="none" stroke="#ee4444" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="242" y="344" fill="#ee4444" font-size="7" text-anchor="middle">right-hand</text>
+
+  <!-- neck (z=14) -->
+  <g id="neck">
+    <rect x="130" y="134" width="18" height="22" fill="#c8915a" stroke="#1a1a1a" stroke-width="2"/>
+  </g>
+  <rect x="126" y="130" width="26" height="30" fill="none" stroke="#aa55cc" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="139" y="174" fill="#aa55cc" font-size="7" text-anchor="middle">neck</text>
+
+  <!-- head (z=15) -->
+  <g id="head">
+    <ellipse cx="139" cy="96" rx="54" ry="40" fill="#c8915a" stroke="#1a1a1a" stroke-width="3"/>
+    <path d="M 88 104 L 96 130 L 139 136 L 182 130 L 190 104" fill="none" stroke="#1a1a1a" stroke-width="3"/>
+    <!-- Hair back -->
+    <path d="M 85 92 Q 84 68 100 60 Q 139 48 178 60 Q 194 68 193 92 Q 186 76 139 74 Q 92 76 85 92 Z"
+          fill="#1a1a1a" stroke="#1a1a1a" stroke-width="1.5"/>
+  </g>
+  <rect x="80" y="44" width="118" height="100" fill="none" stroke="#cc2244" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="139" y="156" fill="#cc2244" font-size="7" text-anchor="middle">head</text>
+  <circle cx="139" cy="96" r="3" fill="#cc2244"/>
+
+  <!-- left-eye (z=16) -->
+  <g id="left-eye">
+    <ellipse cx="116" cy="92" rx="16" ry="18" fill="#1a1a1a"/>
+    <ellipse cx="116" cy="92" rx="10" ry="12" fill="#553300"/>
+    <ellipse cx="116" cy="92" rx="5" ry="6" fill="#111"/>
+    <circle  cx="119" cy="88" r="3" fill="#ffffff"/>
+  </g>
+  <rect x="97" y="72" width="38" height="40" fill="none" stroke="#aa2266" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="116" y="122" fill="#aa2266" font-size="7" text-anchor="middle">left-eye</text>
+
+  <!-- right-eye (z=17) -->
+  <g id="right-eye">
+    <ellipse cx="162" cy="92" rx="16" ry="18" fill="#1a1a1a"/>
+    <ellipse cx="162" cy="92" rx="10" ry="12" fill="#553300"/>
+    <ellipse cx="162" cy="92" rx="5" ry="6" fill="#111"/>
+    <circle  cx="165" cy="88" r="3" fill="#ffffff"/>
+  </g>
+  <rect x="143" y="72" width="38" height="40" fill="none" stroke="#882244" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="162" y="122" fill="#882244" font-size="7" text-anchor="middle">right-eye</text>
+
+  <!-- hair-front (z=19) -->
+  <g id="hair-front">
+    <!-- side strands -->
+    <path d="M 85 92 Q 76 106 80 126 L 90 120 Q 90 102 98 92 Z" fill="#1a1a1a"/>
+    <path d="M 193 92 Q 202 106 198 126 L 188 120 Q 188 102 180 92 Z" fill="#1a1a1a"/>
+  </g>
+  <rect x="74" y="52" width="24" height="80" fill="none" stroke="#558822" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="86" y="142" fill="#558822" font-size="7" text-anchor="middle">hair-front</text>
+
+  <!-- accessory-1 (z=21) — cap brim -->
+  <g id="accessory-1">
+    <path d="M 106 58 L 102 44 L 176 44 L 172 58 Z" fill="#cc0000" stroke="#1a1a1a" stroke-width="2"/>
+    <path d="M 78 62 L 200 62 L 195 68 L 83 68 Z" fill="#cc0000" stroke="#1a1a1a" stroke-width="1.5"/>
+  </g>
+  <rect x="74" y="38" width="130" height="34" fill="none" stroke="#888822" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="139" y="84" fill="#888822" font-size="7" text-anchor="middle">accessory-1</text>
+
+  <!-- accessory-2 (z=22) — chain/pendant -->
+  <g id="accessory-2">
+    <line x1="110" y1="166" x2="139" y2="184" stroke="#ccaa00" stroke-width="2"/>
+    <line x1="139" y1="184" x2="168" y2="166" stroke="#ccaa00" stroke-width="2"/>
+    <circle cx="139" cy="186" r="8" fill="#ccaa00" stroke="#1a1a1a" stroke-width="1.5"/>
+    <text x="139" y="190" fill="#1a1a1a" font-size="7" text-anchor="middle" font-weight="bold">★</text>
+  </g>
+  <rect x="104" y="162" width="70" height="36" fill="none" stroke="#aaaa22" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="139" y="212" fill="#aaaa22" font-size="7" text-anchor="middle">accessory-2</text>
+
+  <!-- ── PART DETAIL TABLE ── -->
+  <rect x="290" y="50" width="420" height="500" fill="#ffffff" stroke="#1a1a1a" stroke-width="1.5" rx="3"/>
+  <rect x="290" y="50" width="420" height="28" fill="#1a1a1a" rx="3"/>
+  <text x="500" y="69" fill="#ffffff" font-size="11" font-weight="bold" text-anchor="middle" letter-spacing="1">PART SPECIFICATIONS</text>
+
+  <text x="300" y="94" fill="#1a1a1a" font-size="9" font-weight="bold">ID</text>
+  <text x="366" y="94" fill="#1a1a1a" font-size="9" font-weight="bold">Shape</text>
+  <text x="444" y="94" fill="#1a1a1a" font-size="9" font-weight="bold">Approx Size</text>
+  <text x="558" y="94" fill="#1a1a1a" font-size="9" font-weight="bold">Pivot</text>
+  <text x="640" y="94" fill="#1a1a1a" font-size="9" font-weight="bold">Layer</text>
+  <line x1="296" y1="99" x2="704" y2="99" stroke="#1a1a1a" stroke-width="1"/>
+
+  <!-- Rows: 22 parts at 18px each -->
+  <text x="300" y="114" fill="#1a1a1a" font-size="8">hair-back</text>      <text x="366" y="114" fill="#555" font-size="8">path</text>        <text x="444" y="114" fill="#555" font-size="8">110×60px</text>        <text x="558" y="114" fill="#555" font-size="8">hairline</text>   <text x="640" y="114" fill="#555" font-size="8">—</text>
+  <line x1="296" y1="118" x2="704" y2="118" stroke="#f0f0f0" stroke-width="1"/>
+  <text x="300" y="132" fill="#1a1a1a" font-size="8">head</text>            <text x="366" y="132" fill="#555" font-size="8">ellipse+path</text> <text x="444" y="132" fill="#555" font-size="8">108×96px</text>        <text x="558" y="132" fill="#555" font-size="8">center</text>     <text x="640" y="132" fill="#555" font-size="8">15</text>
+  <line x1="296" y1="136" x2="704" y2="136" stroke="#f0f0f0" stroke-width="1"/>
+  <text x="300" y="150" fill="#1a1a1a" font-size="8">hair-front</text>      <text x="366" y="150" fill="#555" font-size="8">path</text>        <text x="444" y="150" fill="#555" font-size="8">24×80px</text>         <text x="558" y="150" fill="#555" font-size="8">top</text>        <text x="640" y="150" fill="#555" font-size="8">19</text>
+  <line x1="296" y1="154" x2="704" y2="154" stroke="#f0f0f0" stroke-width="1"/>
+  <text x="300" y="168" fill="#1a1a1a" font-size="8">left-eye</text>        <text x="366" y="168" fill="#555" font-size="8">ellipse</text>    <text x="444" y="168" fill="#555" font-size="8">32×36px</text>         <text x="558" y="168" fill="#555" font-size="8">center</text>     <text x="640" y="168" fill="#555" font-size="8">16</text>
+  <line x1="296" y1="172" x2="704" y2="172" stroke="#f0f0f0" stroke-width="1"/>
+  <text x="300" y="186" fill="#1a1a1a" font-size="8">right-eye</text>       <text x="366" y="186" fill="#555" font-size="8">ellipse</text>    <text x="444" y="186" fill="#555" font-size="8">32×36px</text>         <text x="558" y="186" fill="#555" font-size="8">center</text>     <text x="640" y="186" fill="#555" font-size="8">17</text>
+  <line x1="296" y1="190" x2="704" y2="190" stroke="#f0f0f0" stroke-width="1"/>
+  <text x="300" y="204" fill="#1a1a1a" font-size="8">face (expr)</text>      <text x="366" y="204" fill="#555" font-size="8">group</text>      <text x="444" y="204" fill="#555" font-size="8">96×80px</text>         <text x="558" y="204" fill="#555" font-size="8">mid-face</text>   <text x="640" y="204" fill="#555" font-size="8">18</text>
+  <line x1="296" y1="208" x2="704" y2="208" stroke="#f0f0f0" stroke-width="1"/>
+  <text x="300" y="222" fill="#1a1a1a" font-size="8">neck</text>             <text x="366" y="222" fill="#555" font-size="8">rect</text>        <text x="444" y="222" fill="#555" font-size="8">18×22px</text>         <text x="558" y="222" fill="#555" font-size="8">top edge</text>   <text x="640" y="222" fill="#555" font-size="8">14</text>
+  <line x1="296" y1="226" x2="704" y2="226" stroke="#f0f0f0" stroke-width="1"/>
+  <text x="300" y="240" fill="#1a1a1a" font-size="8">torso</text>            <text x="366" y="240" fill="#555" font-size="8">polygon</text>    <text x="444" y="240" fill="#555" font-size="8">150×120px</text>       <text x="558" y="240" fill="#555" font-size="8">waist ctr</text>  <text x="640" y="240" fill="#555" font-size="8">10</text>
+  <line x1="296" y1="244" x2="704" y2="244" stroke="#f0f0f0" stroke-width="1"/>
+  <text x="300" y="258" fill="#1a1a1a" font-size="8">left-upper-arm</text>  <text x="366" y="258" fill="#555" font-size="8">polygon</text>    <text x="444" y="258" fill="#555" font-size="8">44×68px</text>         <text x="558" y="258" fill="#555" font-size="8">shoulder</text>   <text x="640" y="258" fill="#555" font-size="8"> 9</text>
+  <line x1="296" y1="262" x2="704" y2="262" stroke="#f0f0f0" stroke-width="1"/>
+  <text x="300" y="276" fill="#1a1a1a" font-size="8">left-forearm</text>    <text x="366" y="276" fill="#555" font-size="8">polygon</text>    <text x="444" y="276" fill="#555" font-size="8">26×84px</text>         <text x="558" y="276" fill="#555" font-size="8">elbow</text>      <text x="640" y="276" fill="#555" font-size="8"> 8</text>
+  <line x1="296" y1="280" x2="704" y2="280" stroke="#f0f0f0" stroke-width="1"/>
+  <text x="300" y="294" fill="#1a1a1a" font-size="8">left-hand</text>       <text x="366" y="294" fill="#555" font-size="8">ellipse</text>    <text x="444" y="294" fill="#555" font-size="8">32×24px</text>         <text x="558" y="294" fill="#555" font-size="8">wrist</text>      <text x="640" y="294" fill="#555" font-size="8"> 7</text>
+  <line x1="296" y1="298" x2="704" y2="298" stroke="#f0f0f0" stroke-width="1"/>
+  <text x="300" y="312" fill="#1a1a1a" font-size="8">right-upper-arm</text> <text x="366" y="312" fill="#555" font-size="8">polygon</text>    <text x="444" y="312" fill="#555" font-size="8">44×68px</text>         <text x="558" y="312" fill="#555" font-size="8">shoulder</text>   <text x="640" y="312" fill="#555" font-size="8">11</text>
+  <line x1="296" y1="316" x2="704" y2="316" stroke="#f0f0f0" stroke-width="1"/>
+  <text x="300" y="330" fill="#1a1a1a" font-size="8">right-forearm</text>   <text x="366" y="330" fill="#555" font-size="8">polygon</text>    <text x="444" y="330" fill="#555" font-size="8">26×84px</text>         <text x="558" y="330" fill="#555" font-size="8">elbow</text>      <text x="640" y="330" fill="#555" font-size="8">12</text>
+  <line x1="296" y1="334" x2="704" y2="334" stroke="#f0f0f0" stroke-width="1"/>
+  <text x="300" y="348" fill="#1a1a1a" font-size="8">right-hand</text>      <text x="366" y="348" fill="#555" font-size="8">ellipse</text>    <text x="444" y="348" fill="#555" font-size="8">32×24px</text>         <text x="558" y="348" fill="#555" font-size="8">wrist</text>      <text x="640" y="348" fill="#555" font-size="8">13</text>
+  <line x1="296" y1="352" x2="704" y2="352" stroke="#f0f0f0" stroke-width="1"/>
+  <text x="300" y="366" fill="#1a1a1a" font-size="8">left-thigh</text>      <text x="366" y="366" fill="#555" font-size="8">polygon</text>    <text x="444" y="366" fill="#555" font-size="8">52×60px</text>         <text x="558" y="366" fill="#555" font-size="8">hip</text>        <text x="640" y="366" fill="#555" font-size="8"> 1</text>
+  <line x1="296" y1="370" x2="704" y2="370" stroke="#f0f0f0" stroke-width="1"/>
+  <text x="300" y="384" fill="#1a1a1a" font-size="8">left-shin</text>       <text x="366" y="384" fill="#555" font-size="8">polygon</text>    <text x="444" y="384" fill="#555" font-size="8">50×68px</text>         <text x="558" y="384" fill="#555" font-size="8">knee</text>       <text x="640" y="384" fill="#555" font-size="8"> 2</text>
+  <line x1="296" y1="388" x2="704" y2="388" stroke="#f0f0f0" stroke-width="1"/>
+  <text x="300" y="402" fill="#1a1a1a" font-size="8">left-foot</text>       <text x="366" y="402" fill="#555" font-size="8">path</text>        <text x="444" y="402" fill="#555" font-size="8">56×24px</text>         <text x="558" y="402" fill="#555" font-size="8">ankle</text>      <text x="640" y="402" fill="#555" font-size="8"> 3</text>
+  <line x1="296" y1="406" x2="704" y2="406" stroke="#f0f0f0" stroke-width="1"/>
+  <text x="300" y="420" fill="#1a1a1a" font-size="8">right-thigh</text>     <text x="366" y="420" fill="#555" font-size="8">polygon</text>    <text x="444" y="420" fill="#555" font-size="8">52×60px</text>         <text x="558" y="420" fill="#555" font-size="8">hip</text>        <text x="640" y="420" fill="#555" font-size="8"> 4</text>
+  <line x1="296" y1="424" x2="704" y2="424" stroke="#f0f0f0" stroke-width="1"/>
+  <text x="300" y="438" fill="#1a1a1a" font-size="8">right-shin</text>      <text x="366" y="438" fill="#555" font-size="8">polygon</text>    <text x="444" y="438" fill="#555" font-size="8">50×68px</text>         <text x="558" y="438" fill="#555" font-size="8">knee</text>       <text x="640" y="438" fill="#555" font-size="8"> 5</text>
+  <line x1="296" y1="442" x2="704" y2="442" stroke="#f0f0f0" stroke-width="1"/>
+  <text x="300" y="456" fill="#1a1a1a" font-size="8">right-foot</text>      <text x="366" y="456" fill="#555" font-size="8">path</text>        <text x="444" y="456" fill="#555" font-size="8">56×24px</text>         <text x="558" y="456" fill="#555" font-size="8">ankle</text>      <text x="640" y="456" fill="#555" font-size="8"> 6</text>
+  <line x1="296" y1="460" x2="704" y2="460" stroke="#f0f0f0" stroke-width="1"/>
+  <text x="300" y="474" fill="#1a1a1a" font-size="8">outfit-overlay</text>  <text x="366" y="474" fill="#555" font-size="8">group</text>      <text x="444" y="474" fill="#555" font-size="8">full body</text>       <text x="558" y="474" fill="#555" font-size="8">n/a</text>        <text x="640" y="474" fill="#555" font-size="8">20</text>
+  <line x1="296" y1="478" x2="704" y2="478" stroke="#f0f0f0" stroke-width="1"/>
+  <text x="300" y="492" fill="#1a1a1a" font-size="8">accessory-1</text>     <text x="366" y="492" fill="#555" font-size="8">custom</text>     <text x="444" y="492" fill="#555" font-size="8">130×34px</text>       <text x="558" y="492" fill="#555" font-size="8">geo ctr</text>    <text x="640" y="492" fill="#555" font-size="8">21</text>
+  <line x1="296" y1="496" x2="704" y2="496" stroke="#f0f0f0" stroke-width="1"/>
+  <text x="300" y="510" fill="#1a1a1a" font-size="8">accessory-2</text>     <text x="366" y="510" fill="#555" font-size="8">custom</text>     <text x="444" y="510" fill="#555" font-size="8">70×36px</text>         <text x="558" y="510" fill="#555" font-size="8">geo ctr</text>    <text x="640" y="510" fill="#555" font-size="8">22</text>
+  <line x1="296" y1="514" x2="704" y2="514" stroke="#cccccc" stroke-width="1.5"/>
+
+  <text x="300" y="532" fill="#1a1a1a" font-size="9" font-weight="bold">SVG Convention:</text>
+  <text x="300" y="548" fill="#555" font-size="9">&lt;g id="[part-name]" transform-origin="[px py]"&gt; ... &lt;/g&gt;</text>
+</svg>

--- a/skills/character-board/templates/shared/color-palettes/skin-tones.svg
+++ b/skills/character-board/templates/shared/color-palettes/skin-tones.svg
@@ -1,0 +1,72 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 340" width="820" height="340" font-family="Arial, sans-serif">
+  <rect width="820" height="340" fill="#f8f8f4"/>
+
+  <!-- Title bar -->
+  <rect x="0" y="0" width="820" height="40" fill="#1a1a1a"/>
+  <text x="14" y="26" fill="#ffffff" font-size="15" font-weight="bold" letter-spacing="2">SHARED — SKIN TONE REFERENCE</text>
+  <text x="600" y="26" fill="#888" font-size="10">UNIVERSAL · BOTH STYLES</text>
+
+  <!-- Column headers -->
+  <text x="70"  y="60" fill="#1a1a1a" font-size="10" font-weight="bold" text-anchor="middle">BASE</text>
+  <text x="170" y="60" fill="#1a1a1a" font-size="10" font-weight="bold" text-anchor="middle">SHADOW</text>
+  <text x="270" y="60" fill="#1a1a1a" font-size="10" font-weight="bold" text-anchor="middle">HIGHLIGHT</text>
+  <text x="400" y="60" fill="#1a1a1a" font-size="10" font-weight="bold" text-anchor="middle">SKIN LINE</text>
+  <text x="500" y="60" fill="#1a1a1a" font-size="10" font-weight="bold" text-anchor="middle">LIP / BLUSH</text>
+  <text x="640" y="60" fill="#1a1a1a" font-size="10" font-weight="bold">USAGE NOTES</text>
+
+  <!-- ── Row 1: Fair / Light ── -->
+  <text x="4" y="100" fill="#555" font-size="9" writing-mode="vertical-rl" transform="rotate(180 4 130)" text-anchor="middle">FAIR</text>
+  <rect x="20"  y="68" width="100" height="70" fill="#ffe0c8" stroke="#1a1a1a" stroke-width="1.5" rx="3"/>
+  <text x="70"  y="148" fill="#555" font-size="8" text-anchor="middle">#FFE0C8</text>
+  <rect x="120" y="68" width="100" height="70" fill="#d4a882" stroke="#1a1a1a" stroke-width="1.5" rx="3"/>
+  <text x="170" y="148" fill="#555" font-size="8" text-anchor="middle">#D4A882</text>
+  <rect x="220" y="68" width="100" height="70" fill="#fff0e0" stroke="#1a1a1a" stroke-width="1.5" rx="3"/>
+  <text x="270" y="148" fill="#555" font-size="8" text-anchor="middle">#FFF0E0</text>
+  <rect x="336" y="68" width="88"  height="70" fill="#b87040" stroke="#1a1a1a" stroke-width="1.5" rx="3"/>
+  <text x="400" y="148" fill="#555" font-size="8" text-anchor="middle">#B87040</text>
+  <rect x="452" y="68" width="88"  height="70" fill="#e8a090" stroke="#1a1a1a" stroke-width="1.5" rx="3"/>
+  <text x="500" y="148" fill="#555" font-size="8" text-anchor="middle">#E8A090</text>
+  <text x="558" y="92"  fill="#555" font-size="9">SP: flat fill only</text>
+  <text x="558" y="106" fill="#555" font-size="9">BD: add highlight on nose bridge</text>
+  <text x="558" y="120" fill="#555" font-size="9">    and cheekbones</text>
+
+  <!-- ── Row 2: Medium / Tan ── -->
+  <text x="4" y="200" fill="#555" font-size="9" writing-mode="vertical-rl" transform="rotate(180 4 210)" text-anchor="middle">TAN</text>
+  <rect x="20"  y="158" width="100" height="70" fill="#c8915a" stroke="#1a1a1a" stroke-width="1.5" rx="3"/>
+  <text x="70"  y="238" fill="#555" font-size="8" text-anchor="middle">#C8915A</text>
+  <rect x="120" y="158" width="100" height="70" fill="#9e6838" stroke="#1a1a1a" stroke-width="1.5" rx="3"/>
+  <text x="170" y="238" fill="#555" font-size="8" text-anchor="middle">#9E6838</text>
+  <rect x="220" y="158" width="100" height="70" fill="#e4b988" stroke="#1a1a1a" stroke-width="1.5" rx="3"/>
+  <text x="270" y="238" fill="#555" font-size="8" text-anchor="middle">#E4B988</text>
+  <rect x="336" y="158" width="88"  height="70" fill="#7a4818" stroke="#1a1a1a" stroke-width="1.5" rx="3"/>
+  <text x="400" y="238" fill="#555" font-size="8" text-anchor="middle">#7A4818</text>
+  <rect x="452" y="158" width="88"  height="70" fill="#cc7060" stroke="#1a1a1a" stroke-width="1.5" rx="3"/>
+  <text x="500" y="238" fill="#555" font-size="8" text-anchor="middle">#CC7060</text>
+  <text x="558" y="182" fill="#555" font-size="9">Default Boondocks palette</text>
+  <text x="558" y="196" fill="#555" font-size="9">SP: flat body fill</text>
+  <text x="558" y="210" fill="#555" font-size="9">BD: primary skin group</text>
+
+  <!-- ── Row 3: Dark / Deep ── -->
+  <text x="4" y="290" fill="#555" font-size="9" writing-mode="vertical-rl" transform="rotate(180 4 296)" text-anchor="middle">DEEP</text>
+  <rect x="20"  y="248" width="100" height="70" fill="#7a4820" stroke="#1a1a1a" stroke-width="1.5" rx="3"/>
+  <text x="70"  y="328" fill="#555" font-size="8" text-anchor="middle">#7A4820</text>
+  <rect x="120" y="248" width="100" height="70" fill="#5c3010" stroke="#1a1a1a" stroke-width="1.5" rx="3"/>
+  <text x="170" y="328" fill="#555" font-size="8" text-anchor="middle">#5C3010</text>
+  <rect x="220" y="248" width="100" height="70" fill="#a06030" stroke="#1a1a1a" stroke-width="1.5" rx="3"/>
+  <text x="270" y="328" fill="#555" font-size="8" text-anchor="middle">#A06030</text>
+  <rect x="336" y="248" width="88"  height="70" fill="#3c2008" stroke="#1a1a1a" stroke-width="1.5" rx="3"/>
+  <text x="400" y="328" fill="#555" font-size="8" text-anchor="middle">#3C2008</text>
+  <rect x="452" y="248" width="88"  height="70" fill="#aa5050" stroke="#1a1a1a" stroke-width="1.5" rx="3"/>
+  <text x="500" y="328" fill="#555" font-size="8" text-anchor="middle">#AA5050</text>
+  <text x="558" y="272" fill="#555" font-size="9">SP: use outline carefully —</text>
+  <text x="558" y="286" fill="#555" font-size="9">    may need #333 instead of</text>
+  <text x="558" y="300" fill="#555" font-size="9">    pure black for contrast</text>
+  <text x="558" y="314" fill="#555" font-size="9">BD: rim-light is key detail</text>
+
+  <!-- Row dividers -->
+  <line x1="14" y1="155" x2="800" y2="155" stroke="#cccccc" stroke-width="1"/>
+  <line x1="14" y1="245" x2="800" y2="245" stroke="#cccccc" stroke-width="1"/>
+  <!-- Column dividers -->
+  <line x1="326" y1="55" x2="326" y2="330" stroke="#cccccc" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="548" y1="55" x2="548" y2="330" stroke="#cccccc" stroke-width="1" stroke-dasharray="3,3"/>
+</svg>

--- a/skills/character-board/templates/shared/geometry/base-grid.svg
+++ b/skills/character-board/templates/shared/geometry/base-grid.svg
@@ -1,0 +1,75 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600" width="800" height="600" font-family="Arial, sans-serif">
+  <!--
+    BASE GRID TEMPLATE
+    Import this as a background layer in other SVGs.
+    Two grids included: 16px (South Park) and 20px (Boondocks).
+    Toggle visibility via display attribute on each <g>.
+  -->
+  <rect width="800" height="600" fill="#fafaf6"/>
+
+  <!-- Title bar -->
+  <rect x="0" y="0" width="800" height="36" fill="#1a1a1a"/>
+  <text x="14" y="24" fill="#ffffff" font-size="13" font-weight="bold" letter-spacing="2">SHARED — BASE SNAP GRID</text>
+  <text x="560" y="24" fill="#888" font-size="10">Import as background layer</text>
+
+  <!-- ── GRID A: 16px (South Park) ── -->
+  <g id="grid-16px" display="inline">
+    <defs>
+      <pattern id="g16-main" width="16" height="16" patternUnits="userSpaceOnUse" x="0" y="0">
+        <path d="M 16 0 L 0 0 0 16" fill="none" stroke="#d8d8cc" stroke-width="0.5"/>
+      </pattern>
+      <pattern id="g16-major" width="80" height="80" patternUnits="userSpaceOnUse" x="0" y="0">
+        <path d="M 80 0 L 0 0 0 80" fill="none" stroke="#c0c0b0" stroke-width="1"/>
+      </pattern>
+    </defs>
+    <rect x="0" y="36" width="380" height="556" fill="url(#g16-main)"/>
+    <rect x="0" y="36" width="380" height="556" fill="url(#g16-major)" opacity="0.6"/>
+
+    <!-- Centerlines -->
+    <line x1="190" y1="36" x2="190" y2="592" stroke="#cc3300" stroke-width="1" stroke-dasharray="8,5" opacity="0.5"/>
+    <line x1="0" y1="314" x2="380" y2="314" stroke="#cc3300" stroke-width="1" stroke-dasharray="8,5" opacity="0.5"/>
+
+    <!-- Labels -->
+    <rect x="2" y="38" width="130" height="18" fill="#e03030" opacity="0.85" rx="2"/>
+    <text x="8" y="51" fill="#ffffff" font-size="9" font-weight="bold">SOUTH PARK · 16px SNAP</text>
+    <text x="8"  y="72" fill="#666" font-size="8">Minor grid: 16px</text>
+    <text x="8"  y="84" fill="#666" font-size="8">Major grid: 80px (5×16)</text>
+    <text x="8"  y="96" fill="#666" font-size="8">Centerlines: red dashed</text>
+    <text x="8"  y="108" fill="#666" font-size="8">All anchor points snap to 16px</text>
+  </g>
+
+  <!-- Divider -->
+  <line x1="400" y1="36" x2="400" y2="592" stroke="#1a1a1a" stroke-width="2"/>
+
+  <!-- ── GRID B: 20px (Boondocks) ── -->
+  <g id="grid-20px" display="inline">
+    <defs>
+      <pattern id="g20-main" width="20" height="20" patternUnits="userSpaceOnUse" x="400" y="0">
+        <path d="M 20 0 L 0 0 0 20" fill="none" stroke="#d4d0c8" stroke-width="0.5"/>
+      </pattern>
+      <pattern id="g20-major" width="100" height="100" patternUnits="userSpaceOnUse" x="400" y="0">
+        <path d="M 100 0 L 0 0 0 100" fill="none" stroke="#b8b4a8" stroke-width="1"/>
+      </pattern>
+    </defs>
+    <rect x="400" y="36" width="400" height="556" fill="url(#g20-main)"/>
+    <rect x="400" y="36" width="400" height="556" fill="url(#g20-major)" opacity="0.6"/>
+
+    <!-- Centerlines -->
+    <line x1="600" y1="36" x2="600" y2="592" stroke="#2266cc" stroke-width="1" stroke-dasharray="10,6" opacity="0.5"/>
+    <line x1="400" y1="314" x2="800" y2="314" stroke="#2266cc" stroke-width="1" stroke-dasharray="10,6" opacity="0.5"/>
+
+    <!-- Labels -->
+    <rect x="402" y="38" width="148" height="18" fill="#2d4a6b" opacity="0.9" rx="2"/>
+    <text x="408" y="51" fill="#ffffff" font-size="9" font-weight="bold">BOONDOCKS · 20px SNAP</text>
+    <text x="408" y="72" fill="#666" font-size="8">Minor grid: 20px</text>
+    <text x="408" y="84" fill="#666" font-size="8">Major grid: 100px (5×20)</text>
+    <text x="408" y="96" fill="#666" font-size="8">Centerlines: blue dashed</text>
+    <text x="408" y="108" fill="#666" font-size="8">All anchor points snap to 20px</text>
+  </g>
+
+  <!-- ── USAGE NOTE (bottom) ── -->
+  <rect x="0" y="548" width="800" height="52" fill="#ffffff" stroke="#cccccc" stroke-width="1"/>
+  <text x="14" y="566" fill="#1a1a1a" font-size="10" font-weight="bold">HOW TO USE:</text>
+  <text x="14" y="582" fill="#555" font-size="9">1. Copy the appropriate &lt;defs&gt; block into your target SVG   2. Add &lt;rect width="100%" height="100%" fill="url(#grid-id)"/&gt; as first child of &lt;svg&gt;</text>
+  <text x="14" y="595" fill="#555" font-size="9">3. Set opacity="0.4" to use as subtle background   4. Remove before export   5. Keep grid layer separate — never merge with artwork</text>
+</svg>

--- a/skills/character-board/templates/south-park/color-palettes/palette.svg
+++ b/skills/character-board/templates/south-park/color-palettes/palette.svg
@@ -1,0 +1,95 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 460" width="880" height="460" font-family="Arial, sans-serif">
+  <!-- Background -->
+  <rect width="880" height="460" fill="#f5f5f0"/>
+
+  <!-- Title bar -->
+  <rect x="0" y="0" width="880" height="44" fill="#1a1a1a"/>
+  <text x="16" y="29" fill="#ffffff" font-size="16" font-weight="bold" letter-spacing="2">COLOR PALETTE — SOUTH PARK FLAT CUTOUT</text>
+  <text x="700" y="29" fill="#666" font-size="11">FLAT FILLS ONLY · NO GRADIENTS</text>
+
+  <!-- SKIN GROUP -->
+  <text x="20" y="68" fill="#1a1a1a" font-size="11" font-weight="bold" letter-spacing="1">SKIN</text>
+  <line x1="20" y1="72" x2="280" y2="72" stroke="#1a1a1a" stroke-width="1"/>
+  <!-- Base -->
+  <rect x="20"  y="78" width="80" height="80" fill="#f5c88a" stroke="#1a1a1a" stroke-width="2" rx="3"/>
+  <text x="60"  y="170" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">BASE</text>
+  <text x="60"  y="182" fill="#555"    font-size="9" text-anchor="middle">#F5C88A</text>
+  <!-- Shadow -->
+  <rect x="110" y="78" width="80" height="80" fill="#d4a164" stroke="#1a1a1a" stroke-width="2" rx="3"/>
+  <text x="150" y="170" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">SHADOW</text>
+  <text x="150" y="182" fill="#555"    font-size="9" text-anchor="middle">#D4A164</text>
+  <!-- Highlight -->
+  <rect x="200" y="78" width="80" height="80" fill="#fae0b2" stroke="#1a1a1a" stroke-width="2" rx="3"/>
+  <text x="240" y="170" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">HIGHLIGHT</text>
+  <text x="240" y="182" fill="#555"    font-size="9" text-anchor="middle">#FAE0B2</text>
+
+  <!-- HAIR GROUP -->
+  <text x="310" y="68" fill="#1a1a1a" font-size="11" font-weight="bold" letter-spacing="1">HAIR</text>
+  <line x1="310" y1="72" x2="570" y2="72" stroke="#1a1a1a" stroke-width="1"/>
+  <rect x="310" y="78" width="80" height="80" fill="#3d2200" stroke="#1a1a1a" stroke-width="2" rx="3"/>
+  <text x="350" y="170" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">BASE</text>
+  <text x="350" y="182" fill="#555"    font-size="9" text-anchor="middle">#3D2200</text>
+  <rect x="400" y="78" width="80" height="80" fill="#241600" stroke="#1a1a1a" stroke-width="2" rx="3"/>
+  <text x="440" y="170" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">SHADOW</text>
+  <text x="440" y="182" fill="#555"    font-size="9" text-anchor="middle">#241600</text>
+  <rect x="490" y="78" width="80" height="80" fill="#7a4f1a" stroke="#1a1a1a" stroke-width="2" rx="3"/>
+  <text x="530" y="170" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">ACCENT</text>
+  <text x="530" y="182" fill="#555"    font-size="9" text-anchor="middle">#7A4F1A</text>
+
+  <!-- OUTLINE GROUP -->
+  <text x="600" y="68" fill="#1a1a1a" font-size="11" font-weight="bold" letter-spacing="1">OUTLINE</text>
+  <line x1="600" y1="72" x2="860" y2="72" stroke="#1a1a1a" stroke-width="1"/>
+  <rect x="600" y="78" width="80" height="80" fill="#1a1a1a" stroke="#555" stroke-width="2" rx="3"/>
+  <text x="640" y="170" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">MAIN</text>
+  <text x="640" y="182" fill="#555"    font-size="9" text-anchor="middle">#1A1A1A</text>
+  <rect x="690" y="78" width="80" height="80" fill="#444444" stroke="#1a1a1a" stroke-width="2" rx="3"/>
+  <text x="730" y="170" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">SECONDARY</text>
+  <text x="730" y="182" fill="#555"    font-size="9" text-anchor="middle">#444444</text>
+
+  <!-- OUTFIT PRIMARY GROUP -->
+  <text x="20" y="216" fill="#1a1a1a" font-size="11" font-weight="bold" letter-spacing="1">OUTFIT PRIMARY</text>
+  <line x1="20" y1="220" x2="280" y2="220" stroke="#1a1a1a" stroke-width="1"/>
+  <rect x="20"  y="226" width="80" height="80" fill="#e03030" stroke="#1a1a1a" stroke-width="2" rx="3"/>
+  <text x="60"  y="318" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">BASE</text>
+  <text x="60"  y="330" fill="#555"    font-size="9" text-anchor="middle">#E03030</text>
+  <rect x="110" y="226" width="80" height="80" fill="#b02020" stroke="#1a1a1a" stroke-width="2" rx="3"/>
+  <text x="150" y="318" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">SHADOW</text>
+  <text x="150" y="330" fill="#555"    font-size="9" text-anchor="middle">#B02020</text>
+  <rect x="200" y="226" width="80" height="80" fill="#ff6060" stroke="#1a1a1a" stroke-width="2" rx="3"/>
+  <text x="240" y="318" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">HIGHLIGHT</text>
+  <text x="240" y="330" fill="#555"    font-size="9" text-anchor="middle">#FF6060</text>
+
+  <!-- OUTFIT SECONDARY GROUP -->
+  <text x="310" y="216" fill="#1a1a1a" font-size="11" font-weight="bold" letter-spacing="1">OUTFIT SECONDARY</text>
+  <line x1="310" y1="220" x2="500" y2="220" stroke="#1a1a1a" stroke-width="1"/>
+  <rect x="310" y="226" width="80" height="80" fill="#2266cc" stroke="#1a1a1a" stroke-width="2" rx="3"/>
+  <text x="350" y="318" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">BASE</text>
+  <text x="350" y="330" fill="#555"    font-size="9" text-anchor="middle">#2266CC</text>
+  <rect x="400" y="226" width="80" height="80" fill="#1a4e99" stroke="#1a1a1a" stroke-width="2" rx="3"/>
+  <text x="440" y="318" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">SHADOW</text>
+  <text x="440" y="330" fill="#555"    font-size="9" text-anchor="middle">#1A4E99</text>
+
+  <!-- EYES GROUP -->
+  <text x="530" y="216" fill="#1a1a1a" font-size="11" font-weight="bold" letter-spacing="1">EYES</text>
+  <line x1="530" y1="220" x2="860" y2="220" stroke="#1a1a1a" stroke-width="1"/>
+  <rect x="530" y="226" width="60" height="60" fill="#1a1a1a" stroke="#555"    stroke-width="2" rx="3"/>
+  <text x="560" y="298" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">PUPIL</text>
+  <text x="560" y="310" fill="#555"    font-size="9" text-anchor="middle">#1A1A1A</text>
+  <rect x="600" y="226" width="60" height="60" fill="#ffffff" stroke="#1a1a1a" stroke-width="2" rx="3"/>
+  <text x="630" y="298" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">WHITE</text>
+  <text x="630" y="310" fill="#555"    font-size="9" text-anchor="middle">#FFFFFF</text>
+  <rect x="670" y="226" width="60" height="60" fill="#4488ee" stroke="#1a1a1a" stroke-width="2" rx="3"/>
+  <text x="700" y="298" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">IRIS</text>
+  <text x="700" y="310" fill="#555"    font-size="9" text-anchor="middle">#4488EE</text>
+  <rect x="740" y="226" width="60" height="60" fill="#eeeeff" stroke="#1a1a1a" stroke-width="2" rx="3"/>
+  <text x="770" y="298" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">REFLECT</text>
+  <text x="770" y="310" fill="#555"    font-size="9" text-anchor="middle">#EEEEFF</text>
+  <rect x="800" y="226" width="60" height="60" fill="#ff9922" stroke="#1a1a1a" stroke-width="2" rx="3"/>
+  <text x="830" y="298" fill="#1a1a1a" font-size="9" text-anchor="middle" font-weight="bold">ACCENT</text>
+  <text x="830" y="310" fill="#555"    font-size="9" text-anchor="middle">#FF9922</text>
+
+  <!-- Footer: Usage rules -->
+  <rect x="0" y="420" width="880" height="40" fill="#1a1a1a" opacity="0.06"/>
+  <text x="20"  y="443" fill="#444" font-size="10" font-weight="bold">RULES:</text>
+  <text x="68"  y="443" fill="#444" font-size="10">Flat fills only · Shadow = base hue −20% lightness · No gradients · No filters · Outline always #1A1A1A · Max 12 colors total</text>
+</svg>

--- a/skills/character-board/templates/south-park/geometry/construction-guide.svg
+++ b/skills/character-board/templates/south-park/geometry/construction-guide.svg
@@ -1,0 +1,134 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 540" width="780" height="540" font-family="Arial, sans-serif">
+  <!-- Background + grid -->
+  <defs>
+    <pattern id="g16" width="16" height="16" patternUnits="userSpaceOnUse">
+      <path d="M 16 0 L 0 0 0 16" fill="none" stroke="#e8e8e0" stroke-width="0.5"/>
+    </pattern>
+  </defs>
+  <rect width="780" height="540" fill="#f8f8f4"/>
+  <rect width="780" height="540" fill="url(#g16)"/>
+
+  <!-- Title bar -->
+  <rect x="0" y="0" width="780" height="40" fill="#1a1a1a"/>
+  <text x="14" y="26" fill="#ffffff" font-size="15" font-weight="bold" letter-spacing="2">GEOMETRY CONSTRUCTION GUIDE — SOUTH PARK</text>
+
+  <!-- ── PROPORTION RULER (left) ── -->
+  <line x1="36" y1="58" x2="36" y2="498" stroke="#1a1a1a" stroke-width="2"/>
+  <!-- Head zone: 58–168 (110px) -->
+  <line x1="28" y1="58"  x2="44" y2="58"  stroke="#1a1a1a" stroke-width="2"/>
+  <line x1="28" y1="168" x2="44" y2="168" stroke="#cc2200" stroke-width="2"/>
+  <!-- Body zone: 168–328 (160px) -->
+  <line x1="28" y1="328" x2="44" y2="328" stroke="#cc2200" stroke-width="2"/>
+  <!-- Leg zone: 328–498 (170px, but rounded) -->
+  <!-- Foot line -->
+  <line x1="28" y1="498" x2="44" y2="498" stroke="#1a1a1a" stroke-width="2"/>
+
+  <text x="22" y="61"  fill="#1a1a1a" font-size="9" text-anchor="end" font-weight="bold">TOP</text>
+  <text x="22" y="171" fill="#cc2200" font-size="9" text-anchor="end" font-weight="bold">1H</text>
+  <text x="22" y="284" fill="#cc2200" font-size="9" text-anchor="end" font-weight="bold">2H</text>
+  <text x="22" y="331" fill="#cc2200" font-size="9" text-anchor="end" font-weight="bold">3H</text>
+  <text x="22" y="415" fill="#cc2200" font-size="9" text-anchor="end" font-weight="bold">3.5H</text>
+  <text x="22" y="501" fill="#1a1a1a" font-size="9" text-anchor="end" font-weight="bold">4H</text>
+
+  <!-- Horizontal proportion lines (dashed) -->
+  <line x1="58" y1="168" x2="720" y2="168" stroke="#cc2200" stroke-width="1" stroke-dasharray="8,5" opacity="0.5"/>
+  <line x1="58" y1="278" x2="720" y2="278" stroke="#cc2200" stroke-width="1" stroke-dasharray="8,5" opacity="0.5"/>
+  <line x1="58" y1="328" x2="720" y2="328" stroke="#cc2200" stroke-width="1" stroke-dasharray="8,5" opacity="0.5"/>
+  <line x1="58" y1="413" x2="720" y2="413" stroke="#cc2200" stroke-width="1" stroke-dasharray="8,5" opacity="0.3"/>
+
+  <!-- Vertical centerline -->
+  <line x1="310" y1="50" x2="310" y2="510" stroke="#2266cc" stroke-width="1.5" stroke-dasharray="10,5" opacity="0.6"/>
+  <text x="314" y="64" fill="#2266cc" font-size="9">CL</text>
+
+  <!-- ── HEAD SHAPE (PRIMITIVE: circle) ── -->
+  <!-- Guide circle (construction) -->
+  <circle cx="310" cy="113" r="55" fill="none" stroke="#aaaaaa" stroke-width="1" stroke-dasharray="4,3"/>
+  <!-- Filled head shape -->
+  <circle cx="310" cy="113" r="55" fill="#f5c88a" stroke="#1a1a1a" stroke-width="3" opacity="0.85"/>
+  <!-- Head label -->
+  <text x="390" y="110" fill="#1a1a1a" font-size="10" font-weight="bold">HEAD</text>
+  <text x="390" y="124" fill="#555" font-size="9">⌀ = 110px (1H)</text>
+  <text x="390" y="138" fill="#555" font-size="9">Shape: Circle</text>
+  <!-- Annotation line -->
+  <line x1="366" y1="113" x2="384" y2="113" stroke="#888" stroke-width="1"/>
+
+  <!-- ── BODY SHAPE (PRIMITIVE: trapezoid) ── -->
+  <!-- Construction rect ghost -->
+  <rect x="252" y="170" width="116" height="156" fill="none" stroke="#aaaaaa" stroke-width="1" stroke-dasharray="4,3"/>
+  <!-- Filled trapezoid -->
+  <path d="M 265 170 L 252 326 L 368 326 L 355 170 Z" fill="#e03030" stroke="#1a1a1a" stroke-width="3" opacity="0.85"/>
+  <text x="390" y="238" fill="#1a1a1a" font-size="10" font-weight="bold">BODY</text>
+  <text x="390" y="252" fill="#555" font-size="9">Shape: Trapezoid</text>
+  <text x="390" y="266" fill="#555" font-size="9">Width: top 90px · bot 116px</text>
+  <text x="390" y="280" fill="#555" font-size="9">Height: 156px (1.42H)</text>
+  <line x1="368" y1="248" x2="384" y2="248" stroke="#888" stroke-width="1"/>
+
+  <!-- ── LEFT ARM (pill shape) ── -->
+  <rect x="192" y="182" width="28" height="100" rx="14" fill="#e03030" stroke="#1a1a1a" stroke-width="3" opacity="0.85"/>
+  <!-- RIGHT ARM -->
+  <rect x="400" y="182" width="28" height="100" rx="14" fill="#e03030" stroke="#1a1a1a" stroke-width="3" opacity="0.85"/>
+  <text x="130" y="232" fill="#1a1a1a" font-size="10" font-weight="bold">ARMS</text>
+  <text x="130" y="246" fill="#555" font-size="9">Pill · 28×100px</text>
+  <text x="130" y="260" fill="#555" font-size="9">Radius: 14px</text>
+  <line x1="192" y1="236" x2="176" y2="236" stroke="#888" stroke-width="1"/>
+
+  <!-- ── LEGS ── -->
+  <rect x="265" y="330" width="42" height="120" rx="12" fill="#2266cc" stroke="#1a1a1a" stroke-width="3" opacity="0.85"/>
+  <rect x="313" y="330" width="42" height="120" rx="12" fill="#2266cc" stroke="#1a1a1a" stroke-width="3" opacity="0.85"/>
+  <text x="390" y="366" fill="#1a1a1a" font-size="10" font-weight="bold">LEGS</text>
+  <text x="390" y="380" fill="#555" font-size="9">Pill · 42×120px</text>
+  <text x="390" y="394" fill="#555" font-size="9">Radius: 12px</text>
+  <line x1="358" y1="376" x2="384" y2="376" stroke="#888" stroke-width="1"/>
+
+  <!-- ── FEET (ellipses) ── -->
+  <ellipse cx="286" cy="456" rx="28" ry="12" fill="#1a1a1a" opacity="0.85"/>
+  <ellipse cx="334" cy="456" rx="28" ry="12" fill="#1a1a1a" opacity="0.85"/>
+  <text x="390" y="454" fill="#1a1a1a" font-size="10" font-weight="bold">FEET</text>
+  <text x="390" y="468" fill="#555" font-size="9">Ellipse · 56×24px</text>
+
+  <!-- ── PROPORTION SUMMARY (right panel) ── -->
+  <rect x="580" y="58" width="190" height="350" fill="#ffffff" stroke="#1a1a1a" stroke-width="1.5" rx="4" opacity="0.9"/>
+  <rect x="580" y="58" width="190" height="30"  fill="#1a1a1a" rx="4"/>
+  <text x="675" y="78" fill="#ffffff" font-size="11" font-weight="bold" text-anchor="middle" letter-spacing="1">PROPORTIONS</text>
+  <text x="594" y="108" fill="#1a1a1a" font-size="10" font-weight="bold">Total height:</text>
+  <text x="756" y="108" fill="#333" font-size="10" text-anchor="end">400px (4H)</text>
+  <line x1="590" y1="114" x2="762" y2="114" stroke="#eee" stroke-width="1"/>
+  <text x="594" y="130" fill="#1a1a1a" font-size="10" font-weight="bold">Head:</text>
+  <text x="756" y="130" fill="#333" font-size="10" text-anchor="end">110px · 1H (27.5%)</text>
+  <line x1="590" y1="136" x2="762" y2="136" stroke="#eee" stroke-width="1"/>
+  <text x="594" y="152" fill="#1a1a1a" font-size="10" font-weight="bold">Body:</text>
+  <text x="756" y="152" fill="#333" font-size="10" text-anchor="end">156px · 1.42H (39%)</text>
+  <line x1="590" y1="158" x2="762" y2="158" stroke="#eee" stroke-width="1"/>
+  <text x="594" y="174" fill="#1a1a1a" font-size="10" font-weight="bold">Legs:</text>
+  <text x="756" y="174" fill="#333" font-size="10" text-anchor="end">120px · 1.09H (30%)</text>
+  <line x1="590" y1="180" x2="762" y2="180" stroke="#eee" stroke-width="1"/>
+  <text x="594" y="196" fill="#1a1a1a" font-size="10" font-weight="bold">Feet:</text>
+  <text x="756" y="196" fill="#333" font-size="10" text-anchor="end">14px · 0.13H (3.5%)</text>
+  <line x1="590" y1="202" x2="762" y2="202" stroke="#cccccc" stroke-width="1.5"/>
+  <text x="594" y="222" fill="#1a1a1a" font-size="10" font-weight="bold">Arm width:</text>
+  <text x="756" y="222" fill="#333" font-size="10" text-anchor="end">28px</text>
+  <text x="594" y="238" fill="#1a1a1a" font-size="10" font-weight="bold">Arm length:</text>
+  <text x="756" y="238" fill="#333" font-size="10" text-anchor="end">100px (body-flush)</text>
+  <line x1="590" y1="244" x2="762" y2="244" stroke="#cccccc" stroke-width="1.5"/>
+  <text x="594" y="266" fill="#1a1a1a" font-size="10" font-weight="bold">Stroke width:</text>
+  <text x="756" y="266" fill="#333" font-size="10" text-anchor="end">3px solid</text>
+  <text x="594" y="282" fill="#1a1a1a" font-size="10" font-weight="bold">Grid snap:</text>
+  <text x="756" y="282" fill="#333" font-size="10" text-anchor="end">16px</text>
+  <text x="594" y="298" fill="#1a1a1a" font-size="10" font-weight="bold">Shading:</text>
+  <text x="756" y="298" fill="#333" font-size="10" text-anchor="end">NONE (flat fill)</text>
+  <text x="594" y="314" fill="#1a1a1a" font-size="10" font-weight="bold">Perspective:</text>
+  <text x="756" y="314" fill="#333" font-size="10" text-anchor="end">NONE (orthographic)</text>
+  <text x="594" y="330" fill="#1a1a1a" font-size="10" font-weight="bold">Gradients:</text>
+  <text x="756" y="330" fill="#333" font-size="10" text-anchor="end">NONE</text>
+  <text x="594" y="346" fill="#1a1a1a" font-size="10" font-weight="bold">Outline:</text>
+  <text x="756" y="346" fill="#333" font-size="10" text-anchor="end">#1A1A1A 3px</text>
+  <text x="594" y="362" fill="#1a1a1a" font-size="10" font-weight="bold">Primary shapes:</text>
+  <text x="756" y="362" fill="#333" font-size="10" text-anchor="end">6 primitives</text>
+  <text x="594" y="378" fill="#555" font-size="9">circle · trapezoid · pill ×4</text>
+  <text x="594" y="392" fill="#555" font-size="9">ellipse ×2</text>
+
+  <!-- Grid snap indicator -->
+  <rect x="580" y="424" width="190" height="46" fill="#fffff0" stroke="#cccc00" stroke-width="1.5" rx="3"/>
+  <text x="675" y="442" fill="#888800" font-size="9" font-weight="bold" text-anchor="middle">SNAP GRID: 16px</text>
+  <text x="675" y="458" fill="#888800" font-size="9" text-anchor="middle">All anchor points on 16px intervals</text>
+</svg>

--- a/skills/character-board/templates/south-park/specs/character-spec.svg
+++ b/skills/character-board/templates/south-park/specs/character-spec.svg
@@ -1,0 +1,152 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 560" width="900" height="560" font-family="Arial Black, Arial, sans-serif">
+  <!-- Background -->
+  <rect width="900" height="560" fill="#f5f5f0"/>
+
+  <!-- Grid overlay (16px) -->
+  <defs>
+    <pattern id="grid16" width="16" height="16" patternUnits="userSpaceOnUse">
+      <path d="M 16 0 L 0 0 0 16" fill="none" stroke="#e0e0d8" stroke-width="0.5"/>
+    </pattern>
+  </defs>
+  <rect width="900" height="560" fill="url(#grid16)"/>
+
+  <!-- Title bar -->
+  <rect x="0" y="0" width="900" height="44" fill="#1a1a1a"/>
+  <text x="16" y="29" fill="#ffffff" font-size="18" font-weight="bold" letter-spacing="2">CHARACTER SPEC — SOUTH PARK FLAT CUTOUT STYLE</text>
+  <text x="744" y="29" fill="#aaaaaa" font-size="12">v1.0 · DATE</text>
+
+  <!-- Section labels -->
+  <text x="130" y="72" fill="#1a1a1a" font-size="11" font-weight="bold" text-anchor="middle" letter-spacing="1">FRONT</text>
+  <text x="380" y="72" fill="#1a1a1a" font-size="11" font-weight="bold" text-anchor="middle" letter-spacing="1">¾ TURN</text>
+  <text x="620" y="72" fill="#1a1a1a" font-size="11" font-weight="bold" text-anchor="middle" letter-spacing="1">SIDE PROFILE</text>
+
+  <!-- Height ruler (left edge) -->
+  <line x1="28" y1="80" x2="28" y2="480" stroke="#1a1a1a" stroke-width="2"/>
+  <line x1="22" y1="80"  x2="34" y2="80"  stroke="#1a1a1a" stroke-width="2"/>
+  <line x1="22" y1="213" x2="34" y2="213" stroke="#1a1a1a" stroke-width="1.5" stroke-dasharray="4,2"/>
+  <line x1="22" y1="346" x2="34" y2="346" stroke="#1a1a1a" stroke-width="1.5" stroke-dasharray="4,2"/>
+  <line x1="22" y1="413" x2="34" y2="413" stroke="#1a1a1a" stroke-width="1.5" stroke-dasharray="4,2"/>
+  <line x1="22" y1="480" x2="34" y2="480" stroke="#1a1a1a" stroke-width="2"/>
+  <text x="18" y="83"  fill="#1a1a1a" font-size="9" text-anchor="end">1H</text>
+  <text x="18" y="216" fill="#1a1a1a" font-size="9" text-anchor="end">2H</text>
+  <text x="18" y="349" fill="#1a1a1a" font-size="9" text-anchor="end">3H</text>
+  <text x="18" y="416" fill="#1a1a1a" font-size="9" text-anchor="end">3.5H</text>
+  <text x="18" y="483" fill="#1a1a1a" font-size="9" text-anchor="end">4H</text>
+
+  <!-- ── FRONT VIEW ── -->
+  <!-- Head (large circle, 1/3 height) -->
+  <circle cx="130" cy="147" r="67" fill="#f5c88a" stroke="#1a1a1a" stroke-width="3"/>
+  <!-- Eyes -->
+  <circle cx="108" cy="140" r="8" fill="#1a1a1a"/>
+  <circle cx="152" cy="140" r="8" fill="#1a1a1a"/>
+  <circle cx="110" cy="138" r="3" fill="#ffffff"/>
+  <circle cx="154" cy="138" r="3" fill="#ffffff"/>
+  <!-- Mouth -->
+  <path d="M 112 162 Q 130 174 148 162" fill="none" stroke="#1a1a1a" stroke-width="3" stroke-linecap="round"/>
+  <!-- Body (trapezoid) -->
+  <path d="M 95 218 L 82 340 L 178 340 L 165 218 Z" fill="#e03030" stroke="#1a1a1a" stroke-width="3"/>
+  <!-- Left arm -->
+  <rect x="58" y="225" width="28" height="90" rx="14" fill="#e03030" stroke="#1a1a1a" stroke-width="3"/>
+  <!-- Right arm -->
+  <rect x="174" y="225" width="28" height="90" rx="14" fill="#e03030" stroke="#1a1a1a" stroke-width="3"/>
+  <!-- Left leg -->
+  <rect x="93" y="343" width="32" height="90" rx="10" fill="#2266cc" stroke="#1a1a1a" stroke-width="3"/>
+  <!-- Right leg -->
+  <rect x="135" y="343" width="32" height="90" rx="10" fill="#2266cc" stroke="#1a1a1a" stroke-width="3"/>
+  <!-- Shoes -->
+  <ellipse cx="109" cy="437" rx="20" ry="9" fill="#1a1a1a"/>
+  <ellipse cx="151" cy="437" rx="20" ry="9" fill="#1a1a1a"/>
+  <!-- Centerline -->
+  <line x1="130" y1="80" x2="130" y2="480" stroke="#cc2200" stroke-width="1" stroke-dasharray="6,4" opacity="0.5"/>
+
+  <!-- ── ¾ TURN VIEW ── -->
+  <!-- Head (slightly oval for 3/4) -->
+  <ellipse cx="380" cy="147" rx="60" ry="67" fill="#f5c88a" stroke="#1a1a1a" stroke-width="3"/>
+  <!-- Eyes (near eye bigger) -->
+  <circle cx="365" cy="140" r="9" fill="#1a1a1a"/>
+  <circle cx="400" cy="140" r="6" fill="#1a1a1a"/>
+  <circle cx="367" cy="138" r="3" fill="#ffffff"/>
+  <circle cx="402" cy="138" r="2" fill="#ffffff"/>
+  <!-- Mouth (shifted) -->
+  <path d="M 358 162 Q 374 174 392 162" fill="none" stroke="#1a1a1a" stroke-width="3" stroke-linecap="round"/>
+  <!-- Nose (visible in 3/4) -->
+  <path d="M 393 148 Q 400 155 395 162" fill="none" stroke="#1a1a1a" stroke-width="2.5" stroke-linecap="round"/>
+  <!-- Body -->
+  <path d="M 342 218 L 330 340 L 425 340 L 420 218 Z" fill="#e03030" stroke="#1a1a1a" stroke-width="3"/>
+  <!-- Visible arm (right) -->
+  <rect x="421" y="225" width="26" height="88" rx="13" fill="#e03030" stroke="#1a1a1a" stroke-width="3"/>
+  <!-- Legs -->
+  <rect x="340" y="343" width="32" height="90" rx="10" fill="#2266cc" stroke="#1a1a1a" stroke-width="3"/>
+  <rect x="383" y="343" width="32" height="90" rx="10" fill="#2266cc" stroke="#1a1a1a" stroke-width="3"/>
+  <ellipse cx="356" cy="437" rx="20" ry="9" fill="#1a1a1a"/>
+  <ellipse cx="399" cy="437" rx="20" ry="9" fill="#1a1a1a"/>
+
+  <!-- ── SIDE PROFILE ── -->
+  <!-- Head -->
+  <ellipse cx="616" cy="147" rx="55" ry="67" fill="#f5c88a" stroke="#1a1a1a" stroke-width="3"/>
+  <!-- Single eye -->
+  <circle cx="600" cy="140" r="8" fill="#1a1a1a"/>
+  <circle cx="602" cy="138" r="3" fill="#ffffff"/>
+  <!-- Nose (side) -->
+  <path d="M 640 148 L 656 158 L 648 168" fill="none" stroke="#1a1a1a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Mouth (side) -->
+  <path d="M 594 162 Q 608 172 620 162" fill="none" stroke="#1a1a1a" stroke-width="3" stroke-linecap="round"/>
+  <!-- Body (side, narrower) -->
+  <path d="M 582 218 L 572 340 L 660 340 L 655 218 Z" fill="#e03030" stroke="#1a1a1a" stroke-width="3"/>
+  <!-- Side arm (visible) -->
+  <rect x="658" y="225" width="24" height="88" rx="12" fill="#e03030" stroke="#1a1a1a" stroke-width="3"/>
+  <!-- Legs (side — one in front, one behind slightly) -->
+  <rect x="578" y="343" width="32" height="90" rx="10" fill="#1d55bb" stroke="#1a1a1a" stroke-width="3"/>
+  <rect x="615" y="343" width="32" height="90" rx="10" fill="#2266cc" stroke="#1a1a1a" stroke-width="3"/>
+  <ellipse cx="594" cy="437" rx="20" ry="9" fill="#111111"/>
+  <ellipse cx="631" cy="437" rx="22" ry="9" fill="#1a1a1a"/>
+
+  <!-- ── EXPRESSION STRIP ── -->
+  <rect x="20" y="494" width="860" height="58" fill="#e8e8e2" rx="4"/>
+  <text x="36" y="510" fill="#1a1a1a" font-size="10" font-weight="bold" letter-spacing="1">EXPRESSIONS</text>
+  <!-- Neutral -->
+  <circle cx="90"  cy="530" r="18" fill="#f5c88a" stroke="#1a1a1a" stroke-width="2"/>
+  <circle cx="84"  cy="526" r="4" fill="#1a1a1a"/>
+  <circle cx="96"  cy="526" r="4" fill="#1a1a1a"/>
+  <path d="M 83 536 L 97 536" stroke="#1a1a1a" stroke-width="2"/>
+  <text x="90" y="554" fill="#555" font-size="8" text-anchor="middle">NEUTRAL</text>
+  <!-- Happy -->
+  <circle cx="168" cy="530" r="18" fill="#f5c88a" stroke="#1a1a1a" stroke-width="2"/>
+  <circle cx="162" cy="526" r="4" fill="#1a1a1a"/>
+  <circle cx="174" cy="526" r="4" fill="#1a1a1a"/>
+  <path d="M 160 534 Q 168 544 176 534" fill="none" stroke="#1a1a1a" stroke-width="2" stroke-linecap="round"/>
+  <text x="168" y="554" fill="#555" font-size="8" text-anchor="middle">HAPPY</text>
+  <!-- Angry -->
+  <circle cx="246" cy="530" r="18" fill="#f5c88a" stroke="#1a1a1a" stroke-width="2"/>
+  <path d="M 238 520 L 244 526 M 254 520 L 248 526" stroke="#1a1a1a" stroke-width="2"/>
+  <circle cx="241" cy="528" r="4" fill="#1a1a1a"/>
+  <circle cx="251" cy="528" r="4" fill="#1a1a1a"/>
+  <path d="M 240 537 L 252 537" stroke="#1a1a1a" stroke-width="2"/>
+  <text x="246" y="554" fill="#555" font-size="8" text-anchor="middle">ANGRY</text>
+  <!-- Surprised -->
+  <circle cx="324" cy="530" r="18" fill="#f5c88a" stroke="#1a1a1a" stroke-width="2"/>
+  <circle cx="318" cy="525" r="5" fill="#1a1a1a"/>
+  <circle cx="330" cy="525" r="5" fill="#1a1a1a"/>
+  <circle cx="318" cy="524" r="2" fill="#ffffff"/>
+  <circle cx="330" cy="524" r="2" fill="#ffffff"/>
+  <ellipse cx="324" cy="537" rx="5" ry="4" fill="#1a1a1a"/>
+  <text x="324" y="554" fill="#555" font-size="8" text-anchor="middle">SURPRISED</text>
+  <!-- Sad -->
+  <circle cx="402" cy="530" r="18" fill="#f5c88a" stroke="#1a1a1a" stroke-width="2"/>
+  <path d="M 395 522 L 398 527 M 409 522 L 406 527" stroke="#1a1a1a" stroke-width="1.5"/>
+  <circle cx="396" cy="528" r="4" fill="#1a1a1a"/>
+  <circle cx="408" cy="528" r="4" fill="#1a1a1a"/>
+  <path d="M 394 539 Q 402 533 410 539" fill="none" stroke="#1a1a1a" stroke-width="2" stroke-linecap="round"/>
+  <text x="402" y="554" fill="#555" font-size="8" text-anchor="middle">SAD</text>
+
+  <!-- CHARACTER NAME plate -->
+  <rect x="760" y="494" width="120" height="58" fill="#1a1a1a" rx="4"/>
+  <text x="820" y="514" fill="#ffffff" font-size="9" font-weight="bold" text-anchor="middle" letter-spacing="1">CHARACTER</text>
+  <text x="820" y="530" fill="#ffdd44" font-size="14" font-weight="bold" text-anchor="middle">NAME</text>
+  <text x="820" y="546" fill="#888888" font-size="8" text-anchor="middle">South Park Style</text>
+
+  <!-- Dividers between views -->
+  <line x1="248" y1="64" x2="248" y2="488" stroke="#cccccc" stroke-width="1" stroke-dasharray="4,4"/>
+  <line x1="500" y1="64" x2="500" y2="488" stroke="#cccccc" stroke-width="1" stroke-dasharray="4,4"/>
+  <line x1="740" y1="64" x2="740" y2="488" stroke="#cccccc" stroke-width="1" stroke-dasharray="4,4"/>
+</svg>

--- a/skills/character-board/templates/south-park/svg-assets/asset-map.svg
+++ b/skills/character-board/templates/south-park/svg-assets/asset-map.svg
@@ -1,0 +1,194 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 860 520" width="860" height="520" font-family="monospace, Arial, sans-serif">
+  <!-- Background -->
+  <rect width="860" height="520" fill="#f5f5f0"/>
+
+  <!-- Title bar -->
+  <rect x="0" y="0" width="860" height="40" fill="#1a1a1a"/>
+  <text x="14" y="26" fill="#ffffff" font-size="15" font-weight="bold" letter-spacing="2">SVG ASSET MAP — SOUTH PARK RIG</text>
+  <text x="600" y="26" fill="#888" font-size="10">FLAT CUTOUT · 8 PARTS</text>
+
+  <!-- ── LEGEND (right) ── -->
+  <rect x="640" y="52" width="206" height="320" fill="#ffffff" stroke="#1a1a1a" stroke-width="1.5" rx="3"/>
+  <rect x="640" y="52" width="206" height="28" fill="#1a1a1a" rx="3"/>
+  <text x="743" y="71" fill="#ffffff" font-size="11" font-weight="bold" text-anchor="middle" letter-spacing="1">LAYER ORDER (z-index)</text>
+  <text x="655" y="100" fill="#1a1a1a" font-size="10" font-weight="bold">Z  ID                   Group</text>
+  <line x1="648" y1="106" x2="838" y2="106" stroke="#ddd" stroke-width="1"/>
+  <!-- Layer rows -->
+  <text x="655" y="122" fill="#cc2200" font-size="10" font-weight="bold">8</text>
+  <text x="670" y="122" fill="#1a1a1a" font-size="10">accessory-2</text>
+  <text x="655" y="140" fill="#cc2200" font-size="10" font-weight="bold">7</text>
+  <text x="670" y="140" fill="#1a1a1a" font-size="10">accessory-1</text>
+  <text x="655" y="158" fill="#cc2200" font-size="10" font-weight="bold">6</text>
+  <text x="670" y="158" fill="#1a1a1a" font-size="10">head</text>
+  <text x="655" y="176" fill="#cc2200" font-size="10" font-weight="bold">5</text>
+  <text x="670" y="176" fill="#1a1a1a" font-size="10">right-arm</text>
+  <text x="655" y="194" fill="#cc2200" font-size="10" font-weight="bold">4</text>
+  <text x="670" y="194" fill="#1a1a1a" font-size="10">body</text>
+  <text x="655" y="212" fill="#cc2200" font-size="10" font-weight="bold">3</text>
+  <text x="670" y="212" fill="#1a1a1a" font-size="10">left-arm</text>
+  <text x="655" y="230" fill="#cc2200" font-size="10" font-weight="bold">2</text>
+  <text x="670" y="230" fill="#1a1a1a" font-size="10">right-leg</text>
+  <text x="655" y="248" fill="#cc2200" font-size="10" font-weight="bold">1</text>
+  <text x="670" y="248" fill="#1a1a1a" font-size="10">left-leg</text>
+  <line x1="648" y1="258" x2="838" y2="258" stroke="#ddd" stroke-width="1"/>
+  <text x="655" y="278" fill="#555" font-size="9">Registration points</text>
+  <text x="655" y="293" fill="#555" font-size="9">● head  → center of circle</text>
+  <text x="655" y="308" fill="#555" font-size="9">● arms  → shoulder joint</text>
+  <text x="655" y="323" fill="#555" font-size="9">● legs  → hip joint (top)</text>
+  <text x="655" y="338" fill="#555" font-size="9">● body  → torso center</text>
+  <text x="655" y="353" fill="#555" font-size="9">● access → geometric center</text>
+
+  <!-- ── CHARACTER EXPLODED VIEW ── -->
+
+  <!-- left-leg (z=1) -->
+  <g id="left-leg" opacity="0.92">
+    <rect x="86" y="340" width="48" height="122" rx="14" fill="#2266cc" stroke="#1a1a1a" stroke-width="2.5"/>
+    <ellipse cx="110" cy="466" rx="26" ry="11" fill="#1a1a1a"/>
+  </g>
+  <rect x="78" y="338" width="64" height="138" fill="none" stroke="#22aa44" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="110" y="490" fill="#22aa44" font-size="9" text-anchor="middle" font-weight="bold">left-leg</text>
+  <circle cx="110" cy="342" r="3" fill="#22aa44"/>
+
+  <!-- right-leg (z=2) -->
+  <g id="right-leg" opacity="0.92">
+    <rect x="142" y="340" width="48" height="122" rx="14" fill="#1d55bb" stroke="#1a1a1a" stroke-width="2.5"/>
+    <ellipse cx="166" cy="466" rx="26" ry="11" fill="#111111"/>
+  </g>
+  <rect x="134" y="338" width="64" height="138" fill="none" stroke="#2299cc" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="166" y="490" fill="#2299cc" font-size="9" text-anchor="middle" font-weight="bold">right-leg</text>
+  <circle cx="166" cy="342" r="3" fill="#2299cc"/>
+
+  <!-- left-arm (z=3) -->
+  <g id="left-arm" opacity="0.92">
+    <rect x="46" y="226" width="34" height="110" rx="17" fill="#dd2e2e" stroke="#1a1a1a" stroke-width="2.5"/>
+  </g>
+  <rect x="38" y="220" width="50" height="122" fill="none" stroke="#cc8800" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="63" y="354" fill="#cc8800" font-size="9" text-anchor="middle" font-weight="bold">left-arm</text>
+  <circle cx="63" cy="226" r="3" fill="#cc8800"/>
+
+  <!-- body (z=4) -->
+  <g id="body" opacity="0.92">
+    <path d="M 108 222 L 96 338 L 204 338 L 192 222 Z" fill="#e03030" stroke="#1a1a1a" stroke-width="2.5"/>
+  </g>
+  <rect x="88" y="214" width="124" height="132" fill="none" stroke="#9922cc" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="150" y="350" fill="#9922cc" font-size="9" text-anchor="middle" font-weight="bold">body</text>
+  <circle cx="150" cy="280" r="3" fill="#9922cc"/>
+
+  <!-- right-arm (z=5) -->
+  <g id="right-arm" opacity="0.92">
+    <rect x="200" y="226" width="34" height="110" rx="17" fill="#dd2e2e" stroke="#1a1a1a" stroke-width="2.5"/>
+  </g>
+  <rect x="194" y="220" width="50" height="122" fill="none" stroke="#cc5500" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="219" y="354" fill="#cc5500" font-size="9" text-anchor="middle" font-weight="bold">right-arm</text>
+  <circle cx="217" cy="226" r="3" fill="#cc5500"/>
+
+  <!-- head (z=6) -->
+  <g id="head" opacity="0.92">
+    <circle cx="150" cy="150" r="70" fill="#f5c88a" stroke="#1a1a1a" stroke-width="2.5"/>
+    <!-- basic face -->
+    <circle cx="128" cy="143" r="9" fill="#1a1a1a"/>
+    <circle cx="172" cy="143" r="9" fill="#1a1a1a"/>
+    <circle cx="130" cy="141" r="3" fill="#ffffff"/>
+    <circle cx="174" cy="141" r="3" fill="#ffffff"/>
+    <path d="M 130 165 Q 150 178 170 165" fill="none" stroke="#1a1a1a" stroke-width="3" stroke-linecap="round"/>
+  </g>
+  <rect x="74" y="74" width="152" height="152" fill="none" stroke="#cc2244" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="150" y="236" fill="#cc2244" font-size="9" text-anchor="middle" font-weight="bold">head</text>
+  <circle cx="150" cy="150" r="3" fill="#cc2244"/>
+
+  <!-- accessory-1 (z=7) — hat placeholder -->
+  <g id="accessory-1" opacity="0.92">
+    <rect x="110" y="80" width="80" height="12" rx="2" fill="#664400" stroke="#1a1a1a" stroke-width="2"/>
+    <path d="M 126 80 L 130 50 L 170 50 L 174 80 Z" fill="#885522" stroke="#1a1a1a" stroke-width="2"/>
+  </g>
+  <rect x="106" y="44" width="88" height="52" fill="none" stroke="#558833" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="150" y="108" fill="#558833" font-size="9" text-anchor="middle" font-weight="bold">accessory-1</text>
+  <circle cx="150" cy="65" r="3" fill="#558833"/>
+
+  <!-- accessory-2 (z=8) — badge placeholder -->
+  <g id="accessory-2" opacity="0.92">
+    <rect x="152" y="256" width="22" height="22" rx="2" fill="#ffdd00" stroke="#1a1a1a" stroke-width="2"/>
+    <text x="163" y="272" fill="#1a1a1a" font-size="8" text-anchor="middle" font-weight="bold">★</text>
+  </g>
+  <rect x="148" y="252" width="30" height="30" fill="none" stroke="#aaaa00" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="163" y="296" fill="#aaaa00" font-size="9" text-anchor="middle" font-weight="bold">accessory-2</text>
+
+  <!-- ── PART DETAIL TABLE ── -->
+  <rect x="310" y="52" width="318" height="360" fill="#ffffff" stroke="#1a1a1a" stroke-width="1.5" rx="3"/>
+  <rect x="310" y="52" width="318" height="28" fill="#1a1a1a" rx="3"/>
+  <text x="469" y="71" fill="#ffffff" font-size="11" font-weight="bold" text-anchor="middle" letter-spacing="1">PART SPECIFICATIONS</text>
+
+  <!-- Table header -->
+  <text x="320" y="96" fill="#1a1a1a" font-size="9" font-weight="bold">ID</text>
+  <text x="380" y="96" fill="#1a1a1a" font-size="9" font-weight="bold">Shape</text>
+  <text x="460" y="96" fill="#1a1a1a" font-size="9" font-weight="bold">Dimensions</text>
+  <text x="568" y="96" fill="#1a1a1a" font-size="9" font-weight="bold">Pivot</text>
+  <line x1="316" y1="100" x2="622" y2="100" stroke="#1a1a1a" stroke-width="1"/>
+
+  <!-- Rows -->
+  <text x="320" y="116" fill="#1a1a1a" font-size="9">head</text>
+  <text x="380" y="116" fill="#555" font-size="9">circle</text>
+  <text x="460" y="116" fill="#555" font-size="9">⌀140px</text>
+  <text x="568" y="116" fill="#555" font-size="9">center</text>
+  <line x1="316" y1="120" x2="622" y2="120" stroke="#eee" stroke-width="1"/>
+
+  <text x="320" y="136" fill="#1a1a1a" font-size="9">body</text>
+  <text x="380" y="136" fill="#555" font-size="9">trapezoid</text>
+  <text x="460" y="136" fill="#555" font-size="9">116×116px</text>
+  <text x="568" y="136" fill="#555" font-size="9">torso ctr</text>
+  <line x1="316" y1="140" x2="622" y2="140" stroke="#eee" stroke-width="1"/>
+
+  <text x="320" y="156" fill="#1a1a1a" font-size="9">left-arm</text>
+  <text x="380" y="156" fill="#555" font-size="9">pill</text>
+  <text x="460" y="156" fill="#555" font-size="9">34×110px r17</text>
+  <text x="568" y="156" fill="#555" font-size="9">shoulder</text>
+  <line x1="316" y1="160" x2="622" y2="160" stroke="#eee" stroke-width="1"/>
+
+  <text x="320" y="176" fill="#1a1a1a" font-size="9">right-arm</text>
+  <text x="380" y="176" fill="#555" font-size="9">pill</text>
+  <text x="460" y="176" fill="#555" font-size="9">34×110px r17</text>
+  <text x="568" y="176" fill="#555" font-size="9">shoulder</text>
+  <line x1="316" y1="180" x2="622" y2="180" stroke="#eee" stroke-width="1"/>
+
+  <text x="320" y="196" fill="#1a1a1a" font-size="9">left-leg</text>
+  <text x="380" y="196" fill="#555" font-size="9">pill + ellipse</text>
+  <text x="460" y="196" fill="#555" font-size="9">48×133px r14</text>
+  <text x="568" y="196" fill="#555" font-size="9">hip top</text>
+  <line x1="316" y1="200" x2="622" y2="200" stroke="#eee" stroke-width="1"/>
+
+  <text x="320" y="216" fill="#1a1a1a" font-size="9">right-leg</text>
+  <text x="380" y="216" fill="#555" font-size="9">pill + ellipse</text>
+  <text x="460" y="216" fill="#555" font-size="9">48×133px r14</text>
+  <text x="568" y="216" fill="#555" font-size="9">hip top</text>
+  <line x1="316" y1="220" x2="622" y2="220" stroke="#eee" stroke-width="1"/>
+
+  <text x="320" y="236" fill="#1a1a1a" font-size="9">accessory-1</text>
+  <text x="380" y="236" fill="#555" font-size="9">custom</text>
+  <text x="460" y="236" fill="#555" font-size="9">88×52px</text>
+  <text x="568" y="236" fill="#555" font-size="9">geo ctr</text>
+  <line x1="316" y1="240" x2="622" y2="240" stroke="#eee" stroke-width="1"/>
+
+  <text x="320" y="256" fill="#1a1a1a" font-size="9">accessory-2</text>
+  <text x="380" y="256" fill="#555" font-size="9">custom</text>
+  <text x="460" y="256" fill="#555" font-size="9">30×30px</text>
+  <text x="568" y="256" fill="#555" font-size="9">geo ctr</text>
+  <line x1="316" y1="260" x2="622" y2="260" stroke="#cccccc" stroke-width="1.5"/>
+
+  <!-- SVG ID convention -->
+  <text x="320" y="280" fill="#1a1a1a" font-size="10" font-weight="bold">SVG Group Convention</text>
+  <text x="320" y="296" fill="#555" font-size="9">&lt;g id="[part-name]"&gt;</text>
+  <text x="320" y="312" fill="#555" font-size="9">  &lt;!-- shapes for this part --&gt;</text>
+  <text x="320" y="328" fill="#555" font-size="9">&lt;/g&gt;</text>
+  <line x1="316" y1="338" x2="622" y2="338" stroke="#cccccc" stroke-width="1.5"/>
+
+  <!-- Animation note -->
+  <text x="320" y="358" fill="#1a1a1a" font-size="10" font-weight="bold">Animation Targets</text>
+  <text x="320" y="374" fill="#555" font-size="9">transform-origin: pivot point per part</text>
+  <text x="320" y="390" fill="#555" font-size="9">Rotate arms/legs · Translate body/head</text>
+  <text x="320" y="406" fill="#555" font-size="9">Scale accessory for squash-stretch</text>
+
+  <!-- Footer -->
+  <rect x="0" y="490" width="860" height="30" fill="#1a1a1a" opacity="0.08"/>
+  <text x="20" y="510" fill="#555" font-size="10" font-weight="bold">FORMAT:</text>
+  <text x="70" y="510" fill="#555" font-size="10">SVG · flat fill only · all parts in single file · each part in named &lt;g&gt; group · no nested transforms</text>
+</svg>


### PR DESCRIPTION
Populates the character-board directory structure for a political satire animation project targeting South Park flat and Boondocks anime styles:

- character-board/README.md — project overview, cast table, style rationale
- character-board/frame/the-anchor.md — frame character spec
- character-board/core-cast/ — 5 archetype character sheets with POV distortion rules, animation notes, signature props
- character-board/assets/color-palettes/ — per-character palette files with extended hex data, cel-shade groups, and application rules
- character-board/assets/svg-maps/README.md — rig part index and SVG conventions for flat (8-part) and fluid (22-part) rigs
- character-board/storyboard/episode-template.md — standard 5-beat POV sequence structure with multi-character and guest character variants

Also adds the character-board skill at skills/character-board/ with SVG templates for both styles: specs, color palettes, geometry construction guides, and asset maps.

 ## Summary
  - Adds `character-board/` project directory with full character specs, color palettes, SVG map index, and episode
  template for a political satire animation project
  - Adds `skills/character-board/` skill with SVG templates for South Park flat and Boondocks anime styles

  ## Characters
  - Frame: The Anchor (South Park flat)
  - Core cast: MAGA Cultist, Typical Leftist, Informed Person, Opportunist, Talking Head

  ## Assets
  - Per-character color palettes with extended hex data and animation rules
  - SVG asset map templates (8-part flat rig, 22-part fluid rig)
  - Episode template with 5-beat POV sequence structure

  🤖 Generated with [Claude Code](https://claude.com/claude-code)