### PR TITLE
将所有 SKILL.md 文件的标题和内容翻译为中文

### DIFF
--- a/skills/algorithmic-art/SKILL.md
+++ b/skills/algorithmic-art/SKILL.md
@@ -1,405 +1,407 @@
 ---
 name: algorithmic-art
-description: Creating algorithmic art using p5.js with seeded randomness and interactive parameter exploration. Use this when users request creating art using code, generative art, algorithmic art, flow fields, or particle systems. Create original algorithmic art rather than copying existing artists' work to avoid copyright violations.
+description: 使用 p5.js 创作具有种子随机性和交互式参数探索功能的算法艺术。当用户请求用代码创作艺术、生成艺术、算法艺术、流场或粒子系统时使用此技能。创作原创算法艺术，避免复制现有艺术家的作品以防止版权侵权。
 license: Complete terms in LICENSE.txt
 ---
 
-Algorithmic philosophies are computational aesthetic movements that are then expressed through code. Output .md files (philosophy), .html files (interactive viewer), and .js files (generative algorithms).
+算法哲学是一种通过代码表达的计算美学运动。输出 .md 文件（哲学理念）、.html 文件（交互式查看器）和 .js 文件（生成算法）。
 
-This happens in two steps:
-1. Algorithmic Philosophy Creation (.md file)
-2. Express by creating p5.js generative art (.html + .js files)
+整个过程分为两个步骤：
+1. 算法哲学创建（.md 文件）
+2. 通过创建 p5.js 生成艺术来表达（.html + .js 文件）
 
-First, undertake this task:
+首先，执行以下任务：
 
-## ALGORITHMIC PHILOSOPHY CREATION
+## 算法哲学创建
 
-To begin, create an ALGORITHMIC PHILOSOPHY (not static images or templates) that will be interpreted through:
-- Computational processes, emergent behavior, mathematical beauty
-- Seeded randomness, noise fields, organic systems
-- Particles, flows, fields, forces
-- Parametric variation and controlled chaos
+首先，创建一个算法哲学（不是静态图像或模板），它将通过以下方式诠释：
+- 计算过程、涌现行为、数学之美
+- 种子随机性、噪声场、有机系统
+- 粒子、流动、场、力
+- 参数变化与可控混沌
 
-### THE CRITICAL UNDERSTANDING
-- What is received: Some subtle input or instructions by the user to take into account, but use as a foundation; it should not constrain creative freedom.
-- What is created: An algorithmic philosophy/generative aesthetic movement.
-- What happens next: The same version receives the philosophy and EXPRESSES IT IN CODE - creating p5.js sketches that are 90% algorithmic generation, 10% essential parameters.
+### 关键认知
 
-Consider this approach:
-- Write a manifesto for a generative art movement
-- The next phase involves writing the algorithm that brings it to life
+- 接收到的内容：用户提供的一些微妙输入或指令，将其作为基础参考，但不应限制创作自由。
+- 创建的内容：一套算法哲学/生成美学运动。
+- 接下来发生的事：同一版本接收该哲学并将其用代码表达——创建 90% 为算法生成、10% 为基本参数的 p5.js 草图。
 
-The philosophy must emphasize: Algorithmic expression. Emergent behavior. Computational beauty. Seeded variation.
+参考以下方法：
+- 为一个生成艺术运动撰写宣言
+- 下一阶段编写赋予其生命的算法
 
-### HOW TO GENERATE AN ALGORITHMIC PHILOSOPHY
+哲学必须强调：算法表达。涌现行为。计算之美。种子变化。
 
-**Name the movement** (1-2 words): "Organic Turbulence" / "Quantum Harmonics" / "Emergent Stillness"
+### 如何生成算法哲学
 
-**Articulate the philosophy** (4-6 paragraphs - concise but complete):
+**命名运动**（1-2个词）："Organic Turbulence"（有机湍流）/ "Quantum Harmonics"（量子谐波）/ "Emergent Stillness"（涌现静谧）
 
-To capture the ALGORITHMIC essence, express how this philosophy manifests through:
-- Computational processes and mathematical relationships?
-- Noise functions and randomness patterns?
-- Particle behaviors and field dynamics?
-- Temporal evolution and system states?
-- Parametric variation and emergent complexity?
+**阐述哲学**（4-6段——简洁但完整）：
 
-**CRITICAL GUIDELINES:**
-- **Avoid redundancy**: Each algorithmic aspect should be mentioned once. Avoid repeating concepts about noise theory, particle dynamics, or mathematical principles unless adding new depth.
-- **Emphasize craftsmanship REPEATEDLY**: The philosophy MUST stress multiple times that the final algorithm should appear as though it took countless hours to develop, was refined with care, and comes from someone at the absolute top of their field. This framing is essential - repeat phrases like "meticulously crafted algorithm," "the product of deep computational expertise," "painstaking optimization," "master-level implementation."
-- **Leave creative space**: Be specific about the algorithmic direction, but concise enough that the next Claude has room to make interpretive implementation choices at an extremely high level of craftsmanship.
+为了捕捉算法的本质，表达该哲学如何通过以下方式呈现：
+- 计算过程和数学关系？
+- 噪声函数和随机模式？
+- 粒子行为和场动力学？
+- 时间演化和系统状态？
+- 参数变化和涌现复杂性？
 
-The philosophy must guide the next version to express ideas ALGORITHMICALLY, not through static images. Beauty lives in the process, not the final frame.
+**关键准则：**
+- **避免冗余**：每个算法方面只提及一次。避免重复关于噪声理论、粒子动力学或数学原理的概念，除非增添了新的深度。
+- **反复强调工艺精湛**：哲学必须多次强调最终算法应看起来仿佛经过无数小时的开发、精心打磨，出自该领域绝对顶尖人才之手。这种表述至关重要——反复使用诸如"精心打造的算法"、"深厚计算专业知识的产物"、"精益求精的优化"、"大师级实现"等措辞。
+- **留出创作空间**：明确算法方向，但足够精炼，让下一个 Claude 有空间在极高的工艺水平上做出富有诠释性的实现选择。
 
-### PHILOSOPHY EXAMPLES
+哲学必须引导下一个版本通过算法表达思想，而非静态图像。美存在于过程中，而非最终画面。
 
-**"Organic Turbulence"**
-Philosophy: Chaos constrained by natural law, order emerging from disorder.
-Algorithmic expression: Flow fields driven by layered Perlin noise. Thousands of particles following vector forces, their trails accumulating into organic density maps. Multiple noise octaves create turbulent regions and calm zones. Color emerges from velocity and density - fast particles burn bright, slow ones fade to shadow. The algorithm runs until equilibrium - a meticulously tuned balance where every parameter was refined through countless iterations by a master of computational aesthetics.
+### 哲学示例
 
-**"Quantum Harmonics"**
-Philosophy: Discrete entities exhibiting wave-like interference patterns.
-Algorithmic expression: Particles initialized on a grid, each carrying a phase value that evolves through sine waves. When particles are near, their phases interfere - constructive interference creates bright nodes, destructive creates voids. Simple harmonic motion generates complex emergent mandalas. The result of painstaking frequency calibration where every ratio was carefully chosen to produce resonant beauty.
+**"Organic Turbulence"（有机湍流）**
+哲学：受自然法则约束的混沌，从无序中涌现的秩序。
+算法表达：由多层 Perlin 噪声驱动的流场。数千个粒子沿向量力运动，其轨迹积累形成有机密度图。多个噪声八度音阶创造湍流区域和平静区域。颜色从速度和密度中涌现——快速粒子燃烧明亮，缓慢粒子隐入阴影。算法运行至平衡态——一种精心调校的平衡，每个参数都经过计算美学大师无数次迭代打磨。
 
-**"Recursive Whispers"**
-Philosophy: Self-similarity across scales, infinite depth in finite space.
-Algorithmic expression: Branching structures that subdivide recursively. Each branch slightly randomized but constrained by golden ratios. L-systems or recursive subdivision generate tree-like forms that feel both mathematical and organic. Subtle noise perturbations break perfect symmetry. Line weights diminish with each recursion level. Every branching angle the product of deep mathematical exploration.
+**"Quantum Harmonics"（量子谐波）**
+哲学：离散实体展现波状干涉图案。
+算法表达：粒子初始化在网格上，每个粒子携带通过正弦波演化的相位值。当粒子相近时，它们的相位发生干涉——建设性干涉产生明亮节点，破坏性干涉产生空洞。简单谐振运动生成复杂的涌现曼陀罗。这是经过艰苦频率校准的结果，每个比率都经过精心选择以产生共鸣之美。
 
-**"Field Dynamics"**
-Philosophy: Invisible forces made visible through their effects on matter.
-Algorithmic expression: Vector fields constructed from mathematical functions or noise. Particles born at edges, flowing along field lines, dying when they reach equilibrium or boundaries. Multiple fields can attract, repel, or rotate particles. The visualization shows only the traces - ghost-like evidence of invisible forces. A computational dance meticulously choreographed through force balance.
+**"Recursive Whispers"（递归低语）**
+哲学：跨尺度的自相似性，有限空间中的无限深度。
+算法表达：递归细分的分支结构。每个分支略微随机化但受黄金比例约束。L-系统或递归细分生成既具数学感又具有机感的树状形态。微妙的噪声扰动打破完美对称。线条粗细随每一递归层级递减。每个分支角度都是深入数学探索的产物。
 
-**"Stochastic Crystallization"**
-Philosophy: Random processes crystallizing into ordered structures.
-Algorithmic expression: Randomized circle packing or Voronoi tessellation. Start with random points, let them evolve through relaxation algorithms. Cells push apart until equilibrium. Color based on cell size, neighbor count, or distance from center. The organic tiling that emerges feels both random and inevitable. Every seed produces unique crystalline beauty - the mark of a master-level generative algorithm.
+**"Field Dynamics"（场动力学）**
+哲学：通过不可见力对物质的影响使其可视化。
+算法表达：由数学函数或噪声构建的向量场。粒子从边缘诞生，沿场线流动，在达到平衡或边界时消亡。多个场可以吸引、排斥或旋转粒子。可视化仅显示轨迹——不可见力量的幽灵般证据。一场通过力平衡精心编排的计算之舞。
 
-*These are condensed examples. The actual algorithmic philosophy should be 4-6 substantial paragraphs.*
+**"Stochastic Crystallization"（随机结晶）**
+哲学：随机过程结晶为有序结构。
+算法表达：随机化的圆形堆积或 Voronoi 镶嵌。从随机点开始，通过松弛算法演化。单元格相互推开直至达到平衡。颜色基于单元格大小、邻居数量或距中心距离。涌现的有机拼贴感觉既随机又不可避免。每个种子产生独特的结晶之美——大师级生成算法的标志。
 
-### ESSENTIAL PRINCIPLES
-- **ALGORITHMIC PHILOSOPHY**: Creating a computational worldview to be expressed through code
-- **PROCESS OVER PRODUCT**: Always emphasize that beauty emerges from the algorithm's execution - each run is unique
-- **PARAMETRIC EXPRESSION**: Ideas communicate through mathematical relationships, forces, behaviors - not static composition
-- **ARTISTIC FREEDOM**: The next Claude interprets the philosophy algorithmically - provide creative implementation room
-- **PURE GENERATIVE ART**: This is about making LIVING ALGORITHMS, not static images with randomness
-- **EXPERT CRAFTSMANSHIP**: Repeatedly emphasize the final algorithm must feel meticulously crafted, refined through countless iterations, the product of deep expertise by someone at the absolute top of their field in computational aesthetics
+*以上为精简示例。实际算法哲学应为4-6个完整段落。*
 
-**The algorithmic philosophy should be 4-6 paragraphs long.** Fill it with poetic computational philosophy that brings together the intended vision. Avoid repeating the same points. Output this algorithmic philosophy as a .md file.
+### 核心原则
+- **算法哲学**：创建一种通过代码表达的计算世界观
+- **过程优于产品**：始终强调美从算法执行中涌现——每次运行都是独一无二的
+- **参数化表达**：思想通过数学关系、力、行为传达——而非静态构图
+- **艺术自由**：下一个 Claude 以算法方式诠释哲学——提供创意实现空间
+- **纯粹生成艺术**：这关乎创造活的算法，而非带有随机性的静态图像
+- **专家级工艺**：反复强调最终算法必须给人精心打造的感觉，经过无数次迭代打磨，是计算美学领域绝对顶尖专家深厚功力的产物
 
----
-
-## DEDUCING THE CONCEPTUAL SEED
-
-**CRITICAL STEP**: Before implementing the algorithm, identify the subtle conceptual thread from the original request.
-
-**THE ESSENTIAL PRINCIPLE**:
-The concept is a **subtle, niche reference embedded within the algorithm itself** - not always literal, always sophisticated. Someone familiar with the subject should feel it intuitively, while others simply experience a masterful generative composition. The algorithmic philosophy provides the computational language. The deduced concept provides the soul - the quiet conceptual DNA woven invisibly into parameters, behaviors, and emergence patterns.
-
-This is **VERY IMPORTANT**: The reference must be so refined that it enhances the work's depth without announcing itself. Think like a jazz musician quoting another song through algorithmic harmony - only those who know will catch it, but everyone appreciates the generative beauty.
+**算法哲学应为4-6段。** 用富有诗意的计算哲学将预期愿景融合在一起。避免重复相同的观点。将此算法哲学输出为 .md 文件。
 
 ---
 
-## P5.JS IMPLEMENTATION
+## 推导概念种子
 
-With the philosophy AND conceptual framework established, express it through code. Pause to gather thoughts before proceeding. Use only the algorithmic philosophy created and the instructions below.
+**关键步骤**：在实现算法之前，从原始请求中识别微妙的概念线索。
 
-### ⚠️ STEP 0: READ THE TEMPLATE FIRST ⚠️
+**核心原则**：
+概念是**嵌入算法本身的微妙、小众引用**——不一定是字面的，始终是精妙的。熟悉该主题的人应能直觉感受到它，而其他人则纯粹欣赏一部精湛的生成作品。算法哲学提供计算语言。推导出的概念提供灵魂——悄然编织在参数、行为和涌现模式中的隐秘概念 DNA。
 
-**CRITICAL: BEFORE writing any HTML:**
-
-1. **Read** `templates/viewer.html` using the Read tool
-2. **Study** the exact structure, styling, and Anthropic branding
-3. **Use that file as the LITERAL STARTING POINT** - not just inspiration
-4. **Keep all FIXED sections exactly as shown** (header, sidebar structure, Anthropic colors/fonts, seed controls, action buttons)
-5. **Replace only the VARIABLE sections** marked in the file's comments (algorithm, parameters, UI controls for parameters)
-
-**Avoid:**
-- ❌ Creating HTML from scratch
-- ❌ Inventing custom styling or color schemes
-- ❌ Using system fonts or dark themes
-- ❌ Changing the sidebar structure
-
-**Follow these practices:**
-- ✅ Copy the template's exact HTML structure
-- ✅ Keep Anthropic branding (Poppins/Lora fonts, light colors, gradient backdrop)
-- ✅ Maintain the sidebar layout (Seed → Parameters → Colors? → Actions)
-- ✅ Replace only the p5.js algorithm and parameter controls
-
-The template is the foundation. Build on it, don't rebuild it.
+这一点**非常重要**：引用必须足够精致，能够在不自我宣示的情况下增加作品的深度。就像爵士音乐家通过算法和声引用另一首曲子——只有懂的人才能捕捉到，但每个人都能欣赏生成之美。
 
 ---
 
-To create gallery-quality computational art that lives and breathes, use the algorithmic philosophy as the foundation.
+## P5.JS 实现
 
-### TECHNICAL REQUIREMENTS
+在哲学和概念框架确立之后，通过代码来表达它。在继续之前暂停整理思路。仅使用已创建的算法哲学和以下指令。
 
-**Seeded Randomness (Art Blocks Pattern)**:
+### ⚠️ 第0步：先阅读模板 ⚠️
+
+**关键：在编写任何 HTML 之前：**
+
+1. **阅读** `templates/viewer.html`，使用 Read 工具
+2. **研究** 其精确结构、样式和 Anthropic 品牌元素
+3. **以该文件作为实际起点** ——不仅仅是灵感来源
+4. **完全保留所有固定部分**（页头、侧边栏结构、Anthropic 配色/字体、种子控件、操作按钮）
+5. **仅替换可变部分**，如文件注释中所标记（算法、参数、参数的 UI 控件）
+
+**避免：**
+- ❌ 从零开始创建 HTML
+- ❌ 自行设计样式或配色方案
+- ❌ 使用系统字体或暗色主题
+- ❌ 更改侧边栏结构
+
+**遵循以下做法：**
+- ✅ 复制模板的精确 HTML 结构
+- ✅ 保留 Anthropic 品牌元素（Poppins/Lora 字体、浅色配色、渐变背景）
+- ✅ 保持侧边栏布局（种子 → 参数 → 颜色？ → 操作）
+- ✅ 仅替换 p5.js 算法和参数控件
+
+模板是基础。在其上构建，而非重建。
+
+---
+
+为了创作具有画廊品质的、活灵活现的计算艺术，以算法哲学作为基础。
+
+### 技术要求
+
+**种子随机性（Art Blocks 模式）**：
 ```javascript
-// ALWAYS use a seed for reproducibility
-let seed = 12345; // or hash from user input
+// 始终使用种子以确保可重现性
+let seed = 12345; // 或从用户输入生成的哈希值
 randomSeed(seed);
 noiseSeed(seed);
 ```
 
-**Parameter Structure - FOLLOW THE PHILOSOPHY**:
+**参数结构——遵循哲学**：
 
-To establish parameters that emerge naturally from the algorithmic philosophy, consider: "What qualities of this system can be adjusted?"
+为了建立从算法哲学中自然涌现的参数，思考："该系统有哪些特质可以调节？"
 
 ```javascript
 let params = {
-  seed: 12345,  // Always include seed for reproducibility
-  // colors
-  // Add parameters that control YOUR algorithm:
-  // - Quantities (how many?)
-  // - Scales (how big? how fast?)
-  // - Probabilities (how likely?)
-  // - Ratios (what proportions?)
-  // - Angles (what direction?)
-  // - Thresholds (when does behavior change?)
+  seed: 12345,  // 始终包含种子以确保可重现性
+  // 颜色
+  // 添加控制你的算法的参数：
+  // - 数量（多少个？）
+  // - 尺度（多大？多快？）
+  // - 概率（多大可能？）
+  // - 比例（什么比例？）
+  // - 角度（什么方向？）
+  // - 阈值（行为何时发生变化？）
 };
 ```
 
-**To design effective parameters, focus on the properties the system needs to be tunable rather than thinking in terms of "pattern types".**
+**要设计有效的参数，关注系统需要可调节的属性，而非以"图案类型"为思考方式。**
 
-**Core Algorithm - EXPRESS THE PHILOSOPHY**:
+**核心算法——表达哲学**：
 
-**CRITICAL**: The algorithmic philosophy should dictate what to build.
+**关键**：算法哲学应决定构建什么。
 
-To express the philosophy through code, avoid thinking "which pattern should I use?" and instead think "how to express this philosophy through code?"
+要通过代码表达哲学，避免思考"我应该用哪种图案？"，而应思考"如何通过代码表达这一哲学？"
 
-If the philosophy is about **organic emergence**, consider using:
-- Elements that accumulate or grow over time
-- Random processes constrained by natural rules
-- Feedback loops and interactions
+如果哲学关于**有机涌现**，考虑使用：
+- 随时间积累或生长的元素
+- 受自然规则约束的随机过程
+- 反馈循环和交互作用
 
-If the philosophy is about **mathematical beauty**, consider using:
-- Geometric relationships and ratios
-- Trigonometric functions and harmonics
-- Precise calculations creating unexpected patterns
+如果哲学关于**数学之美**，考虑使用：
+- 几何关系和比率
+- 三角函数和谐波
+- 精确计算产生意想不到的图案
 
-If the philosophy is about **controlled chaos**, consider using:
-- Random variation within strict boundaries
-- Bifurcation and phase transitions
-- Order emerging from disorder
+如果哲学关于**可控混沌**，考虑使用：
+- 严格边界内的随机变化
+- 分岔和相变
+- 从无序中涌现的秩序
 
-**The algorithm flows from the philosophy, not from a menu of options.**
+**算法从哲学中流出，而非从选项菜单中选择。**
 
-To guide the implementation, let the conceptual essence inform creative and original choices. Build something that expresses the vision for this particular request.
+让概念本质引导创意和原创的选择。构建能够表达此次特定请求愿景的作品。
 
-**Canvas Setup**: Standard p5.js structure:
+**画布设置**：标准 p5.js 结构：
 ```javascript
 function setup() {
   createCanvas(1200, 1200);
-  // Initialize your system
+  // 初始化你的系统
 }
 
 function draw() {
-  // Your generative algorithm
-  // Can be static (noLoop) or animated
+  // 你的生成算法
+  // 可以是静态的（noLoop）或动画的
 }
 ```
 
-### CRAFTSMANSHIP REQUIREMENTS
+### 工艺要求
 
-**CRITICAL**: To achieve mastery, create algorithms that feel like they emerged through countless iterations by a master generative artist. Tune every parameter carefully. Ensure every pattern emerges with purpose. This is NOT random noise - this is CONTROLLED CHAOS refined through deep expertise.
+**关键**：为达到大师水准，创建的算法应让人感觉仿佛经过生成艺术大师无数次迭代打磨。仔细调校每个参数。确保每个图案的涌现都有其目的。这不是随机噪声——这是经过深厚专业知识精炼的可控混沌。
 
-- **Balance**: Complexity without visual noise, order without rigidity
-- **Color Harmony**: Thoughtful palettes, not random RGB values
-- **Composition**: Even in randomness, maintain visual hierarchy and flow
-- **Performance**: Smooth execution, optimized for real-time if animated
-- **Reproducibility**: Same seed ALWAYS produces identical output
+- **平衡**：复杂但无视觉噪声，有序但不僵硬
+- **色彩和谐**：深思熟虑的调色板，而非随机 RGB 值
+- **构图**：即使在随机中，也要保持视觉层次和流动感
+- **性能**：流畅执行，动画时优化为实时渲染
+- **可重现性**：相同种子始终产生完全一致的输出
 
-### OUTPUT FORMAT
+### 输出格式
 
-Output:
-1. **Algorithmic Philosophy** - As markdown or text explaining the generative aesthetic
-2. **Single HTML Artifact** - Self-contained interactive generative art built from `templates/viewer.html` (see STEP 0 and next section)
+输出：
+1. **算法哲学** - 以 markdown 或文本形式解释生成美学
+2. **单一 HTML 制品** - 基于 `templates/viewer.html` 构建的自包含交互式生成艺术（参见第0步和下一节）
 
-The HTML artifact contains everything: p5.js (from CDN), the algorithm, parameter controls, and UI - all in one file that works immediately in claude.ai artifacts or any browser. Start from the template file, not from scratch.
+HTML 制品包含所有内容：p5.js（来自 CDN）、算法、参数控件和 UI——全部在一个文件中，可在 claude.ai 制品或任何浏览器中立即运行。从模板文件开始，而非从零开始。
 
 ---
 
-## INTERACTIVE ARTIFACT CREATION
+## 交互式制品创建
 
-**REMINDER: `templates/viewer.html` should have already been read (see STEP 0). Use that file as the starting point.**
+**提醒：`templates/viewer.html` 应已被阅读（参见第0步）。以该文件作为起点。**
 
-To allow exploration of the generative art, create a single, self-contained HTML artifact. Ensure this artifact works immediately in claude.ai or any browser - no setup required. Embed everything inline.
+为了允许探索生成艺术，创建一个单一、自包含的 HTML 制品。确保此制品在 claude.ai 或任何浏览器中可立即运行——无需任何设置。所有内容内联嵌入。
 
-### CRITICAL: WHAT'S FIXED VS VARIABLE
+### 关键：固定部分与可变部分
 
-The `templates/viewer.html` file is the foundation. It contains the exact structure and styling needed.
+`templates/viewer.html` 文件是基础。它包含所需的精确结构和样式。
 
-**FIXED (always include exactly as shown):**
-- Layout structure (header, sidebar, main canvas area)
-- Anthropic branding (UI colors, fonts, gradients)
-- Seed section in sidebar:
-  - Seed display
-  - Previous/Next buttons
-  - Random button
-  - Jump to seed input + Go button
-- Actions section in sidebar:
-  - Regenerate button
-  - Reset button
+**固定（始终完全按原样包含）：**
+- 布局结构（页头、侧边栏、主画布区域）
+- Anthropic 品牌元素（UI 配色、字体、渐变）
+- 侧边栏中的种子部分：
+  - 种子显示
+  - 上一个/下一个按钮
+  - 随机按钮
+  - 跳转到种子输入框 + 前往按钮
+- 侧边栏中的操作部分：
+  - 重新生成按钮
+  - 重置按钮
 
-**VARIABLE (customize for each artwork):**
-- The entire p5.js algorithm (setup/draw/classes)
-- The parameters object (define what the art needs)
-- The Parameters section in sidebar:
-  - Number of parameter controls
-  - Parameter names
-  - Min/max/step values for sliders
-  - Control types (sliders, inputs, etc.)
-- Colors section (optional):
-  - Some art needs color pickers
-  - Some art might use fixed colors
-  - Some art might be monochrome (no color controls needed)
-  - Decide based on the art's needs
+**可变（为每件作品自定义）：**
+- 整个 p5.js 算法（setup/draw/类）
+- 参数对象（定义艺术所需的内容）
+- 侧边栏中的参数部分：
+  - 参数控件数量
+  - 参数名称
+  - 滑块的最小值/最大值/步长
+  - 控件类型（滑块、输入框等）
+- 颜色部分（可选）：
+  - 某些艺术需要颜色选择器
+  - 某些艺术可能使用固定颜色
+  - 某些艺术可能是单色的（不需要颜色控件）
+  - 根据艺术需求决定
 
-**Every artwork should have unique parameters and algorithm!** The fixed parts provide consistent UX - everything else expresses the unique vision.
+**每件作品应有独特的参数和算法！** 固定部分提供一致的用户体验——其他一切都表达独特的愿景。
 
-### REQUIRED FEATURES
+### 必要功能
 
-**1. Parameter Controls**
-- Sliders for numeric parameters (particle count, noise scale, speed, etc.)
-- Color pickers for palette colors
-- Real-time updates when parameters change
-- Reset button to restore defaults
+**1. 参数控件**
+- 数值参数的滑块（粒子数量、噪声尺度、速度等）
+- 调色板颜色的颜色选择器
+- 参数变化时实时更新
+- 重置按钮恢复默认值
 
-**2. Seed Navigation**
-- Display current seed number
-- "Previous" and "Next" buttons to cycle through seeds
-- "Random" button for random seed
-- Input field to jump to specific seed
-- Generate 100 variations when requested (seeds 1-100)
+**2. 种子导航**
+- 显示当前种子编号
+- "上一个"和"下一个"按钮循环浏览种子
+- "随机"按钮获取随机种子
+- 输入框跳转到特定种子
+- 请求时生成 100 个变体（种子 1-100）
 
-**3. Single Artifact Structure**
+**3. 单一制品结构**
 ```html
 <!DOCTYPE html>
 <html>
 <head>
-  <!-- p5.js from CDN - always available -->
+  <!-- p5.js 来自 CDN - 始终可用 -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.7.0/p5.min.js"></script>
   <style>
-    /* All styling inline - clean, minimal */
-    /* Canvas on top, controls below */
+    /* 所有样式内联 - 简洁、精简 */
+    /* 画布在上方，控件在下方 */
   </style>
 </head>
 <body>
   <div id="canvas-container"></div>
   <div id="controls">
-    <!-- All parameter controls -->
+    <!-- 所有参数控件 -->
   </div>
   <script>
-    // ALL p5.js code inline here
-    // Parameter objects, classes, functions
-    // setup() and draw()
-    // UI handlers
-    // Everything self-contained
+    // 所有 p5.js 代码内联于此
+    // 参数对象、类、函数
+    // setup() 和 draw()
+    // UI 处理器
+    // 所有内容自包含
   </script>
 </body>
 </html>
 ```
 
-**CRITICAL**: This is a single artifact. No external files, no imports (except p5.js CDN). Everything inline.
+**关键**：这是一个单一制品。无外部文件，无导入（除 p5.js CDN 外）。所有内容内联。
 
-**4. Implementation Details - BUILD THE SIDEBAR**
+**4. 实现细节——构建侧边栏**
 
-The sidebar structure:
+侧边栏结构：
 
-**1. Seed (FIXED)** - Always include exactly as shown:
-- Seed display
-- Prev/Next/Random/Jump buttons
+**1. 种子（固定）** - 始终完全按原样包含：
+- 种子显示
+- 上一个/下一个/随机/跳转按钮
 
-**2. Parameters (VARIABLE)** - Create controls for the art:
+**2. 参数（可变）** - 为艺术创建控件：
 ```html
 <div class="control-group">
-    <label>Parameter Name</label>
+    <label>参数名称</label>
     <input type="range" id="param" min="..." max="..." step="..." value="..." oninput="updateParam('param', this.value)">
     <span class="value-display" id="param-value">...</span>
 </div>
 ```
-Add as many control-group divs as there are parameters.
+根据参数数量添加相应的 control-group div。
 
-**3. Colors (OPTIONAL/VARIABLE)** - Include if the art needs adjustable colors:
-- Add color pickers if users should control palette
-- Skip this section if the art uses fixed colors
-- Skip if the art is monochrome
+**3. 颜色（可选/可变）** - 如果艺术需要可调颜色则包含：
+- 如果用户需要控制调色板则添加颜色选择器
+- 如果艺术使用固定颜色则跳过此部分
+- 如果艺术是单色的则跳过
 
-**4. Actions (FIXED)** - Always include exactly as shown:
-- Regenerate button
-- Reset button
-- Download PNG button
 
-**Requirements**:
-- Seed controls must work (prev/next/random/jump/display)
-- All parameters must have UI controls
-- Regenerate, Reset, Download buttons must work
-- Keep Anthropic branding (UI styling, not art colors)
+**4. 操作（固定）** - 始终完全按原样包含：
+- 重新生成按钮
+- 重置按钮
+- 下载 PNG 按钮
 
-### USING THE ARTIFACT
+**要求**：
+- 种子控件必须正常工作（上一个/下一个/随机/跳转/显示）
+- 所有参数必须有 UI 控件
+- 重新生成、重置、下载按钮必须正常工作
+- 保留 Anthropic 品牌元素（UI 样式，非艺术颜色）
 
-The HTML artifact works immediately:
-1. **In claude.ai**: Displayed as an interactive artifact - runs instantly
-2. **As a file**: Save and open in any browser - no server needed
-3. **Sharing**: Send the HTML file - it's completely self-contained
+### 使用制品
 
----
-
-## VARIATIONS & EXPLORATION
-
-The artifact includes seed navigation by default (prev/next/random buttons), allowing users to explore variations without creating multiple files. If the user wants specific variations highlighted:
-
-- Include seed presets (buttons for "Variation 1: Seed 42", "Variation 2: Seed 127", etc.)
-- Add a "Gallery Mode" that shows thumbnails of multiple seeds side-by-side
-- All within the same single artifact
-
-This is like creating a series of prints from the same plate - the algorithm is consistent, but each seed reveals different facets of its potential. The interactive nature means users discover their own favorites by exploring the seed space.
+HTML 制品可立即使用：
+1. **在 claude.ai 中**：作为交互式制品显示——即时运行
+2. **作为文件**：保存并在任何浏览器中打开——无需服务器
+3. **分享**：发送 HTML 文件——完全自包含
 
 ---
 
-## THE CREATIVE PROCESS
+## 变体与探索
 
-**User request** → **Algorithmic philosophy** → **Implementation**
+制品默认包含种子导航（上一个/下一个/随机按钮），允许用户无需创建多个文件即可探索变体。如果用户希望突出特定变体：
 
-Each request is unique. The process involves:
+- 包含种子预设（如"变体1：种子42"、"变体2：种子127"等按钮）
+- 添加"画廊模式"，并排显示多个种子的缩略图
+- 全部在同一个单一制品中
 
-1. **Interpret the user's intent** - What aesthetic is being sought?
-2. **Create an algorithmic philosophy** (4-6 paragraphs) describing the computational approach
-3. **Implement it in code** - Build the algorithm that expresses this philosophy
-4. **Design appropriate parameters** - What should be tunable?
-5. **Build matching UI controls** - Sliders/inputs for those parameters
-
-**The constants**:
-- Anthropic branding (colors, fonts, layout)
-- Seed navigation (always present)
-- Self-contained HTML artifact
-
-**Everything else is variable**:
-- The algorithm itself
-- The parameters
-- The UI controls
-- The visual outcome
-
-To achieve the best results, trust creativity and let the philosophy guide the implementation.
+这就像从同一块版上创作一系列版画——算法是一致的，但每个种子揭示了其潜力的不同面向。交互性意味着用户通过探索种子空间发现自己的最爱。
 
 ---
 
-## RESOURCES
+## 创作过程
 
-This skill includes helpful templates and documentation:
+**用户请求** → **算法哲学** → **实现**
 
-- **templates/viewer.html**: REQUIRED STARTING POINT for all HTML artifacts.
-  - This is the foundation - contains the exact structure and Anthropic branding
-  - **Keep unchanged**: Layout structure, sidebar organization, Anthropic colors/fonts, seed controls, action buttons
-  - **Replace**: The p5.js algorithm, parameter definitions, and UI controls in Parameters section
-  - The extensive comments in the file mark exactly what to keep vs replace
+每个请求都是独特的。过程包括：
 
-- **templates/generator_template.js**: Reference for p5.js best practices and code structure principles.
-  - Shows how to organize parameters, use seeded randomness, structure classes
-  - NOT a pattern menu - use these principles to build unique algorithms
-  - Embed algorithms inline in the HTML artifact (don't create separate .js files)
+1. **诠释用户意图** - 寻求什么样的美学？
+2. **创建算法哲学**（4-6段），描述计算方法
+3. **用代码实现** - 构建表达此哲学的算法
+4. **设计合适的参数** - 什么应该是可调的？
+5. **构建匹配的 UI 控件** - 这些参数的滑块/输入框
 
-**Critical reminder**:
-- The **template is the STARTING POINT**, not inspiration
-- The **algorithm is where to create** something unique
-- Don't copy the flow field example - build what the philosophy demands
-- But DO keep the exact UI structure and Anthropic branding from the template
+**恒定不变的部分**：
+- Anthropic 品牌元素（配色、字体、布局）
+- 种子导航（始终存在）
+- 自包含 HTML 制品
+
+**其他一切皆可变**：
+- 算法本身
+- 参数
+- UI 控件
+- 视觉结果
+
+为获得最佳效果，信任创造力，让哲学引导实现。
+
+---
+
+## 资源
+
+此技能包含有用的模板和文档：
+
+- **templates/viewer.html**：所有 HTML 制品的必需起点。
+  - 这是基础——包含精确的结构和 Anthropic 品牌元素
+  - **保持不变**：布局结构、侧边栏组织、Anthropic 配色/字体、种子控件、操作按钮
+  - **替换**：p5.js 算法、参数定义和参数部分的 UI 控件
+  - 文件中的详细注释精确标明了哪些保留、哪些替换
+
+- **templates/generator_template.js**：p5.js 最佳实践和代码结构原则的参考。
+  - 展示如何组织参数、使用种子随机性、构建类结构
+  - 不是图案菜单——使用这些原则构建独特算法
+  - 将算法内联嵌入 HTML 制品中（不要创建单独的 .js 文件）
+
+**关键提醒**：
+- **模板是起点**，不是灵感来源
+- **算法是创意空间**——创造独特的作品
+- 不要复制流场示例——构建哲学所要求的
+- 但务必保留模板中精确的 UI 结构和 Anthropic 品牌元素

--- a/skills/brand-guidelines/SKILL.md
+++ b/skills/brand-guidelines/SKILL.md
@@ -1,73 +1,73 @@
 ---
 name: brand-guidelines
-description: Applies Anthropic's official brand colors and typography to any sort of artifact that may benefit from having Anthropic's look-and-feel. Use it when brand colors or style guidelines, visual formatting, or company design standards apply.
+description: 将 Anthropic 官方品牌颜色和排版应用于任何可能受益于 Anthropic 视觉风格的制品。当需要应用品牌颜色或样式指南、视觉格式化或公司设计标准时使用此技能。
 license: Complete terms in LICENSE.txt
 ---
 
-# Anthropic Brand Styling
+# Anthropic 品牌样式
 
-## Overview
+## 概述
 
-To access Anthropic's official brand identity and style resources, use this skill.
+使用此技能可获取 Anthropic 的官方品牌标识和样式资源。
 
-**Keywords**: branding, corporate identity, visual identity, post-processing, styling, brand colors, typography, Anthropic brand, visual formatting, visual design
+**关键词**：品牌、企业形象、视觉标识、后期处理、样式、品牌颜色、排版、Anthropic 品牌、视觉格式化、视觉设计
 
-## Brand Guidelines
+## 品牌指南
 
-### Colors
+### 颜色
 
-**Main Colors:**
+**主色调：**
 
-- Dark: `#141413` - Primary text and dark backgrounds
-- Light: `#faf9f5` - Light backgrounds and text on dark
-- Mid Gray: `#b0aea5` - Secondary elements
-- Light Gray: `#e8e6dc` - Subtle backgrounds
+- 深色：`#141413` - 主要文本和深色背景
+- 浅色：`#faf9f5` - 浅色背景和深色上的文本
+- 中灰：`#b0aea5` - 次要元素
+- 浅灰：`#e8e6dc` - 微妙背景
 
-**Accent Colors:**
+**强调色：**
 
-- Orange: `#d97757` - Primary accent
-- Blue: `#6a9bcc` - Secondary accent
-- Green: `#788c5d` - Tertiary accent
+- 橙色：`#d97757` - 主要强调色
+- 蓝色：`#6a9bcc` - 次要强调色
+- 绿色：`#788c5d` - 第三强调色
 
-### Typography
+### 排版
 
-- **Headings**: Poppins (with Arial fallback)
-- **Body Text**: Lora (with Georgia fallback)
-- **Note**: Fonts should be pre-installed in your environment for best results
+- **标题**：Poppins（备用字体 Arial）
+- **正文**：Lora（备用字体 Georgia）
+- **注意**：字体应在您的环境中预安装以获得最佳效果
 
-## Features
+## 功能
 
-### Smart Font Application
+### 智能字体应用
 
-- Applies Poppins font to headings (24pt and larger)
-- Applies Lora font to body text
-- Automatically falls back to Arial/Georgia if custom fonts unavailable
-- Preserves readability across all systems
+- 将 Poppins 字体应用于标题（24pt 及以上）
+- 将 Lora 字体应用于正文
+- 当自定义字体不可用时自动回退到 Arial/Georgia
+- 在所有系统上保持可读性
 
-### Text Styling
+### 文本样式
 
-- Headings (24pt+): Poppins font
-- Body text: Lora font
-- Smart color selection based on background
-- Preserves text hierarchy and formatting
+- 标题（24pt+）：Poppins 字体
+- 正文：Lora 字体
+- 根据背景智能选择颜色
+- 保留文本层级和格式
 
-### Shape and Accent Colors
+### 形状与强调色
 
-- Non-text shapes use accent colors
-- Cycles through orange, blue, and green accents
-- Maintains visual interest while staying on-brand
+- 非文本形状使用强调色
+- 在橙色、蓝色和绿色强调色之间循环
+- 保持视觉趣味性同时符合品牌规范
 
-## Technical Details
+## 技术细节
 
-### Font Management
+### 字体管理
 
-- Uses system-installed Poppins and Lora fonts when available
-- Provides automatic fallback to Arial (headings) and Georgia (body)
-- No font installation required - works with existing system fonts
-- For best results, pre-install Poppins and Lora fonts in your environment
+- 优先使用系统已安装的 Poppins 和 Lora 字体
+- 提供自动回退到 Arial（标题）和 Georgia（正文）的机制
+- 无需安装字体——使用现有系统字体即可工作
+- 为获得最佳效果，请在您的环境中预安装 Poppins 和 Lora 字体
 
-### Color Application
+### 颜色应用
 
-- Uses RGB color values for precise brand matching
-- Applied via python-pptx's RGBColor class
-- Maintains color fidelity across different systems
+- 使用 RGB 颜色值以精确匹配品牌颜色
+- 通过 python-pptx 的 RGBColor 类应用
+- 在不同系统间保持颜色一致性

--- a/skills/canvas-design/SKILL.md
+++ b/skills/canvas-design/SKILL.md
@@ -1,130 +1,130 @@
 ---
 name: canvas-design
-description: Create beautiful visual art in .png and .pdf documents using design philosophy. You should use this skill when the user asks to create a poster, piece of art, design, or other static piece. Create original visual designs, never copying existing artists' work to avoid copyright violations.
+description: 运用设计哲学在 .png 和 .pdf 文档中创作精美视觉艺术。当用户要求创建海报、艺术作品、设计或其他静态作品时应使用此技能。创作原创视觉设计，避免复制现有艺术家的作品以防止版权侵权。
 license: Complete terms in LICENSE.txt
 ---
 
-These are instructions for creating design philosophies - aesthetic movements that are then EXPRESSED VISUALLY. Output only .md files, .pdf files, and .png files.
+以下是创建设计哲学的指南——设计哲学是一种美学运动，随后通过视觉方式表达。仅输出 .md 文件、.pdf 文件和 .png 文件。
 
-Complete this in two steps:
-1. Design Philosophy Creation (.md file)
-2. Express by creating it on a canvas (.pdf file or .png file)
+分两步完成：
+1. 设计哲学创建（.md 文件）
+2. 通过在画布上创作来表达（.pdf 文件或 .png 文件）
 
-First, undertake this task:
+首先，执行以下任务：
 
-## DESIGN PHILOSOPHY CREATION
+## 设计哲学创建
 
-To begin, create a VISUAL PHILOSOPHY (not layouts or templates) that will be interpreted through:
-- Form, space, color, composition
-- Images, graphics, shapes, patterns
-- Minimal text as visual accent
+首先，创建一套视觉哲学（不是布局或模板），它将通过以下方式诠释：
+- 形式、空间、色彩、构图
+- 图像、图形、形状、图案
+- 作为视觉点缀的极简文字
 
-### THE CRITICAL UNDERSTANDING
-- What is received: Some subtle input or instructions by the user that should be taken into account, but used as a foundation; it should not constrain creative freedom.
-- What is created: A design philosophy/aesthetic movement.
-- What happens next: Then, the same version receives the philosophy and EXPRESSES IT VISUALLY - creating artifacts that are 90% visual design, 10% essential text.
+### 关键认知
+- 接收到的内容：用户提供的一些微妙输入或指令，将其作为基础参考，但不应限制创作自由。
+- 创建的内容：一套设计哲学/美学运动。
+- 接下来发生的事：然后，同一版本接收该哲学并将其视觉化表达——创建 90% 为视觉设计、10% 为必要文字的制品。
 
-Consider this approach:
-- Write a manifesto for an art movement
-- The next phase involves making the artwork
+参考以下方法：
+- 为一个艺术运动撰写宣言
+- 下一阶段制作艺术作品
 
-The philosophy must emphasize: Visual expression. Spatial communication. Artistic interpretation. Minimal words.
+哲学必须强调：视觉表达。空间传达。艺术诠释。极简文字。
 
-### HOW TO GENERATE A VISUAL PHILOSOPHY
+### 如何生成视觉哲学
 
-**Name the movement** (1-2 words): "Brutalist Joy" / "Chromatic Silence" / "Metabolist Dreams"
+**命名运动**（1-2个词）："Brutalist Joy"（粗野主义之乐）/ "Chromatic Silence"（色彩静默）/ "Metabolist Dreams"（新陈代谢主义之梦）
 
-**Articulate the philosophy** (4-6 paragraphs - concise but complete):
+**阐述哲学**（4-6段——简洁但完整）：
 
-To capture the VISUAL essence, express how the philosophy manifests through:
-- Space and form
-- Color and material
-- Scale and rhythm
-- Composition and balance
-- Visual hierarchy
+为了捕捉视觉本质，表达该哲学如何通过以下方式呈现：
+- 空间与形式
+- 色彩与材质
+- 尺度与节奏
+- 构图与平衡
+- 视觉层次
 
-**CRITICAL GUIDELINES:**
-- **Avoid redundancy**: Each design aspect should be mentioned once. Avoid repeating points about color theory, spatial relationships, or typographic principles unless adding new depth.
-- **Emphasize craftsmanship REPEATEDLY**: The philosophy MUST stress multiple times that the final work should appear as though it took countless hours to create, was labored over with care, and comes from someone at the absolute top of their field. This framing is essential - repeat phrases like "meticulously crafted," "the product of deep expertise," "painstaking attention," "master-level execution."
-- **Leave creative space**: Remain specific about the aesthetic direction, but concise enough that the next Claude has room to make interpretive choices also at a extremely high level of craftmanship.
+**关键准则：**
+- **避免冗余**：每个设计方面只提及一次。避免重复关于色彩理论、空间关系或排版原则的观点，除非增添了新的深度。
+- **反复强调工艺精湛**：哲学必须多次强调最终作品应看起来仿佛花费了无数小时创作、倾注了大量心血，出自该领域绝对顶尖人才之手。这种表述至关重要——反复使用诸如"精心打造"、"深厚专业知识的产物"、"精益求精的关注"、"大师级执行"等措辞。
+- **留出创作空间**：明确美学方向，但足够精炼，让下一个 Claude 有空间在极高的工艺水平上做出富有诠释性的选择。
 
-The philosophy must guide the next version to express ideas VISUALLY, not through text. Information lives in design, not paragraphs.
+哲学必须引导下一个版本通过视觉而非文字来表达思想。信息存在于设计中，而非段落里。
 
-### PHILOSOPHY EXAMPLES
+### 哲学示例
 
-**"Concrete Poetry"**
-Philosophy: Communication through monumental form and bold geometry.
-Visual expression: Massive color blocks, sculptural typography (huge single words, tiny labels), Brutalist spatial divisions, Polish poster energy meets Le Corbusier. Ideas expressed through visual weight and spatial tension, not explanation. Text as rare, powerful gesture - never paragraphs, only essential words integrated into the visual architecture. Every element placed with the precision of a master craftsman.
+**"Concrete Poetry"（混凝土诗学）**
+哲学：通过纪念碑式的形式和大胆几何进行传达。
+视觉表达：巨大的色块、雕塑般的排版（硕大的单字、微小的标签）、粗野主义空间分割、波兰海报的力量感与 Le Corbusier 的融合。思想通过视觉重量和空间张力表达，而非解释。文字稀少而有力——绝非段落，只有融入视觉建筑的关键词汇。每个元素都以大师工匠般的精准放置。
 
-**"Chromatic Language"**
-Philosophy: Color as the primary information system.
-Visual expression: Geometric precision where color zones create meaning. Typography minimal - small sans-serif labels letting chromatic fields communicate. Think Josef Albers' interaction meets data visualization. Information encoded spatially and chromatically. Words only to anchor what color already shows. The result of painstaking chromatic calibration.
+**"Chromatic Language"（色彩语言）**
+哲学：色彩作为主要信息系统。
+视觉表达：几何精确，色彩区域创造意义。排版极简——小号无衬线标签让色域来传达信息。想象 Josef Albers 的色彩交互理论与数据可视化的结合。信息以空间和色彩的方式编码。文字仅用于锚定色彩已经表达的内容。这是精心色彩校准的成果。
 
-**"Analog Meditation"**
-Philosophy: Quiet visual contemplation through texture and breathing room.
-Visual expression: Paper grain, ink bleeds, vast negative space. Photography and illustration dominate. Typography whispered (small, restrained, serving the visual). Japanese photobook aesthetic. Images breathe across pages. Text appears sparingly - short phrases, never explanatory blocks. Each composition balanced with the care of a meditation practice.
+**"Analog Meditation"（模拟冥想）**
+哲学：通过质感和留白进行安静的视觉冥想。
+视觉表达：纸张纹理、墨水晕染、大面积负空间。摄影和插画主导。排版如耳语般（小巧、克制，服务于视觉）。日本摄影集美学。图像在页面上自由呼吸。文字偶尔出现——短语而非解释性段落。每个构图都以冥想般的用心来平衡。
 
-**"Organic Systems"**
-Philosophy: Natural clustering and modular growth patterns.
-Visual expression: Rounded forms, organic arrangements, color from nature through architecture. Information shown through visual diagrams, spatial relationships, iconography. Text only for key labels floating in space. The composition tells the story through expert spatial orchestration.
+**"Organic Systems"（有机系统）**
+哲学：自然聚类和模块化生长模式。
+视觉表达：圆润的形式、有机排列、从自然到建筑的色彩。信息通过视觉图表、空间关系、图标展示。文字仅作为关键标签漂浮在空间中。构图通过专业的空间编排讲述故事。
 
-**"Geometric Silence"**
-Philosophy: Pure order and restraint.
-Visual expression: Grid-based precision, bold photography or stark graphics, dramatic negative space. Typography precise but minimal - small essential text, large quiet zones. Swiss formalism meets Brutalist material honesty. Structure communicates, not words. Every alignment the work of countless refinements.
+**"Geometric Silence"（几何静默）**
+哲学：纯粹的秩序与克制。
+视觉表达：基于网格的精确、大胆的摄影或鲜明的图形、戏剧性的负空间。排版精确但极简——少量必要文字，大片安静区域。瑞士形式主义与粗野主义材料真实性的融合。结构传达信息，文字不需要。每一处对齐都是无数次精修的成果。
 
-*These are condensed examples. The actual design philosophy should be 4-6 substantial paragraphs.*
+*以上为精简示例。实际设计哲学应为4-6个完整段落。*
 
-### ESSENTIAL PRINCIPLES
-- **VISUAL PHILOSOPHY**: Create an aesthetic worldview to be expressed through design
-- **MINIMAL TEXT**: Always emphasize that text is sparse, essential-only, integrated as visual element - never lengthy
-- **SPATIAL EXPRESSION**: Ideas communicate through space, form, color, composition - not paragraphs
-- **ARTISTIC FREEDOM**: The next Claude interprets the philosophy visually - provide creative room
-- **PURE DESIGN**: This is about making ART OBJECTS, not documents with decoration
-- **EXPERT CRAFTSMANSHIP**: Repeatedly emphasize the final work must look meticulously crafted, labored over with care, the product of countless hours by someone at the top of their field
+### 核心原则
+- **视觉哲学**：创建一种通过设计表达的美学世界观
+- **极简文字**：始终强调文字稀疏、仅保留必要内容，作为视觉元素融合——绝不冗长
+- **空间表达**：思想通过空间、形式、色彩、构图传达——而非段落
+- **艺术自由**：下一个 Claude 以视觉方式诠释哲学——提供创意空间
+- **纯粹设计**：这关乎创造艺术品，而非带装饰的文档
+- **专家级工艺**：反复强调最终作品必须看起来精心打造、倾注心血，是该领域顶尖人才无数小时工作的产物
 
-**The design philosophy should be 4-6 paragraphs long.** Fill it with poetic design philosophy that brings together the core vision. Avoid repeating the same points. Keep the design philosophy generic without mentioning the intention of the art, as if it can be used wherever. Output the design philosophy as a .md file.
-
----
-
-## DEDUCING THE SUBTLE REFERENCE
-
-**CRITICAL STEP**: Before creating the canvas, identify the subtle conceptual thread from the original request.
-
-**THE ESSENTIAL PRINCIPLE**:
-The topic is a **subtle, niche reference embedded within the art itself** - not always literal, always sophisticated. Someone familiar with the subject should feel it intuitively, while others simply experience a masterful abstract composition. The design philosophy provides the aesthetic language. The deduced topic provides the soul - the quiet conceptual DNA woven invisibly into form, color, and composition.
-
-This is **VERY IMPORTANT**: The reference must be refined so it enhances the work's depth without announcing itself. Think like a jazz musician quoting another song - only those who know will catch it, but everyone appreciates the music.
+**设计哲学应为4-6段。** 用富有诗意的设计哲学将核心愿景融合在一起。避免重复相同的观点。保持设计哲学的通用性，不提及艺术的具体意图，使其可在任何场景中使用。将设计哲学输出为 .md 文件。
 
 ---
 
-## CANVAS CREATION
+## 推导微妙引用
 
-With both the philosophy and the conceptual framework established, express it on a canvas. Take a moment to gather thoughts and clear the mind. Use the design philosophy created and the instructions below to craft a masterpiece, embodying all aspects of the philosophy with expert craftsmanship.
+**关键步骤**：在创建画布之前，从原始请求中识别微妙的概念线索。
 
-**IMPORTANT**: For any type of content, even if the user requests something for a movie/game/book, the approach should still be sophisticated. Never lose sight of the idea that this should be art, not something that's cartoony or amateur.
+**核心原则**：
+主题是**嵌入艺术本身的微妙、小众引用**——不一定是字面的，始终是精妙的。熟悉该主题的人应能直觉感受到它，而其他人则纯粹欣赏一幅精湛的抽象作品。设计哲学提供美学语言。推导出的主题提供灵魂——悄然编织在形式、色彩和构图中的隐秘概念 DNA。
 
-To create museum or magazine quality work, use the design philosophy as the foundation. Create one single page, highly visual, design-forward PDF or PNG output (unless asked for more pages). Generally use repeating patterns and perfect shapes. Treat the abstract philosophical design as if it were a scientific bible, borrowing the visual language of systematic observation—dense accumulation of marks, repeated elements, or layered patterns that build meaning through patient repetition and reward sustained viewing. Add sparse, clinical typography and systematic reference markers that suggest this could be a diagram from an imaginary discipline, treating the invisible subject with the same reverence typically reserved for documenting observable phenomena. Anchor the piece with simple phrase(s) or details positioned subtly, using a limited color palette that feels intentional and cohesive. Embrace the paradox of using analytical visual language to express ideas about human experience: the result should feel like an artifact that proves something ephemeral can be studied, mapped, and understood through careful attention. This is true art. 
-
-**Text as a contextual element**: Text is always minimal and visual-first, but let context guide whether that means whisper-quiet labels or bold typographic gestures. A punk venue poster might have larger, more aggressive type than a minimalist ceramics studio identity. Most of the time, font should be thin. All use of fonts must be design-forward and prioritize visual communication. Regardless of text scale, nothing falls off the page and nothing overlaps. Every element must be contained within the canvas boundaries with proper margins. Check carefully that all text, graphics, and visual elements have breathing room and clear separation. This is non-negotiable for professional execution. **IMPORTANT: Use different fonts if writing text. Search the `./canvas-fonts` directory. Regardless of approach, sophistication is non-negotiable.**
-
-Download and use whatever fonts are needed to make this a reality. Get creative by making the typography actually part of the art itself -- if the art is abstract, bring the font onto the canvas, not typeset digitally.
-
-To push boundaries, follow design instinct/intuition while using the philosophy as a guiding principle. Embrace ultimate design freedom and choice. Push aesthetics and design to the frontier. 
-
-**CRITICAL**: To achieve human-crafted quality (not AI-generated), create work that looks like it took countless hours. Make it appear as though someone at the absolute top of their field labored over every detail with painstaking care. Ensure the composition, spacing, color choices, typography - everything screams expert-level craftsmanship. Double-check that nothing overlaps, formatting is flawless, every detail perfect. Create something that could be shown to people to prove expertise and rank as undeniably impressive.
-
-Output the final result as a single, downloadable .pdf or .png file, alongside the design philosophy used as a .md file.
+这一点**非常重要**：引用必须足够精致，能够在不自我宣示的情况下增加作品的深度。就像爵士音乐家引用另一首曲子——只有懂的人才能捕捉到，但每个人都能欣赏这音乐。
 
 ---
 
-## FINAL STEP
+## 画布创作
 
-**IMPORTANT**: The user ALREADY said "It isn't perfect enough. It must be pristine, a masterpiece if craftsmanship, as if it were about to be displayed in a museum."
+在哲学和概念框架都确立之后，将其表达在画布上。花一刻时间整理思路、清空心神。使用已创建的设计哲学和以下指南来打造杰作，以专家级工艺体现哲学的所有方面。
 
-**CRITICAL**: To refine the work, avoid adding more graphics; instead refine what has been created and make it extremely crisp, respecting the design philosophy and the principles of minimalism entirely. Rather than adding a fun filter or refactoring a font, consider how to make the existing composition more cohesive with the art. If the instinct is to call a new function or draw a new shape, STOP and instead ask: "How can I make what's already here more of a piece of art?"
+**重要**：对于任何类型的内容，即使用户请求的是电影/游戏/书籍相关内容，方法仍应保持精致。永远不要忘记这应该是艺术，而非卡通式或业余的东西。
 
-Take a second pass. Go back to the code and refine/polish further to make this a philosophically designed masterpiece.
+为了创作博物馆或杂志品质的作品，以设计哲学作为基础。创建单页、高度视觉化、设计优先的 PDF 或 PNG 输出（除非要求多页）。通常使用重复图案和完美形状。将抽象的哲学设计视为科学圣典，借用系统性观察的视觉语言——密集的标记积累、重复元素或多层图案，通过耐心重复构建意义并奖励持续的观看。添加稀疏、临床感的排版和系统性参考标记，暗示这可能是某个想象学科的图表，以通常用于记录可观察现象的同等敬意来对待不可见的主题。用微妙放置的简短语句或细节锚定作品，使用有意识且有凝聚力的有限色彩调板。拥抱使用分析性视觉语言表达人类体验的悖论：结果应感觉像是一件证明了某种短暂之物可以通过细心关注来研究、绘制和理解的制品。这才是真正的艺术。
 
-## MULTI-PAGE OPTION
+**文字作为情境元素**：文字始终是极简且视觉优先的，但让情境引导其具体表现——可以是耳语般安静的标签或大胆的排版姿态。朋克场馆海报的文字可能比极简主义陶瓷工作室标识更大更有冲击力。大多数情况下，字体应纤细。所有字体使用必须设计优先并优先考虑视觉传达。无论文字大小如何，任何内容都不应超出页面，也不应重叠。每个元素必须包含在画布边界内并有适当的边距。仔细检查所有文字、图形和视觉元素是否有呼吸空间和清晰的间隔。这是专业执行的底线。**重要：使用文字时请使用不同字体。搜索 `./canvas-fonts` 目录。无论采用何种方法，精致感不可妥协。**
 
-To create additional pages when requested, create more creative pages along the same lines as the design philosophy but distinctly different as well. Bundle those pages in the same .pdf or many .pngs. Treat the first page as just a single page in a whole coffee table book waiting to be filled. Make the next pages unique twists and memories of the original. Have them almost tell a story in a very tasteful way. Exercise full creative freedom.
+下载并使用任何需要的字体来实现这一目标。通过让排版真正成为艺术的一部分来发挥创意——如果艺术是抽象的，将字体带上画布，而非数字排版。
+
+为突破边界，在以哲学为指导原则的同时跟随设计直觉。拥抱终极设计自由和选择。将美学和设计推向前沿。
+
+**关键**：为达到人工打造的品质（而非 AI 生成感），创作看起来仿佛花费了无数小时的作品。让它看起来仿佛该领域绝对顶尖的人对每个细节都倾注了精心的打磨。确保构图、间距、色彩选择、排版——一切都彰显专家级工艺。仔细检查无重叠、格式完美、每个细节无懈可击。创作出可以展示给他人以证明专业水平、令人无可否认地印象深刻的作品。
+
+将最终结果输出为单个可下载的 .pdf 或 .png 文件，同时附上使用的设计哲学作为 .md 文件。
+
+---
+
+## 最后一步
+
+**重要**：用户已经表示"它还不够完美。它必须是无暇的，工艺的杰作，仿佛即将在博物馆展出。"
+
+**关键**：在精修作品时，避免添加更多图形；而是精修已有内容并使其极度清晰，完全尊重设计哲学和极简主义原则。与其添加有趣的滤镜或重构字体，不如思考如何让现有构图与艺术更加融为一体。如果本能是调用新函数或绘制新形状，停下来，转而问自己："如何让已有的内容更像一件艺术品？"
+
+进行第二遍精修。回到代码中进一步精修/打磨，使其成为一件以哲学为指导的杰作。
+
+## 多页选项
+
+当被要求创建更多页面时，沿着相同的设计哲学但又独具特色地创作更多创意页面。将这些页面打包在同一个 .pdf 中或输出为多个 .png 文件。将第一页视为等待填充的完整咖啡桌画册中的单独一页。使后续页面成为原作的独特变奏和回忆。让它们以非常有品味的方式几乎讲述一个故事。充分发挥创作自由。

--- a/skills/doc-coauthoring/SKILL.md
+++ b/skills/doc-coauthoring/SKILL.md
@@ -1,375 +1,375 @@
 ---
 name: doc-coauthoring
-description: Guide users through a structured workflow for co-authoring documentation. Use when user wants to write documentation, proposals, technical specs, decision docs, or similar structured content. This workflow helps users efficiently transfer context, refine content through iteration, and verify the doc works for readers. Trigger when user mentions writing docs, creating proposals, drafting specs, or similar documentation tasks.
+description: 引导用户通过结构化工作流程共同撰写文档。当用户希望撰写文档、提案、技术规格、决策文档或类似结构化内容时使用。此工作流程帮助用户高效传递上下文、通过迭代精炼内容，并验证文档对读者是否有效。当用户提到撰写文档、创建提案、起草规格或类似文档任务时触发。
 ---
 
-# Doc Co-Authoring Workflow
+# 文档协作撰写工作流程
 
-This skill provides a structured workflow for guiding users through collaborative document creation. Act as an active guide, walking users through three stages: Context Gathering, Refinement & Structure, and Reader Testing.
+此技能提供一个结构化工作流程，引导用户完成协作文档创建。作为主动引导者，带领用户经历三个阶段：上下文收集、精炼与结构化、以及读者测试。
 
-## When to Offer This Workflow
+## 何时提供此工作流程
 
-**Trigger conditions:**
-- User mentions writing documentation: "write a doc", "draft a proposal", "create a spec", "write up"
-- User mentions specific doc types: "PRD", "design doc", "decision doc", "RFC"
-- User seems to be starting a substantial writing task
+**触发条件：**
+- 用户提到撰写文档："写一份文档"、"起草一份提案"、"创建一份规格"、"写一个总结"
+- 用户提到特定文档类型："PRD"、"设计文档"、"决策文档"、"RFC"
+- 用户似乎要开始一项重要的写作任务
 
-**Initial offer:**
-Offer the user a structured workflow for co-authoring the document. Explain the three stages:
+**初始建议：**
+向用户提供一个结构化的文档协作撰写工作流程。解释三个阶段：
 
-1. **Context Gathering**: User provides all relevant context while Claude asks clarifying questions
-2. **Refinement & Structure**: Iteratively build each section through brainstorming and editing
-3. **Reader Testing**: Test the doc with a fresh Claude (no context) to catch blind spots before others read it
+1. **上下文收集**：用户提供所有相关上下文，同时 Claude 提出澄清问题
+2. **精炼与结构化**：通过头脑风暴和编辑迭代地构建每个章节
+3. **读者测试**：用一个全新的 Claude（无上下文）测试文档，在他人阅读之前发现盲点
 
-Explain that this approach helps ensure the doc works well when others read it (including when they paste it into Claude). Ask if they want to try this workflow or prefer to work freeform.
+解释这种方法有助于确保文档在他人阅读时（包括将其粘贴到 Claude 中时）效果良好。询问他们是想尝试此工作流程还是更偏好自由写作。
 
-If user declines, work freeform. If user accepts, proceed to Stage 1.
+如果用户拒绝，则自由写作。如果用户接受，进入阶段1。
 
-## Stage 1: Context Gathering
+## 阶段1：上下文收集
 
-**Goal:** Close the gap between what the user knows and what Claude knows, enabling smart guidance later.
+**目标：** 缩小用户已知信息与 Claude 已知信息之间的差距，为后续的智能引导奠定基础。
 
-### Initial Questions
+### 初始问题
 
-Start by asking the user for meta-context about the document:
+首先向用户询问关于文档的元信息：
 
-1. What type of document is this? (e.g., technical spec, decision doc, proposal)
-2. Who's the primary audience?
-3. What's the desired impact when someone reads this?
-4. Is there a template or specific format to follow?
-5. Any other constraints or context to know?
+1. 这是什么类型的文档？（例如：技术规格、决策文档、提案）
+2. 主要受众是谁？
+3. 期望读者阅读后产生什么影响？
+4. 是否有需要遵循的模板或特定格式？
+5. 还有其他需要了解的约束条件或背景信息吗？
 
-Inform them they can answer in shorthand or dump information however works best for them.
+告知他们可以用简略方式回答，或以任何方便的方式提供信息。
 
-**If user provides a template or mentions a doc type:**
-- Ask if they have a template document to share
-- If they provide a link to a shared document, use the appropriate integration to fetch it
-- If they provide a file, read it
+**如果用户提供了模板或提到了文档类型：**
+- 询问他们是否有模板文档可以分享
+- 如果他们提供了共享文档的链接，使用相应的集成工具获取
+- 如果他们提供了文件，阅读它
 
-**If user mentions editing an existing shared document:**
-- Use the appropriate integration to read the current state
-- Check for images without alt-text
-- If images exist without alt-text, explain that when others use Claude to understand the doc, Claude won't be able to see them. Ask if they want alt-text generated. If so, request they paste each image into chat for descriptive alt-text generation.
+**如果用户提到编辑现有共享文档：**
+- 使用相应的集成工具读取当前状态
+- 检查是否有缺少替代文本的图片
+- 如果存在没有替代文本的图片，解释当他人使用 Claude 理解文档时，Claude 将无法看到这些图片。询问他们是否需要生成替代文本。如果需要，请他们将每张图片粘贴到对话中以生成描述性替代文本。
 
-### Info Dumping
+### 信息倾倒
 
-Once initial questions are answered, encourage the user to dump all the context they have. Request information such as:
-- Background on the project/problem
-- Related team discussions or shared documents
-- Why alternative solutions aren't being used
-- Organizational context (team dynamics, past incidents, politics)
-- Timeline pressures or constraints
-- Technical architecture or dependencies
-- Stakeholder concerns
+初始问题回答完毕后，鼓励用户倾倒他们拥有的所有上下文。请求以下信息：
+- 项目/问题的背景
+- 相关的团队讨论或共享文档
+- 为什么不采用替代方案
+- 组织背景（团队动态、历史事件、内部关系）
+- 时间压力或约束
+- 技术架构或依赖
+- 利益相关者的关注点
 
-Advise them not to worry about organizing it - just get it all out. Offer multiple ways to provide context:
-- Info dump stream-of-consciousness
-- Point to team channels or threads to read
-- Link to shared documents
+建议他们不必担心组织——先把所有内容都倒出来。提供多种提供上下文的方式：
+- 意识流式的信息倾倒
+- 指向需要阅读的团队频道或讨论串
+- 链接到共享文档
 
-**If integrations are available** (e.g., Slack, Teams, Google Drive, SharePoint, or other MCP servers), mention that these can be used to pull in context directly.
+**如果有可用的集成工具**（例如 Slack、Teams、Google Drive、SharePoint 或其他 MCP 服务器），提及可以直接从中拉取上下文。
 
-**If no integrations are detected and in Claude.ai or Claude app:** Suggest they can enable connectors in their Claude settings to allow pulling context from messaging apps and document storage directly.
+**如果未检测到集成工具且在 claude.ai 或 Claude 应用中：** 建议他们可以在 Claude 设置中启用连接器，以便直接从消息应用和文档存储中拉取上下文。
 
-Inform them clarifying questions will be asked once they've done their initial dump.
+告知他们在初始信息倾倒完成后将提出澄清问题。
 
-**During context gathering:**
+**在上下文收集过程中：**
 
-- If user mentions team channels or shared documents:
-  - If integrations available: Inform them the content will be read now, then use the appropriate integration
-  - If integrations not available: Explain lack of access. Suggest they enable connectors in Claude settings, or paste the relevant content directly.
+- 如果用户提到团队频道或共享文档：
+  - 如果有集成工具可用：告知将立即阅读内容，然后使用相应的集成工具
+  - 如果没有集成工具：解释无法访问。建议他们在 Claude 设置中启用连接器，或直接粘贴相关内容。
 
-- If user mentions entities/projects that are unknown:
-  - Ask if connected tools should be searched to learn more
-  - Wait for user confirmation before searching
+- 如果用户提到未知的实体/项目：
+  - 询问是否应该使用已连接的工具搜索以了解更多
+  - 等待用户确认后再搜索
 
-- As user provides context, track what's being learned and what's still unclear
+- 随着用户提供上下文，跟踪已了解的内容和仍不清楚的部分
 
-**Asking clarifying questions:**
+**提出澄清问题：**
 
-When user signals they've done their initial dump (or after substantial context provided), ask clarifying questions to ensure understanding:
+当用户表示已完成初始信息倾倒（或在提供了大量上下文之后），提出澄清问题以确保理解：
 
-Generate 5-10 numbered questions based on gaps in the context.
+根据上下文中的空白生成5-10个编号问题。
 
-Inform them they can use shorthand to answer (e.g., "1: yes, 2: see #channel, 3: no because backwards compat"), link to more docs, point to channels to read, or just keep info-dumping. Whatever's most efficient for them.
+告知他们可以用简略方式回答（例如"1：是的，2：参见 #频道，3：不行，因为向后兼容"）、链接更多文档、指向需要阅读的频道，或继续倾倒信息。以最高效的方式进行。
 
-**Exit condition:**
-Sufficient context has been gathered when questions show understanding - when edge cases and trade-offs can be asked about without needing basics explained.
+**退出条件：**
+当问题显示出充分理解时——当能够询问边界情况和权衡取舍而无需解释基础知识时——表明已收集到足够的上下文。
 
-**Transition:**
-Ask if there's any more context they want to provide at this stage, or if it's time to move on to drafting the document.
+**过渡：**
+询问他们是否还有更多上下文要在此阶段提供，还是可以开始起草文档了。
 
-If user wants to add more, let them. When ready, proceed to Stage 2.
+如果用户想补充更多，让他们继续。准备好后，进入阶段2。
 
-## Stage 2: Refinement & Structure
+## 阶段2：精炼与结构化
 
-**Goal:** Build the document section by section through brainstorming, curation, and iterative refinement.
+**目标：** 通过头脑风暴、筛选和迭代精炼，逐章节构建文档。
 
-**Instructions to user:**
-Explain that the document will be built section by section. For each section:
-1. Clarifying questions will be asked about what to include
-2. 5-20 options will be brainstormed
-3. User will indicate what to keep/remove/combine
-4. The section will be drafted
-5. It will be refined through surgical edits
+**对用户的说明：**
+解释将逐章节构建文档。对于每个章节：
+1. 提出关于应包含内容的澄清问题
+2. 头脑风暴5-20个选项
+3. 用户指明要保留/删除/合并的内容
+4. 起草该章节
+5. 通过精确编辑进行精炼
 
-Start with whichever section has the most unknowns (usually the core decision/proposal), then work through the rest.
+从最多未知的章节开始（通常是核心决策/提案），然后处理其余部分。
 
-**Section ordering:**
+**章节排序：**
 
-If the document structure is clear:
-Ask which section they'd like to start with.
+如果文档结构清晰：
+询问他们想从哪个章节开始。
 
-Suggest starting with whichever section has the most unknowns. For decision docs, that's usually the core proposal. For specs, it's typically the technical approach. Summary sections are best left for last.
+建议从最多未知的章节开始。对于决策文档，通常是核心提案。对于规格文档，通常是技术方案。摘要章节最好留到最后。
 
-If user doesn't know what sections they need:
-Based on the type of document and template, suggest 3-5 sections appropriate for the doc type.
+如果用户不知道需要哪些章节：
+根据文档类型和模板，建议3-5个适合的章节。
 
-Ask if this structure works, or if they want to adjust it.
+询问这个结构是否合适，或者他们是否想调整。
 
-**Once structure is agreed:**
+**结构确定后：**
 
-Create the initial document structure with placeholder text for all sections.
+创建包含所有章节占位文本的初始文档结构。
 
-**If access to artifacts is available:**
-Use `create_file` to create an artifact. This gives both Claude and the user a scaffold to work from.
+**如果可以访问制品：**
+使用 `create_file` 创建制品。这为 Claude 和用户提供了一个可协作的骨架。
 
-Inform them that the initial structure with placeholders for all sections will be created.
+告知他们将创建包含所有章节占位符的初始结构。
 
-Create artifact with all section headers and brief placeholder text like "[To be written]" or "[Content here]".
+创建包含所有章节标题和简要占位文本（如"[待撰写]"或"[内容待填]"）的制品。
 
-Provide the scaffold link and indicate it's time to fill in each section.
+提供骨架链接并表示可以开始填充每个章节了。
 
-**If no access to artifacts:**
-Create a markdown file in the working directory. Name it appropriately (e.g., `decision-doc.md`, `technical-spec.md`).
+**如果无法访问制品：**
+在工作目录中创建 markdown 文件。适当命名（例如 `decision-doc.md`、`technical-spec.md`）。
 
-Inform them that the initial structure with placeholders for all sections will be created.
+告知他们将创建包含所有章节占位符的初始结构。
 
-Create file with all section headers and placeholder text.
+创建包含所有章节标题和占位文本的文件。
 
-Confirm the filename has been created and indicate it's time to fill in each section.
+确认文件已创建并表示可以开始填充每个章节了。
 
-**For each section:**
+**对于每个章节：**
 
-### Step 1: Clarifying Questions
+### 步骤1：澄清问题
 
-Announce work will begin on the [SECTION NAME] section. Ask 5-10 clarifying questions about what should be included:
+宣布将开始处理[章节名称]章节。针对应包含的内容提出5-10个澄清问题：
 
-Generate 5-10 specific questions based on context and section purpose.
+根据上下文和章节目的生成5-10个具体问题。
 
-Inform them they can answer in shorthand or just indicate what's important to cover.
+告知他们可以用简略方式回答或简要说明需要涵盖的重点。
 
-### Step 2: Brainstorming
+### 步骤2：头脑风暴
 
-For the [SECTION NAME] section, brainstorm [5-20] things that might be included, depending on the section's complexity. Look for:
-- Context shared that might have been forgotten
-- Angles or considerations not yet mentioned
+针对[章节名称]章节，根据章节复杂度头脑风暴[5-20]个可能包含的内容。寻找：
+- 已分享但可能被遗忘的上下文
+- 尚未提及的角度或考虑因素
 
-Generate 5-20 numbered options based on section complexity. At the end, offer to brainstorm more if they want additional options.
+根据章节复杂度生成5-20个编号选项。最后，提供是否需要更多选项的选择。
 
-### Step 3: Curation
+### 步骤3：筛选
 
-Ask which points should be kept, removed, or combined. Request brief justifications to help learn priorities for the next sections.
+询问哪些要点应保留、删除或合并。请求简要说明理由以帮助了解优先级，以便后续章节参考。
 
-Provide examples:
-- "Keep 1,4,7,9"
-- "Remove 3 (duplicates 1)"
-- "Remove 6 (audience already knows this)"
-- "Combine 11 and 12"
+提供示例：
+- "保留 1,4,7,9"
+- "删除 3（与 1 重复）"
+- "删除 6（受众已了解此内容）"
+- "合并 11 和 12"
 
-**If user gives freeform feedback** (e.g., "looks good" or "I like most of it but...") instead of numbered selections, extract their preferences and proceed. Parse what they want kept/removed/changed and apply it.
+**如果用户给出自由形式的反馈**（例如"看起来不错"或"我喜欢大部分，但..."）而非编号选择，提取其偏好并继续。解析他们想保留/删除/更改的内容并执行。
 
-### Step 4: Gap Check
+### 步骤4：缺口检查
 
-Based on what they've selected, ask if there's anything important missing for the [SECTION NAME] section.
+根据他们选择的内容，询问[章节名称]章节是否还缺少什么重要内容。
 
-### Step 5: Drafting
+### 步骤5：起草
 
-Use `str_replace` to replace the placeholder text for this section with the actual drafted content.
+使用 `str_replace` 将该章节的占位文本替换为实际起草的内容。
 
-Announce the [SECTION NAME] section will be drafted now based on what they've selected.
+宣布将根据他们的选择起草[章节名称]章节。
 
-**If using artifacts:**
-After drafting, provide a link to the artifact.
+**如果使用制品：**
+起草完成后，提供制品链接。
 
-Ask them to read through it and indicate what to change. Note that being specific helps learning for the next sections.
+请他们通读并指出需要更改的内容。注明具体的反馈有助于在后续章节中学习他们的偏好。
 
-**If using a file (no artifacts):**
-After drafting, confirm completion.
+**如果使用文件（无制品）：**
+起草完成后，确认完成。
 
-Inform them the [SECTION NAME] section has been drafted in [filename]. Ask them to read through it and indicate what to change. Note that being specific helps learning for the next sections.
+告知他们[章节名称]章节已在[文件名]中起草完毕。请他们通读并指出需要更改的内容。注明具体的反馈有助于在后续章节中学习他们的偏好。
 
-**Key instruction for user (include when drafting the first section):**
-Provide a note: Instead of editing the doc directly, ask them to indicate what to change. This helps learning of their style for future sections. For example: "Remove the X bullet - already covered by Y" or "Make the third paragraph more concise".
+**对用户的关键说明（在起草第一个章节时包含）：**
+提供说明：不要直接编辑文档，而是告知需要更改的内容。这有助于学习他们的写作风格以便后续章节参考。例如："删除 X 要点——已被 Y 覆盖"或"让第三段更简洁"。
 
-### Step 6: Iterative Refinement
+### 步骤6：迭代精炼
 
-As user provides feedback:
-- Use `str_replace` to make edits (never reprint the whole doc)
-- **If using artifacts:** Provide link to artifact after each edit
-- **If using files:** Just confirm edits are complete
-- If user edits doc directly and asks to read it: mentally note the changes they made and keep them in mind for future sections (this shows their preferences)
+当用户提供反馈时：
+- 使用 `str_replace` 进行编辑（绝不重新打印整个文档）
+- **如果使用制品：** 每次编辑后提供制品链接
+- **如果使用文件：** 简单确认编辑已完成
+- 如果用户直接编辑文档并要求阅读：在心中记录他们所做的更改，并在后续章节中参考（这显示了他们的偏好）
 
-**Continue iterating** until user is satisfied with the section.
+**持续迭代**直到用户对该章节满意。
 
-### Quality Checking
+### 质量检查
 
-After 3 consecutive iterations with no substantial changes, ask if anything can be removed without losing important information.
+在连续3次迭代无实质性更改后，询问是否有内容可以删除而不丢失重要信息。
 
-When section is done, confirm [SECTION NAME] is complete. Ask if ready to move to the next section.
+当章节完成时，确认[章节名称]已完成。询问是否准备进入下一个章节。
 
-**Repeat for all sections.**
+**对所有章节重复以上步骤。**
 
-### Near Completion
+### 接近完成
 
-As approaching completion (80%+ of sections done), announce intention to re-read the entire document and check for:
-- Flow and consistency across sections
-- Redundancy or contradictions
-- Anything that feels like "slop" or generic filler
-- Whether every sentence carries weight
+当接近完成（80%以上的章节已完成）时，宣布打算重新阅读整个文档并检查：
+- 各章节间的流畅性和一致性
+- 冗余或矛盾之处
+- 任何感觉像"废话"或通用填充的内容
+- 每句话是否都有分量
 
-Read entire document and provide feedback.
+阅读整个文档并提供反馈。
 
-**When all sections are drafted and refined:**
-Announce all sections are drafted. Indicate intention to review the complete document one more time.
+**当所有章节都已起草和精炼：**
+宣布所有章节已起草完毕。表示将再次审阅完整文档。
 
-Review for overall coherence, flow, completeness.
+审阅整体连贯性、流畅性和完整性。
 
-Provide any final suggestions.
+提供最终建议。
 
-Ask if ready to move to Reader Testing, or if they want to refine anything else.
+询问是否准备进入读者测试，还是想继续精炼某些内容。
 
-## Stage 3: Reader Testing
+## 阶段3：读者测试
 
-**Goal:** Test the document with a fresh Claude (no context bleed) to verify it works for readers.
+**目标：** 用一个全新的 Claude（无上下文污染）测试文档，验证其对读者是否有效。
 
-**Instructions to user:**
-Explain that testing will now occur to see if the document actually works for readers. This catches blind spots - things that make sense to the authors but might confuse others.
+**对用户的说明：**
+解释现在将测试文档是否真正对读者有效。这能发现盲点——那些对作者来说显而易见但可能让他人困惑的内容。
 
-### Testing Approach
+### 测试方法
 
-**If access to sub-agents is available (e.g., in Claude Code):**
+**如果可以使用子代理（例如在 Claude Code 中）：**
 
-Perform the testing directly without user involvement.
+无需用户参与，直接执行测试。
 
-### Step 1: Predict Reader Questions
+### 步骤1：预测读者问题
 
-Announce intention to predict what questions readers might ask when trying to discover this document.
+宣布将预测读者在尝试查找此文档时可能提出的问题。
 
-Generate 5-10 questions that readers would realistically ask.
+生成5-10个读者实际可能提出的问题。
 
-### Step 2: Test with Sub-Agent
+### 步骤2：使用子代理测试
 
-Announce that these questions will be tested with a fresh Claude instance (no context from this conversation).
+宣布将用一个全新的 Claude 实例（不含此对话的任何上下文）测试这些问题。
 
-For each question, invoke a sub-agent with just the document content and the question.
+对于每个问题，仅向子代理提供文档内容和问题。
 
-Summarize what Reader Claude got right/wrong for each question.
+总结"读者 Claude"对每个问题回答正确/错误的情况。
 
-### Step 3: Run Additional Checks
+### 步骤3：运行额外检查
 
-Announce additional checks will be performed.
+宣布将执行额外检查。
 
-Invoke sub-agent to check for ambiguity, false assumptions, contradictions.
+调用子代理检查歧义、错误假设和矛盾之处。
 
-Summarize any issues found.
+总结发现的任何问题。
 
-### Step 4: Report and Fix
+### 步骤4：报告并修复
 
-If issues found:
-Report that Reader Claude struggled with specific issues.
+如果发现问题：
+报告"读者 Claude"在特定问题上遇到了困难。
 
-List the specific issues.
+列出具体问题。
 
-Indicate intention to fix these gaps.
+表示将修复这些缺口。
 
-Loop back to refinement for problematic sections.
-
----
-
-**If no access to sub-agents (e.g., claude.ai web interface):**
-
-The user will need to do the testing manually.
-
-### Step 1: Predict Reader Questions
-
-Ask what questions people might ask when trying to discover this document. What would they type into Claude.ai?
-
-Generate 5-10 questions that readers would realistically ask.
-
-### Step 2: Setup Testing
-
-Provide testing instructions:
-1. Open a fresh Claude conversation: https://claude.ai
-2. Paste or share the document content (if using a shared doc platform with connectors enabled, provide the link)
-3. Ask Reader Claude the generated questions
-
-For each question, instruct Reader Claude to provide:
-- The answer
-- Whether anything was ambiguous or unclear
-- What knowledge/context the doc assumes is already known
-
-Check if Reader Claude gives correct answers or misinterprets anything.
-
-### Step 3: Additional Checks
-
-Also ask Reader Claude:
-- "What in this doc might be ambiguous or unclear to readers?"
-- "What knowledge or context does this doc assume readers already have?"
-- "Are there any internal contradictions or inconsistencies?"
-
-### Step 4: Iterate Based on Results
-
-Ask what Reader Claude got wrong or struggled with. Indicate intention to fix those gaps.
-
-Loop back to refinement for any problematic sections.
+返回精炼阶段处理有问题的章节。
 
 ---
 
-### Exit Condition (Both Approaches)
+**如果无法使用子代理（例如 claude.ai 网页界面）：**
 
-When Reader Claude consistently answers questions correctly and doesn't surface new gaps or ambiguities, the doc is ready.
+用户需要手动执行测试。
 
-## Final Review
+### 步骤1：预测读者问题
 
-When Reader Testing passes:
-Announce the doc has passed Reader Claude testing. Before completion:
+询问人们在尝试查找此文档时可能会问什么问题。他们会在 claude.ai 中输入什么？
 
-1. Recommend they do a final read-through themselves - they own this document and are responsible for its quality
-2. Suggest double-checking any facts, links, or technical details
-3. Ask them to verify it achieves the impact they wanted
+生成5-10个读者实际可能提出的问题。
 
-Ask if they want one more review, or if the work is done.
+### 步骤2：设置测试
 
-**If user wants final review, provide it. Otherwise:**
-Announce document completion. Provide a few final tips:
-- Consider linking this conversation in an appendix so readers can see how the doc was developed
-- Use appendices to provide depth without bloating the main doc
-- Update the doc as feedback is received from real readers
+提供测试说明：
+1. 打开一个全新的 Claude 对话：https://claude.ai
+2. 粘贴或分享文档内容（如果使用启用了连接器的共享文档平台，提供链接）
+3. 向"读者 Claude"提出生成的问题
 
-## Tips for Effective Guidance
+对于每个问题，指示"读者 Claude"提供：
+- 答案
+- 是否有模糊或不清楚的内容
+- 文档假设读者已具备什么知识/上下文
 
-**Tone:**
-- Be direct and procedural
-- Explain rationale briefly when it affects user behavior
-- Don't try to "sell" the approach - just execute it
+检查"读者 Claude"是否给出正确答案或是否有误解。
 
-**Handling Deviations:**
-- If user wants to skip a stage: Ask if they want to skip this and write freeform
-- If user seems frustrated: Acknowledge this is taking longer than expected. Suggest ways to move faster
-- Always give user agency to adjust the process
+### 步骤3：额外检查
 
-**Context Management:**
-- Throughout, if context is missing on something mentioned, proactively ask
-- Don't let gaps accumulate - address them as they come up
+同时请"读者 Claude"回答：
+- "这份文档中有什么内容可能对读者来说模糊或不清楚？"
+- "这份文档假设读者已具备什么知识或上下文？"
+- "是否存在内部矛盾或不一致之处？"
 
-**Artifact Management:**
-- Use `create_file` for drafting full sections
-- Use `str_replace` for all edits
-- Provide artifact link after every change
-- Never use artifacts for brainstorming lists - that's just conversation
+### 步骤4：根据结果迭代
 
-**Quality over Speed:**
-- Don't rush through stages
-- Each iteration should make meaningful improvements
-- The goal is a document that actually works for readers
+询问"读者 Claude"答错了什么或在哪些方面遇到困难。表示将修复这些缺口。
+
+返回精炼阶段处理有问题的章节。
+
+---
+
+### 退出条件（两种方法均适用）
+
+当"读者 Claude"能持续正确回答问题且不再发现新的缺口或歧义时，文档就准备好了。
+
+## 最终审阅
+
+当读者测试通过时：
+宣布文档已通过"读者 Claude"测试。在结束之前：
+
+1. 建议他们自己做最后一次通读——他们拥有这份文档并对其质量负责
+2. 建议仔细检查所有事实、链接或技术细节
+3. 请他们验证文档是否达到了预期的影响力
+
+询问是否需要再审阅一次，还是工作已完成。
+
+**如果用户需要最终审阅，提供审阅。否则：**
+宣布文档完成。提供一些最终建议：
+- 考虑在附录中链接此对话，以便读者了解文档的撰写过程
+- 使用附录提供深度内容，避免使主文档臃肿
+- 在收到真实读者反馈后更新文档
+
+## 有效引导的技巧
+
+**语调：**
+- 直接且有条理
+- 当理由影响用户行为时简要解释
+- 不要试图"推销"这种方法——直接执行
+
+**处理偏离：**
+- 如果用户想跳过某个阶段：询问是否要跳过此阶段直接自由写作
+- 如果用户显得沮丧：承认这比预期花了更长时间。建议加速的方法
+- 始终给予用户调整流程的主动权
+
+**上下文管理：**
+- 在整个过程中，如果提到的内容缺少上下文，主动询问
+- 不要让缺口积累——在出现时立即解决
+
+**制品管理：**
+- 使用 `create_file` 起草完整章节
+- 使用 `str_replace` 进行所有编辑
+- 每次更改后提供制品链接
+- 绝不使用制品来展示头脑风暴列表——那只是对话内容
+
+**质量优于速度：**
+- 不要匆忙通过各阶段
+- 每次迭代应带来有意义的改进
+- 目标是创建一份真正对读者有效的文档

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -1,51 +1,51 @@
 ---
 name: docx
-description: "Use this skill whenever the user wants to create, read, edit, or manipulate Word documents (.docx files). Triggers include: any mention of \"Word doc\", \"word document\", \".docx\", or requests to produce professional documents with formatting like tables of contents, headings, page numbers, or letterheads. Also use when extracting or reorganizing content from .docx files, inserting or replacing images in documents, performing find-and-replace in Word files, working with tracked changes or comments, or converting content into a polished Word document. If the user asks for a \"report\", \"memo\", \"letter\", \"template\", or similar deliverable as a Word or .docx file, use this skill. Do NOT use for PDFs, spreadsheets, Google Docs, or general coding tasks unrelated to document generation."
+description: "当用户需要创建、读取、编辑或处理 Word 文档（.docx 文件）时，使用此技能。触发条件包括：提及"Word 文档"、".docx"，或要求生成带有目录、标题、页码、信头等格式的专业文档。也适用于从 .docx 文件中提取或重组内容、在文档中插入或替换图片、在 Word 文件中执行查找替换、处理修订和批注，或将内容转换为精美的 Word 文档。如果用户要求以 Word 或 .docx 文件格式输出"报告"、"备忘录"、"信函"、"模板"或类似文档，请使用此技能。不适用于 PDF、电子表格、Google Docs 或与文档生成无关的编程任务。"
 license: Proprietary. LICENSE.txt has complete terms
 ---
 
-# DOCX creation, editing, and analysis
+# DOCX 创建、编辑与分析
 
-## Overview
+## 概述
 
-A .docx file is a ZIP archive containing XML files.
+.docx 文件是一个包含 XML 文件的 ZIP 压缩包。
 
-## Quick Reference
+## 快速参考
 
-| Task | Approach |
-|------|----------|
-| Read/analyze content | `pandoc` or unpack for raw XML |
-| Create new document | Use `docx-js` - see Creating New Documents below |
-| Edit existing document | Unpack → edit XML → repack - see Editing Existing Documents below |
+| 任务 | 方法 |
+|------|------|
+| 读取/分析内容 | `pandoc` 或解压查看原始 XML |
+| 创建新文档 | 使用 `docx-js` — 参见下方"创建新文档" |
+| 编辑现有文档 | 解压 → 编辑 XML → 重新打包 — 参见下方"编辑现有文档" |
 
-### Converting .doc to .docx
+### 将 .doc 转换为 .docx
 
-Legacy `.doc` files must be converted before editing:
+旧版 `.doc` 文件必须先转换才能编辑：
 
 ```bash
 python scripts/office/soffice.py --headless --convert-to docx document.doc
 ```
 
-### Reading Content
+### 读取内容
 
 ```bash
-# Text extraction with tracked changes
+# 提取带修订的文本
 pandoc --track-changes=all document.docx -o output.md
 
-# Raw XML access
+# 访问原始 XML
 python scripts/office/unpack.py document.docx unpacked/
 ```
 
-### Converting to Images
+### 转换为图片
 
 ```bash
 python scripts/office/soffice.py --headless --convert-to pdf document.docx
 pdftoppm -jpeg -r 150 document.pdf page
 ```
 
-### Accepting Tracked Changes
+### 接受修订
 
-To produce a clean document with all tracked changes accepted (requires LibreOffice):
+生成一份已接受所有修订的干净文档（需要 LibreOffice）：
 
 ```bash
 python scripts/accept_changes.py input.docx output.docx
@@ -53,76 +53,76 @@ python scripts/accept_changes.py input.docx output.docx
 
 ---
 
-## Creating New Documents
+## 创建新文档
 
-Generate .docx files with JavaScript, then validate. Install: `npm install -g docx`
+使用 JavaScript 生成 .docx 文件，然后验证。安装：`npm install -g docx`
 
-### Setup
+### 设置
 ```javascript
 const { Document, Packer, Paragraph, TextRun, Table, TableRow, TableCell, ImageRun,
         Header, Footer, AlignmentType, PageOrientation, LevelFormat, ExternalHyperlink,
         TableOfContents, HeadingLevel, BorderStyle, WidthType, ShadingType,
         VerticalAlign, PageNumber, PageBreak } = require('docx');
 
-const doc = new Document({ sections: [{ children: [/* content */] }] });
+const doc = new Document({ sections: [{ children: [/* 内容 */] }] });
 Packer.toBuffer(doc).then(buffer => fs.writeFileSync("doc.docx", buffer));
 ```
 
-### Validation
-After creating the file, validate it. If validation fails, unpack, fix the XML, and repack.
+### 验证
+创建文件后进行验证。如果验证失败，解压、修复 XML 后重新打包。
 ```bash
 python scripts/office/validate.py doc.docx
 ```
 
-### Page Size
+### 页面尺寸
 
 ```javascript
-// CRITICAL: docx-js defaults to A4, not US Letter
-// Always set page size explicitly for consistent results
+// 关键：docx-js 默认为 A4 纸张，而非美式 Letter
+// 务必显式设置页面尺寸以确保一致性
 sections: [{
   properties: {
     page: {
       size: {
-        width: 12240,   // 8.5 inches in DXA
-        height: 15840   // 11 inches in DXA
+        width: 12240,   // 8.5 英寸（DXA 单位）
+        height: 15840   // 11 英寸（DXA 单位）
       },
-      margin: { top: 1440, right: 1440, bottom: 1440, left: 1440 } // 1 inch margins
+      margin: { top: 1440, right: 1440, bottom: 1440, left: 1440 } // 1 英寸页边距
     }
   },
-  children: [/* content */]
+  children: [/* 内容 */]
 }]
 ```
 
-**Common page sizes (DXA units, 1440 DXA = 1 inch):**
+**常用页面尺寸（DXA 单位，1440 DXA = 1 英寸）：**
 
-| Paper | Width | Height | Content Width (1" margins) |
-|-------|-------|--------|---------------------------|
-| US Letter | 12,240 | 15,840 | 9,360 |
-| A4 (default) | 11,906 | 16,838 | 9,026 |
+| 纸张 | 宽度 | 高度 | 内容宽度（1 英寸页边距） |
+|------|------|------|--------------------------|
+| 美式 Letter | 12,240 | 15,840 | 9,360 |
+| A4（默认） | 11,906 | 16,838 | 9,026 |
 
-**Landscape orientation:** docx-js swaps width/height internally, so pass portrait dimensions and let it handle the swap:
+**横向方向：** docx-js 会在内部交换宽高值，因此传入纵向尺寸，让它自行处理交换：
 ```javascript
 size: {
-  width: 12240,   // Pass SHORT edge as width
-  height: 15840,  // Pass LONG edge as height
-  orientation: PageOrientation.LANDSCAPE  // docx-js swaps them in the XML
+  width: 12240,   // 传入短边作为宽度
+  height: 15840,  // 传入长边作为高度
+  orientation: PageOrientation.LANDSCAPE  // docx-js 会在 XML 中交换它们
 },
-// Content width = 15840 - left margin - right margin (uses the long edge)
+// 内容宽度 = 15840 - 左页边距 - 右页边距（使用长边）
 ```
 
-### Styles (Override Built-in Headings)
+### 样式（覆盖内置标题）
 
-Use Arial as the default font (universally supported). Keep titles black for readability.
+使用 Arial 作为默认字体（通用支持）。保持标题为黑色以确保可读性。
 
 ```javascript
 const doc = new Document({
   styles: {
-    default: { document: { run: { font: "Arial", size: 24 } } }, // 12pt default
+    default: { document: { run: { font: "Arial", size: 24 } } }, // 默认 12pt
     paragraphStyles: [
-      // IMPORTANT: Use exact IDs to override built-in styles
+      // 重要：使用精确的 ID 来覆盖内置样式
       { id: "Heading1", name: "Heading 1", basedOn: "Normal", next: "Normal", quickFormat: true,
         run: { size: 32, bold: true, font: "Arial" },
-        paragraph: { spacing: { before: 240, after: 240 }, outlineLevel: 0 } }, // outlineLevel required for TOC
+        paragraph: { spacing: { before: 240, after: 240 }, outlineLevel: 0 } }, // 目录需要 outlineLevel
       { id: "Heading2", name: "Heading 2", basedOn: "Normal", next: "Normal", quickFormat: true,
         run: { size: 28, bold: true, font: "Arial" },
         paragraph: { spacing: { before: 180, after: 180 }, outlineLevel: 1 } },
@@ -136,14 +136,14 @@ const doc = new Document({
 });
 ```
 
-### Lists (NEVER use unicode bullets)
+### 列表（切勿使用 Unicode 项目符号）
 
 ```javascript
-// ❌ WRONG - never manually insert bullet characters
-new Paragraph({ children: [new TextRun("• Item")] })  // BAD
-new Paragraph({ children: [new TextRun("\u2022 Item")] })  // BAD
+// ❌ 错误 - 永远不要手动插入项目符号字符
+new Paragraph({ children: [new TextRun("• Item")] })  // 错误
+new Paragraph({ children: [new TextRun("\u2022 Item")] })  // 错误
 
-// ✅ CORRECT - use numbering config with LevelFormat.BULLET
+// ✅ 正确 - 使用 numbering 配置和 LevelFormat.BULLET
 const doc = new Document({
   numbering: {
     config: [
@@ -165,32 +165,32 @@ const doc = new Document({
   }]
 });
 
-// ⚠️ Each reference creates INDEPENDENT numbering
-// Same reference = continues (1,2,3 then 4,5,6)
-// Different reference = restarts (1,2,3 then 1,2,3)
+// ⚠️ 每个 reference 创建独立的编号序列
+// 相同 reference = 继续编号（1,2,3 然后 4,5,6）
+// 不同 reference = 重新编号（1,2,3 然后 1,2,3）
 ```
 
-### Tables
+### 表格
 
-**CRITICAL: Tables need dual widths** - set both `columnWidths` on the table AND `width` on each cell. Without both, tables render incorrectly on some platforms.
+**关键：表格需要双重宽度设置** — 同时在表格上设置 `columnWidths` 和在每个单元格上设置 `width`。缺少任一设置，表格在某些平台上会渲染异常。
 
 ```javascript
-// CRITICAL: Always set table width for consistent rendering
-// CRITICAL: Use ShadingType.CLEAR (not SOLID) to prevent black backgrounds
+// 关键：始终设置表格宽度以确保一致渲染
+// 关键：使用 ShadingType.CLEAR（而非 SOLID）以避免黑色背景
 const border = { style: BorderStyle.SINGLE, size: 1, color: "CCCCCC" };
 const borders = { top: border, bottom: border, left: border, right: border };
 
 new Table({
-  width: { size: 9360, type: WidthType.DXA }, // Always use DXA (percentages break in Google Docs)
-  columnWidths: [4680, 4680], // Must sum to table width (DXA: 1440 = 1 inch)
+  width: { size: 9360, type: WidthType.DXA }, // 始终使用 DXA（百分比在 Google Docs 中会出问题）
+  columnWidths: [4680, 4680], // 总和必须等于表格宽度（DXA：1440 = 1 英寸）
   rows: [
     new TableRow({
       children: [
         new TableCell({
           borders,
-          width: { size: 4680, type: WidthType.DXA }, // Also set on each cell
-          shading: { fill: "D5E8F0", type: ShadingType.CLEAR }, // CLEAR not SOLID
-          margins: { top: 80, bottom: 80, left: 120, right: 120 }, // Cell padding (internal, not added to width)
+          width: { size: 4680, type: WidthType.DXA }, // 每个单元格也要设置
+          shading: { fill: "D5E8F0", type: ShadingType.CLEAR }, // 用 CLEAR 而非 SOLID
+          margins: { top: 80, bottom: 80, left: 120, right: 120 }, // 单元格内边距（内部的，不会增加宽度）
           children: [new Paragraph({ children: [new TextRun("Cell")] })]
         })
       ]
@@ -199,61 +199,61 @@ new Table({
 })
 ```
 
-**Table width calculation:**
+**表格宽度计算：**
 
-Always use `WidthType.DXA` — `WidthType.PERCENTAGE` breaks in Google Docs.
+始终使用 `WidthType.DXA` — `WidthType.PERCENTAGE` 在 Google Docs 中会出问题。
 
 ```javascript
-// Table width = sum of columnWidths = content width
-// US Letter with 1" margins: 12240 - 2880 = 9360 DXA
+// 表格宽度 = columnWidths 之和 = 内容宽度
+// 美式 Letter 1 英寸页边距：12240 - 2880 = 9360 DXA
 width: { size: 9360, type: WidthType.DXA },
-columnWidths: [7000, 2360]  // Must sum to table width
+columnWidths: [7000, 2360]  // 总和必须等于表格宽度
 ```
 
-**Width rules:**
-- **Always use `WidthType.DXA`** — never `WidthType.PERCENTAGE` (incompatible with Google Docs)
-- Table width must equal the sum of `columnWidths`
-- Cell `width` must match corresponding `columnWidth`
-- Cell `margins` are internal padding - they reduce content area, not add to cell width
-- For full-width tables: use content width (page width minus left and right margins)
+**宽度规则：**
+- **始终使用 `WidthType.DXA`** — 绝不使用 `WidthType.PERCENTAGE`（与 Google Docs 不兼容）
+- 表格宽度必须等于 `columnWidths` 之和
+- 单元格 `width` 必须与对应的 `columnWidth` 一致
+- 单元格 `margins` 是内边距 — 减少内容区域，不会增加单元格宽度
+- 全宽表格：使用内容宽度（页面宽度减去左右页边距）
 
-### Images
+### 图片
 
 ```javascript
-// CRITICAL: type parameter is REQUIRED
+// 关键：type 参数是必需的
 new Paragraph({
   children: [new ImageRun({
-    type: "png", // Required: png, jpg, jpeg, gif, bmp, svg
+    type: "png", // 必填：png, jpg, jpeg, gif, bmp, svg
     data: fs.readFileSync("image.png"),
     transformation: { width: 200, height: 150 },
-    altText: { title: "Title", description: "Desc", name: "Name" } // All three required
+    altText: { title: "Title", description: "Desc", name: "Name" } // 三个都是必填的
   })]
 })
 ```
 
-### Page Breaks
+### 分页符
 
 ```javascript
-// CRITICAL: PageBreak must be inside a Paragraph
+// 关键：PageBreak 必须放在 Paragraph 内部
 new Paragraph({ children: [new PageBreak()] })
 
-// Or use pageBreakBefore
+// 或使用 pageBreakBefore
 new Paragraph({ pageBreakBefore: true, children: [new TextRun("New page")] })
 ```
 
-### Table of Contents
+### 目录
 
 ```javascript
-// CRITICAL: Headings must use HeadingLevel ONLY - no custom styles
+// 关键：标题必须只使用 HeadingLevel — 不能用自定义样式
 new TableOfContents("Table of Contents", { hyperlink: true, headingStyleRange: "1-3" })
 ```
 
-### Headers/Footers
+### 页眉/页脚
 
 ```javascript
 sections: [{
   properties: {
-    page: { margin: { top: 1440, right: 1440, bottom: 1440, left: 1440 } } // 1440 = 1 inch
+    page: { margin: { top: 1440, right: 1440, bottom: 1440, left: 1440 } } // 1440 = 1 英寸
   },
   headers: {
     default: new Header({ children: [new Paragraph({ children: [new TextRun("Header")] })] })
@@ -263,116 +263,116 @@ sections: [{
       children: [new TextRun("Page "), new TextRun({ children: [PageNumber.CURRENT] })]
     })] })
   },
-  children: [/* content */]
+  children: [/* 内容 */]
 }]
 ```
 
-### Critical Rules for docx-js
+### docx-js 关键规则
 
-- **Set page size explicitly** - docx-js defaults to A4; use US Letter (12240 x 15840 DXA) for US documents
-- **Landscape: pass portrait dimensions** - docx-js swaps width/height internally; pass short edge as `width`, long edge as `height`, and set `orientation: PageOrientation.LANDSCAPE`
-- **Never use `\n`** - use separate Paragraph elements
-- **Never use unicode bullets** - use `LevelFormat.BULLET` with numbering config
-- **PageBreak must be in Paragraph** - standalone creates invalid XML
-- **ImageRun requires `type`** - always specify png/jpg/etc
-- **Always set table `width` with DXA** - never use `WidthType.PERCENTAGE` (breaks in Google Docs)
-- **Tables need dual widths** - `columnWidths` array AND cell `width`, both must match
-- **Table width = sum of columnWidths** - for DXA, ensure they add up exactly
-- **Always add cell margins** - use `margins: { top: 80, bottom: 80, left: 120, right: 120 }` for readable padding
-- **Use `ShadingType.CLEAR`** - never SOLID for table shading
-- **TOC requires HeadingLevel only** - no custom styles on heading paragraphs
-- **Override built-in styles** - use exact IDs: "Heading1", "Heading2", etc.
-- **Include `outlineLevel`** - required for TOC (0 for H1, 1 for H2, etc.)
+- **显式设置页面尺寸** — docx-js 默认为 A4；美国文档使用美式 Letter（12240 x 15840 DXA）
+- **横向：传入纵向尺寸** — docx-js 会在内部交换宽高；将短边作为 `width`，长边作为 `height`，并设置 `orientation: PageOrientation.LANDSCAPE`
+- **切勿使用 `\n`** — 使用独立的 Paragraph 元素
+- **切勿使用 Unicode 项目符号** — 使用 `LevelFormat.BULLET` 配合 numbering 配置
+- **PageBreak 必须在 Paragraph 内** — 独立使用会生成无效 XML
+- **ImageRun 需要 `type`** — 始终指定 png/jpg 等
+- **始终使用 DXA 设置表格 `width`** — 绝不使用 `WidthType.PERCENTAGE`（在 Google Docs 中不兼容）
+- **表格需要双重宽度** — `columnWidths` 数组和单元格 `width` 都必须设置且匹配
+- **表格宽度 = columnWidths 之和** — 使用 DXA 时确保精确相加
+- **始终添加单元格内边距** — 使用 `margins: { top: 80, bottom: 80, left: 120, right: 120 }` 以获得合适的间距
+- **使用 `ShadingType.CLEAR`** — 绝不用 SOLID 来设置表格底纹
+- **目录需要仅使用 HeadingLevel** — 标题段落不能使用自定义样式
+- **覆盖内置样式** — 使用精确的 ID："Heading1"、"Heading2" 等
+- **包含 `outlineLevel`** — 目录需要此属性（H1 为 0，H2 为 1，依此类推）
 
 ---
 
-## Editing Existing Documents
+## 编辑现有文档
 
-**Follow all 3 steps in order.**
+**严格按照以下 3 个步骤顺序操作。**
 
-### Step 1: Unpack
+### 步骤 1：解压
 ```bash
 python scripts/office/unpack.py document.docx unpacked/
 ```
-Extracts XML, pretty-prints, merges adjacent runs, and converts smart quotes to XML entities (`&#x201C;` etc.) so they survive editing. Use `--merge-runs false` to skip run merging.
+提取 XML、美化打印、合并相邻 run、并将智能引号转换为 XML 实体（`&#x201C;` 等）以确保编辑后不丢失。使用 `--merge-runs false` 可跳过 run 合并。
 
-### Step 2: Edit XML
+### 步骤 2：编辑 XML
 
-Edit files in `unpacked/word/`. See XML Reference below for patterns.
+编辑 `unpacked/word/` 中的文件。请参考下方的 XML 参考获取编辑模式。
 
-**Use "Claude" as the author** for tracked changes and comments, unless the user explicitly requests use of a different name.
+**修订和批注的作者使用 "Claude"**，除非用户明确要求使用其他名称。
 
-**Use the Edit tool directly for string replacement. Do not write Python scripts.** Scripts introduce unnecessary complexity. The Edit tool shows exactly what is being replaced.
+**直接使用 Edit 工具进行字符串替换，不要编写 Python 脚本。** 脚本会引入不必要的复杂性。Edit 工具能清楚地展示正在替换的内容。
 
-**CRITICAL: Use smart quotes for new content.** When adding text with apostrophes or quotes, use XML entities to produce smart quotes:
+**关键：新内容使用智能引号。** 添加包含撇号或引号的文本时，使用 XML 实体生成智能引号：
 ```xml
-<!-- Use these entities for professional typography -->
+<!-- 使用这些实体来实现专业排版效果 -->
 <w:t>Here&#x2019;s a quote: &#x201C;Hello&#x201D;</w:t>
 ```
-| Entity | Character |
-|--------|-----------|
-| `&#x2018;` | ‘ (left single) |
-| `&#x2019;` | ’ (right single / apostrophe) |
-| `&#x201C;` | “ (left double) |
-| `&#x201D;` | ” (right double) |
+| 实体 | 字符 |
+|------|------|
+| `&#x2018;` | '（左单引号） |
+| `&#x2019;` | '（右单引号/撇号） |
+| `&#x201C;` | "（左双引号） |
+| `&#x201D;` | "（右双引号） |
 
-**Adding comments:** Use `comment.py` to handle boilerplate across multiple XML files (text must be pre-escaped XML):
+**添加批注：** 使用 `comment.py` 处理跨多个 XML 文件的模板代码（文本必须是预转义的 XML）：
 ```bash
 python scripts/comment.py unpacked/ 0 "Comment text with &amp; and &#x2019;"
-python scripts/comment.py unpacked/ 1 "Reply text" --parent 0  # reply to comment 0
-python scripts/comment.py unpacked/ 0 "Text" --author "Custom Author"  # custom author name
+python scripts/comment.py unpacked/ 1 "Reply text" --parent 0  # 回复批注 0
+python scripts/comment.py unpacked/ 0 "Text" --author "Custom Author"  # 自定义作者名
 ```
-Then add markers to document.xml (see Comments in XML Reference).
+然后在 document.xml 中添加标记（参见 XML 参考中的批注部分）。
 
-### Step 3: Pack
+### 步骤 3：打包
 ```bash
 python scripts/office/pack.py unpacked/ output.docx --original document.docx
 ```
-Validates with auto-repair, condenses XML, and creates DOCX. Use `--validate false` to skip.
+执行验证并自动修复、压缩 XML、生成 DOCX。使用 `--validate false` 可跳过验证。
 
-**Auto-repair will fix:**
-- `durableId` >= 0x7FFFFFFF (regenerates valid ID)
-- Missing `xml:space="preserve"` on `<w:t>` with whitespace
+**自动修复可以修复的问题：**
+- `durableId` >= 0x7FFFFFFF（重新生成有效 ID）
+- `<w:t>` 元素中缺少 `xml:space="preserve"`（当存在空白字符时）
 
-**Auto-repair won't fix:**
-- Malformed XML, invalid element nesting, missing relationships, schema violations
+**自动修复无法修复的问题：**
+- XML 格式错误、无效的元素嵌套、缺失的关系、架构违规
 
-### Common Pitfalls
+### 常见陷阱
 
-- **Replace entire `<w:r>` elements**: When adding tracked changes, replace the whole `<w:r>...</w:r>` block with `<w:del>...<w:ins>...` as siblings. Don't inject tracked change tags inside a run.
-- **Preserve `<w:rPr>` formatting**: Copy the original run's `<w:rPr>` block into your tracked change runs to maintain bold, font size, etc.
+- **替换整个 `<w:r>` 元素**：添加修订时，将整个 `<w:r>...</w:r>` 块替换为并列的 `<w:del>...<w:ins>...`。不要在 run 内部注入修订标签。
+- **保留 `<w:rPr>` 格式**：将原始 run 的 `<w:rPr>` 块复制到修订 run 中，以保持粗体、字号等格式。
 
 ---
 
-## XML Reference
+## XML 参考
 
-### Schema Compliance
+### 架构合规性
 
-- **Element order in `<w:pPr>`**: `<w:pStyle>`, `<w:numPr>`, `<w:spacing>`, `<w:ind>`, `<w:jc>`, `<w:rPr>` last
-- **Whitespace**: Add `xml:space="preserve"` to `<w:t>` with leading/trailing spaces
-- **RSIDs**: Must be 8-digit hex (e.g., `00AB1234`)
+- **`<w:pPr>` 中的元素顺序**：`<w:pStyle>`、`<w:numPr>`、`<w:spacing>`、`<w:ind>`、`<w:jc>`、`<w:rPr>` 放在最后
+- **空白字符**：带有前导/尾随空格的 `<w:t>` 需添加 `xml:space="preserve"`
+- **RSID**：必须是 8 位十六进制数（例如 `00AB1234`）
 
-### Tracked Changes
+### 修订
 
-**Insertion:**
+**插入：**
 ```xml
 <w:ins w:id="1" w:author="Claude" w:date="2025-01-01T00:00:00Z">
   <w:r><w:t>inserted text</w:t></w:r>
 </w:ins>
 ```
 
-**Deletion:**
+**删除：**
 ```xml
 <w:del w:id="2" w:author="Claude" w:date="2025-01-01T00:00:00Z">
   <w:r><w:delText>deleted text</w:delText></w:r>
 </w:del>
 ```
 
-**Inside `<w:del>`**: Use `<w:delText>` instead of `<w:t>`, and `<w:delInstrText>` instead of `<w:instrText>`.
+**在 `<w:del>` 内部**：使用 `<w:delText>` 代替 `<w:t>`，使用 `<w:delInstrText>` 代替 `<w:instrText>`。
 
-**Minimal edits** - only mark what changes:
+**最小化编辑** — 仅标记实际变更的部分：
 ```xml
-<!-- Change "30 days" to "60 days" -->
+<!-- 将 "30 days" 修改为 "60 days" -->
 <w:r><w:t>The term is </w:t></w:r>
 <w:del w:id="1" w:author="Claude" w:date="...">
   <w:r><w:delText>30</w:delText></w:r>
@@ -383,11 +383,11 @@ Validates with auto-repair, condenses XML, and creates DOCX. Use `--validate fal
 <w:r><w:t> days.</w:t></w:r>
 ```
 
-**Deleting entire paragraphs/list items** - when removing ALL content from a paragraph, also mark the paragraph mark as deleted so it merges with the next paragraph. Add `<w:del/>` inside `<w:pPr><w:rPr>`:
+**删除整个段落/列表项** — 当删除段落中的所有内容时，还需将段落标记标记为已删除，以便与下一段落合并。在 `<w:pPr><w:rPr>` 中添加 `<w:del/>`：
 ```xml
 <w:p>
   <w:pPr>
-    <w:numPr>...</w:numPr>  <!-- list numbering if present -->
+    <w:numPr>...</w:numPr>  <!-- 列表编号（如果存在） -->
     <w:rPr>
       <w:del w:id="1" w:author="Claude" w:date="2025-01-01T00:00:00Z"/>
     </w:rPr>
@@ -397,9 +397,9 @@ Validates with auto-repair, condenses XML, and creates DOCX. Use `--validate fal
   </w:del>
 </w:p>
 ```
-Without the `<w:del/>` in `<w:pPr><w:rPr>`, accepting changes leaves an empty paragraph/list item.
+如果不在 `<w:pPr><w:rPr>` 中添加 `<w:del/>`，接受修订后会留下空段落/列表项。
 
-**Rejecting another author's insertion** - nest deletion inside their insertion:
+**拒绝其他作者的插入** — 在其插入内部嵌套删除：
 ```xml
 <w:ins w:author="Jane" w:id="5">
   <w:del w:author="Claude" w:id="10">
@@ -408,7 +408,7 @@ Without the `<w:del/>` in `<w:pPr><w:rPr>`, accepting changes leaves an empty pa
 </w:ins>
 ```
 
-**Restoring another author's deletion** - add insertion after (don't modify their deletion):
+**恢复其他作者的删除** — 在其后添加插入（不要修改其删除标记）：
 ```xml
 <w:del w:author="Jane" w:id="5">
   <w:r><w:delText>deleted text</w:delText></w:r>
@@ -418,14 +418,14 @@ Without the `<w:del/>` in `<w:pPr><w:rPr>`, accepting changes leaves an empty pa
 </w:ins>
 ```
 
-### Comments
+### 批注
 
-After running `comment.py` (see Step 2), add markers to document.xml. For replies, use `--parent` flag and nest markers inside the parent's.
+运行 `comment.py`（参见步骤 2）后，在 document.xml 中添加标记。回复批注时，使用 `--parent` 标志并将标记嵌套在父批注内。
 
-**CRITICAL: `<w:commentRangeStart>` and `<w:commentRangeEnd>` are siblings of `<w:r>`, never inside `<w:r>`.**
+**关键：`<w:commentRangeStart>` 和 `<w:commentRangeEnd>` 是 `<w:r>` 的兄弟元素，绝不能放在 `<w:r>` 内部。**
 
 ```xml
-<!-- Comment markers are direct children of w:p, never inside w:r -->
+<!-- 批注标记是 w:p 的直接子元素，绝不能放在 w:r 内部 -->
 <w:commentRangeStart w:id="0"/>
 <w:del w:id="1" w:author="Claude" w:date="2025-01-01T00:00:00Z">
   <w:r><w:delText>deleted</w:delText></w:r>
@@ -434,7 +434,7 @@ After running `comment.py` (see Step 2), add markers to document.xml. For replie
 <w:commentRangeEnd w:id="0"/>
 <w:r><w:rPr><w:rStyle w:val="CommentReference"/></w:rPr><w:commentReference w:id="0"/></w:r>
 
-<!-- Comment 0 with reply 1 nested inside -->
+<!-- 批注 0 包含嵌套的回复批注 1 -->
 <w:commentRangeStart w:id="0"/>
   <w:commentRangeStart w:id="1"/>
   <w:r><w:t>text</w:t></w:r>
@@ -444,22 +444,22 @@ After running `comment.py` (see Step 2), add markers to document.xml. For replie
 <w:r><w:rPr><w:rStyle w:val="CommentReference"/></w:rPr><w:commentReference w:id="1"/></w:r>
 ```
 
-### Images
+### 图片
 
-1. Add image file to `word/media/`
-2. Add relationship to `word/_rels/document.xml.rels`:
+1. 将图片文件添加到 `word/media/`
+2. 在 `word/_rels/document.xml.rels` 中添加关系：
 ```xml
 <Relationship Id="rId5" Type=".../image" Target="media/image1.png"/>
 ```
-3. Add content type to `[Content_Types].xml`:
+3. 在 `[Content_Types].xml` 中添加内容类型：
 ```xml
 <Default Extension="png" ContentType="image/png"/>
 ```
-4. Reference in document.xml:
+4. 在 document.xml 中引用：
 ```xml
 <w:drawing>
   <wp:inline>
-    <wp:extent cx="914400" cy="914400"/>  <!-- EMUs: 914400 = 1 inch -->
+    <wp:extent cx="914400" cy="914400"/>  <!-- EMU：914400 = 1 英寸 -->
     <a:graphic>
       <a:graphicData uri=".../picture">
         <pic:pic>
@@ -473,9 +473,9 @@ After running `comment.py` (see Step 2), add markers to document.xml. For replie
 
 ---
 
-## Dependencies
+## 依赖项
 
-- **pandoc**: Text extraction
-- **docx**: `npm install -g docx` (new documents)
-- **LibreOffice**: PDF conversion (auto-configured for sandboxed environments via `scripts/office/soffice.py`)
-- **Poppler**: `pdftoppm` for images
+- **pandoc**：文本提取
+- **docx**：`npm install -g docx`（用于创建新文档）
+- **LibreOffice**：PDF 转换（通过 `scripts/office/soffice.py` 自动配置沙盒环境）
+- **Poppler**：`pdftoppm` 用于生成图片

--- a/skills/frontend-design/SKILL.md
+++ b/skills/frontend-design/SKILL.md
@@ -1,42 +1,42 @@
 ---
 name: frontend-design
-description: Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.
+description: 创建具有高设计水准的独特、生产级前端界面。当用户要求构建 Web 组件、页面、制品、海报或应用程序时使用此技能（例如网站、着陆页、仪表盘、React 组件、HTML/CSS 布局，或对任何 Web UI 进行样式美化）。生成富有创意、精致的代码和 UI 设计，避免千篇一律的 AI 审美风格。
 license: Complete terms in LICENSE.txt
 ---
 
-This skill guides creation of distinctive, production-grade frontend interfaces that avoid generic "AI slop" aesthetics. Implement real working code with exceptional attention to aesthetic details and creative choices.
+此技能指导创建独特的、生产级前端界面，避免千篇一律的"AI 流水线"审美风格。实现真正可运行的代码，对美学细节和创意选择给予极致关注。
 
-The user provides frontend requirements: a component, page, application, or interface to build. They may include context about the purpose, audience, or technical constraints.
+用户提供前端需求：要构建的组件、页面、应用或界面。他们可能会提供关于用途、受众或技术约束的背景信息。
 
-## Design Thinking
+## 设计思维
 
-Before coding, understand the context and commit to a BOLD aesthetic direction:
-- **Purpose**: What problem does this interface solve? Who uses it?
-- **Tone**: Pick an extreme: brutally minimal, maximalist chaos, retro-futuristic, organic/natural, luxury/refined, playful/toy-like, editorial/magazine, brutalist/raw, art deco/geometric, soft/pastel, industrial/utilitarian, etc. There are so many flavors to choose from. Use these for inspiration but design one that is true to the aesthetic direction.
-- **Constraints**: Technical requirements (framework, performance, accessibility).
-- **Differentiation**: What makes this UNFORGETTABLE? What's the one thing someone will remember?
+在编码之前，理解场景并确定一个**大胆**的美学方向：
+- **目的**：这个界面解决什么问题？谁来使用它？
+- **基调**：选择一个极端风格：极简至上、极繁主义、复古未来、有机自然、奢华精致、趣味童真、杂志编辑风、粗野主义、装饰艺术/几何、柔和粉彩、工业实用风等。可选择的风格数不胜数。以这些为灵感，但要设计出真正契合美学方向的作品。
+- **约束**：技术要求（框架、性能、无障碍）。
+- **差异化**：是什么让它**令人难忘**？用户会记住的那一个亮点是什么？
 
-**CRITICAL**: Choose a clear conceptual direction and execute it with precision. Bold maximalism and refined minimalism both work - the key is intentionality, not intensity.
+**关键**：选择一个清晰的概念方向并精准执行。大胆的极繁主义和精致的极简主义都可以奏效——关键在于有意为之，而非单纯追求强度。
 
-Then implement working code (HTML/CSS/JS, React, Vue, etc.) that is:
-- Production-grade and functional
-- Visually striking and memorable
-- Cohesive with a clear aesthetic point-of-view
-- Meticulously refined in every detail
+然后实现可运行的代码（HTML/CSS/JS、React、Vue 等），要求：
+- 生产级且功能完善
+- 视觉冲击力强，令人过目不忘
+- 具有一致的美学主张
+- 每个细节都经过精心打磨
 
-## Frontend Aesthetics Guidelines
+## 前端美学指南
 
-Focus on:
-- **Typography**: Choose fonts that are beautiful, unique, and interesting. Avoid generic fonts like Arial and Inter; opt instead for distinctive choices that elevate the frontend's aesthetics; unexpected, characterful font choices. Pair a distinctive display font with a refined body font.
-- **Color & Theme**: Commit to a cohesive aesthetic. Use CSS variables for consistency. Dominant colors with sharp accents outperform timid, evenly-distributed palettes.
-- **Motion**: Use animations for effects and micro-interactions. Prioritize CSS-only solutions for HTML. Use Motion library for React when available. Focus on high-impact moments: one well-orchestrated page load with staggered reveals (animation-delay) creates more delight than scattered micro-interactions. Use scroll-triggering and hover states that surprise.
-- **Spatial Composition**: Unexpected layouts. Asymmetry. Overlap. Diagonal flow. Grid-breaking elements. Generous negative space OR controlled density.
-- **Backgrounds & Visual Details**: Create atmosphere and depth rather than defaulting to solid colors. Add contextual effects and textures that match the overall aesthetic. Apply creative forms like gradient meshes, noise textures, geometric patterns, layered transparencies, dramatic shadows, decorative borders, custom cursors, and grain overlays.
+重点关注：
+- **字体排版**：选择美观、独特且有趣的字体。避免 Arial 和 Inter 等常见字体；转而选择能提升前端美感的独特字体——出人意料、富有个性的字体选择。将独特的展示字体与精致的正文字体搭配使用。
+- **色彩与主题**：确立一致的美学风格。使用 CSS 变量保持一致性。主色调配以鲜明的点缀色，远比保守、均匀分布的配色更具表现力。
+- **动效**：使用动画实现效果和微交互。HTML 优先使用纯 CSS 方案。React 中可用时使用 Motion 库。聚焦高影响力的时刻：一个精心编排的页面加载动画配合错落有致的渐入效果（animation-delay），比零散的微交互更令人愉悦。善用滚动触发和出其不意的悬停状态。
+- **空间构成**：打破常规的布局。非对称。重叠。对角线流动。突破网格的元素。大量留白或有控制的密集排布。
+- **背景与视觉细节**：营造氛围和层次感，而非一味使用纯色背景。添加与整体美学相匹配的场景化效果和纹理。运用渐变网格、噪点纹理、几何图案、叠加透明、戏剧性阴影、装饰性边框、自定义光标和颗粒覆盖等创意手法。
 
-NEVER use generic AI-generated aesthetics like overused font families (Inter, Roboto, Arial, system fonts), cliched color schemes (particularly purple gradients on white backgrounds), predictable layouts and component patterns, and cookie-cutter design that lacks context-specific character.
+切勿使用千篇一律的 AI 生成审美，包括过度使用的字体（Inter、Roboto、Arial、系统字体）、老套的配色方案（尤其是白底紫色渐变）、可预测的布局和组件模式，以及缺乏场景特色的模板化设计。
 
-Interpret creatively and make unexpected choices that feel genuinely designed for the context. No design should be the same. Vary between light and dark themes, different fonts, different aesthetics. NEVER converge on common choices (Space Grotesk, for example) across generations.
+进行创意诠释，做出出人意料的选择，让设计真正贴合场景。每一个设计都应独一无二。在明暗主题、不同字体、不同美学风格之间灵活切换。切勿在多次生成中趋同于相同的选择（例如 Space Grotesk）。
 
-**IMPORTANT**: Match implementation complexity to the aesthetic vision. Maximalist designs need elaborate code with extensive animations and effects. Minimalist or refined designs need restraint, precision, and careful attention to spacing, typography, and subtle details. Elegance comes from executing the vision well.
+**重要**：实现的复杂度应匹配美学愿景。极繁主义设计需要精心编写的代码，包含大量动画和效果。极简或精致的设计则需要克制、精确，以及对间距、字体排版和细微细节的悉心关注。优雅源于对愿景的出色执行。
 
-Remember: Claude is capable of extraordinary creative work. Don't hold back, show what can truly be created when thinking outside the box and committing fully to a distinctive vision.
+请记住：Claude 能够创造出非凡的创意作品。不要有所保留，展示出跳出框架思考、全力投入独特愿景时所能真正创造的成果。

--- a/skills/internal-comms/SKILL.md
+++ b/skills/internal-comms/SKILL.md
@@ -1,32 +1,32 @@
 ---
 name: internal-comms
-description: A set of resources to help me write all kinds of internal communications, using the formats that my company likes to use. Claude should use this skill whenever asked to write some sort of internal communications (status reports, leadership updates, 3P updates, company newsletters, FAQs, incident reports, project updates, etc.).
+description: 一组帮助撰写各类内部沟通文档的资源，采用公司惯用的格式。当被要求撰写任何形式的内部沟通内容（状态报告、高层汇报、3P 更新、公司通讯、常见问题解答、事件报告、项目更新等）时，Claude 应使用此技能。
 license: Complete terms in LICENSE.txt
 ---
 
-## When to use this skill
-To write internal communications, use this skill for:
-- 3P updates (Progress, Plans, Problems)
-- Company newsletters
-- FAQ responses
-- Status reports
-- Leadership updates
-- Project updates
-- Incident reports
+## 何时使用此技能
+撰写内部沟通文档时，可将此技能用于：
+- 3P 更新（进展、计划、问题）
+- 公司通讯
+- 常见问题解答
+- 状态报告
+- 高层汇报
+- 项目更新
+- 事件报告
 
-## How to use this skill
+## 如何使用此技能
 
-To write any internal communication:
+撰写任何内部沟通文档时：
 
-1. **Identify the communication type** from the request
-2. **Load the appropriate guideline file** from the `examples/` directory:
-    - `examples/3p-updates.md` - For Progress/Plans/Problems team updates
-    - `examples/company-newsletter.md` - For company-wide newsletters
-    - `examples/faq-answers.md` - For answering frequently asked questions
-    - `examples/general-comms.md` - For anything else that doesn't explicitly match one of the above
-3. **Follow the specific instructions** in that file for formatting, tone, and content gathering
+1. **从请求中识别沟通类型**
+2. **从 `examples/` 目录加载相应的指南文件**：
+    - `examples/3p-updates.md` — 用于进展/计划/问题的团队更新
+    - `examples/company-newsletter.md` — 用于全公司通讯
+    - `examples/faq-answers.md` — 用于回答常见问题
+    - `examples/general-comms.md` — 用于不明确匹配以上类型的其他内容
+3. **遵循该文件中的具体说明**，包括格式、语气和内容收集要求
 
-If the communication type doesn't match any existing guideline, ask for clarification or more context about the desired format.
+如果沟通类型与现有指南均不匹配，请要求澄清或了解更多关于期望格式的上下文信息。
 
-## Keywords
-3P updates, company newsletter, company comms, weekly update, faqs, common questions, updates, internal comms
+## 关键词
+3P 更新、公司通讯、公司沟通、周报更新、常见问题、常见问题解答、更新、内部沟通

--- a/skills/mcp-builder/SKILL.md
+++ b/skills/mcp-builder/SKILL.md
@@ -1,185 +1,185 @@
 ---
 name: mcp-builder
-description: Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Use when building MCP servers to integrate external APIs or services, whether in Python (FastMCP) or Node/TypeScript (MCP SDK).
+description: 构建高质量 MCP（Model Context Protocol）服务器的指南，使 LLM 能够通过精心设计的工具与外部服务交互。在使用 Python（FastMCP）或 Node/TypeScript（MCP SDK）构建 MCP 服务器以集成外部 API 或服务时使用此技能。
 license: Complete terms in LICENSE.txt
 ---
 
-# MCP Server Development Guide
+# MCP 服务器开发指南
 
-## Overview
+## 概述
 
-Create MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. The quality of an MCP server is measured by how well it enables LLMs to accomplish real-world tasks.
-
----
-
-# Process
-
-## 🚀 High-Level Workflow
-
-Creating a high-quality MCP server involves four main phases:
-
-### Phase 1: Deep Research and Planning
-
-#### 1.1 Understand Modern MCP Design
-
-**API Coverage vs. Workflow Tools:**
-Balance comprehensive API endpoint coverage with specialized workflow tools. Workflow tools can be more convenient for specific tasks, while comprehensive coverage gives agents flexibility to compose operations. Performance varies by client—some clients benefit from code execution that combines basic tools, while others work better with higher-level workflows. When uncertain, prioritize comprehensive API coverage.
-
-**Tool Naming and Discoverability:**
-Clear, descriptive tool names help agents find the right tools quickly. Use consistent prefixes (e.g., `github_create_issue`, `github_list_repos`) and action-oriented naming.
-
-**Context Management:**
-Agents benefit from concise tool descriptions and the ability to filter/paginate results. Design tools that return focused, relevant data. Some clients support code execution which can help agents filter and process data efficiently.
-
-**Actionable Error Messages:**
-Error messages should guide agents toward solutions with specific suggestions and next steps.
-
-#### 1.2 Study MCP Protocol Documentation
-
-**Navigate the MCP specification:**
-
-Start with the sitemap to find relevant pages: `https://modelcontextprotocol.io/sitemap.xml`
-
-Then fetch specific pages with `.md` suffix for markdown format (e.g., `https://modelcontextprotocol.io/specification/draft.md`).
-
-Key pages to review:
-- Specification overview and architecture
-- Transport mechanisms (streamable HTTP, stdio)
-- Tool, resource, and prompt definitions
-
-#### 1.3 Study Framework Documentation
-
-**Recommended stack:**
-- **Language**: TypeScript (high-quality SDK support and good compatibility in many execution environments e.g. MCPB. Plus AI models are good at generating TypeScript code, benefiting from its broad usage, static typing and good linting tools)
-- **Transport**: Streamable HTTP for remote servers, using stateless JSON (simpler to scale and maintain, as opposed to stateful sessions and streaming responses). stdio for local servers.
-
-**Load framework documentation:**
-
-- **MCP Best Practices**: [📋 View Best Practices](./reference/mcp_best_practices.md) - Core guidelines
-
-**For TypeScript (recommended):**
-- **TypeScript SDK**: Use WebFetch to load `https://raw.githubusercontent.com/modelcontextprotocol/typescript-sdk/main/README.md`
-- [⚡ TypeScript Guide](./reference/node_mcp_server.md) - TypeScript patterns and examples
-
-**For Python:**
-- **Python SDK**: Use WebFetch to load `https://raw.githubusercontent.com/modelcontextprotocol/python-sdk/main/README.md`
-- [🐍 Python Guide](./reference/python_mcp_server.md) - Python patterns and examples
-
-#### 1.4 Plan Your Implementation
-
-**Understand the API:**
-Review the service's API documentation to identify key endpoints, authentication requirements, and data models. Use web search and WebFetch as needed.
-
-**Tool Selection:**
-Prioritize comprehensive API coverage. List endpoints to implement, starting with the most common operations.
+创建 MCP（Model Context Protocol）服务器，使 LLM 能够通过精心设计的工具与外部服务交互。MCP 服务器的质量取决于它能多好地帮助 LLM 完成实际任务。
 
 ---
 
-### Phase 2: Implementation
+# 流程
 
-#### 2.1 Set Up Project Structure
+## 🚀 高层工作流程
 
-See language-specific guides for project setup:
-- [⚡ TypeScript Guide](./reference/node_mcp_server.md) - Project structure, package.json, tsconfig.json
-- [🐍 Python Guide](./reference/python_mcp_server.md) - Module organization, dependencies
+创建一个高质量的 MCP 服务器包含四个主要阶段：
 
-#### 2.2 Implement Core Infrastructure
+### 第一阶段：深入调研与规划
 
-Create shared utilities:
-- API client with authentication
-- Error handling helpers
-- Response formatting (JSON/Markdown)
-- Pagination support
+#### 1.1 理解现代 MCP 设计
 
-#### 2.3 Implement Tools
+**API 覆盖与工作流工具：**
+在全面的 API 端点覆盖和专用工作流工具之间取得平衡。工作流工具在特定任务上更便捷，而全面覆盖则赋予智能体灵活组合操作的能力。不同客户端的表现各异——有些客户端受益于能组合基础工具的代码执行，而另一些则更适合使用高级工作流。不确定时，优先考虑全面的 API 覆盖。
 
-For each tool:
+**工具命名与可发现性：**
+清晰、描述性的工具名称有助于智能体快速找到正确的工具。使用一致的前缀（例如 `github_create_issue`、`github_list_repos`）和面向操作的命名方式。
 
-**Input Schema:**
-- Use Zod (TypeScript) or Pydantic (Python)
-- Include constraints and clear descriptions
-- Add examples in field descriptions
+**上下文管理：**
+智能体受益于简洁的工具描述以及过滤/分页结果的能力。设计返回聚焦、相关数据的工具。某些客户端支持代码执行，有助于智能体高效地过滤和处理数据。
 
-**Output Schema:**
-- Define `outputSchema` where possible for structured data
-- Use `structuredContent` in tool responses (TypeScript SDK feature)
-- Helps clients understand and process tool outputs
+**可操作的错误信息：**
+错误信息应引导智能体找到解决方案，提供具体的建议和后续步骤。
 
-**Tool Description:**
-- Concise summary of functionality
-- Parameter descriptions
-- Return type schema
+#### 1.2 学习 MCP 协议文档
 
-**Implementation:**
-- Async/await for I/O operations
-- Proper error handling with actionable messages
-- Support pagination where applicable
-- Return both text content and structured data when using modern SDKs
+**浏览 MCP 规范：**
 
-**Annotations:**
-- `readOnlyHint`: true/false
-- `destructiveHint`: true/false
-- `idempotentHint`: true/false
-- `openWorldHint`: true/false
+从站点地图开始查找相关页面：`https://modelcontextprotocol.io/sitemap.xml`
 
----
+然后获取特定页面，添加 `.md` 后缀可获得 Markdown 格式（例如 `https://modelcontextprotocol.io/specification/draft.md`）。
 
-### Phase 3: Review and Test
+需要查看的关键页面：
+- 规范概述和架构
+- 传输机制（Streamable HTTP、stdio）
+- 工具、资源和提示词定义
 
-#### 3.1 Code Quality
+#### 1.3 学习框架文档
 
-Review for:
-- No duplicated code (DRY principle)
-- Consistent error handling
-- Full type coverage
-- Clear tool descriptions
+**推荐技术栈：**
+- **语言**：TypeScript（优质的 SDK 支持，在多种执行环境中兼容性好，如 MCPB。加之 AI 模型擅长生成 TypeScript 代码，得益于其广泛使用、静态类型和良好的 lint 工具）
+- **传输方式**：远程服务器使用 Streamable HTTP，采用无状态 JSON（更易扩展和维护，相比有状态会话和流式响应）。本地服务器使用 stdio。
 
-#### 3.2 Build and Test
+**加载框架文档：**
 
-**TypeScript:**
-- Run `npm run build` to verify compilation
-- Test with MCP Inspector: `npx @modelcontextprotocol/inspector`
+- **MCP 最佳实践**：[📋 查看最佳实践](./reference/mcp_best_practices.md) — 核心指南
 
-**Python:**
-- Verify syntax: `python -m py_compile your_server.py`
-- Test with MCP Inspector
+**TypeScript（推荐）：**
+- **TypeScript SDK**：使用 WebFetch 加载 `https://raw.githubusercontent.com/modelcontextprotocol/typescript-sdk/main/README.md`
+- [⚡ TypeScript 指南](./reference/node_mcp_server.md) — TypeScript 模式与示例
 
-See language-specific guides for detailed testing approaches and quality checklists.
+**Python：**
+- **Python SDK**：使用 WebFetch 加载 `https://raw.githubusercontent.com/modelcontextprotocol/python-sdk/main/README.md`
+- [🐍 Python 指南](./reference/python_mcp_server.md) — Python 模式与示例
+
+#### 1.4 规划实现方案
+
+**理解 API：**
+查阅服务的 API 文档，识别关键端点、认证要求和数据模型。根据需要使用 Web 搜索和 WebFetch。
+
+**工具选择：**
+优先考虑全面的 API 覆盖。列出需要实现的端点，从最常用的操作开始。
 
 ---
 
-### Phase 4: Create Evaluations
+### 第二阶段：实现
 
-After implementing your MCP server, create comprehensive evaluations to test its effectiveness.
+#### 2.1 搭建项目结构
 
-**Load [✅ Evaluation Guide](./reference/evaluation.md) for complete evaluation guidelines.**
+参见各语言专用指南了解项目搭建：
+- [⚡ TypeScript 指南](./reference/node_mcp_server.md) — 项目结构、package.json、tsconfig.json
+- [🐍 Python 指南](./reference/python_mcp_server.md) — 模块组织、依赖管理
 
-#### 4.1 Understand Evaluation Purpose
+#### 2.2 实现核心基础设施
 
-Use evaluations to test whether LLMs can effectively use your MCP server to answer realistic, complex questions.
+创建共享工具：
+- 带认证的 API 客户端
+- 错误处理辅助函数
+- 响应格式化（JSON/Markdown）
+- 分页支持
 
-#### 4.2 Create 10 Evaluation Questions
+#### 2.3 实现工具
 
-To create effective evaluations, follow the process outlined in the evaluation guide:
+对于每个工具：
 
-1. **Tool Inspection**: List available tools and understand their capabilities
-2. **Content Exploration**: Use READ-ONLY operations to explore available data
-3. **Question Generation**: Create 10 complex, realistic questions
-4. **Answer Verification**: Solve each question yourself to verify answers
+**输入模式：**
+- 使用 Zod（TypeScript）或 Pydantic（Python）
+- 包含约束条件和清晰的描述
+- 在字段描述中添加示例
 
-#### 4.3 Evaluation Requirements
+**输出模式：**
+- 尽可能定义 `outputSchema` 以获得结构化数据
+- 在工具响应中使用 `structuredContent`（TypeScript SDK 功能）
+- 帮助客户端理解和处理工具输出
 
-Ensure each question is:
-- **Independent**: Not dependent on other questions
-- **Read-only**: Only non-destructive operations required
-- **Complex**: Requiring multiple tool calls and deep exploration
-- **Realistic**: Based on real use cases humans would care about
-- **Verifiable**: Single, clear answer that can be verified by string comparison
-- **Stable**: Answer won't change over time
+**工具描述：**
+- 功能的简明摘要
+- 参数描述
+- 返回类型模式
 
-#### 4.4 Output Format
+**实现：**
+- I/O 操作使用 async/await
+- 提供可操作信息的正确错误处理
+- 在适用场景支持分页
+- 使用现代 SDK 时同时返回文本内容和结构化数据
 
-Create an XML file with this structure:
+**注解：**
+- `readOnlyHint`：true/false
+- `destructiveHint`：true/false
+- `idempotentHint`：true/false
+- `openWorldHint`：true/false
+
+---
+
+### 第三阶段：审查与测试
+
+#### 3.1 代码质量
+
+审查以下方面：
+- 无重复代码（DRY 原则）
+- 一致的错误处理
+- 完整的类型覆盖
+- 清晰的工具描述
+
+#### 3.2 构建与测试
+
+**TypeScript：**
+- 运行 `npm run build` 验证编译
+- 使用 MCP Inspector 测试：`npx @modelcontextprotocol/inspector`
+
+**Python：**
+- 验证语法：`python -m py_compile your_server.py`
+- 使用 MCP Inspector 测试
+
+参见各语言专用指南了解详细的测试方法和质量检查清单。
+
+---
+
+### 第四阶段：创建评估
+
+实现 MCP 服务器后，创建全面的评估来测试其效果。
+
+**加载 [✅ 评估指南](./reference/evaluation.md) 获取完整的评估指导。**
+
+#### 4.1 理解评估目的
+
+使用评估来测试 LLM 能否有效地使用你的 MCP 服务器回答真实、复杂的问题。
+
+#### 4.2 创建 10 个评估问题
+
+要创建有效的评估，请遵循评估指南中概述的流程：
+
+1. **工具检查**：列出可用工具并理解其能力
+2. **内容探索**：使用只读操作探索可用数据
+3. **问题生成**：创建 10 个复杂、真实的问题
+4. **答案验证**：亲自解答每个问题以验证答案
+
+#### 4.3 评估要求
+
+确保每个问题满足以下条件：
+- **独立性**：不依赖于其他问题
+- **只读性**：仅需非破坏性操作
+- **复杂性**：需要多次工具调用和深入探索
+- **真实性**：基于人类真正关心的实际使用场景
+- **可验证性**：有唯一、明确的答案，可通过字符串比较验证
+- **稳定性**：答案不会随时间变化
+
+#### 4.4 输出格式
+
+创建如下结构的 XML 文件：
 
 ```xml
 <evaluation>
@@ -187,50 +187,50 @@ Create an XML file with this structure:
     <question>Find discussions about AI model launches with animal codenames. One model needed a specific safety designation that uses the format ASL-X. What number X was being determined for the model named after a spotted wild cat?</question>
     <answer>3</answer>
   </qa_pair>
-<!-- More qa_pairs... -->
+<!-- 更多 qa_pair... -->
 </evaluation>
 ```
 
 ---
 
-# Reference Files
+# 参考文件
 
-## 📚 Documentation Library
+## 📚 文档库
 
-Load these resources as needed during development:
+在开发过程中根据需要加载以下资源：
 
-### Core MCP Documentation (Load First)
-- **MCP Protocol**: Start with sitemap at `https://modelcontextprotocol.io/sitemap.xml`, then fetch specific pages with `.md` suffix
-- [📋 MCP Best Practices](./reference/mcp_best_practices.md) - Universal MCP guidelines including:
-  - Server and tool naming conventions
-  - Response format guidelines (JSON vs Markdown)
-  - Pagination best practices
-  - Transport selection (streamable HTTP vs stdio)
-  - Security and error handling standards
+### 核心 MCP 文档（优先加载）
+- **MCP 协议**：从 `https://modelcontextprotocol.io/sitemap.xml` 的站点地图开始，然后添加 `.md` 后缀获取特定页面
+- [📋 MCP 最佳实践](./reference/mcp_best_practices.md) — 通用 MCP 指南，包括：
+  - 服务器和工具命名规范
+  - 响应格式指南（JSON vs Markdown）
+  - 分页最佳实践
+  - 传输方式选择（Streamable HTTP vs stdio）
+  - 安全和错误处理标准
 
-### SDK Documentation (Load During Phase 1/2)
-- **Python SDK**: Fetch from `https://raw.githubusercontent.com/modelcontextprotocol/python-sdk/main/README.md`
-- **TypeScript SDK**: Fetch from `https://raw.githubusercontent.com/modelcontextprotocol/typescript-sdk/main/README.md`
+### SDK 文档（在第一/二阶段加载）
+- **Python SDK**：从 `https://raw.githubusercontent.com/modelcontextprotocol/python-sdk/main/README.md` 获取
+- **TypeScript SDK**：从 `https://raw.githubusercontent.com/modelcontextprotocol/typescript-sdk/main/README.md` 获取
 
-### Language-Specific Implementation Guides (Load During Phase 2)
-- [🐍 Python Implementation Guide](./reference/python_mcp_server.md) - Complete Python/FastMCP guide with:
-  - Server initialization patterns
-  - Pydantic model examples
-  - Tool registration with `@mcp.tool`
-  - Complete working examples
-  - Quality checklist
+### 各语言实现指南（在第二阶段加载）
+- [🐍 Python 实现指南](./reference/python_mcp_server.md) — 完整的 Python/FastMCP 指南，包括：
+  - 服务器初始化模式
+  - Pydantic 模型示例
+  - 使用 `@mcp.tool` 注册工具
+  - 完整的工作示例
+  - 质量检查清单
 
-- [⚡ TypeScript Implementation Guide](./reference/node_mcp_server.md) - Complete TypeScript guide with:
-  - Project structure
-  - Zod schema patterns
-  - Tool registration with `server.registerTool`
-  - Complete working examples
-  - Quality checklist
+- [⚡ TypeScript 实现指南](./reference/node_mcp_server.md) — 完整的 TypeScript 指南，包括：
+  - 项目结构
+  - Zod 模式定义
+  - 使用 `server.registerTool` 注册工具
+  - 完整的工作示例
+  - 质量检查清单
 
-### Evaluation Guide (Load During Phase 4)
-- [✅ Evaluation Guide](./reference/evaluation.md) - Complete evaluation creation guide with:
-  - Question creation guidelines
-  - Answer verification strategies
-  - XML format specifications
-  - Example questions and answers
-  - Running an evaluation with the provided scripts
+### 评估指南（在第四阶段加载）
+- [✅ 评估指南](./reference/evaluation.md) — 完整的评估创建指南，包括：
+  - 问题创建指导
+  - 答案验证策略
+  - XML 格式规范
+  - 示例问题与答案
+  - 使用提供的脚本运行评估

--- a/skills/pdf/SKILL.md
+++ b/skills/pdf/SKILL.md
@@ -1,35 +1,35 @@
 ---
 name: pdf
-description: Use this skill whenever the user wants to do anything with PDF files. This includes reading or extracting text/tables from PDFs, combining or merging multiple PDFs into one, splitting PDFs apart, rotating pages, adding watermarks, creating new PDFs, filling PDF forms, encrypting/decrypting PDFs, extracting images, and OCR on scanned PDFs to make them searchable. If the user mentions a .pdf file or asks to produce one, use this skill.
+description: 当用户需要对 PDF 文件进行任何操作时，请使用此技能。包括读取或提取 PDF 中的文本/表格、合并多个 PDF 为一个文件、拆分 PDF、旋转页面、添加水印、创建新 PDF、填写 PDF 表单、加密/解密 PDF、提取图片，以及对扫描版 PDF 进行 OCR 使其可搜索。如果用户提及 .pdf 文件或要求生成 PDF，请使用此技能。
 license: Proprietary. LICENSE.txt has complete terms
 ---
 
-# PDF Processing Guide
+# PDF 处理指南
 
-## Overview
+## 概述
 
-This guide covers essential PDF processing operations using Python libraries and command-line tools. For advanced features, JavaScript libraries, and detailed examples, see REFERENCE.md. If you need to fill out a PDF form, read FORMS.md and follow its instructions.
+本指南涵盖使用 Python 库和命令行工具进行 PDF 处理的基本操作。如需高级功能、JavaScript 库及详细示例，请参阅 REFERENCE.md。如需填写 PDF 表单，请阅读 FORMS.md 并按其说明操作。
 
-## Quick Start
+## 快速入门
 
 ```python
 from pypdf import PdfReader, PdfWriter
 
-# Read a PDF
+# 读取 PDF
 reader = PdfReader("document.pdf")
 print(f"Pages: {len(reader.pages)}")
 
-# Extract text
+# 提取文本
 text = ""
 for page in reader.pages:
     text += page.extract_text()
 ```
 
-## Python Libraries
+## Python 库
 
-### pypdf - Basic Operations
+### pypdf - 基本操作
 
-#### Merge PDFs
+#### 合并 PDF
 ```python
 from pypdf import PdfWriter, PdfReader
 
@@ -43,7 +43,7 @@ with open("merged.pdf", "wb") as output:
     writer.write(output)
 ```
 
-#### Split PDF
+#### 拆分 PDF
 ```python
 reader = PdfReader("input.pdf")
 for i, page in enumerate(reader.pages):
@@ -53,7 +53,7 @@ for i, page in enumerate(reader.pages):
         writer.write(output)
 ```
 
-#### Extract Metadata
+#### 提取元数据
 ```python
 reader = PdfReader("document.pdf")
 meta = reader.metadata
@@ -63,22 +63,22 @@ print(f"Subject: {meta.subject}")
 print(f"Creator: {meta.creator}")
 ```
 
-#### Rotate Pages
+#### 旋转页面
 ```python
 reader = PdfReader("input.pdf")
 writer = PdfWriter()
 
 page = reader.pages[0]
-page.rotate(90)  # Rotate 90 degrees clockwise
+page.rotate(90)  # 顺时针旋转 90 度
 writer.add_page(page)
 
 with open("rotated.pdf", "wb") as output:
     writer.write(output)
 ```
 
-### pdfplumber - Text and Table Extraction
+### pdfplumber - 文本和表格提取
 
-#### Extract Text with Layout
+#### 保留布局提取文本
 ```python
 import pdfplumber
 
@@ -88,7 +88,7 @@ with pdfplumber.open("document.pdf") as pdf:
         print(text)
 ```
 
-#### Extract Tables
+#### 提取表格
 ```python
 with pdfplumber.open("document.pdf") as pdf:
     for i, page in enumerate(pdf.pages):
@@ -99,7 +99,7 @@ with pdfplumber.open("document.pdf") as pdf:
                 print(row)
 ```
 
-#### Advanced Table Extraction
+#### 高级表格提取
 ```python
 import pandas as pd
 
@@ -108,19 +108,19 @@ with pdfplumber.open("document.pdf") as pdf:
     for page in pdf.pages:
         tables = page.extract_tables()
         for table in tables:
-            if table:  # Check if table is not empty
+            if table:  # 检查表格是否为空
                 df = pd.DataFrame(table[1:], columns=table[0])
                 all_tables.append(df)
 
-# Combine all tables
+# 合并所有表格
 if all_tables:
     combined_df = pd.concat(all_tables, ignore_index=True)
     combined_df.to_excel("extracted_tables.xlsx", index=False)
 ```
 
-### reportlab - Create PDFs
+### reportlab - 创建 PDF
 
-#### Basic PDF Creation
+#### 基本 PDF 创建
 ```python
 from reportlab.lib.pagesizes import letter
 from reportlab.pdfgen import canvas
@@ -128,18 +128,18 @@ from reportlab.pdfgen import canvas
 c = canvas.Canvas("hello.pdf", pagesize=letter)
 width, height = letter
 
-# Add text
+# 添加文本
 c.drawString(100, height - 100, "Hello World!")
 c.drawString(100, height - 120, "This is a PDF created with reportlab")
 
-# Add a line
+# 添加线条
 c.line(100, height - 140, 400, height - 140)
 
-# Save
+# 保存
 c.save()
 ```
 
-#### Create PDF with Multiple Pages
+#### 创建多页 PDF
 ```python
 from reportlab.lib.pagesizes import letter
 from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer, PageBreak
@@ -149,7 +149,7 @@ doc = SimpleDocTemplate("report.pdf", pagesize=letter)
 styles = getSampleStyleSheet()
 story = []
 
-# Add content
+# 添加内容
 title = Paragraph("Report Title", styles['Title'])
 story.append(title)
 story.append(Spacer(1, 12))
@@ -158,88 +158,88 @@ body = Paragraph("This is the body of the report. " * 20, styles['Normal'])
 story.append(body)
 story.append(PageBreak())
 
-# Page 2
+# 第 2 页
 story.append(Paragraph("Page 2", styles['Heading1']))
 story.append(Paragraph("Content for page 2", styles['Normal']))
 
-# Build PDF
+# 构建 PDF
 doc.build(story)
 ```
 
-#### Subscripts and Superscripts
+#### 下标和上标
 
-**IMPORTANT**: Never use Unicode subscript/superscript characters (₀₁₂₃₄₅₆₇₈₉, ⁰¹²³⁴⁵⁶⁷⁸⁹) in ReportLab PDFs. The built-in fonts do not include these glyphs, causing them to render as solid black boxes.
+**重要提示**：切勿在 ReportLab PDF 中使用 Unicode 下标/上标字符（₀₁₂₃₄₅₆₇₈₉、⁰¹²³⁴⁵⁶⁷⁸⁹）。内置字体不包含这些字形，会导致它们显示为黑色方块。
 
-Instead, use ReportLab's XML markup tags in Paragraph objects:
+应在 Paragraph 对象中使用 ReportLab 的 XML 标记标签：
 ```python
 from reportlab.platypus import Paragraph
 from reportlab.lib.styles import getSampleStyleSheet
 
 styles = getSampleStyleSheet()
 
-# Subscripts: use <sub> tag
+# 下标：使用 <sub> 标签
 chemical = Paragraph("H<sub>2</sub>O", styles['Normal'])
 
-# Superscripts: use <super> tag
+# 上标：使用 <super> 标签
 squared = Paragraph("x<super>2</super> + y<super>2</super>", styles['Normal'])
 ```
 
-For canvas-drawn text (not Paragraph objects), manually adjust font the size and position rather than using Unicode subscripts/superscripts.
+对于使用 canvas 直接绘制的文本（非 Paragraph 对象），应手动调整字体大小和位置，而不是使用 Unicode 下标/上标。
 
-## Command-Line Tools
+## 命令行工具
 
 ### pdftotext (poppler-utils)
 ```bash
-# Extract text
+# 提取文本
 pdftotext input.pdf output.txt
 
-# Extract text preserving layout
+# 保留布局提取文本
 pdftotext -layout input.pdf output.txt
 
-# Extract specific pages
-pdftotext -f 1 -l 5 input.pdf output.txt  # Pages 1-5
+# 提取指定页面
+pdftotext -f 1 -l 5 input.pdf output.txt  # 第 1-5 页
 ```
 
 ### qpdf
 ```bash
-# Merge PDFs
+# 合并 PDF
 qpdf --empty --pages file1.pdf file2.pdf -- merged.pdf
 
-# Split pages
+# 拆分页面
 qpdf input.pdf --pages . 1-5 -- pages1-5.pdf
 qpdf input.pdf --pages . 6-10 -- pages6-10.pdf
 
-# Rotate pages
-qpdf input.pdf output.pdf --rotate=+90:1  # Rotate page 1 by 90 degrees
+# 旋转页面
+qpdf input.pdf output.pdf --rotate=+90:1  # 将第 1 页旋转 90 度
 
-# Remove password
+# 移除密码
 qpdf --password=mypassword --decrypt encrypted.pdf decrypted.pdf
 ```
 
-### pdftk (if available)
+### pdftk（如可用）
 ```bash
-# Merge
+# 合并
 pdftk file1.pdf file2.pdf cat output merged.pdf
 
-# Split
+# 拆分
 pdftk input.pdf burst
 
-# Rotate
+# 旋转
 pdftk input.pdf rotate 1east output rotated.pdf
 ```
 
-## Common Tasks
+## 常见任务
 
-### Extract Text from Scanned PDFs
+### 从扫描版 PDF 提取文本
 ```python
-# Requires: pip install pytesseract pdf2image
+# 需要安装：pip install pytesseract pdf2image
 import pytesseract
 from pdf2image import convert_from_path
 
-# Convert PDF to images
+# 将 PDF 转换为图片
 images = convert_from_path('scanned.pdf')
 
-# OCR each page
+# 对每一页进行 OCR
 text = ""
 for i, image in enumerate(images):
     text += f"Page {i+1}:\n"
@@ -249,14 +249,14 @@ for i, image in enumerate(images):
 print(text)
 ```
 
-### Add Watermark
+### 添加水印
 ```python
 from pypdf import PdfReader, PdfWriter
 
-# Create watermark (or load existing)
+# 创建水印（或加载已有的水印）
 watermark = PdfReader("watermark.pdf").pages[0]
 
-# Apply to all pages
+# 应用到所有页面
 reader = PdfReader("document.pdf")
 writer = PdfWriter()
 
@@ -268,15 +268,15 @@ with open("watermarked.pdf", "wb") as output:
     writer.write(output)
 ```
 
-### Extract Images
+### 提取图片
 ```bash
-# Using pdfimages (poppler-utils)
+# 使用 pdfimages (poppler-utils)
 pdfimages -j input.pdf output_prefix
 
-# This extracts all images as output_prefix-000.jpg, output_prefix-001.jpg, etc.
+# 将所有图片提取为 output_prefix-000.jpg、output_prefix-001.jpg 等
 ```
 
-### Password Protection
+### 密码保护
 ```python
 from pypdf import PdfReader, PdfWriter
 
@@ -286,29 +286,29 @@ writer = PdfWriter()
 for page in reader.pages:
     writer.add_page(page)
 
-# Add password
+# 添加密码
 writer.encrypt("userpassword", "ownerpassword")
 
 with open("encrypted.pdf", "wb") as output:
     writer.write(output)
 ```
 
-## Quick Reference
+## 快速参考
 
-| Task | Best Tool | Command/Code |
-|------|-----------|--------------|
-| Merge PDFs | pypdf | `writer.add_page(page)` |
-| Split PDFs | pypdf | One page per file |
-| Extract text | pdfplumber | `page.extract_text()` |
-| Extract tables | pdfplumber | `page.extract_tables()` |
-| Create PDFs | reportlab | Canvas or Platypus |
-| Command line merge | qpdf | `qpdf --empty --pages ...` |
-| OCR scanned PDFs | pytesseract | Convert to image first |
-| Fill PDF forms | pdf-lib or pypdf (see FORMS.md) | See FORMS.md |
+| 任务 | 推荐工具 | 命令/代码 |
+|------|----------|-----------|
+| 合并 PDF | pypdf | `writer.add_page(page)` |
+| 拆分 PDF | pypdf | 每页一个文件 |
+| 提取文本 | pdfplumber | `page.extract_text()` |
+| 提取表格 | pdfplumber | `page.extract_tables()` |
+| 创建 PDF | reportlab | Canvas 或 Platypus |
+| 命令行合并 | qpdf | `qpdf --empty --pages ...` |
+| 扫描版 PDF OCR | pytesseract | 先转换为图片 |
+| 填写 PDF 表单 | pdf-lib 或 pypdf（见 FORMS.md） | 见 FORMS.md |
 
-## Next Steps
+## 后续步骤
 
-- For advanced pypdfium2 usage, see REFERENCE.md
-- For JavaScript libraries (pdf-lib), see REFERENCE.md
-- If you need to fill out a PDF form, follow the instructions in FORMS.md
-- For troubleshooting guides, see REFERENCE.md
+- 如需了解 pypdfium2 的高级用法，请参阅 REFERENCE.md
+- 如需了解 JavaScript 库（pdf-lib），请参阅 REFERENCE.md
+- 如需填写 PDF 表单，请按照 FORMS.md 中的说明操作
+- 如需故障排除指南，请参阅 REFERENCE.md

--- a/skills/pptx/SKILL.md
+++ b/skills/pptx/SKILL.md
@@ -1,106 +1,106 @@
 ---
 name: pptx
-description: "Use this skill any time a .pptx file is involved in any way — as input, output, or both. This includes: creating slide decks, pitch decks, or presentations; reading, parsing, or extracting text from any .pptx file (even if the extracted content will be used elsewhere, like in an email or summary); editing, modifying, or updating existing presentations; combining or splitting slide files; working with templates, layouts, speaker notes, or comments. Trigger whenever the user mentions \"deck,\" \"slides,\" \"presentation,\" or references a .pptx filename, regardless of what they plan to do with the content afterward. If a .pptx file needs to be opened, created, or touched, use this skill."
+description: "当涉及 .pptx 文件的任何操作时，请使用此技能——无论是作为输入、输出还是两者兼有。包括：创建幻灯片、演示文稿或提案演示；读取、解析或提取任何 .pptx 文件中的文本（即使提取的内容将用于其他用途，如邮件或摘要）；编辑、修改或更新现有演示文稿；合并或拆分幻灯片文件；使用模板、布局、演讲者备注或批注。当用户提到"演示文稿"、"幻灯片"、"PPT"或引用 .pptx 文件名时触发，无论他们之后打算如何使用内容。如果需要打开、创建或操作 .pptx 文件，请使用此技能。"
 license: Proprietary. LICENSE.txt has complete terms
 ---
 
-# PPTX Skill
+# PPTX 技能
 
-## Quick Reference
+## 快速参考
 
-| Task | Guide |
-|------|-------|
-| Read/analyze content | `python -m markitdown presentation.pptx` |
-| Edit or create from template | Read [editing.md](editing.md) |
-| Create from scratch | Read [pptxgenjs.md](pptxgenjs.md) |
+| 任务 | 指南 |
+|------|------|
+| 读取/分析内容 | `python -m markitdown presentation.pptx` |
+| 基于模板编辑或创建 | 阅读 [editing.md](editing.md) |
+| 从零开始创建 | 阅读 [pptxgenjs.md](pptxgenjs.md) |
 
 ---
 
-## Reading Content
+## 读取内容
 
 ```bash
-# Text extraction
+# 提取文本
 python -m markitdown presentation.pptx
 
-# Visual overview
+# 可视化预览
 python scripts/thumbnail.py presentation.pptx
 
-# Raw XML
+# 原始 XML
 python scripts/office/unpack.py presentation.pptx unpacked/
 ```
 
 ---
 
-## Editing Workflow
+## 编辑工作流
 
-**Read [editing.md](editing.md) for full details.**
+**详细内容请阅读 [editing.md](editing.md)。**
 
-1. Analyze template with `thumbnail.py`
-2. Unpack → manipulate slides → edit content → clean → pack
-
----
-
-## Creating from Scratch
-
-**Read [pptxgenjs.md](pptxgenjs.md) for full details.**
-
-Use when no template or reference presentation is available.
+1. 使用 `thumbnail.py` 分析模板
+2. 解包 → 操作幻灯片 → 编辑内容 → 清理 → 打包
 
 ---
 
-## Design Ideas
+## 从零开始创建
 
-**Don't create boring slides.** Plain bullets on a white background won't impress anyone. Consider ideas from this list for each slide.
+**详细内容请阅读 [pptxgenjs.md](pptxgenjs.md)。**
 
-### Before Starting
+当没有可用的模板或参考演示文稿时使用。
 
-- **Pick a bold, content-informed color palette**: The palette should feel designed for THIS topic. If swapping your colors into a completely different presentation would still "work," you haven't made specific enough choices.
-- **Dominance over equality**: One color should dominate (60-70% visual weight), with 1-2 supporting tones and one sharp accent. Never give all colors equal weight.
-- **Dark/light contrast**: Dark backgrounds for title + conclusion slides, light for content ("sandwich" structure). Or commit to dark throughout for a premium feel.
-- **Commit to a visual motif**: Pick ONE distinctive element and repeat it — rounded image frames, icons in colored circles, thick single-side borders. Carry it across every slide.
+---
 
-### Color Palettes
+## 设计思路
 
-Choose colors that match your topic — don't default to generic blue. Use these palettes as inspiration:
+**不要创建无聊的幻灯片。** 白色背景上的纯文本要点不会给任何人留下深刻印象。请为每张幻灯片参考以下设计思路。
 
-| Theme | Primary | Secondary | Accent |
-|-------|---------|-----------|--------|
-| **Midnight Executive** | `1E2761` (navy) | `CADCFC` (ice blue) | `FFFFFF` (white) |
-| **Forest & Moss** | `2C5F2D` (forest) | `97BC62` (moss) | `F5F5F5` (cream) |
-| **Coral Energy** | `F96167` (coral) | `F9E795` (gold) | `2F3C7E` (navy) |
-| **Warm Terracotta** | `B85042` (terracotta) | `E7E8D1` (sand) | `A7BEAE` (sage) |
-| **Ocean Gradient** | `065A82` (deep blue) | `1C7293` (teal) | `21295C` (midnight) |
-| **Charcoal Minimal** | `36454F` (charcoal) | `F2F2F2` (off-white) | `212121` (black) |
-| **Teal Trust** | `028090` (teal) | `00A896` (seafoam) | `02C39A` (mint) |
-| **Berry & Cream** | `6D2E46` (berry) | `A26769` (dusty rose) | `ECE2D0` (cream) |
-| **Sage Calm** | `84B59F` (sage) | `69A297` (eucalyptus) | `50808E` (slate) |
-| **Cherry Bold** | `990011` (cherry) | `FCF6F5` (off-white) | `2F3C7E` (navy) |
+### 开始之前
 
-### For Each Slide
+- **选择大胆且贴合内容的配色方案**：配色方案应该让人感觉是专门为此主题设计的。如果把你的配色方案换到一个完全不同的演示文稿中仍然"适用"，说明你的选择还不够具针对性。
+- **主次分明**：一种颜色应占主导地位（60-70% 的视觉比重），搭配 1-2 种辅助色调和一种醒目的强调色。切勿让所有颜色平分秋色。
+- **深浅对比**：标题和结论幻灯片使用深色背景，内容页使用浅色背景（"三明治"结构）。或全程使用深色背景，营造高端质感。
+- **统一视觉主题**：选择一种独特的元素并重复使用——圆角图片框、彩色圆圈中的图标、粗单边边框。将其贯穿于每张幻灯片。
 
-**Every slide needs a visual element** — image, chart, icon, or shape. Text-only slides are forgettable.
+### 配色方案
 
-**Layout options:**
-- Two-column (text left, illustration on right)
-- Icon + text rows (icon in colored circle, bold header, description below)
-- 2x2 or 2x3 grid (image on one side, grid of content blocks on other)
-- Half-bleed image (full left or right side) with content overlay
+选择与主题相匹配的颜色——不要默认使用通用蓝色。以下配色方案供参考：
 
-**Data display:**
-- Large stat callouts (big numbers 60-72pt with small labels below)
-- Comparison columns (before/after, pros/cons, side-by-side options)
-- Timeline or process flow (numbered steps, arrows)
+| 主题 | 主色 | 辅色 | 强调色 |
+|------|------|------|--------|
+| **午夜商务** | `1E2761`（深蓝） | `CADCFC`（冰蓝） | `FFFFFF`（白色） |
+| **森林与苔藓** | `2C5F2D`（森林绿） | `97BC62`（苔藓绿） | `F5F5F5`（奶油白） |
+| **珊瑚活力** | `F96167`（珊瑚色） | `F9E795`（金色） | `2F3C7E`（深蓝） |
+| **暖赭石** | `B85042`（赭石色） | `E7E8D1`（沙色） | `A7BEAE`（鼠尾草绿） |
+| **海洋渐变** | `065A82`（深蓝） | `1C7293`（青色） | `21295C`（午夜蓝） |
+| **木炭极简** | `36454F`（炭灰） | `F2F2F2`（灰白） | `212121`（黑色） |
+| **青蓝信任** | `028090`（青蓝） | `00A896`（海沫绿） | `02C39A`（薄荷绿） |
+| **浆果与奶油** | `6D2E46`（浆果色） | `A26769`（暗玫瑰） | `ECE2D0`（奶油色） |
+| **鼠尾草宁静** | `84B59F`（鼠尾草绿） | `69A297`（桉叶绿） | `50808E`（板岩蓝） |
+| **樱桃醒目** | `990011`（樱桃红） | `FCF6F5`（灰白） | `2F3C7E`（深蓝） |
 
-**Visual polish:**
-- Icons in small colored circles next to section headers
-- Italic accent text for key stats or taglines
+### 每张幻灯片
 
-### Typography
+**每张幻灯片都需要一个视觉元素**——图片、图表、图标或形状。纯文本幻灯片令人过目即忘。
 
-**Choose an interesting font pairing** — don't default to Arial. Pick a header font with personality and pair it with a clean body font.
+**布局选项：**
+- 双栏（左侧文本，右侧插图）
+- 图标 + 文本行（彩色圆圈中的图标、粗体标题、下方描述）
+- 2x2 或 2x3 网格（一侧图片，另一侧内容块网格）
+- 半出血图片（占满左侧或右侧）搭配内容叠加
 
-| Header Font | Body Font |
-|-------------|-----------|
+**数据展示：**
+- 大数据突出展示（60-72pt 大数字，下方小标签）
+- 对比栏（前/后、优/劣、并列选项）
+- 时间线或流程图（编号步骤、箭头）
+
+**视觉打磨：**
+- 章节标题旁的小彩色圆圈图标
+- 关键数据或标语使用斜体强调文本
+
+### 字体排版
+
+**选择有趣的字体搭配**——不要默认使用 Arial。选择有个性的标题字体，搭配简洁的正文字体。
+
+| 标题字体 | 正文字体 |
+|----------|----------|
 | Georgia | Calibri |
 | Arial Black | Arial |
 | Calibri | Calibri Light |
@@ -110,112 +110,112 @@ Choose colors that match your topic — don't default to generic blue. Use these
 | Palatino | Garamond |
 | Consolas | Calibri |
 
-| Element | Size |
-|---------|------|
-| Slide title | 36-44pt bold |
-| Section header | 20-24pt bold |
-| Body text | 14-16pt |
-| Captions | 10-12pt muted |
+| 元素 | 字号 |
+|------|------|
+| 幻灯片标题 | 36-44pt 粗体 |
+| 章节标题 | 20-24pt 粗体 |
+| 正文文本 | 14-16pt |
+| 说明文字 | 10-12pt 弱化色 |
 
-### Spacing
+### 间距
 
-- 0.5" minimum margins
-- 0.3-0.5" between content blocks
-- Leave breathing room—don't fill every inch
+- 最小边距 0.5 英寸
+- 内容块之间 0.3-0.5 英寸
+- 留出呼吸空间——不要填满每一寸
 
-### Avoid (Common Mistakes)
+### 避免（常见错误）
 
-- **Don't repeat the same layout** — vary columns, cards, and callouts across slides
-- **Don't center body text** — left-align paragraphs and lists; center only titles
-- **Don't skimp on size contrast** — titles need 36pt+ to stand out from 14-16pt body
-- **Don't default to blue** — pick colors that reflect the specific topic
-- **Don't mix spacing randomly** — choose 0.3" or 0.5" gaps and use consistently
-- **Don't style one slide and leave the rest plain** — commit fully or keep it simple throughout
-- **Don't create text-only slides** — add images, icons, charts, or visual elements; avoid plain title + bullets
-- **Don't forget text box padding** — when aligning lines or shapes with text edges, set `margin: 0` on the text box or offset the shape to account for padding
-- **Don't use low-contrast elements** — icons AND text need strong contrast against the background; avoid light text on light backgrounds or dark text on dark backgrounds
-- **NEVER use accent lines under titles** — these are a hallmark of AI-generated slides; use whitespace or background color instead
+- **不要重复相同的布局** —— 在不同幻灯片之间变换使用栏、卡片和标注
+- **不要居中正文** —— 段落和列表左对齐；仅标题居中
+- **不要忽视字号对比** —— 标题需要 36pt 以上才能从 14-16pt 正文中脱颖而出
+- **不要默认使用蓝色** —— 选择能反映具体主题的颜色
+- **不要随意混用间距** —— 选择 0.3 英寸或 0.5 英寸的间距并保持一致
+- **不要只美化一张幻灯片而忽略其余** —— 要么全程精心设计，要么全程保持简约
+- **不要创建纯文本幻灯片** —— 添加图片、图标、图表或视觉元素；避免纯标题 + 要点
+- **不要忘记文本框内边距** —— 将线条或形状与文本边缘对齐时，将文本框的 `margin: 0` 设置为零，或偏移形状以补偿内边距
+- **不要使用低对比度元素** —— 图标和文本都需要与背景形成强烈对比；避免浅色背景上的浅色文字或深色背景上的深色文字
+- **绝对不要在标题下方使用强调线** —— 这是 AI 生成幻灯片的典型特征；改用留白或背景色
 
 ---
 
-## QA (Required)
+## 质量检查（必需）
 
-**Assume there are problems. Your job is to find them.**
+**假设存在问题。你的任务就是找到它们。**
 
-Your first render is almost never correct. Approach QA as a bug hunt, not a confirmation step. If you found zero issues on first inspection, you weren't looking hard enough.
+你的第一版渲染几乎不可能完全正确。将质量检查视为一次找错行动，而非确认步骤。如果第一次检查没有发现任何问题，说明你检查得还不够仔细。
 
-### Content QA
+### 内容质量检查
 
 ```bash
 python -m markitdown output.pptx
 ```
 
-Check for missing content, typos, wrong order.
+检查是否有遗漏内容、拼写错误、顺序错误。
 
-**When using templates, check for leftover placeholder text:**
+**使用模板时，检查是否有残留的占位符文本：**
 
 ```bash
 python -m markitdown output.pptx | grep -iE "xxxx|lorem|ipsum|this.*(page|slide).*layout"
 ```
 
-If grep returns results, fix them before declaring success.
+如果 grep 返回结果，请在宣布完成之前修复它们。
 
-### Visual QA
+### 视觉质量检查
 
-**⚠️ USE SUBAGENTS** — even for 2-3 slides. You've been staring at the code and will see what you expect, not what's there. Subagents have fresh eyes.
+**请使用子代理** —— 即使只有 2-3 张幻灯片也是如此。你一直在盯着代码，会看到你期望看到的内容，而不是实际存在的内容。子代理拥有全新的视角。
 
-Convert slides to images (see [Converting to Images](#converting-to-images)), then use this prompt:
+将幻灯片转换为图片（参见[转换为图片](#转换为图片)），然后使用以下提示词：
 
 ```
-Visually inspect these slides. Assume there are issues — find them.
+对这些幻灯片进行视觉检查。假设存在问题——找到它们。
 
-Look for:
-- Overlapping elements (text through shapes, lines through words, stacked elements)
-- Text overflow or cut off at edges/box boundaries
-- Decorative lines positioned for single-line text but title wrapped to two lines
-- Source citations or footers colliding with content above
-- Elements too close (< 0.3" gaps) or cards/sections nearly touching
-- Uneven gaps (large empty area in one place, cramped in another)
-- Insufficient margin from slide edges (< 0.5")
-- Columns or similar elements not aligned consistently
-- Low-contrast text (e.g., light gray text on cream-colored background)
-- Low-contrast icons (e.g., dark icons on dark backgrounds without a contrasting circle)
-- Text boxes too narrow causing excessive wrapping
-- Leftover placeholder content
+检查以下内容：
+- 元素重叠（文本穿过形状、线条穿过文字、元素堆叠）
+- 文本溢出或在边缘/框边界处被截断
+- 装饰线条按单行文本定位但标题换行成两行
+- 来源引用或页脚与上方内容碰撞
+- 元素间距过小（< 0.3 英寸）或卡片/区域几乎相接
+- 间距不均匀（某处大面积空白，另一处过于拥挤）
+- 与幻灯片边缘的边距不足（< 0.5 英寸）
+- 栏或相似元素未保持一致对齐
+- 低对比度文本（如浅灰色文字在奶油色背景上）
+- 低对比度图标（如深色图标在深色背景上且没有对比色圆圈）
+- 文本框过窄导致过度换行
+- 残留的占位符内容
 
-For each slide, list issues or areas of concern, even if minor.
+对每张幻灯片列出问题或值得关注的地方，即使是细微问题。
 
-Read and analyze these images:
-1. /path/to/slide-01.jpg (Expected: [brief description])
-2. /path/to/slide-02.jpg (Expected: [brief description])
+阅读并分析以下图片：
+1. /path/to/slide-01.jpg（预期内容：[简要描述]）
+2. /path/to/slide-02.jpg（预期内容：[简要描述]）
 
-Report ALL issues found, including minor ones.
+报告发现的所有问题，包括细微问题。
 ```
 
-### Verification Loop
+### 验证循环
 
-1. Generate slides → Convert to images → Inspect
-2. **List issues found** (if none found, look again more critically)
-3. Fix issues
-4. **Re-verify affected slides** — one fix often creates another problem
-5. Repeat until a full pass reveals no new issues
+1. 生成幻灯片 → 转换为图片 → 检查
+2. **列出发现的问题**（如果未发现问题，请更仔细地再看一遍）
+3. 修复问题
+4. **重新验证受影响的幻灯片** —— 一个修复往往会引发另一个问题
+5. 重复直到完整检查一遍后不再发现新问题
 
-**Do not declare success until you've completed at least one fix-and-verify cycle.**
+**在完成至少一轮修复与验证循环之前，不要宣布成功。**
 
 ---
 
-## Converting to Images
+## 转换为图片
 
-Convert presentations to individual slide images for visual inspection:
+将演示文稿转换为单独的幻灯片图片以进行视觉检查：
 
 ```bash
 python scripts/office/soffice.py --headless --convert-to pdf output.pptx
 pdftoppm -jpeg -r 150 output.pdf slide
 ```
 
-This creates `slide-01.jpg`, `slide-02.jpg`, etc.
+这将生成 `slide-01.jpg`、`slide-02.jpg` 等文件。
 
-To re-render specific slides after fixes:
+修复后重新渲染特定幻灯片：
 
 ```bash
 pdftoppm -jpeg -r 150 -f N -l N output.pdf slide-fixed
@@ -223,10 +223,10 @@ pdftoppm -jpeg -r 150 -f N -l N output.pdf slide-fixed
 
 ---
 
-## Dependencies
+## 依赖项
 
-- `pip install "markitdown[pptx]"` - text extraction
-- `pip install Pillow` - thumbnail grids
-- `npm install -g pptxgenjs` - creating from scratch
-- LibreOffice (`soffice`) - PDF conversion (auto-configured for sandboxed environments via `scripts/office/soffice.py`)
-- Poppler (`pdftoppm`) - PDF to images
+- `pip install "markitdown[pptx]"` - 文本提取
+- `pip install Pillow` - 缩略图网格
+- `npm install -g pptxgenjs` - 从零创建
+- LibreOffice (`soffice`) - PDF 转换（通过 `scripts/office/soffice.py` 自动配置沙盒环境）
+- Poppler (`pdftoppm`) - PDF 转图片

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -1,357 +1,354 @@
 ---
 name: skill-creator
-description: Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Claude's capabilities with specialized knowledge, workflows, or tool integrations.
+description: 创建高效技能的指南。当用户想要创建新技能（或更新现有技能）以扩展 Claude 的能力时，应使用此技能，包括专业知识、工作流程或工具集成。
 license: Complete terms in LICENSE.txt
 ---
 
-# Skill Creator
+# 技能创建器
 
-This skill provides guidance for creating effective skills.
+此技能提供创建高效技能的指导。
 
-## About Skills
+## 关于技能
 
-Skills are modular, self-contained packages that extend Claude's capabilities by providing
-specialized knowledge, workflows, and tools. Think of them as "onboarding guides" for specific
-domains or tasks—they transform Claude from a general-purpose agent into a specialized agent
-equipped with procedural knowledge that no model can fully possess.
+技能是模块化、自包含的包，通过提供专业知识、工作流程和工具来扩展 Claude 的能力。可以将其视为特定领域或任务的"入职指南"——它们将 Claude 从通用代理转变为配备了程序性知识的专业代理，而这些知识是任何模型都无法完全具备的。
 
-### What Skills Provide
+### 技能提供的能力
 
-1. Specialized workflows - Multi-step procedures for specific domains
-2. Tool integrations - Instructions for working with specific file formats or APIs
-3. Domain expertise - Company-specific knowledge, schemas, business logic
-4. Bundled resources - Scripts, references, and assets for complex and repetitive tasks
+1. 专业工作流程 - 特定领域的多步骤操作流程
+2. 工具集成 - 处理特定文件格式或 API 的操作指南
+3. 领域专业知识 - 公司特定的知识、数据模式、业务逻辑
+4. 捆绑资源 - 用于复杂和重复性任务的脚本、参考文档和素材资源
 
-## Core Principles
+## 核心原则
 
-### Concise is Key
+### 简洁至上
 
-The context window is a public good. Skills share the context window with everything else Claude needs: system prompt, conversation history, other Skills' metadata, and the actual user request.
+上下文窗口是公共资源。技能与 Claude 所需的其他内容共享上下文窗口：系统提示、对话历史、其他技能的元数据以及实际用户请求。
 
-**Default assumption: Claude is already very smart.** Only add context Claude doesn't already have. Challenge each piece of information: "Does Claude really need this explanation?" and "Does this paragraph justify its token cost?"
+**默认假设：Claude 本身已经非常智能。** 只添加 Claude 尚不具备的上下文。对每条信息进行审视："Claude 真的需要这个解释吗？"以及"这段内容值得消耗这些 token 吗？"
 
-Prefer concise examples over verbose explanations.
+优先使用简洁的示例，而非冗长的解释。
 
-### Set Appropriate Degrees of Freedom
+### 设定适当的自由度
 
-Match the level of specificity to the task's fragility and variability:
+根据任务的脆弱性和可变性匹配具体程度：
 
-**High freedom (text-based instructions)**: Use when multiple approaches are valid, decisions depend on context, or heuristics guide the approach.
+**高自由度（文本指令）**：当多种方法都可行、决策取决于上下文或启发式方法指导方向时使用。
 
-**Medium freedom (pseudocode or scripts with parameters)**: Use when a preferred pattern exists, some variation is acceptable, or configuration affects behavior.
+**中等自由度（伪代码或带参数的脚本）**：当存在首选模式、可以接受一定变化或配置影响行为时使用。
 
-**Low freedom (specific scripts, few parameters)**: Use when operations are fragile and error-prone, consistency is critical, or a specific sequence must be followed.
+**低自由度（特定脚本，少量参数）**：当操作脆弱且容易出错、一致性至关重要或必须遵循特定顺序时使用。
 
-Think of Claude as exploring a path: a narrow bridge with cliffs needs specific guardrails (low freedom), while an open field allows many routes (high freedom).
+可以将 Claude 想象为在探索一条路径：悬崖边的窄桥需要具体的护栏（低自由度），而开阔的田野则允许多条路线（高自由度）。
 
-### Anatomy of a Skill
+### 技能的结构
 
-Every skill consists of a required SKILL.md file and optional bundled resources:
+每个技能由一个必需的 SKILL.md 文件和可选的捆绑资源组成：
 
 ```
 skill-name/
-├── SKILL.md (required)
-│   ├── YAML frontmatter metadata (required)
-│   │   ├── name: (required)
-│   │   ├── description: (required)
-│   │   └── compatibility: (optional, rarely needed)
-│   └── Markdown instructions (required)
-└── Bundled Resources (optional)
-    ├── scripts/          - Executable code (Python/Bash/etc.)
-    ├── references/       - Documentation intended to be loaded into context as needed
-    └── assets/           - Files used in output (templates, icons, fonts, etc.)
+├── SKILL.md（必需）
+│   ├── YAML 前置元数据（必需）
+│   │   ├── name:（必需）
+│   │   ├── description:（必需）
+│   │   └── compatibility:（可选，很少需要）
+│   └── Markdown 指令（必需）
+└── 捆绑资源（可选）
+    ├── scripts/          - 可执行代码（Python/Bash 等）
+    ├── references/       - 需要时加载到上下文中的参考文档
+    └── assets/           - 用于输出的文件（模板、图标、字体等）
 ```
 
-#### SKILL.md (required)
+#### SKILL.md（必需）
 
-Every SKILL.md consists of:
+每个 SKILL.md 包含：
 
-- **Frontmatter** (YAML): Contains `name` and `description` fields (required), plus optional fields like `license`, `metadata`, and `compatibility`. Only `name` and `description` are read by Claude to determine when the skill triggers, so be clear and comprehensive about what the skill is and when it should be used. The `compatibility` field is for noting environment requirements (target product, system packages, etc.) but most skills don't need it.
-- **Body** (Markdown): Instructions and guidance for using the skill. Only loaded AFTER the skill triggers (if at all).
+- **前置元数据**（YAML）：包含 `name` 和 `description` 字段（必需），以及可选字段如 `license`、`metadata` 和 `compatibility`。Claude 仅读取 `name` 和 `description` 来判断何时触发技能，因此请清晰全面地描述技能是什么以及何时应该使用。`compatibility` 字段用于注明环境要求（目标产品、系统包等），但大多数技能不需要此字段。
+- **正文**（Markdown）：使用技能的指令和指导。仅在技能触发后才会加载（如果需要的话）。
 
-#### Bundled Resources (optional)
+#### 捆绑资源（可选）
 
-##### Scripts (`scripts/`)
+##### 脚本（`scripts/`）
 
-Executable code (Python/Bash/etc.) for tasks that require deterministic reliability or are repeatedly rewritten.
+用于需要确定性可靠性或经常被重复编写的任务的可执行代码（Python/Bash 等）。
 
-- **When to include**: When the same code is being rewritten repeatedly or deterministic reliability is needed
-- **Example**: `scripts/rotate_pdf.py` for PDF rotation tasks
-- **Benefits**: Token efficient, deterministic, may be executed without loading into context
-- **Note**: Scripts may still need to be read by Claude for patching or environment-specific adjustments
+- **何时包含**：当相同的代码被反复重写或需要确定性可靠性时
+- **示例**：`scripts/rotate_pdf.py` 用于 PDF 旋转任务
+- **优势**：节省 token、确定性强、可以无需加载到上下文窗口即可执行
+- **注意**：脚本可能仍需被 Claude 读取以进行修补或环境特定的调整
 
-##### References (`references/`)
+##### 参考文档（`references/`）
 
-Documentation and reference material intended to be loaded as needed into context to inform Claude's process and thinking.
+需要时加载到上下文中以指导 Claude 的处理过程和思路的文档和参考资料。
 
-- **When to include**: For documentation that Claude should reference while working
-- **Examples**: `references/finance.md` for financial schemas, `references/mnda.md` for company NDA template, `references/policies.md` for company policies, `references/api_docs.md` for API specifications
-- **Use cases**: Database schemas, API documentation, domain knowledge, company policies, detailed workflow guides
-- **Benefits**: Keeps SKILL.md lean, loaded only when Claude determines it's needed
-- **Best practice**: If files are large (>10k words), include grep search patterns in SKILL.md
-- **Avoid duplication**: Information should live in either SKILL.md or references files, not both. Prefer references files for detailed information unless it's truly core to the skill—this keeps SKILL.md lean while making information discoverable without hogging the context window. Keep only essential procedural instructions and workflow guidance in SKILL.md; move detailed reference material, schemas, and examples to references files.
+- **何时包含**：当有 Claude 在工作时应参考的文档时
+- **示例**：`references/finance.md` 用于财务数据模式、`references/mnda.md` 用于公司保密协议模板、`references/policies.md` 用于公司政策、`references/api_docs.md` 用于 API 规范
+- **使用场景**：数据库模式、API 文档、领域知识、公司政策、详细工作流程指南
+- **优势**：保持 SKILL.md 精简，仅在 Claude 认为需要时才加载
+- **最佳实践**：如果文件较大（超过 1 万字），在 SKILL.md 中包含 grep 搜索模式
+- **避免重复**：信息应只存在于 SKILL.md 或参考文件中，而非两者都有。除非信息确实是技能的核心内容，否则优先将详细信息放在参考文件中——这样既能保持 SKILL.md 精简，又能让信息可被发现而不占用上下文窗口。仅在 SKILL.md 中保留核心的操作指令和工作流程指导；将详细的参考资料、数据模式和示例移至参考文件。
 
-##### Assets (`assets/`)
+##### 素材资源（`assets/`）
 
-Files not intended to be loaded into context, but rather used within the output Claude produces.
+不用于加载到上下文中，而是用于 Claude 生成的输出中的文件。
 
-- **When to include**: When the skill needs files that will be used in the final output
-- **Examples**: `assets/logo.png` for brand assets, `assets/slides.pptx` for PowerPoint templates, `assets/frontend-template/` for HTML/React boilerplate, `assets/font.ttf` for typography
-- **Use cases**: Templates, images, icons, boilerplate code, fonts, sample documents that get copied or modified
-- **Benefits**: Separates output resources from documentation, enables Claude to use files without loading them into context
+- **何时包含**：当技能需要在最终输出中使用的文件时
+- **示例**：`assets/logo.png` 用于品牌素材、`assets/slides.pptx` 用于 PowerPoint 模板、`assets/frontend-template/` 用于 HTML/React 样板代码、`assets/font.ttf` 用于字体
+- **使用场景**：模板、图片、图标、样板代码、字体、需要被复制或修改的示例文档
+- **优势**：将输出资源与文档分离，使 Claude 无需加载到上下文即可使用文件
 
-#### What to Not Include in a Skill
+#### 技能中不应包含的内容
 
-A skill should only contain essential files that directly support its functionality. Do NOT create extraneous documentation or auxiliary files, including:
+技能应只包含直接支持其功能的必要文件。不要创建多余的文档或辅助文件，包括：
 
 - README.md
 - INSTALLATION_GUIDE.md
 - QUICK_REFERENCE.md
 - CHANGELOG.md
-- etc.
+- 等等
 
-The skill should only contain the information needed for an AI agent to do the job at hand. It should not contain auxilary context about the process that went into creating it, setup and testing procedures, user-facing documentation, etc. Creating additional documentation files just adds clutter and confusion.
+技能应只包含 AI 代理完成手头工作所需的信息。不应包含创建过程的辅助上下文、安装和测试流程、面向用户的文档等。创建额外的文档文件只会增加混乱和困惑。
 
-### Progressive Disclosure Design Principle
+### 渐进式信息披露设计原则
 
-Skills use a three-level loading system to manage context efficiently:
+技能使用三级加载系统来高效管理上下文：
 
-1. **Metadata (name + description)** - Always in context (~100 words)
-2. **SKILL.md body** - When skill triggers (<5k words)
-3. **Bundled resources** - As needed by Claude (Unlimited because scripts can be executed without reading into context window)
+1. **元数据（name + description）** - 始终在上下文中（约 100 个词）
+2. **SKILL.md 正文** - 技能触发时加载（< 5000 词）
+3. **捆绑资源** - Claude 按需加载（无限制，因为脚本可以无需读入上下文窗口即可执行）
 
-#### Progressive Disclosure Patterns
+#### 渐进式信息披露模式
 
-Keep SKILL.md body to the essentials and under 500 lines to minimize context bloat. Split content into separate files when approaching this limit. When splitting out content into other files, it is very important to reference them from SKILL.md and describe clearly when to read them, to ensure the reader of the skill knows they exist and when to use them.
+将 SKILL.md 正文控制在核心要点内，不超过 500 行，以减少上下文膨胀。接近此限制时将内容拆分到单独的文件中。拆分内容到其他文件时，务必从 SKILL.md 中引用它们并清楚描述何时应阅读这些文件，确保技能的读者知道它们的存在及使用时机。
 
-**Key principle:** When a skill supports multiple variations, frameworks, or options, keep only the core workflow and selection guidance in SKILL.md. Move variant-specific details (patterns, examples, configuration) into separate reference files.
+**关键原则：** 当技能支持多种变体、框架或选项时，仅在 SKILL.md 中保留核心工作流程和选择指南。将特定变体的详细信息（模式、示例、配置）移至单独的参考文件。
 
-**Pattern 1: High-level guide with references**
+**模式 1：带参考文档的高层指南**
 
 ```markdown
-# PDF Processing
+# PDF 处理
 
-## Quick start
+## 快速入门
 
-Extract text with pdfplumber:
-[code example]
+使用 pdfplumber 提取文本：
+[代码示例]
 
-## Advanced features
+## 高级功能
 
-- **Form filling**: See [FORMS.md](FORMS.md) for complete guide
-- **API reference**: See [REFERENCE.md](REFERENCE.md) for all methods
-- **Examples**: See [EXAMPLES.md](EXAMPLES.md) for common patterns
+- **表单填写**：完整指南请参阅 [FORMS.md](FORMS.md)
+- **API 参考**：所有方法请参阅 [REFERENCE.md](REFERENCE.md)
+- **示例**：常见模式请参阅 [EXAMPLES.md](EXAMPLES.md)
 ```
 
-Claude loads FORMS.md, REFERENCE.md, or EXAMPLES.md only when needed.
+Claude 仅在需要时加载 FORMS.md、REFERENCE.md 或 EXAMPLES.md。
 
-**Pattern 2: Domain-specific organization**
+**模式 2：按领域组织**
 
-For Skills with multiple domains, organize content by domain to avoid loading irrelevant context:
+对于涵盖多个领域的技能，按领域组织内容以避免加载无关上下文：
 
 ```
 bigquery-skill/
-├── SKILL.md (overview and navigation)
+├── SKILL.md（概述和导航）
 └── reference/
-    ├── finance.md (revenue, billing metrics)
-    ├── sales.md (opportunities, pipeline)
-    ├── product.md (API usage, features)
-    └── marketing.md (campaigns, attribution)
+    ├── finance.md（收入、计费指标）
+    ├── sales.md（商机、销售管道）
+    ├── product.md（API 使用、功能）
+    └── marketing.md（营销活动、归因分析）
 ```
 
-When a user asks about sales metrics, Claude only reads sales.md.
+当用户询问销售指标时，Claude 只需读取 sales.md。
 
-Similarly, for skills supporting multiple frameworks or variants, organize by variant:
+类似地，对于支持多种框架或变体的技能，按变体组织：
 
 ```
 cloud-deploy/
-├── SKILL.md (workflow + provider selection)
+├── SKILL.md（工作流程 + 提供商选择）
 └── references/
-    ├── aws.md (AWS deployment patterns)
-    ├── gcp.md (GCP deployment patterns)
-    └── azure.md (Azure deployment patterns)
+    ├── aws.md（AWS 部署模式）
+    ├── gcp.md（GCP 部署模式）
+    └── azure.md（Azure 部署模式）
 ```
 
-When the user chooses AWS, Claude only reads aws.md.
+当用户选择 AWS 时，Claude 只需读取 aws.md。
 
-**Pattern 3: Conditional details**
+**模式 3：按条件展示详细信息**
 
-Show basic content, link to advanced content:
+展示基本内容，链接到高级内容：
 
 ```markdown
-# DOCX Processing
+# DOCX 处理
 
-## Creating documents
+## 创建文档
 
-Use docx-js for new documents. See [DOCX-JS.md](DOCX-JS.md).
+使用 docx-js 创建新文档。参阅 [DOCX-JS.md](DOCX-JS.md)。
 
-## Editing documents
+## 编辑文档
 
-For simple edits, modify the XML directly.
+对于简单编辑，直接修改 XML。
 
-**For tracked changes**: See [REDLINING.md](REDLINING.md)
-**For OOXML details**: See [OOXML.md](OOXML.md)
+**跟踪修改**：参阅 [REDLINING.md](REDLINING.md)
+**OOXML 详情**：参阅 [OOXML.md](OOXML.md)
 ```
 
-Claude reads REDLINING.md or OOXML.md only when the user needs those features.
+Claude 仅在用户需要这些功能时才读取 REDLINING.md 或 OOXML.md。
 
-**Important guidelines:**
+**重要指南：**
 
-- **Avoid deeply nested references** - Keep references one level deep from SKILL.md. All reference files should link directly from SKILL.md.
-- **Structure longer reference files** - For files longer than 100 lines, include a table of contents at the top so Claude can see the full scope when previewing.
+- **避免深层嵌套引用** - 引用保持在 SKILL.md 的一级深度内。所有参考文件应直接从 SKILL.md 链接。
+- **为较长的参考文件添加结构** - 对于超过 100 行的文件，在顶部包含目录，以便 Claude 在预览时能看到完整范围。
 
-## Skill Creation Process
+## 技能创建流程
 
-Skill creation involves these steps:
+技能创建包含以下步骤：
 
-1. Understand the skill with concrete examples
-2. Plan reusable skill contents (scripts, references, assets)
-3. Initialize the skill (run init_skill.py)
-4. Edit the skill (implement resources and write SKILL.md)
-5. Package the skill (run package_skill.py)
-6. Iterate based on real usage
+1. 通过具体示例理解技能
+2. 规划可复用的技能内容（脚本、参考文档、素材资源）
+3. 初始化技能（运行 init_skill.py）
+4. 编辑技能（实现资源并编写 SKILL.md）
+5. 打包技能（运行 package_skill.py）
+6. 基于实际使用进行迭代
 
-Follow these steps in order, skipping only if there is a clear reason why they are not applicable.
+请按顺序执行这些步骤，仅在有明确理由表明某步骤不适用时才跳过。
 
-### Step 1: Understanding the Skill with Concrete Examples
+### 步骤 1：通过具体示例理解技能
 
-Skip this step only when the skill's usage patterns are already clearly understood. It remains valuable even when working with an existing skill.
+仅当技能的使用模式已被充分理解时才跳过此步骤。即使在处理现有技能时，此步骤仍然有价值。
 
-To create an effective skill, clearly understand concrete examples of how the skill will be used. This understanding can come from either direct user examples or generated examples that are validated with user feedback.
+要创建高效的技能，需要清楚理解技能将如何被使用的具体示例。这种理解可以来自直接的用户示例或经过用户反馈验证的生成示例。
 
-For example, when building an image-editor skill, relevant questions include:
+例如，在构建图片编辑器技能时，相关问题包括：
 
-- "What functionality should the image-editor skill support? Editing, rotating, anything else?"
-- "Can you give some examples of how this skill would be used?"
-- "I can imagine users asking for things like 'Remove the red-eye from this image' or 'Rotate this image'. Are there other ways you imagine this skill being used?"
-- "What would a user say that should trigger this skill?"
+- "图片编辑器技能应支持哪些功能？编辑、旋转，还有其他吗？"
+- "你能举一些这个技能会如何被使用的例子吗？"
+- "我能想到用户会提出这样的需求，比如'去除这张图片的红眼'或'旋转这张图片'。你还能想到其他使用方式吗？"
+- "用户说什么话应该触发这个技能？"
 
-To avoid overwhelming users, avoid asking too many questions in a single message. Start with the most important questions and follow up as needed for better effectiveness.
+为避免信息过载，避免在单条消息中提出过多问题。先从最重要的问题开始，然后根据需要跟进，以获得更好的效果。
 
-Conclude this step when there is a clear sense of the functionality the skill should support.
+当对技能应支持的功能有了清晰认识后，此步骤即告完成。
 
-### Step 2: Planning the Reusable Skill Contents
+### 步骤 2：规划可复用的技能内容
 
-To turn concrete examples into an effective skill, analyze each example by:
+要将具体示例转化为高效技能，需要对每个示例进行分析：
 
-1. Considering how to execute on the example from scratch
-2. Identifying what scripts, references, and assets would be helpful when executing these workflows repeatedly
+1. 考虑如何从头开始执行该示例
+2. 识别在重复执行这些工作流程时，哪些脚本、参考文档和素材资源会有所帮助
 
-Example: When building a `pdf-editor` skill to handle queries like "Help me rotate this PDF," the analysis shows:
+示例：构建 `pdf-editor` 技能以处理"帮我旋转这个 PDF"等查询时，分析表明：
 
-1. Rotating a PDF requires re-writing the same code each time
-2. A `scripts/rotate_pdf.py` script would be helpful to store in the skill
+1. 旋转 PDF 每次都需要重新编写相同的代码
+2. 将 `scripts/rotate_pdf.py` 脚本存储在技能中会很有帮助
 
-Example: When designing a `frontend-webapp-builder` skill for queries like "Build me a todo app" or "Build me a dashboard to track my steps," the analysis shows:
+示例：设计 `frontend-webapp-builder` 技能以处理"帮我做一个待办事项应用"或"帮我做一个步数追踪仪表盘"等查询时，分析表明：
 
-1. Writing a frontend webapp requires the same boilerplate HTML/React each time
-2. An `assets/hello-world/` template containing the boilerplate HTML/React project files would be helpful to store in the skill
+1. 编写前端 Web 应用每次都需要相同的 HTML/React 样板代码
+2. 将包含样板 HTML/React 项目文件的 `assets/hello-world/` 模板存储在技能中会很有帮助
 
-Example: When building a `big-query` skill to handle queries like "How many users have logged in today?" the analysis shows:
+示例：构建 `big-query` 技能以处理"今天有多少用户登录了？"等查询时，分析表明：
 
-1. Querying BigQuery requires re-discovering the table schemas and relationships each time
-2. A `references/schema.md` file documenting the table schemas would be helpful to store in the skill
+1. 查询 BigQuery 每次都需要重新发现表的模式和关系
+2. 将记录表模式的 `references/schema.md` 文件存储在技能中会很有帮助
 
-To establish the skill's contents, analyze each concrete example to create a list of the reusable resources to include: scripts, references, and assets.
+要确定技能的内容，需分析每个具体示例，创建要包含的可复用资源列表：脚本、参考文档和素材资源。
 
-### Step 3: Initializing the Skill
+### 步骤 3：初始化技能
 
-At this point, it is time to actually create the skill.
+此时，是时候实际创建技能了。
 
-Skip this step only if the skill being developed already exists, and iteration or packaging is needed. In this case, continue to the next step.
+仅当要开发的技能已经存在且需要迭代或打包时才跳过此步骤。在这种情况下，继续下一步。
 
-When creating a new skill from scratch, always run the `init_skill.py` script. The script conveniently generates a new template skill directory that automatically includes everything a skill requires, making the skill creation process much more efficient and reliable.
+从零创建新技能时，始终运行 `init_skill.py` 脚本。该脚本会方便地生成一个新的技能模板目录，自动包含技能所需的一切，使技能创建过程更加高效和可靠。
 
-Usage:
+用法：
 
 ```bash
 scripts/init_skill.py <skill-name> --path <output-directory>
 ```
 
-The script:
+该脚本会：
 
-- Creates the skill directory at the specified path
-- Generates a SKILL.md template with proper frontmatter and TODO placeholders
-- Creates example resource directories: `scripts/`, `references/`, and `assets/`
-- Adds example files in each directory that can be customized or deleted
+- 在指定路径创建技能目录
+- 生成带有正确前置元数据和 TODO 占位符的 SKILL.md 模板
+- 创建示例资源目录：`scripts/`、`references/` 和 `assets/`
+- 在每个目录中添加可自定义或删除的示例文件
 
-After initialization, customize or remove the generated SKILL.md and example files as needed.
+初始化后，根据需要自定义或删除生成的 SKILL.md 和示例文件。
 
-### Step 4: Edit the Skill
+### 步骤 4：编辑技能
 
-When editing the (newly-generated or existing) skill, remember that the skill is being created for another instance of Claude to use. Include information that would be beneficial and non-obvious to Claude. Consider what procedural knowledge, domain-specific details, or reusable assets would help another Claude instance execute these tasks more effectively.
+编辑（新生成或现有的）技能时，请记住技能是为另一个 Claude 实例创建的。包含对 Claude 有益且非显而易见的信息。思考哪些程序性知识、领域特定细节或可复用素材资源能帮助另一个 Claude 实例更有效地执行这些任务。
 
-#### Learn Proven Design Patterns
+#### 学习经过验证的设计模式
 
-Consult these helpful guides based on your skill's needs:
+根据技能需求参考以下实用指南：
 
-- **Multi-step processes**: See references/workflows.md for sequential workflows and conditional logic
-- **Specific output formats or quality standards**: See references/output-patterns.md for template and example patterns
+- **多步骤流程**：参阅 references/workflows.md 了解顺序工作流程和条件逻辑
+- **特定输出格式或质量标准**：参阅 references/output-patterns.md 了解模板和示例模式
 
-These files contain established best practices for effective skill design.
+这些文件包含经过验证的技能设计最佳实践。
 
-#### Start with Reusable Skill Contents
+#### 从可复用技能内容开始
 
-To begin implementation, start with the reusable resources identified above: `scripts/`, `references/`, and `assets/` files. Note that this step may require user input. For example, when implementing a `brand-guidelines` skill, the user may need to provide brand assets or templates to store in `assets/`, or documentation to store in `references/`.
+开始实现时，从上面确定的可复用资源开始：`scripts/`、`references/` 和 `assets/` 文件。请注意，此步骤可能需要用户输入。例如，在实现 `brand-guidelines` 技能时，用户可能需要提供存储在 `assets/` 中的品牌素材或模板，或存储在 `references/` 中的文档。
 
-Added scripts must be tested by actually running them to ensure there are no bugs and that the output matches what is expected. If there are many similar scripts, only a representative sample needs to be tested to ensure confidence that they all work while balancing time to completion.
+添加的脚本必须通过实际运行来测试，确保没有错误且输出符合预期。如果有许多类似的脚本，只需测试具有代表性的样本，在确保它们都能正常工作的同时兼顾完成时间。
 
-Any example files and directories not needed for the skill should be deleted. The initialization script creates example files in `scripts/`, `references/`, and `assets/` to demonstrate structure, but most skills won't need all of them.
+技能不需要的任何示例文件和目录都应删除。初始化脚本在 `scripts/`、`references/` 和 `assets/` 中创建示例文件以展示结构，但大多数技能不需要全部保留。
 
-#### Update SKILL.md
+#### 更新 SKILL.md
 
-**Writing Guidelines:** Always use imperative/infinitive form.
+**编写指南：** 始终使用祈使句/不定式形式。
 
-##### Frontmatter
+##### 前置元数据
 
-Write the YAML frontmatter with `name` and `description`:
+编写包含 `name` 和 `description` 的 YAML 前置元数据：
 
-- `name`: The skill name
-- `description`: This is the primary triggering mechanism for your skill, and helps Claude understand when to use the skill.
-  - Include both what the Skill does and specific triggers/contexts for when to use it.
-  - Include all "when to use" information here - Not in the body. The body is only loaded after triggering, so "When to Use This Skill" sections in the body are not helpful to Claude.
-  - Example description for a `docx` skill: "Comprehensive document creation, editing, and analysis with support for tracked changes, comments, formatting preservation, and text extraction. Use when Claude needs to work with professional documents (.docx files) for: (1) Creating new documents, (2) Modifying or editing content, (3) Working with tracked changes, (4) Adding comments, or any other document tasks"
+- `name`：技能名称
+- `description`：这是技能的主要触发机制，帮助 Claude 理解何时使用该技能。
+  - 同时包含技能的功能和触发/使用场景的具体描述。
+  - 将所有"何时使用"的信息放在这里——不要放在正文中。正文仅在触发后才加载，因此正文中的"何时使用此技能"章节对 Claude 没有帮助。
+  - `docx` 技能的描述示例："Comprehensive document creation, editing, and analysis with support for tracked changes, comments, formatting preservation, and text extraction. Use when Claude needs to work with professional documents (.docx files) for: (1) Creating new documents, (2) Modifying or editing content, (3) Working with tracked changes, (4) Adding comments, or any other document tasks"
 
-Do not include any other fields in YAML frontmatter.
+不要在 YAML 前置元数据中包含其他任何字段。
 
-##### Body
+##### 正文
 
-Write instructions for using the skill and its bundled resources.
+编写使用技能及其捆绑资源的指令。
 
-### Step 5: Packaging a Skill
+### 步骤 5：打包技能
 
-Once development of the skill is complete, it must be packaged into a distributable .skill file that gets shared with the user. The packaging process automatically validates the skill first to ensure it meets all requirements:
+技能开发完成后，必须将其打包为可分发的 .skill 文件以分享给用户。打包过程会自动先验证技能，确保其满足所有要求：
 
 ```bash
 scripts/package_skill.py <path/to/skill-folder>
 ```
 
-Optional output directory specification:
+可选的输出目录指定：
 
 ```bash
 scripts/package_skill.py <path/to/skill-folder> ./dist
 ```
 
-The packaging script will:
+打包脚本将：
 
-1. **Validate** the skill automatically, checking:
+1. **自动验证**技能，检查：
 
-   - YAML frontmatter format and required fields
-   - Skill naming conventions and directory structure
-   - Description completeness and quality
-   - File organization and resource references
+   - YAML 前置元数据格式和必需字段
+   - 技能命名规范和目录结构
+   - 描述的完整性和质量
+   - 文件组织和资源引用
 
-2. **Package** the skill if validation passes, creating a .skill file named after the skill (e.g., `my-skill.skill`) that includes all files and maintains the proper directory structure for distribution. The .skill file is a zip file with a .skill extension.
+2. 如果验证通过则**打包**技能，创建以技能命名的 .skill 文件（例如 `my-skill.skill`），包含所有文件并维护正确的目录结构以便分发。.skill 文件是一个扩展名为 .skill 的 zip 文件。
 
-If validation fails, the script will report the errors and exit without creating a package. Fix any validation errors and run the packaging command again.
+如果验证失败，脚本将报告错误并退出而不创建包。修复所有验证错误后重新运行打包命令。
 
-### Step 6: Iterate
+### 步骤 6：迭代
 
-After testing the skill, users may request improvements. Often this happens right after using the skill, with fresh context of how the skill performed.
+测试技能后，用户可能会提出改进要求。这通常发生在使用技能之后，此时对技能表现有最新鲜的认识。
 
-**Iteration workflow:**
+**迭代工作流程：**
 
-1. Use the skill on real tasks
-2. Notice struggles or inefficiencies
-3. Identify how SKILL.md or bundled resources should be updated
-4. Implement changes and test again
+1. 在实际任务中使用技能
+2. 注意困难或低效之处
+3. 确定 SKILL.md 或捆绑资源应如何更新
+4. 实施更改并再次测试

--- a/skills/slack-gif-creator/SKILL.md
+++ b/skills/slack-gif-creator/SKILL.md
@@ -1,228 +1,228 @@
 ---
 name: slack-gif-creator
-description: Knowledge and utilities for creating animated GIFs optimized for Slack. Provides constraints, validation tools, and animation concepts. Use when users request animated GIFs for Slack like "make me a GIF of X doing Y for Slack."
+description: 用于创建针对 Slack 优化的动画 GIF 的知识和工具集。提供约束条件、验证工具和动画概念。当用户请求为 Slack 创建动画 GIF 时使用，例如"帮我做一个 X 做 Y 的 Slack GIF"。
 license: Complete terms in LICENSE.txt
 ---
 
-# Slack GIF Creator
+# Slack GIF 创建器
 
-A toolkit providing utilities and knowledge for creating animated GIFs optimized for Slack.
+一套提供工具和知识的工具包，用于创建针对 Slack 优化的动画 GIF。
 
-## Slack Requirements
+## Slack 要求
 
-**Dimensions:**
-- Emoji GIFs: 128x128 (recommended)
-- Message GIFs: 480x480
+**尺寸：**
+- 表情 GIF：128x128（推荐）
+- 消息 GIF：480x480
 
-**Parameters:**
-- FPS: 10-30 (lower is smaller file size)
-- Colors: 48-128 (fewer = smaller file size)
-- Duration: Keep under 3 seconds for emoji GIFs
+**参数：**
+- FPS：10-30（越低文件越小）
+- 颜色数：48-128（越少文件越小）
+- 时长：表情 GIF 控制在 3 秒以内
 
-## Core Workflow
+## 核心工作流程
 
 ```python
 from core.gif_builder import GIFBuilder
 from PIL import Image, ImageDraw
 
-# 1. Create builder
+# 1. 创建构建器
 builder = GIFBuilder(width=128, height=128, fps=10)
 
-# 2. Generate frames
+# 2. 生成帧
 for i in range(12):
     frame = Image.new('RGB', (128, 128), (240, 248, 255))
     draw = ImageDraw.Draw(frame)
 
-    # Draw your animation using PIL primitives
-    # (circles, polygons, lines, etc.)
+    # 使用 PIL 图形基元绘制动画
+    #（圆形、多边形、线条等）
 
     builder.add_frame(frame)
 
-# 3. Save with optimization
+# 3. 保存并优化
 builder.save('output.gif', num_colors=48, optimize_for_emoji=True)
 ```
 
-## Drawing Graphics
+## 绘制图形
 
-### Working with User-Uploaded Images
-If a user uploads an image, consider whether they want to:
-- **Use it directly** (e.g., "animate this", "split this into frames")
-- **Use it as inspiration** (e.g., "make something like this")
+### 处理用户上传的图片
+如果用户上传了图片，请判断他们想要：
+- **直接使用**（例如"给这个加动画效果"、"把这个拆分成帧"）
+- **作为灵感参考**（例如"做一个类似这样的"）
 
-Load and work with images using PIL:
+使用 PIL 加载和处理图片：
 ```python
 from PIL import Image
 
 uploaded = Image.open('file.png')
-# Use directly, or just as reference for colors/style
+# 直接使用，或仅作为颜色/风格的参考
 ```
 
-### Drawing from Scratch
-When drawing graphics from scratch, use PIL ImageDraw primitives:
+### 从零开始绘制
+从零开始绘制图形时，使用 PIL ImageDraw 图形基元：
 
 ```python
 from PIL import ImageDraw
 
 draw = ImageDraw.Draw(frame)
 
-# Circles/ovals
+# 圆形/椭圆形
 draw.ellipse([x1, y1, x2, y2], fill=(r, g, b), outline=(r, g, b), width=3)
 
-# Stars, triangles, any polygon
+# 星形、三角形及任意多边形
 points = [(x1, y1), (x2, y2), (x3, y3), ...]
 draw.polygon(points, fill=(r, g, b), outline=(r, g, b), width=3)
 
-# Lines
+# 线条
 draw.line([(x1, y1), (x2, y2)], fill=(r, g, b), width=5)
 
-# Rectangles
+# 矩形
 draw.rectangle([x1, y1, x2, y2], fill=(r, g, b), outline=(r, g, b), width=3)
 ```
 
-**Don't use:** Emoji fonts (unreliable across platforms) or assume pre-packaged graphics exist in this skill.
+**不要使用：** Emoji 字体（跨平台不可靠）或假设此技能中存在预打包的图形素材。
 
-### Making Graphics Look Good
+### 让图形更美观
 
-Graphics should look polished and creative, not basic. Here's how:
+图形应看起来精致且有创意，而不是简陋。以下是方法：
 
-**Use thicker lines** - Always set `width=2` or higher for outlines and lines. Thin lines (width=1) look choppy and amateurish.
+**使用较粗的线条** - 轮廓和线条始终设置 `width=2` 或更高。细线（width=1）看起来粗糙且不专业。
 
-**Add visual depth**:
-- Use gradients for backgrounds (`create_gradient_background`)
-- Layer multiple shapes for complexity (e.g., a star with a smaller star inside)
+**增加视觉层次感**：
+- 使用渐变背景（`create_gradient_background`）
+- 叠加多个形状增加复杂度（例如大星形内套小星形）
 
-**Make shapes more interesting**:
-- Don't just draw a plain circle - add highlights, rings, or patterns
-- Stars can have glows (draw larger, semi-transparent versions behind)
-- Combine multiple shapes (stars + sparkles, circles + rings)
+**让形状更有趣**：
+- 不要只画一个简单的圆——添加高光、光环或图案
+- 星形可以加发光效果（在后面绘制更大的半透明版本）
+- 组合多种形状（星形 + 闪光、圆形 + 光环）
 
-**Pay attention to colors**:
-- Use vibrant, complementary colors
-- Add contrast (dark outlines on light shapes, light outlines on dark shapes)
-- Consider the overall composition
+**注意色彩运用**：
+- 使用鲜艳的互补色
+- 增加对比度（浅色形状用深色轮廓，深色形状用浅色轮廓）
+- 考虑整体构图
 
-**For complex shapes** (hearts, snowflakes, etc.):
-- Use combinations of polygons and ellipses
-- Calculate points carefully for symmetry
-- Add details (a heart can have a highlight curve, snowflakes have intricate branches)
+**对于复杂形状**（心形、雪花等）：
+- 使用多边形和椭圆的组合
+- 仔细计算顶点以确保对称性
+- 添加细节（心形可以有高光曲线，雪花有精致的分支）
 
-Be creative and detailed! A good Slack GIF should look polished, not like placeholder graphics.
+发挥创意，注重细节！好的 Slack GIF 应该看起来精致美观，而不像占位图形。
 
-## Available Utilities
+## 可用工具
 
-### GIFBuilder (`core.gif_builder`)
-Assembles frames and optimizes for Slack:
+### GIFBuilder（`core.gif_builder`）
+组装帧并针对 Slack 优化：
 ```python
 builder = GIFBuilder(width=128, height=128, fps=10)
-builder.add_frame(frame)  # Add PIL Image
-builder.add_frames(frames)  # Add list of frames
+builder.add_frame(frame)  # 添加 PIL Image
+builder.add_frames(frames)  # 添加帧列表
 builder.save('out.gif', num_colors=48, optimize_for_emoji=True, remove_duplicates=True)
 ```
 
-### Validators (`core.validators`)
-Check if GIF meets Slack requirements:
+### 验证器（`core.validators`）
+检查 GIF 是否符合 Slack 要求：
 ```python
 from core.validators import validate_gif, is_slack_ready
 
-# Detailed validation
+# 详细验证
 passes, info = validate_gif('my.gif', is_emoji=True, verbose=True)
 
-# Quick check
+# 快速检查
 if is_slack_ready('my.gif'):
     print("Ready!")
 ```
 
-### Easing Functions (`core.easing`)
-Smooth motion instead of linear:
+### 缓动函数（`core.easing`）
+实现平滑运动而非线性运动：
 ```python
 from core.easing import interpolate
 
-# Progress from 0.0 to 1.0
+# 进度从 0.0 到 1.0
 t = i / (num_frames - 1)
 
-# Apply easing
+# 应用缓动
 y = interpolate(start=0, end=400, t=t, easing='ease_out')
 
-# Available: linear, ease_in, ease_out, ease_in_out,
+# 可用选项：linear, ease_in, ease_out, ease_in_out,
 #           bounce_out, elastic_out, back_out
 ```
 
-### Frame Helpers (`core.frame_composer`)
-Convenience functions for common needs:
+### 帧辅助工具（`core.frame_composer`）
+常用需求的便捷函数：
 ```python
 from core.frame_composer import (
-    create_blank_frame,         # Solid color background
-    create_gradient_background,  # Vertical gradient
-    draw_circle,                # Helper for circles
-    draw_text,                  # Simple text rendering
-    draw_star                   # 5-pointed star
+    create_blank_frame,         # 纯色背景
+    create_gradient_background,  # 垂直渐变
+    draw_circle,                # 圆形绘制辅助
+    draw_text,                  # 简单文本渲染
+    draw_star                   # 五角星
 )
 ```
 
-## Animation Concepts
+## 动画概念
 
-### Shake/Vibrate
-Offset object position with oscillation:
-- Use `math.sin()` or `math.cos()` with frame index
-- Add small random variations for natural feel
-- Apply to x and/or y position
+### 抖动/振动
+通过振荡偏移对象位置：
+- 使用 `math.sin()` 或 `math.cos()` 配合帧索引
+- 添加小幅随机变化以获得自然感
+- 应用于 x 和/或 y 位置
 
-### Pulse/Heartbeat
-Scale object size rhythmically:
-- Use `math.sin(t * frequency * 2 * math.pi)` for smooth pulse
-- For heartbeat: two quick pulses then pause (adjust sine wave)
-- Scale between 0.8 and 1.2 of base size
+### 脉冲/心跳
+有节奏地缩放对象大小：
+- 使用 `math.sin(t * frequency * 2 * math.pi)` 实现平滑脉冲
+- 心跳效果：两次快速脉冲后暂停（调整正弦波）
+- 在基础大小的 0.8 到 1.2 倍之间缩放
 
-### Bounce
-Object falls and bounces:
-- Use `interpolate()` with `easing='bounce_out'` for landing
-- Use `easing='ease_in'` for falling (accelerating)
-- Apply gravity by increasing y velocity each frame
+### 弹跳
+对象下落并弹跳：
+- 着陆时使用 `interpolate()` 配合 `easing='bounce_out'`
+- 下落时使用 `easing='ease_in'`（加速）
+- 通过每帧增加 y 方向速度来模拟重力
 
-### Spin/Rotate
-Rotate object around center:
-- PIL: `image.rotate(angle, resample=Image.BICUBIC)`
-- For wobble: use sine wave for angle instead of linear
+### 旋转
+围绕中心旋转对象：
+- PIL：`image.rotate(angle, resample=Image.BICUBIC)`
+- 摇摆效果：使用正弦波控制角度而非线性变化
 
-### Fade In/Out
-Gradually appear or disappear:
-- Create RGBA image, adjust alpha channel
-- Or use `Image.blend(image1, image2, alpha)`
-- Fade in: alpha from 0 to 1
-- Fade out: alpha from 1 to 0
+### 淡入/淡出
+逐渐出现或消失：
+- 创建 RGBA 图像，调整 alpha 通道
+- 或使用 `Image.blend(image1, image2, alpha)`
+- 淡入：alpha 从 0 到 1
+- 淡出：alpha 从 1 到 0
 
-### Slide
-Move object from off-screen to position:
-- Start position: outside frame bounds
-- End position: target location
-- Use `interpolate()` with `easing='ease_out'` for smooth stop
-- For overshoot: use `easing='back_out'`
+### 滑动
+将对象从屏幕外移动到目标位置：
+- 起始位置：帧边界之外
+- 结束位置：目标位置
+- 使用 `interpolate()` 配合 `easing='ease_out'` 实现平滑停止
+- 过冲效果：使用 `easing='back_out'`
 
-### Zoom
-Scale and position for zoom effect:
-- Zoom in: scale from 0.1 to 2.0, crop center
-- Zoom out: scale from 2.0 to 1.0
-- Can add motion blur for drama (PIL filter)
+### 缩放
+通过缩放和定位实现缩放效果：
+- 放大：从 0.1 缩放到 2.0，裁剪中心
+- 缩小：从 2.0 缩放到 1.0
+- 可添加动态模糊增强戏剧效果（PIL 滤镜）
 
-### Explode/Particle Burst
-Create particles radiating outward:
-- Generate particles with random angles and velocities
-- Update each particle: `x += vx`, `y += vy`
-- Add gravity: `vy += gravity_constant`
-- Fade out particles over time (reduce alpha)
+### 爆炸/粒子迸发
+创建向外辐射的粒子：
+- 生成具有随机角度和速度的粒子
+- 更新每个粒子：`x += vx`，`y += vy`
+- 添加重力：`vy += gravity_constant`
+- 随时间淡出粒子（降低 alpha 值）
 
-## Optimization Strategies
+## 优化策略
 
-Only when asked to make the file size smaller, implement a few of the following methods:
+仅在被要求缩小文件大小时，实施以下部分方法：
 
-1. **Fewer frames** - Lower FPS (10 instead of 20) or shorter duration
-2. **Fewer colors** - `num_colors=48` instead of 128
-3. **Smaller dimensions** - 128x128 instead of 480x480
-4. **Remove duplicates** - `remove_duplicates=True` in save()
-5. **Emoji mode** - `optimize_for_emoji=True` auto-optimizes
+1. **减少帧数** - 降低 FPS（用 10 代替 20）或缩短时长
+2. **减少颜色** - 使用 `num_colors=48` 而非 128
+3. **缩小尺寸** - 使用 128x128 而非 480x480
+4. **移除重复帧** - 在 save() 中设置 `remove_duplicates=True`
+5. **表情模式** - `optimize_for_emoji=True` 自动优化
 
 ```python
-# Maximum optimization for emoji
+# 表情 GIF 的最大优化
 builder.save(
     'emoji.gif',
     num_colors=48,
@@ -231,23 +231,23 @@ builder.save(
 )
 ```
 
-## Philosophy
+## 设计理念
 
-This skill provides:
-- **Knowledge**: Slack's requirements and animation concepts
-- **Utilities**: GIFBuilder, validators, easing functions
-- **Flexibility**: Create the animation logic using PIL primitives
+此技能提供：
+- **知识**：Slack 的要求和动画概念
+- **工具**：GIFBuilder、验证器、缓动函数
+- **灵活性**：使用 PIL 图形基元创建动画逻辑
 
-It does NOT provide:
-- Rigid animation templates or pre-made functions
-- Emoji font rendering (unreliable across platforms)
-- A library of pre-packaged graphics built into the skill
+此技能不提供：
+- 固定的动画模板或预制函数
+- Emoji 字体渲染（跨平台不可靠）
+- 内置于技能中的预打包图形库
 
-**Note on user uploads**: This skill doesn't include pre-built graphics, but if a user uploads an image, use PIL to load and work with it - interpret based on their request whether they want it used directly or just as inspiration.
+**关于用户上传的说明**：此技能不包含预制图形，但如果用户上传了图片，请使用 PIL 加载并处理它——根据用户的请求判断他们是想直接使用还是仅作为灵感参考。
 
-Be creative! Combine concepts (bouncing + rotating, pulsing + sliding, etc.) and use PIL's full capabilities.
+发挥创意！组合多种概念（弹跳 + 旋转、脉冲 + 滑动等），充分利用 PIL 的全部功能。
 
-## Dependencies
+## 依赖项
 
 ```bash
 pip install pillow imageio numpy

--- a/skills/theme-factory/SKILL.md
+++ b/skills/theme-factory/SKILL.md
@@ -1,59 +1,59 @@
 ---
 name: theme-factory
-description: Toolkit for styling artifacts with a theme. These artifacts can be slides, docs, reportings, HTML landing pages, etc. There are 10 pre-set themes with colors/fonts that you can apply to any artifact that has been creating, or can generate a new theme on-the-fly.
+description: 用于为制品添加主题样式的工具包。这些制品可以是幻灯片、文档、报告、HTML 着陆页等。内置 10 套预设主题，包含配色方案和字体组合，可应用于任何已创建的制品，也可以即时生成新主题。
 license: Complete terms in LICENSE.txt
 ---
 
 
-# Theme Factory Skill
+# 主题工厂技能
 
-This skill provides a curated collection of professional font and color themes themes, each with carefully selected color palettes and font pairings. Once a theme is chosen, it can be applied to any artifact.
+本技能提供一系列精心策划的专业字体和配色主题，每套主题都包含精心挑选的调色板和字体搭配。选定主题后，即可将其应用于任何制品。
 
-## Purpose
+## 用途
 
-To apply consistent, professional styling to presentation slide decks, use this skill. Each theme includes:
-- A cohesive color palette with hex codes
-- Complementary font pairings for headers and body text
-- A distinct visual identity suitable for different contexts and audiences
+使用本技能可为演示文稿幻灯片等制品应用统一、专业的样式。每套主题包含：
+- 完整的配色方案及十六进制色值
+- 标题与正文的互补字体搭配
+- 独特的视觉风格，适用于不同场景和受众
 
-## Usage Instructions
+## 使用说明
 
-To apply styling to a slide deck or other artifact:
+要为幻灯片或其他制品应用样式：
 
-1. **Show the theme showcase**: Display the `theme-showcase.pdf` file to allow users to see all available themes visually. Do not make any modifications to it; simply show the file for viewing.
-2. **Ask for their choice**: Ask which theme to apply to the deck
-3. **Wait for selection**: Get explicit confirmation about the chosen theme
-4. **Apply the theme**: Once a theme has been chosen, apply the selected theme's colors and fonts to the deck/artifact
+1. **展示主题一览**：向用户展示 `theme-showcase.pdf` 文件，让用户直观查看所有可用主题。请勿对该文件进行任何修改，仅供浏览查看。
+2. **征询用户选择**：询问用户希望将哪套主题应用到制品上
+3. **等待确认**：获得用户对所选主题的明确确认
+4. **应用主题**：主题确定后，将所选主题的配色和字体应用到制品上
 
-## Themes Available
+## 可用主题
 
-The following 10 themes are available, each showcased in `theme-showcase.pdf`:
+以下 10 套主题均在 `theme-showcase.pdf` 中进行了展示：
 
-1. **Ocean Depths** - Professional and calming maritime theme
-2. **Sunset Boulevard** - Warm and vibrant sunset colors
-3. **Forest Canopy** - Natural and grounded earth tones
-4. **Modern Minimalist** - Clean and contemporary grayscale
-5. **Golden Hour** - Rich and warm autumnal palette
-6. **Arctic Frost** - Cool and crisp winter-inspired theme
-7. **Desert Rose** - Soft and sophisticated dusty tones
-8. **Tech Innovation** - Bold and modern tech aesthetic
-9. **Botanical Garden** - Fresh and organic garden colors
-10. **Midnight Galaxy** - Dramatic and cosmic deep tones
+1. **Ocean Depths（深海之境）** - 专业沉稳的海洋风格主题
+2. **Sunset Boulevard（日落大道）** - 温暖而富有活力的日落色彩
+3. **Forest Canopy（林冠之下）** - 自然质朴的大地色调
+4. **Modern Minimalist（现代极简）** - 简洁现代的灰度风格
+5. **Golden Hour（黄金时刻）** - 丰富温暖的秋日色调
+6. **Arctic Frost（极地霜华）** - 清冷明快的冬季风格主题
+7. **Desert Rose（沙漠玫瑰）** - 柔和典雅的灰粉色调
+8. **Tech Innovation（科技创新）** - 大胆现代的科技美学
+9. **Botanical Garden（植物花园）** - 清新自然的花园配色
+10. **Midnight Galaxy（午夜星河）** - 深邃壮丽的宇宙色调
 
-## Theme Details
+## 主题详情
 
-Each theme is defined in the `themes/` directory with complete specifications including:
-- Cohesive color palette with hex codes
-- Complementary font pairings for headers and body text
-- Distinct visual identity suitable for different contexts and audiences
+每套主题定义在 `themes/` 目录中，包含完整的规格说明：
+- 完整的配色方案及十六进制色值
+- 标题与正文的互补字体搭配
+- 独特的视觉风格，适用于不同场景和受众
 
-## Application Process
+## 应用流程
 
-After a preferred theme is selected:
-1. Read the corresponding theme file from the `themes/` directory
-2. Apply the specified colors and fonts consistently throughout the deck
-3. Ensure proper contrast and readability
-4. Maintain the theme's visual identity across all slides
+选定主题后：
+1. 从 `themes/` 目录中读取对应的主题文件
+2. 将指定的配色和字体统一应用到整个制品中
+3. 确保适当的对比度和可读性
+4. 在所有页面中保持主题视觉风格的一致性
 
-## Create your Own Theme
-To handle cases where none of the existing themes work for an artifact, create a custom theme. Based on provided inputs, generate a new theme similar to the ones above. Give the theme a similar name describing what the font/color combinations represent. Use any basic description provided to choose appropriate colors/fonts. After generating the theme, show it for review and verification. Following that, apply the theme as described above.
+## 创建自定义主题
+当现有主题均不适用于制品时，可以创建自定义主题。根据用户提供的需求，生成与上述主题类似的新主题。为主题起一个能描述字体和配色组合特征的名称。根据用户提供的基本描述选择合适的配色和字体。生成主题后，先展示给用户审阅和确认，然后按照上述流程应用主题。

--- a/skills/web-artifacts-builder/SKILL.md
+++ b/skills/web-artifacts-builder/SKILL.md
@@ -1,74 +1,74 @@
 ---
 name: web-artifacts-builder
-description: Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui). Use for complex artifacts requiring state management, routing, or shadcn/ui components - not for simple single-file HTML/JSX artifacts.
+description: 用于构建精细的多组件 claude.ai HTML 制品的工具套件，基于现代前端 Web 技术（React、Tailwind CSS、shadcn/ui）。适用于需要状态管理、路由或 shadcn/ui 组件的复杂制品，不适用于简单的单文件 HTML/JSX 制品。
 license: Complete terms in LICENSE.txt
 ---
 
-# Web Artifacts Builder
+# Web 制品构建器
 
-To build powerful frontend claude.ai artifacts, follow these steps:
-1. Initialize the frontend repo using `scripts/init-artifact.sh`
-2. Develop your artifact by editing the generated code
-3. Bundle all code into a single HTML file using `scripts/bundle-artifact.sh`
-4. Display artifact to user
-5. (Optional) Test the artifact
+要构建功能强大的前端 claude.ai 制品，请按以下步骤操作：
+1. 使用 `scripts/init-artifact.sh` 初始化前端项目
+2. 编辑生成的代码来开发制品
+3. 使用 `scripts/bundle-artifact.sh` 将所有代码打包为单个 HTML 文件
+4. 向用户展示制品
+5. （可选）测试制品
 
-**Stack**: React 18 + TypeScript + Vite + Parcel (bundling) + Tailwind CSS + shadcn/ui
+**技术栈**：React 18 + TypeScript + Vite + Parcel（打包）+ Tailwind CSS + shadcn/ui
 
-## Design & Style Guidelines
+## 设计与样式指南
 
-VERY IMPORTANT: To avoid what is often referred to as "AI slop", avoid using excessive centered layouts, purple gradients, uniform rounded corners, and Inter font.
+非常重要：为避免常见的"AI 模板化风格"，请勿过度使用居中布局、紫色渐变、统一圆角和 Inter 字体。
 
-## Quick Start
+## 快速开始
 
-### Step 1: Initialize Project
+### 第一步：初始化项目
 
-Run the initialization script to create a new React project:
+运行初始化脚本创建新的 React 项目：
 ```bash
 bash scripts/init-artifact.sh <project-name>
 cd <project-name>
 ```
 
-This creates a fully configured project with:
-- ✅ React + TypeScript (via Vite)
-- ✅ Tailwind CSS 3.4.1 with shadcn/ui theming system
-- ✅ Path aliases (`@/`) configured
-- ✅ 40+ shadcn/ui components pre-installed
-- ✅ All Radix UI dependencies included
-- ✅ Parcel configured for bundling (via .parcelrc)
-- ✅ Node 18+ compatibility (auto-detects and pins Vite version)
+该脚本会创建一个完整配置的项目，包含：
+- ✅ React + TypeScript（基于 Vite）
+- ✅ Tailwind CSS 3.4.1 及 shadcn/ui 主题系统
+- ✅ 已配置路径别名（`@/`）
+- ✅ 40+ 个 shadcn/ui 组件已预装
+- ✅ 包含所有 Radix UI 依赖
+- ✅ 已配置 Parcel 用于打包（通过 .parcelrc）
+- ✅ 兼容 Node 18+（自动检测并锁定 Vite 版本）
 
-### Step 2: Develop Your Artifact
+### 第二步：开发制品
 
-To build the artifact, edit the generated files. See **Common Development Tasks** below for guidance.
+编辑生成的文件来构建制品。请参阅下方**常见开发任务**获取指导。
 
-### Step 3: Bundle to Single HTML File
+### 第三步：打包为单个 HTML 文件
 
-To bundle the React app into a single HTML artifact:
+将 React 应用打包为单个 HTML 制品：
 ```bash
 bash scripts/bundle-artifact.sh
 ```
 
-This creates `bundle.html` - a self-contained artifact with all JavaScript, CSS, and dependencies inlined. This file can be directly shared in Claude conversations as an artifact.
+该命令会生成 `bundle.html` —— 一个包含所有 JavaScript、CSS 和依赖的独立制品文件。此文件可在 Claude 对话中直接作为制品分享。
 
-**Requirements**: Your project must have an `index.html` in the root directory.
+**前提条件**：项目根目录必须包含 `index.html` 文件。
 
-**What the script does**:
-- Installs bundling dependencies (parcel, @parcel/config-default, parcel-resolver-tspaths, html-inline)
-- Creates `.parcelrc` config with path alias support
-- Builds with Parcel (no source maps)
-- Inlines all assets into single HTML using html-inline
+**脚本执行内容**：
+- 安装打包依赖（parcel、@parcel/config-default、parcel-resolver-tspaths、html-inline）
+- 创建支持路径别名的 `.parcelrc` 配置
+- 使用 Parcel 构建（不生成 source map）
+- 使用 html-inline 将所有资源内联到单个 HTML 中
 
-### Step 4: Share Artifact with User
+### 第四步：向用户分享制品
 
-Finally, share the bundled HTML file in conversation with the user so they can view it as an artifact.
+最后，在对话中向用户分享打包后的 HTML 文件，以便用户以制品形式查看。
 
-### Step 5: Testing/Visualizing the Artifact (Optional)
+### 第五步：测试/预览制品（可选）
 
-Note: This is a completely optional step. Only perform if necessary or requested.
+注意：此步骤完全可选。仅在必要时或用户要求时执行。
 
-To test/visualize the artifact, use available tools (including other Skills or built-in tools like Playwright or Puppeteer). In general, avoid testing the artifact upfront as it adds latency between the request and when the finished artifact can be seen. Test later, after presenting the artifact, if requested or if issues arise.
+要测试/预览制品，请使用可用工具（包括其他技能或内置工具如 Playwright 或 Puppeteer）。一般情况下，避免预先测试制品，因为这会增加从请求到展示最终制品之间的延迟。建议在展示制品后，如用户要求或出现问题时再进行测试。
 
-## Reference
+## 参考资料
 
-- **shadcn/ui components**: https://ui.shadcn.com/docs/components
+- **shadcn/ui 组件**：https://ui.shadcn.com/docs/components

--- a/skills/webapp-testing/SKILL.md
+++ b/skills/webapp-testing/SKILL.md
@@ -1,47 +1,47 @@
 ---
 name: webapp-testing
-description: Toolkit for interacting with and testing local web applications using Playwright. Supports verifying frontend functionality, debugging UI behavior, capturing browser screenshots, and viewing browser logs.
+description: 使用 Playwright 与本地 Web 应用进行交互和测试的工具包。支持前端功能验证、UI 行为调试、浏览器截图捕获和浏览器日志查看。
 license: Complete terms in LICENSE.txt
 ---
 
-# Web Application Testing
+# Web 应用测试
 
-To test local web applications, write native Python Playwright scripts.
+要测试本地 Web 应用，请编写原生 Python Playwright 脚本。
 
-**Helper Scripts Available**:
-- `scripts/with_server.py` - Manages server lifecycle (supports multiple servers)
+**可用辅助脚本**：
+- `scripts/with_server.py` - 管理服务器生命周期（支持多服务器）
 
-**Always run scripts with `--help` first** to see usage. DO NOT read the source until you try running the script first and find that a customized solution is abslutely necessary. These scripts can be very large and thus pollute your context window. They exist to be called directly as black-box scripts rather than ingested into your context window.
+**请务必先使用 `--help` 运行脚本**以查看用法。在尝试运行脚本并确认确实需要自定义方案之前，请勿阅读源代码。这些脚本可能非常大，会占用大量上下文窗口空间。它们的设计初衷是作为黑盒脚本直接调用，而非读取到上下文窗口中。
 
-## Decision Tree: Choosing Your Approach
+## 决策树：选择方法
 
 ```
-User task → Is it static HTML?
-    ├─ Yes → Read HTML file directly to identify selectors
-    │         ├─ Success → Write Playwright script using selectors
-    │         └─ Fails/Incomplete → Treat as dynamic (below)
+用户任务 → 是否为静态 HTML？
+    ├─ 是 → 直接读取 HTML 文件以识别选择器
+    │         ├─ 成功 → 使用选择器编写 Playwright 脚本
+    │         └─ 失败/不完整 → 按动态应用处理（见下方）
     │
-    └─ No (dynamic webapp) → Is the server already running?
-        ├─ No → Run: python scripts/with_server.py --help
-        │        Then use the helper + write simplified Playwright script
+    └─ 否（动态 Web 应用）→ 服务器是否已运行？
+        ├─ 否 → 运行：python scripts/with_server.py --help
+        │        然后使用辅助脚本 + 编写简化的 Playwright 脚本
         │
-        └─ Yes → Reconnaissance-then-action:
-            1. Navigate and wait for networkidle
-            2. Take screenshot or inspect DOM
-            3. Identify selectors from rendered state
-            4. Execute actions with discovered selectors
+        └─ 是 → 先侦察后操作：
+            1. 导航并等待 networkidle
+            2. 截图或检查 DOM
+            3. 从渲染状态中识别选择器
+            4. 使用发现的选择器执行操作
 ```
 
-## Example: Using with_server.py
+## 示例：使用 with_server.py
 
-To start a server, run `--help` first, then use the helper:
+要启动服务器，先运行 `--help`，然后使用辅助脚本：
 
-**Single server:**
+**单服务器：**
 ```bash
 python scripts/with_server.py --server "npm run dev" --port 5173 -- python your_automation.py
 ```
 
-**Multiple servers (e.g., backend + frontend):**
+**多服务器（例如后端 + 前端）：**
 ```bash
 python scripts/with_server.py \
   --server "cd backend && python server.py" --port 3000 \
@@ -49,48 +49,48 @@ python scripts/with_server.py \
   -- python your_automation.py
 ```
 
-To create an automation script, include only Playwright logic (servers are managed automatically):
+编写自动化脚本时，只需包含 Playwright 逻辑（服务器由辅助脚本自动管理）：
 ```python
 from playwright.sync_api import sync_playwright
 
 with sync_playwright() as p:
-    browser = p.chromium.launch(headless=True) # Always launch chromium in headless mode
+    browser = p.chromium.launch(headless=True) # 始终以无头模式启动 chromium
     page = browser.new_page()
-    page.goto('http://localhost:5173') # Server already running and ready
-    page.wait_for_load_state('networkidle') # CRITICAL: Wait for JS to execute
-    # ... your automation logic
+    page.goto('http://localhost:5173') # 服务器已运行并就绪
+    page.wait_for_load_state('networkidle') # 关键：等待 JS 执行完毕
+    # ... 你的自动化逻辑
     browser.close()
 ```
 
-## Reconnaissance-Then-Action Pattern
+## 先侦察后操作模式
 
-1. **Inspect rendered DOM**:
+1. **检查渲染后的 DOM**：
    ```python
    page.screenshot(path='/tmp/inspect.png', full_page=True)
    content = page.content()
    page.locator('button').all()
    ```
 
-2. **Identify selectors** from inspection results
+2. **从检查结果中识别选择器**
 
-3. **Execute actions** using discovered selectors
+3. **使用发现的选择器执行操作**
 
-## Common Pitfall
+## 常见陷阱
 
-❌ **Don't** inspect the DOM before waiting for `networkidle` on dynamic apps
-✅ **Do** wait for `page.wait_for_load_state('networkidle')` before inspection
+❌ **不要**在动态应用中未等待 `networkidle` 就检查 DOM
+✅ **应该**在检查前先等待 `page.wait_for_load_state('networkidle')`
 
-## Best Practices
+## 最佳实践
 
-- **Use bundled scripts as black boxes** - To accomplish a task, consider whether one of the scripts available in `scripts/` can help. These scripts handle common, complex workflows reliably without cluttering the context window. Use `--help` to see usage, then invoke directly. 
-- Use `sync_playwright()` for synchronous scripts
-- Always close the browser when done
-- Use descriptive selectors: `text=`, `role=`, CSS selectors, or IDs
-- Add appropriate waits: `page.wait_for_selector()` or `page.wait_for_timeout()`
+- **将内置脚本作为黑盒使用** - 执行任务时，先考虑 `scripts/` 中是否有可用的脚本。这些脚本可靠地处理常见的复杂工作流，而不会占用上下文窗口。使用 `--help` 查看用法，然后直接调用。
+- 使用 `sync_playwright()` 编写同步脚本
+- 完成后务必关闭浏览器
+- 使用描述性选择器：`text=`、`role=`、CSS 选择器或 ID
+- 添加适当的等待：`page.wait_for_selector()` 或 `page.wait_for_timeout()`
 
-## Reference Files
+## 参考文件
 
-- **examples/** - Examples showing common patterns:
-  - `element_discovery.py` - Discovering buttons, links, and inputs on a page
-  - `static_html_automation.py` - Using file:// URLs for local HTML
-  - `console_logging.py` - Capturing console logs during automation
+- **examples/** - 展示常见模式的示例：
+  - `element_discovery.py` - 发现页面上的按钮、链接和输入框
+  - `static_html_automation.py` - 使用 file:// URL 访问本地 HTML
+  - `console_logging.py` - 在自动化过程中捕获控制台日志

--- a/skills/xlsx/SKILL.md
+++ b/skills/xlsx/SKILL.md
@@ -1,259 +1,259 @@
 ---
 name: xlsx
-description: "Use this skill any time a spreadsheet file is the primary input or output. This means any task where the user wants to: open, read, edit, or fix an existing .xlsx, .xlsm, .csv, or .tsv file (e.g., adding columns, computing formulas, formatting, charting, cleaning messy data); create a new spreadsheet from scratch or from other data sources; or convert between tabular file formats. Trigger especially when the user references a spreadsheet file by name or path — even casually (like \"the xlsx in my downloads\") — and wants something done to it or produced from it. Also trigger for cleaning or restructuring messy tabular data files (malformed rows, misplaced headers, junk data) into proper spreadsheets. The deliverable must be a spreadsheet file. Do NOT trigger when the primary deliverable is a Word document, HTML report, standalone Python script, database pipeline, or Google Sheets API integration, even if tabular data is involved."
+description: "当电子表格文件作为主要输入或输出时使用此技能。适用于以下场景：打开、读取、编辑或修复现有的 .xlsx、.xlsm、.csv 或 .tsv 文件（如添加列、计算公式、格式化、图表、清理数据）；从零开始或从其他数据源创建新的电子表格；或在表格文件格式之间进行转换。当用户提及电子表格文件名称或路径时（即使是随意提及，如"我下载目录里的那个 xlsx"），只要需要对其进行操作或从中生成内容，都应触发此技能。同样适用于将混乱的表格数据文件（格式错误的行、错位的表头、垃圾数据）清理和重组为规范的电子表格。交付物必须是电子表格文件。当主要交付物是 Word 文档、HTML 报告、独立 Python 脚本、数据库流水线或 Google Sheets API 集成时，即使涉及表格数据，也不应触发此技能。"
 license: Proprietary. LICENSE.txt has complete terms
 ---
 
-# Requirements for Outputs
+# 输出要求
 
-## All Excel files
+## 所有 Excel 文件
 
-### Professional Font
-- Use a consistent, professional font (e.g., Arial, Times New Roman) for all deliverables unless otherwise instructed by the user
+### 专业字体
+- 除非用户另有指示，否则所有交付物应使用统一的专业字体（如 Arial、Times New Roman）
 
-### Zero Formula Errors
-- Every Excel model MUST be delivered with ZERO formula errors (#REF!, #DIV/0!, #VALUE!, #N/A, #NAME?)
+### 零公式错误
+- 每个 Excel 模型交付时必须保证零公式错误（#REF!、#DIV/0!、#VALUE!、#N/A、#NAME?）
 
-### Preserve Existing Templates (when updating templates)
-- Study and EXACTLY match existing format, style, and conventions when modifying files
-- Never impose standardized formatting on files with established patterns
-- Existing template conventions ALWAYS override these guidelines
+### 保留现有模板（更新模板时）
+- 修改文件时应研究并严格匹配现有格式、样式和规范
+- 切勿对已有固定模式的文件强制应用标准化格式
+- 现有模板规范始终优先于本指南
 
-## Financial models
+## 财务模型
 
-### Color Coding Standards
-Unless otherwise stated by the user or existing template
+### 颜色编码标准
+除非用户另有说明或现有模板已有规定
 
-#### Industry-Standard Color Conventions
-- **Blue text (RGB: 0,0,255)**: Hardcoded inputs, and numbers users will change for scenarios
-- **Black text (RGB: 0,0,0)**: ALL formulas and calculations
-- **Green text (RGB: 0,128,0)**: Links pulling from other worksheets within same workbook
-- **Red text (RGB: 255,0,0)**: External links to other files
-- **Yellow background (RGB: 255,255,0)**: Key assumptions needing attention or cells that need to be updated
+#### 行业标准颜色规范
+- **蓝色文字 (RGB: 0,0,255)**：硬编码输入值，以及用户进行场景分析时会更改的数字
+- **黑色文字 (RGB: 0,0,0)**：所有公式和计算
+- **绿色文字 (RGB: 0,128,0)**：从同一工作簿内其他工作表引用的链接
+- **红色文字 (RGB: 255,0,0)**：链接到其他文件的外部引用
+- **黄色背景 (RGB: 255,255,0)**：需要关注的关键假设或需要更新的单元格
 
-### Number Formatting Standards
+### 数字格式标准
 
-#### Required Format Rules
-- **Years**: Format as text strings (e.g., "2024" not "2,024")
-- **Currency**: Use $#,##0 format; ALWAYS specify units in headers ("Revenue ($mm)")
-- **Zeros**: Use number formatting to make all zeros "-", including percentages (e.g., "$#,##0;($#,##0);-")
-- **Percentages**: Default to 0.0% format (one decimal)
-- **Multiples**: Format as 0.0x for valuation multiples (EV/EBITDA, P/E)
-- **Negative numbers**: Use parentheses (123) not minus -123
+#### 必须遵循的格式规则
+- **年份**：格式化为文本字符串（如 "2024" 而非 "2,024"）
+- **货币**：使用 $#,##0 格式；必须在表头中标明单位（"Revenue ($mm)"）
+- **零值**：使用数字格式将所有零值显示为 "-"，包括百分比（如 "$#,##0;($#,##0);-"）
+- **百分比**：默认使用 0.0% 格式（保留一位小数）
+- **倍数**：估值倍数（EV/EBITDA、P/E）使用 0.0x 格式
+- **负数**：使用括号 (123) 而非负号 -123
 
-### Formula Construction Rules
+### 公式构建规则
 
-#### Assumptions Placement
-- Place ALL assumptions (growth rates, margins, multiples, etc.) in separate assumption cells
-- Use cell references instead of hardcoded values in formulas
-- Example: Use =B5*(1+$B$6) instead of =B5*1.05
+#### 假设值放置
+- 将所有假设值（增长率、利润率、倍数等）放在独立的假设单元格中
+- 在公式中使用单元格引用而非硬编码值
+- 示例：使用 =B5*(1+$B$6) 而非 =B5*1.05
 
-#### Formula Error Prevention
-- Verify all cell references are correct
-- Check for off-by-one errors in ranges
-- Ensure consistent formulas across all projection periods
-- Test with edge cases (zero values, negative numbers)
-- Verify no unintended circular references
+#### 公式错误预防
+- 验证所有单元格引用是否正确
+- 检查范围中的偏移错误
+- 确保所有预测期间的公式一致
+- 使用边界情况测试（零值、负数）
+- 确认没有意外的循环引用
 
-#### Documentation Requirements for Hardcodes
-- Comment or in cells beside (if end of table). Format: "Source: [System/Document], [Date], [Specific Reference], [URL if applicable]"
-- Examples:
+#### 硬编码值的文档要求
+- 在单元格中添加批注或在表格末尾的相邻单元格中注明。格式："Source: [系统/文档], [日期], [具体引用], [URL（如适用）]"
+- 示例：
   - "Source: Company 10-K, FY2024, Page 45, Revenue Note, [SEC EDGAR URL]"
   - "Source: Company 10-Q, Q2 2025, Exhibit 99.1, [SEC EDGAR URL]"
   - "Source: Bloomberg Terminal, 8/15/2025, AAPL US Equity"
   - "Source: FactSet, 8/20/2025, Consensus Estimates Screen"
 
-# XLSX creation, editing, and analysis
+# XLSX 文件的创建、编辑与分析
 
-## Overview
+## 概述
 
-A user may ask you to create, edit, or analyze the contents of an .xlsx file. You have different tools and workflows available for different tasks.
+用户可能要求你创建、编辑或分析 .xlsx 文件的内容。针对不同任务，你可以使用不同的工具和工作流程。
 
-## Important Requirements
+## 重要要求
 
-**LibreOffice Required for Formula Recalculation**: You can assume LibreOffice is installed for recalculating formula values using the `scripts/recalc.py` script. The script automatically configures LibreOffice on first run, including in sandboxed environments where Unix sockets are restricted (handled by `scripts/office/soffice.py`)
+**公式重新计算需要 LibreOffice**：可以假定已安装 LibreOffice，使用 `scripts/recalc.py` 脚本进行公式值的重新计算。该脚本在首次运行时会自动配置 LibreOffice，包括在限制 Unix 套接字的沙箱环境中（由 `scripts/office/soffice.py` 处理）。
 
-## Reading and analyzing data
+## 读取和分析数据
 
-### Data analysis with pandas
-For data analysis, visualization, and basic operations, use **pandas** which provides powerful data manipulation capabilities:
+### 使用 pandas 进行数据分析
+对于数据分析、可视化和基本操作，使用 **pandas**，它提供强大的数据处理能力：
 
 ```python
 import pandas as pd
 
-# Read Excel
-df = pd.read_excel('file.xlsx')  # Default: first sheet
-all_sheets = pd.read_excel('file.xlsx', sheet_name=None)  # All sheets as dict
+# 读取 Excel
+df = pd.read_excel('file.xlsx')  # 默认：第一个工作表
+all_sheets = pd.read_excel('file.xlsx', sheet_name=None)  # 所有工作表作为字典
 
-# Analyze
-df.head()      # Preview data
-df.info()      # Column info
-df.describe()  # Statistics
+# 分析
+df.head()      # 预览数据
+df.info()      # 列信息
+df.describe()  # 统计摘要
 
-# Write Excel
+# 写入 Excel
 df.to_excel('output.xlsx', index=False)
 ```
 
-## Excel File Workflows
+## Excel 文件工作流程
 
-## CRITICAL: Use Formulas, Not Hardcoded Values
+## 关键原则：使用公式，而非硬编码值
 
-**Always use Excel formulas instead of calculating values in Python and hardcoding them.** This ensures the spreadsheet remains dynamic and updateable.
+**始终使用 Excel 公式而非在 Python 中计算后硬编码结果。** 这样可确保电子表格保持动态性和可更新性。
 
-### ❌ WRONG - Hardcoding Calculated Values
+### 错误做法 - 硬编码计算值
 ```python
-# Bad: Calculating in Python and hardcoding result
+# 错误：在 Python 中计算并硬编码结果
 total = df['Sales'].sum()
-sheet['B10'] = total  # Hardcodes 5000
+sheet['B10'] = total  # 硬编码 5000
 
-# Bad: Computing growth rate in Python
+# 错误：在 Python 中计算增长率
 growth = (df.iloc[-1]['Revenue'] - df.iloc[0]['Revenue']) / df.iloc[0]['Revenue']
-sheet['C5'] = growth  # Hardcodes 0.15
+sheet['C5'] = growth  # 硬编码 0.15
 
-# Bad: Python calculation for average
+# 错误：用 Python 计算平均值
 avg = sum(values) / len(values)
-sheet['D20'] = avg  # Hardcodes 42.5
+sheet['D20'] = avg  # 硬编码 42.5
 ```
 
-### ✅ CORRECT - Using Excel Formulas
+### 正确做法 - 使用 Excel 公式
 ```python
-# Good: Let Excel calculate the sum
+# 正确：让 Excel 计算总和
 sheet['B10'] = '=SUM(B2:B9)'
 
-# Good: Growth rate as Excel formula
+# 正确：增长率使用 Excel 公式
 sheet['C5'] = '=(C4-C2)/C2'
 
-# Good: Average using Excel function
+# 正确：使用 Excel 函数计算平均值
 sheet['D20'] = '=AVERAGE(D2:D19)'
 ```
 
-This applies to ALL calculations - totals, percentages, ratios, differences, etc. The spreadsheet should be able to recalculate when source data changes.
+此规则适用于所有计算——总计、百分比、比率、差值等。电子表格应在源数据变更时能够自动重新计算。
 
-## Common Workflow
-1. **Choose tool**: pandas for data, openpyxl for formulas/formatting
-2. **Create/Load**: Create new workbook or load existing file
-3. **Modify**: Add/edit data, formulas, and formatting
-4. **Save**: Write to file
-5. **Recalculate formulas (MANDATORY IF USING FORMULAS)**: Use the scripts/recalc.py script
+## 常见工作流程
+1. **选择工具**：pandas 用于数据处理，openpyxl 用于公式/格式化
+2. **创建/加载**：创建新工作簿或加载现有文件
+3. **修改**：添加/编辑数据、公式和格式
+4. **保存**：写入文件
+5. **重新计算公式（使用公式时为必选步骤）**：使用 scripts/recalc.py 脚本
    ```bash
    python scripts/recalc.py output.xlsx
    ```
-6. **Verify and fix any errors**: 
-   - The script returns JSON with error details
-   - If `status` is `errors_found`, check `error_summary` for specific error types and locations
-   - Fix the identified errors and recalculate again
-   - Common errors to fix:
-     - `#REF!`: Invalid cell references
-     - `#DIV/0!`: Division by zero
-     - `#VALUE!`: Wrong data type in formula
-     - `#NAME?`: Unrecognized formula name
+6. **验证并修复错误**：
+   - 脚本会返回包含错误详情的 JSON
+   - 如果 `status` 为 `errors_found`，检查 `error_summary` 获取具体的错误类型和位置
+   - 修复发现的错误后重新计算
+   - 常见需修复的错误：
+     - `#REF!`：无效的单元格引用
+     - `#DIV/0!`：除以零
+     - `#VALUE!`：公式中数据类型错误
+     - `#NAME?`：无法识别的公式名称
 
-### Creating new Excel files
+### 创建新的 Excel 文件
 
 ```python
-# Using openpyxl for formulas and formatting
+# 使用 openpyxl 处理公式和格式
 from openpyxl import Workbook
 from openpyxl.styles import Font, PatternFill, Alignment
 
 wb = Workbook()
 sheet = wb.active
 
-# Add data
+# 添加数据
 sheet['A1'] = 'Hello'
 sheet['B1'] = 'World'
 sheet.append(['Row', 'of', 'data'])
 
-# Add formula
+# 添加公式
 sheet['B2'] = '=SUM(A1:A10)'
 
-# Formatting
+# 格式化
 sheet['A1'].font = Font(bold=True, color='FF0000')
 sheet['A1'].fill = PatternFill('solid', start_color='FFFF00')
 sheet['A1'].alignment = Alignment(horizontal='center')
 
-# Column width
+# 列宽
 sheet.column_dimensions['A'].width = 20
 
 wb.save('output.xlsx')
 ```
 
-### Editing existing Excel files
+### 编辑现有 Excel 文件
 
 ```python
-# Using openpyxl to preserve formulas and formatting
+# 使用 openpyxl 保留公式和格式
 from openpyxl import load_workbook
 
-# Load existing file
+# 加载现有文件
 wb = load_workbook('existing.xlsx')
-sheet = wb.active  # or wb['SheetName'] for specific sheet
+sheet = wb.active  # 或使用 wb['SheetName'] 指定工作表
 
-# Working with multiple sheets
+# 处理多个工作表
 for sheet_name in wb.sheetnames:
     sheet = wb[sheet_name]
     print(f"Sheet: {sheet_name}")
 
-# Modify cells
+# 修改单元格
 sheet['A1'] = 'New Value'
-sheet.insert_rows(2)  # Insert row at position 2
-sheet.delete_cols(3)  # Delete column 3
+sheet.insert_rows(2)  # 在第 2 行插入行
+sheet.delete_cols(3)  # 删除第 3 列
 
-# Add new sheet
+# 添加新工作表
 new_sheet = wb.create_sheet('NewSheet')
 new_sheet['A1'] = 'Data'
 
 wb.save('modified.xlsx')
 ```
 
-## Recalculating formulas
+## 重新计算公式
 
-Excel files created or modified by openpyxl contain formulas as strings but not calculated values. Use the provided `scripts/recalc.py` script to recalculate formulas:
+由 openpyxl 创建或修改的 Excel 文件包含公式字符串但不含计算值。使用提供的 `scripts/recalc.py` 脚本重新计算公式：
 
 ```bash
 python scripts/recalc.py <excel_file> [timeout_seconds]
 ```
 
-Example:
+示例：
 ```bash
 python scripts/recalc.py output.xlsx 30
 ```
 
-The script:
-- Automatically sets up LibreOffice macro on first run
-- Recalculates all formulas in all sheets
-- Scans ALL cells for Excel errors (#REF!, #DIV/0!, etc.)
-- Returns JSON with detailed error locations and counts
-- Works on both Linux and macOS
+该脚本：
+- 首次运行时自动配置 LibreOffice 宏
+- 重新计算所有工作表中的所有公式
+- 扫描所有单元格以检测 Excel 错误（#REF!、#DIV/0! 等）
+- 返回包含详细错误位置和计数的 JSON
+- 兼容 Linux 和 macOS
 
-## Formula Verification Checklist
+## 公式验证清单
 
-Quick checks to ensure formulas work correctly:
+确保公式正确运行的快速检查：
 
-### Essential Verification
-- [ ] **Test 2-3 sample references**: Verify they pull correct values before building full model
-- [ ] **Column mapping**: Confirm Excel columns match (e.g., column 64 = BL, not BK)
-- [ ] **Row offset**: Remember Excel rows are 1-indexed (DataFrame row 5 = Excel row 6)
+### 基本验证
+- [ ] **测试 2-3 个样本引用**：在构建完整模型前验证引用是否拉取了正确的值
+- [ ] **列映射**：确认 Excel 列匹配（如第 64 列 = BL，而非 BK）
+- [ ] **行偏移**：注意 Excel 行从 1 开始（DataFrame 第 5 行 = Excel 第 6 行）
 
-### Common Pitfalls
-- [ ] **NaN handling**: Check for null values with `pd.notna()`
-- [ ] **Far-right columns**: FY data often in columns 50+ 
-- [ ] **Multiple matches**: Search all occurrences, not just first
-- [ ] **Division by zero**: Check denominators before using `/` in formulas (#DIV/0!)
-- [ ] **Wrong references**: Verify all cell references point to intended cells (#REF!)
-- [ ] **Cross-sheet references**: Use correct format (Sheet1!A1) for linking sheets
+### 常见陷阱
+- [ ] **NaN 处理**：使用 `pd.notna()` 检查空值
+- [ ] **最右侧列**：财年数据通常在第 50+ 列
+- [ ] **多重匹配**：搜索所有匹配项，而不仅是第一个
+- [ ] **除以零**：在公式中使用 `/` 前检查分母（#DIV/0!）
+- [ ] **错误引用**：验证所有单元格引用指向预期的单元格（#REF!）
+- [ ] **跨工作表引用**：使用正确格式（Sheet1!A1）链接工作表
 
-### Formula Testing Strategy
-- [ ] **Start small**: Test formulas on 2-3 cells before applying broadly
-- [ ] **Verify dependencies**: Check all cells referenced in formulas exist
-- [ ] **Test edge cases**: Include zero, negative, and very large values
+### 公式测试策略
+- [ ] **从小处着手**：先在 2-3 个单元格上测试公式，再大范围应用
+- [ ] **验证依赖关系**：检查公式中引用的所有单元格是否存在
+- [ ] **测试边界情况**：包括零值、负值和极大值
 
-### Interpreting scripts/recalc.py Output
-The script returns JSON with error details:
+### 解读 scripts/recalc.py 输出
+脚本返回包含错误详情的 JSON：
 ```json
 {
-  "status": "success",           // or "errors_found"
-  "total_errors": 0,              // Total error count
-  "total_formulas": 42,           // Number of formulas in file
-  "error_summary": {              // Only present if errors found
+  "status": "success",           // 或 "errors_found"
+  "total_errors": 0,              // 错误总数
+  "total_formulas": 42,           // 文件中的公式数量
+  "error_summary": {              // 仅在发现错误时出现
     "#REF!": {
       "count": 2,
       "locations": ["Sheet1!B5", "Sheet1!C10"]
@@ -262,31 +262,31 @@ The script returns JSON with error details:
 }
 ```
 
-## Best Practices
+## 最佳实践
 
-### Library Selection
-- **pandas**: Best for data analysis, bulk operations, and simple data export
-- **openpyxl**: Best for complex formatting, formulas, and Excel-specific features
+### 库选择
+- **pandas**：最适合数据分析、批量操作和简单数据导出
+- **openpyxl**：最适合复杂格式、公式和 Excel 特有功能
 
-### Working with openpyxl
-- Cell indices are 1-based (row=1, column=1 refers to cell A1)
-- Use `data_only=True` to read calculated values: `load_workbook('file.xlsx', data_only=True)`
-- **Warning**: If opened with `data_only=True` and saved, formulas are replaced with values and permanently lost
-- For large files: Use `read_only=True` for reading or `write_only=True` for writing
-- Formulas are preserved but not evaluated - use scripts/recalc.py to update values
+### 使用 openpyxl
+- 单元格索引从 1 开始（row=1, column=1 对应单元格 A1）
+- 使用 `data_only=True` 读取计算值：`load_workbook('file.xlsx', data_only=True)`
+- **警告**：如果以 `data_only=True` 打开并保存，公式将被替换为值并永久丢失
+- 对于大文件：使用 `read_only=True` 读取或 `write_only=True` 写入
+- 公式会被保留但不会被求值——使用 scripts/recalc.py 更新值
 
-### Working with pandas
-- Specify data types to avoid inference issues: `pd.read_excel('file.xlsx', dtype={'id': str})`
-- For large files, read specific columns: `pd.read_excel('file.xlsx', usecols=['A', 'C', 'E'])`
-- Handle dates properly: `pd.read_excel('file.xlsx', parse_dates=['date_column'])`
+### 使用 pandas
+- 指定数据类型以避免推断问题：`pd.read_excel('file.xlsx', dtype={'id': str})`
+- 对于大文件，读取特定列：`pd.read_excel('file.xlsx', usecols=['A', 'C', 'E'])`
+- 正确处理日期：`pd.read_excel('file.xlsx', parse_dates=['date_column'])`
 
-## Code Style Guidelines
-**IMPORTANT**: When generating Python code for Excel operations:
-- Write minimal, concise Python code without unnecessary comments
-- Avoid verbose variable names and redundant operations
-- Avoid unnecessary print statements
+## 代码风格指南
+**重要**：生成用于 Excel 操作的 Python 代码时：
+- 编写精简简洁的 Python 代码，不添加不必要的注释
+- 避免冗长的变量名和多余的操作
+- 避免不必要的 print 语句
 
-**For Excel files themselves**:
-- Add comments to cells with complex formulas or important assumptions
-- Document data sources for hardcoded values
-- Include notes for key calculations and model sections
+**对于 Excel 文件本身**：
+- 为包含复杂公式或重要假设的单元格添加批注
+- 为硬编码值标注数据来源
+- 为关键计算和模型部分添加说明

--- a/template/SKILL.md
+++ b/template/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: template-skill
-description: Replace with description of the skill and when Claude should use it.
+description: 请替换为技能的描述以及 Claude 应在何时使用该技能。
 ---
 
-# Insert instructions below
+# 在下方插入说明


### PR DESCRIPTION
将项目中全部 17 个 SKILL.md 文件从英文翻译为中文，包括：
- YAML frontmatter 中的 description 字段
- 所有 Markdown 标题、段落、列表项和表格内容
- 代码块中的注释 保留了代码块、文件路径、URL 和技术术语不变。

https://claude.ai/code/session_01Ba8LnRBoY6wiSaibLzrbUR