### PR TITLE
fix: correct typos and grammar errors in skill documentation

### DIFF
--- a/skills/internal-comms/examples/company-newsletter.md
+++ b/skills/internal-comms/examples/company-newsletter.md
@@ -2,7 +2,7 @@
 You are being asked to write a company-wide newsletter update. You are meant to summarize the past week/month of a company in the form of a newsletter that the entire company will read. It should be maybe ~20-25 bullet points long. It will be sent via Slack and email, so make it consumable for that.
 
 Ideally it includes the following attributes:
-- Lots of links: pulling documents from Google Drive that are very relevant, linking to prominent Slack messages in announce channels and from executives, perhgaps referencing emails that went company-wide, highlighting significant things that have happened in the company.
+- Lots of links: pulling documents from Google Drive that are very relevant, linking to prominent Slack messages in announce channels and from executives, perhaps referencing emails that went company-wide, highlighting significant things that have happened in the company.
 - Short and to-the-point: each bullet should probably be no longer than ~1-2 sentences
 - Use the "we" tense, as you are part of the company. Many of the bullets should say "we did this" or "we did that"
 

--- a/skills/theme-factory/SKILL.md
+++ b/skills/theme-factory/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: theme-factory
-description: Toolkit for styling artifacts with a theme. These artifacts can be slides, docs, reportings, HTML landing pages, etc. There are 10 pre-set themes with colors/fonts that you can apply to any artifact that has been creating, or can generate a new theme on-the-fly.
+description: Toolkit for styling artifacts with a theme. These artifacts can be slides, docs, reports, HTML landing pages, etc. There are 10 pre-set themes with colors/fonts that you can apply to any artifact that has been created, or can generate a new theme on-the-fly.
 license: Complete terms in LICENSE.txt
 ---
 
 
 # Theme Factory Skill
 
-This skill provides a curated collection of professional font and color themes themes, each with carefully selected color palettes and font pairings. Once a theme is chosen, it can be applied to any artifact.
+This skill provides a curated collection of professional font and color themes, each with carefully selected color palettes and font pairings. Once a theme is chosen, it can be applied to any artifact.
 
 ## Purpose
 

--- a/skills/webapp-testing/SKILL.md
+++ b/skills/webapp-testing/SKILL.md
@@ -11,7 +11,7 @@ To test local web applications, write native Python Playwright scripts.
 **Helper Scripts Available**:
 - `scripts/with_server.py` - Manages server lifecycle (supports multiple servers)
 
-**Always run scripts with `--help` first** to see usage. DO NOT read the source until you try running the script first and find that a customized solution is abslutely necessary. These scripts can be very large and thus pollute your context window. They exist to be called directly as black-box scripts rather than ingested into your context window.
+**Always run scripts with `--help` first** to see usage. DO NOT read the source until you try running the script first and find that a customized solution is absolutely necessary. These scripts can be very large and thus pollute your context window. They exist to be called directly as black-box scripts rather than ingested into your context window.
 
 ## Decision Tree: Choosing Your Approach
 


### PR DESCRIPTION
## Summary
- Fix "perhgaps" → "perhaps" in company-newsletter.md
- Fix "abslutely" → "absolutely" in webapp-testing/SKILL.md
- Fix "reportings" → "reports" in theme-factory/SKILL.md
- Fix "has been creating" → "has been created" in theme-factory/SKILL.md
- Fix duplicate "themes themes" → "themes" in theme-factory/SKILL.md

## Test plan
- [x] Verified all typos are corrected
- [x] No functional changes, documentation only

🤖 Generated with [Claude Code](https://claude.ai/code)