### PR TITLE
Add CogmemAi to Partner Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,4 +92,4 @@ The markdown content below contains the instructions, examples, and guidelines t
 Skills are a great way to teach Claude how to get better at using specific pieces of software. As we see awesome example skills from partners, we may highlight some of them here:
 
 - **Notion** - [Notion Skills for Claude](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0)
-- **CogmemAi** - [CogmemAi Memory Skill for Claude Code](https://github.com/hifriendbot/cogmemai-mcp/tree/master/skill/cogmemai-memory) — Persistent memory management for AI coding assistants. Teaches Claude best practices for saving, organizing, and recalling memories across sessions using the [CogmemAi MCP server](https://github.com/hifriendbot/cogmemai-mcp).
+- **CogmemAi** - [CogmemAi Memory Skill for Claude Code](https://github.com/hifriendbot/cogmemai-mcp/tree/main/skill/cogmemai-memory) — Persistent memory management for AI coding assistants. Teaches Claude best practices for saving, organizing, and recalling memories across sessions using the [CogmemAi MCP server](https://github.com/hifriendbot/cogmemai-mcp).

--- a/README.md
+++ b/README.md
@@ -92,3 +92,4 @@ The markdown content below contains the instructions, examples, and guidelines t
 Skills are a great way to teach Claude how to get better at using specific pieces of software. As we see awesome example skills from partners, we may highlight some of them here:
 
 - **Notion** - [Notion Skills for Claude](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0)
+- **CogmemAi** - [CogmemAi Memory Skill for Claude Code](https://github.com/hifriendbot/cogmemai-mcp/tree/main/skill/cogmemai-memory) — Persistent memory management for AI coding assistants. Teaches Claude best practices for saving, organizing, and recalling memories across sessions using the [CogmemAi MCP server](https://github.com/hifriendbot/cogmemai-mcp).

--- a/README.md
+++ b/README.md
@@ -92,4 +92,4 @@ The markdown content below contains the instructions, examples, and guidelines t
 Skills are a great way to teach Claude how to get better at using specific pieces of software. As we see awesome example skills from partners, we may highlight some of them here:
 
 - **Notion** - [Notion Skills for Claude](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0)
-- **CogmemAi** - [CogmemAi Memory Skill for Claude Code](https://github.com/hifriendbot/cogmemai-mcp/tree/main/skill/cogmemai-memory) — Persistent memory management for AI coding assistants. Teaches Claude best practices for saving, organizing, and recalling memories across sessions using the [CogmemAi MCP server](https://github.com/hifriendbot/cogmemai-mcp).
+- **CogmemAi** - [CogmemAi Memory Skill for Claude Code](https://github.com/hifriendbot/cogmemai-mcp/tree/master/skill/cogmemai-memory) — Persistent memory management for AI coding assistants. Teaches Claude best practices for saving, organizing, and recalling memories across sessions using the [CogmemAi MCP server](https://github.com/hifriendbot/cogmemai-mcp).


### PR DESCRIPTION
## Summary

Adds [CogmemAi](https://github.com/hifriendbot/cogmemai-mcp) to the Partner Skills section. CogmemAi is an MCP server that gives Claude Code persistent memory across sessions.

The skill ([SKILL.md](https://github.com/hifriendbot/cogmemai-mcp/tree/main/skill/cogmemai-memory)) is a Category 3 MCP Enhancement that teaches Claude:

- **When and what to save** — importance scoring guidelines, memory type selection, scoping (project vs global)
- **Session lifecycle** — loading context at start, saving memories while working, session summaries at end
- **Workflows** — project onboarding, memory health checks, context recovery after compaction, semantic search
- **Best practices** — concise memories, descriptive subjects, update vs duplicate, common mistakes to avoid

### About CogmemAi

- **npm:** [`cogmemai-mcp`](https://www.npmjs.com/package/cogmemai-mcp) (v2.7.2)
- **18 MCP tools** for memory CRUD, AI-powered extraction, organization (linking, tags, versioning), analytics, and data portability
- **3 hooks** for automatic context management: PreCompact (saves transcript), UserPromptSubmit (reloads context), Stop (session summary)
- Solves the context compaction problem — memories persist even when Claude's context window resets

### Why this fits Partner Skills

The README says: *"Skills are a great way to teach Claude how to get better at using specific pieces of software."* That's exactly what this skill does — it teaches Claude the best practices for using CogmemAi's 18 tools effectively, including importance scoring, memory types, and session management workflows.