### PR TITLE
Add temporal-cortex skills (datetime + scheduling + router + calendar-scheduling alias)

### DIFF
--- a/skills/calendar-scheduling/SKILL.md
+++ b/skills/calendar-scheduling/SKILL.md
@@ -1,7 +1,9 @@
+<!-- DO NOT EDIT — generated from skills/temporal-cortex/SKILL.md by scripts/generate-alias.sh -->
 ---
-name: temporal-cortex
+name: calendar-scheduling
 description: |-
   Schedule meetings, check availability, and manage calendars across Google, Outlook, and CalDAV. Routes to focused sub-skills for datetime resolution and calendar scheduling.
+  Previously published as calendar-scheduling, now maintained as temporal-cortex — this listing is kept for backward compatibility.
 license: MIT
 compatibility: |-
   Requires npx (Node.js 18+) or Docker to install the MCP server binary. python3 optional (configure/status scripts). Stores OAuth credentials at ~/.config/temporal-cortex/. Works with Claude Code, Claude Desktop, Cursor, Windsurf, and any MCP-compatible client.
@@ -25,6 +27,8 @@ metadata:
 ---
 
 # Temporal Cortex — Calendar Scheduling Router
+
+> **Renamed:** This skill was previously published as `calendar-scheduling`. It is now maintained as [`temporal-cortex`](https://github.com/temporal-cortex/skills/blob/main/skills/temporal-cortex/SKILL.md). Both slugs install the same MCP server and provide identical functionality.
 
 This is the router skill for Temporal Cortex calendar operations. It routes your task to the right sub-skill based on intent.
 
@@ -135,4 +139,4 @@ Layer 1 tools work immediately with zero configuration. Calendar tools require a
 
 ## Additional References
 
-- [Security Model](references/SECURITY-MODEL.md) — Content sanitization, filesystem containment, network scope, tool annotations
+- [Security Model](https://github.com/temporal-cortex/skills/blob/main/skills/temporal-cortex/references/SECURITY-MODEL.md) — Content sanitization, filesystem containment, network scope, tool annotations

--- a/skills/temporal-cortex-datetime/SKILL.md
+++ b/skills/temporal-cortex-datetime/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: temporal-cortex-datetime
+description: |-
+  Convert timezones, resolve natural language times ("next Tuesday at 2pm"), compute durations, and adjust timestamps with DST awareness. Zero-setup — no API calls or credentials needed. Use this skill when the user asks about current time, timezone conversion, duration calculation, or natural language date resolution.
+license: MIT
+---
+
+# Temporal Context & Datetime Resolution
+
+5 tools for temporal orientation and datetime computation. All are pure computation (no external API calls), read-only, and idempotent. No OAuth or calendar credentials required.
+
+## Tools
+
+| Tool | When to Use |
+|------|------------|
+| `get_temporal_context` | First call in any session. Returns current time, timezone, UTC offset, DST status, DST prediction, day of week. |
+| `resolve_datetime` | Convert human expressions to RFC 3339. Supports 60+ patterns: `"next Tuesday at 2pm"`, `"tomorrow morning"`, `"+2h"`, `"start of next week"`, `"third Friday of March"`. |
+| `convert_timezone` | Convert RFC 3339 datetime between IANA timezones. |
+| `compute_duration` | Duration between two timestamps (days, hours, minutes). |
+| `adjust_timestamp` | DST-aware timestamp adjustment. `"+1d"` across spring-forward = same wall-clock time. |
+
+## Critical Rules
+
+1. **Always call `get_temporal_context` before time-dependent work** — never assume the time or timezone.
+2. **Resolve before querying** — convert `"next Tuesday at 2pm"` to RFC 3339 with `resolve_datetime` before passing to calendar tools.
+3. **Timezone awareness** — all datetime tools produce RFC 3339 with timezone offsets.
+
+## resolve_datetime Expression Patterns
+
+The expression parser supports 60+ patterns across 10 categories:
+
+| Category | Examples |
+|----------|---------|
+| Relative | `"now"`, `"today"`, `"tomorrow"`, `"yesterday"` |
+| Named days | `"next Monday"`, `"this Friday"`, `"last Wednesday"` |
+| Time of day | `"morning"` (09:00), `"noon"`, `"evening"` (18:00), `"eob"` (17:00) |
+| Clock time | `"2pm"`, `"14:00"`, `"3:30pm"` |
+| Offsets | `"+2h"`, `"-30m"`, `"in 2 hours"`, `"3 days ago"` |
+| Compound | `"next Tuesday at 2pm"`, `"tomorrow morning"`, `"this Friday at noon"` |
+| Period boundaries | `"start of week"`, `"end of month"`, `"start of next week"` |
+| Ordinal weekday | `"first Monday of March"`, `"third Friday of next month"` |
+| RFC 3339 passthrough | `"2026-03-15T14:00:00-04:00"` (returned as-is) |
+| Week start aware | Uses configured `WEEK_START` (Monday default, Sunday option) |
+
+## Common Patterns
+
+### Get Current Time Context
+
+```
+get_temporal_context()
+→ utc, local, timezone, utc_offset, dst_active, dst_next_transition,
+  day_of_week, iso_week, is_weekday, day_of_year, week_start
+```
+
+### Resolve a Meeting Time
+
+```
+resolve_datetime("next Tuesday at 2pm")
+→ resolved_utc, resolved_local, timezone, interpretation
+```
+
+### Convert Across Timezones
+
+```
+1. get_temporal_context → user's timezone
+2. convert_timezone(datetime: "2026-03-15T14:00:00-04:00", target_timezone: "Asia/Tokyo")
+   → same moment in Tokyo time with DST and offset info
+```
+
+### Calculate Duration
+
+```
+compute_duration(start: "2026-03-15T09:00:00-04:00", end: "2026-03-15T17:30:00-04:00")
+→ total_seconds: 30600, hours: 8, minutes: 30, human_readable: "8 hours 30 minutes"
+```
+
+### DST-Aware Adjustment
+
+```
+adjust_timestamp(
+  datetime: "2026-03-07T23:00:00-05:00",
+  adjustment: "+1d",
+  timezone: "America/New_York"
+) → same wall-clock time (23:00) on March 8, even though DST spring-forward occurs
+```
+
+## MCP Server Connection
+
+```json
+{
+  "mcpServers": {
+    "temporal-cortex": {
+      "command": "npx",
+      "args": ["-y", "@temporal-cortex/cortex-mcp@0.5.3"]
+    }
+  }
+}
+```
+
+All 5 datetime tools work immediately — no OAuth setup needed.
+
+For full documentation, see the [skills repository](https://github.com/temporal-cortex/skills).

--- a/skills/temporal-cortex-datetime/SKILL.md
+++ b/skills/temporal-cortex-datetime/SKILL.md
@@ -1,13 +1,31 @@
 ---
 name: temporal-cortex-datetime
 description: |-
-  Convert timezones, resolve natural language times ("next Tuesday at 2pm"), compute durations, and adjust timestamps with DST awareness. Zero-setup — no API calls or credentials needed. Use this skill when the user asks about current time, timezone conversion, duration calculation, or natural language date resolution.
+  Convert timezones, resolve natural language times ("next Tuesday at 2pm"), compute durations, and adjust timestamps with DST awareness. No credentials needed — all tools run fully offline after one-time binary install.
 license: MIT
+compatibility: |-
+  Requires npx (Node.js 18+) or Docker to install the MCP server binary (one-time). After installation, all 5 tools run fully offline with zero network access. No OAuth or credentials needed. Works with Claude Code, Claude Desktop, Cursor, Windsurf, and any MCP-compatible client.
+metadata:
+  author: temporal-cortex
+  version: "0.7.5"
+  mcp-server: "@temporal-cortex/cortex-mcp"
+  homepage: "https://temporal-cortex.com"
+  repository: "https://github.com/temporal-cortex/skills"
+  openclaw:
+    install:
+      - kind: node
+        package: "@temporal-cortex/cortex-mcp@0.7.5"
+        bins: [cortex-mcp]
+    requires:
+      bins:
+        - npx
+      config:
+        - ~/.config/temporal-cortex/config.json
 ---
 
 # Temporal Context & Datetime Resolution
 
-5 tools for temporal orientation and datetime computation. All are pure computation (no external API calls), read-only, and idempotent. No OAuth or calendar credentials required.
+5 tools for temporal orientation and datetime computation. All tools execute locally within the compiled MCP server binary — no external API calls, no network access at runtime, no credential files. The binary is installed once via npm (or built from source with Docker) and all subsequent executions are fully offline. No OAuth, credentials, or configuration required.
 
 ## Tools
 
@@ -18,6 +36,56 @@ license: MIT
 | `convert_timezone` | Convert RFC 3339 datetime between IANA timezones. |
 | `compute_duration` | Duration between two timestamps (days, hours, minutes). |
 | `adjust_timestamp` | DST-aware timestamp adjustment. `"+1d"` across spring-forward = same wall-clock time. |
+
+## Runtime
+
+These tools run inside the [Temporal Cortex MCP server](https://github.com/temporal-cortex/mcp) (`@temporal-cortex/cortex-mcp`), a compiled Rust binary distributed as an npm package.
+
+**Install and startup lifecycle:**
+1. `npx` resolves `@temporal-cortex/cortex-mcp` from the npm registry (one-time, cached locally after first download)
+2. The postinstall script downloads the platform-specific binary from the [GitHub Release](https://github.com/temporal-cortex/mcp/releases/tag/mcp-v0.7.5) and verifies its SHA256 checksum against the embedded `checksums.json` — **installation halts on mismatch**
+3. The MCP server starts as a local process communicating over stdio (no listening ports)
+4. All 5 datetime tools execute locally — zero network access, zero filesystem writes, no credentials
+
+**Network access:** Only during the initial npm download. Once cached, subsequent launches are fully offline. The 5 datetime tools make zero network requests — all computation is local.
+
+**File access:** The binary reads only `~/.config/temporal-cortex/config.json` (for timezone and week-start preferences). No filesystem writes. No credential files accessed.
+
+**No credentials required.** Unlike the scheduling skill, this skill needs no OAuth tokens or API keys.
+
+**Pre-run verification** (recommended before first use):
+1. Inspect the npm package without executing: `npm pack @temporal-cortex/cortex-mcp --dry-run`
+2. Verify checksums independently against the [GitHub Release](https://github.com/temporal-cortex/mcp/releases/download/mcp-v0.7.5/SHA256SUMS.txt) (see verification pipeline below)
+3. For full containment, run in Docker instead of npx (see Docker containment below)
+
+**Verification pipeline:** Checksums are published independently at each [GitHub Release](https://github.com/temporal-cortex/mcp/releases/tag/mcp-v0.7.5) as `SHA256SUMS.txt` — verify the binary before first use:
+
+```bash
+# 1. Fetch checksums from GitHub (independent of the npm package)
+curl -sL https://github.com/temporal-cortex/mcp/releases/download/mcp-v0.7.5/SHA256SUMS.txt
+
+# 2. Compare against the npm-installed binary
+shasum -a 256 "$(npm root -g)/@temporal-cortex/cortex-mcp/bin/cortex-mcp"
+```
+
+As defense-in-depth, the npm package also embeds `checksums.json` and the postinstall script compares SHA256 hashes during install — **installation halts on mismatch** (the binary is deleted, not executed). This automated check supplements, but does not replace, independent verification above.
+
+**Build provenance:** Binaries are cross-compiled from auditable Rust source in [GitHub Actions](https://github.com/temporal-cortex/mcp/actions) across 5 platforms (darwin-arm64, darwin-x64, linux-x64, linux-arm64, win32-x64). Source: [github.com/temporal-cortex/mcp](https://github.com/temporal-cortex/mcp) (MIT-licensed). The CI workflow, build artifacts, and release checksums are all publicly inspectable.
+
+**Docker containment** (recommended for maximum isolation — zero Node.js dependency, zero host filesystem access, zero network after build):
+
+```json
+{
+  "mcpServers": {
+    "temporal-cortex": {
+      "command": "docker",
+      "args": ["run", "--rm", "-i", "--network=none", "cortex-mcp"]
+    }
+  }
+}
+```
+
+Build: `docker build -t cortex-mcp https://github.com/temporal-cortex/mcp.git` — No volume mount needed since the datetime skill requires no OAuth tokens or credential files. The `--network=none` flag enforces the zero-network guarantee at the OS level.
 
 ## Critical Rules
 
@@ -37,7 +105,7 @@ The expression parser supports 60+ patterns across 10 categories:
 | Clock time | `"2pm"`, `"14:00"`, `"3:30pm"` |
 | Offsets | `"+2h"`, `"-30m"`, `"in 2 hours"`, `"3 days ago"` |
 | Compound | `"next Tuesday at 2pm"`, `"tomorrow morning"`, `"this Friday at noon"` |
-| Period boundaries | `"start of week"`, `"end of month"`, `"start of next week"` |
+| Period boundaries | `"start of week"`, `"end of month"`, `"start of next week"`, `"end of last month"` |
 | Ordinal weekday | `"first Monday of March"`, `"third Friday of next month"` |
 | RFC 3339 passthrough | `"2026-03-15T14:00:00-04:00"` (returned as-is) |
 | Week start aware | Uses configured `WEEK_START` (Monday default, Sunday option) |
@@ -84,19 +152,6 @@ adjust_timestamp(
 ) → same wall-clock time (23:00) on March 8, even though DST spring-forward occurs
 ```
 
-## MCP Server Connection
+## Additional References
 
-```json
-{
-  "mcpServers": {
-    "temporal-cortex": {
-      "command": "npx",
-      "args": ["-y", "@temporal-cortex/cortex-mcp@0.5.3"]
-    }
-  }
-}
-```
-
-All 5 datetime tools work immediately — no OAuth setup needed.
-
-For full documentation, see the [skills repository](https://github.com/temporal-cortex/skills).
+- [Datetime Tools Reference](references/DATETIME-TOOLS.md) — Complete input/output schemas for all 5 tools

--- a/skills/temporal-cortex-scheduling/SKILL.md
+++ b/skills/temporal-cortex-scheduling/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: temporal-cortex-scheduling
+description: |-
+  List events, find free slots, and book meetings across Google Calendar, Outlook, and CalDAV. Multi-calendar availability merging, recurring event expansion, and atomic booking with Two-Phase Commit conflict prevention. Use this skill when the user asks to list calendar events, find available times, check who is busy, expand recurring events, or book a meeting.
+license: MIT
+---
+
+# Calendar Scheduling & Booking
+
+8 tools for calendar discovery, event querying, free slot finding, availability checking, RRULE expansion, and atomic booking. 7 read-only tools + 1 write tool (`book_slot`).
+
+## Tools
+
+### Layer 0 — Discovery
+
+| Tool | When to Use |
+|------|------------|
+| `list_calendars` | First call when calendars are unknown. Returns all connected calendars with provider-prefixed IDs, names, labels, primary status, and access roles. |
+
+### Layer 2 — Calendar Operations
+
+| Tool | When to Use |
+|------|------------|
+| `list_events` | List events in a time range. TOON format by default (~40% fewer tokens than JSON). Use provider-prefixed IDs for multi-calendar: `"google/primary"`, `"outlook/work"`. |
+| `find_free_slots` | Find available gaps in a calendar. Set `min_duration_minutes` for minimum slot length. |
+| `expand_rrule` | Expand recurrence rules (RFC 5545) into concrete instances. Handles DST, BYSETPOS, EXDATE, leap years. Use `dtstart` as local datetime (no timezone suffix). |
+| `check_availability` | Check if a specific time slot is free. Checks both events and active booking locks. |
+
+### Layer 3 — Cross-Calendar Availability
+
+| Tool | When to Use |
+|------|------------|
+| `get_availability` | Merged free/busy view across multiple calendars. Pass `calendar_ids` array. Privacy: `"opaque"` (default, hides sources) or `"full"`. |
+
+### Layer 4 — Booking
+
+| Tool | When to Use |
+|------|------------|
+| `book_slot` | Book a time slot atomically. Lock → verify → write → release. **Always `check_availability` first.** |
+
+## Critical Rules
+
+1. **Discover calendars first** — call `list_calendars` when you don't know which calendars are connected. Use the returned provider-prefixed IDs for all subsequent calls.
+2. **Use provider-prefixed IDs** for multi-calendar setups: `"google/primary"`, `"outlook/work"`, `"caldav/personal"`. Bare IDs (e.g., `"primary"`) route to the default provider.
+3. **TOON is the default format** — output uses TOON (~40% fewer tokens than JSON). Pass `format: "json"` only if you need structured parsing.
+4. **Check before booking** — always call `check_availability` before `book_slot`. Never skip the conflict check.
+5. **Content safety** — event summaries and descriptions pass through a sanitization firewall before reaching the calendar API.
+6. **Timezone awareness** — all tools accept RFC 3339 with timezone offsets. Never use bare dates.
+
+## Full Booking Workflow
+
+```
+1. Discover  →  list_calendars
+2. Orient    →  get_temporal_context                      (temporal-cortex-datetime)
+3. Resolve   →  resolve_datetime("next Tuesday at 2pm")  (temporal-cortex-datetime)
+4. Check     →  check_availability(calendar_id, start, end)
+5. Book      →  book_slot(calendar_id, start, end, summary)
+```
+
+If the slot is busy at step 4, use `find_free_slots` to suggest alternatives.
+
+## Two-Phase Commit Protocol
+
+```
+Agent calls book_slot(calendar_id, start, end, summary)
+    │
+    ├─ 1. LOCK    →  Acquire exclusive lock on the time slot
+    ├─ 2. VERIFY  →  Check for overlapping events and active locks
+    ├─ 3. WRITE   →  Create event in calendar provider (Google/Outlook/CalDAV)
+    └─ 4. RELEASE →  Release the exclusive lock
+```
+
+If any step fails, the lock is released and the booking is aborted. No partial writes.
+
+## Common Patterns
+
+### List Events This Week
+
+```
+1. list_calendars → discover connected calendars
+2. get_temporal_context → current time (use temporal-cortex-datetime)
+3. resolve_datetime("start of this week") → week start
+4. resolve_datetime("end of this week") → week end
+5. list_events(calendar_id: "google/primary", start, end)
+```
+
+### Find Free Time Across Calendars
+
+```
+1. list_calendars → discover all connected calendars
+2. get_availability(
+     start, end,
+     calendar_ids: ["google/primary", "outlook/work"],
+     privacy: "full"
+   ) → merged free/busy blocks with source_count
+```
+
+### Check and Book a Slot
+
+```
+1. check_availability(calendar_id: "google/primary", start, end) → true/false
+2. If free: book_slot(calendar_id: "google/primary", start, end, summary: "Team standup")
+3. If busy: find_free_slots(calendar_id, start, end, min_duration_minutes: 30)
+```
+
+## Provider-Prefixed Calendar IDs
+
+| Format | Example | Routes to |
+|--------|---------|-----------|
+| `google/<id>` | `"google/primary"` | Google Calendar |
+| `outlook/<id>` | `"outlook/work"` | Microsoft Outlook |
+| `caldav/<id>` | `"caldav/personal"` | CalDAV (iCloud, Fastmail) |
+| `<id>` (bare) | `"primary"` | Default provider |
+
+## Error Handling
+
+| Error | Action |
+|-------|--------|
+| "No credentials found" | Run: `npx @temporal-cortex/cortex-mcp auth google` (or `outlook` / `caldav`). |
+| "Timezone not configured" | Prompt for IANA timezone. Or run the auth command which configures timezone. |
+| Slot is busy / conflict | Use `find_free_slots` to suggest alternatives. Present options to user. |
+| Lock acquisition failed | Another agent is booking the same slot. Wait briefly and retry, or suggest alternative times. |
+
+## MCP Server Connection
+
+```json
+{
+  "mcpServers": {
+    "temporal-cortex": {
+      "command": "npx",
+      "args": ["-y", "@temporal-cortex/cortex-mcp@0.5.3"]
+    }
+  }
+}
+```
+
+Calendar tools require a one-time OAuth setup — run `npx @temporal-cortex/cortex-mcp auth google` (or `outlook` / `caldav`).
+
+For full documentation, presets, and setup scripts, see the [skills repository](https://github.com/temporal-cortex/skills).

--- a/skills/temporal-cortex-scheduling/SKILL.md
+++ b/skills/temporal-cortex-scheduling/SKILL.md
@@ -1,26 +1,90 @@
 ---
 name: temporal-cortex-scheduling
 description: |-
-  List events, find free slots, and book meetings across Google Calendar, Outlook, and CalDAV. Multi-calendar availability merging, recurring event expansion, and atomic booking with Two-Phase Commit conflict prevention. Use this skill when the user asks to list calendar events, find available times, check who is busy, expand recurring events, or book a meeting.
+  List events, find free slots, and book meetings across Google Calendar, Outlook, and CalDAV. Multi-calendar availability merging, recurring event expansion, and atomic booking with Two-Phase Commit conflict prevention.
 license: MIT
+compatibility: |-
+  Requires npx (Node.js 18+) or Docker for the MCP server. Stores OAuth credentials at ~/.config/temporal-cortex/. Works with Claude Code, Claude Desktop, Cursor, Windsurf, and any MCP-compatible client.
+metadata:
+  author: temporal-cortex
+  version: "0.7.5"
+  mcp-server: "@temporal-cortex/cortex-mcp"
+  homepage: "https://temporal-cortex.com"
+  repository: "https://github.com/temporal-cortex/skills"
+  openclaw:
+    install:
+      - kind: node
+        package: "@temporal-cortex/cortex-mcp@0.7.5"
+        bins: [cortex-mcp]
+    requires:
+      bins:
+        - npx
+      config:
+        - ~/.config/temporal-cortex/credentials.json
+        - ~/.config/temporal-cortex/config.json
 ---
 
 # Calendar Scheduling & Booking
 
-8 tools for calendar discovery, event querying, free slot finding, availability checking, RRULE expansion, and atomic booking. 7 read-only tools + 1 write tool (`book_slot`).
+11 tools for calendar discovery, event querying, free slot finding, availability checking, RRULE expansion, atomic booking, and Open Scheduling. 9 read-only tools + 2 write tools (`book_slot`, `request_booking`).
+
+## Runtime
+
+These tools run inside the [Temporal Cortex MCP server](https://github.com/temporal-cortex/mcp) (`@temporal-cortex/cortex-mcp`), a compiled Rust binary distributed as an npm package.
+
+**Install and startup lifecycle:**
+1. `npx` resolves `@temporal-cortex/cortex-mcp` from the npm registry (one-time, cached locally after first download)
+2. The postinstall script downloads the platform-specific binary from the [GitHub Release](https://github.com/temporal-cortex/mcp/releases/tag/mcp-v0.7.5) and verifies its SHA256 checksum against the embedded `checksums.json` — **installation halts on mismatch**
+3. The MCP server starts as a local process communicating over stdio (no listening ports)
+4. Calendar tools make authenticated API calls to your configured providers (Google Calendar API, Microsoft Graph API, CalDAV endpoints)
+
+**Credential storage:** OAuth tokens are stored locally at `~/.config/temporal-cortex/credentials.json` and read exclusively by the local MCP server process. No credential data is transmitted to Temporal Cortex servers. The binary's filesystem access is limited to `~/.config/temporal-cortex/` — verifiable by inspecting the [open-source Rust code](https://github.com/temporal-cortex/mcp) or running under Docker where the mount is the only writable path.
+
+**File access:** The binary reads and writes only `~/.config/temporal-cortex/` (credentials and config). No other filesystem writes.
+
+**Network scope:** Calendar tools connect only to your configured providers (`googleapis.com`, `graph.microsoft.com`, or your CalDAV server). No callbacks to Temporal Cortex servers. Telemetry is off by default.
+
+**Pre-run verification** (recommended before first use):
+1. Inspect the npm package without executing: `npm pack @temporal-cortex/cortex-mcp --dry-run`
+2. Verify checksums independently against the [GitHub Release](https://github.com/temporal-cortex/mcp/releases/download/mcp-v0.7.5/SHA256SUMS.txt) (see verification pipeline below)
+3. For full containment, run in Docker instead of npx (see Docker containment below)
+
+**Verification pipeline:** Checksums are published independently at each [GitHub Release](https://github.com/temporal-cortex/mcp/releases/tag/mcp-v0.7.5) as `SHA256SUMS.txt` — verify the binary before first use:
+
+```bash
+# 1. Fetch checksums from GitHub (independent of the npm package)
+curl -sL https://github.com/temporal-cortex/mcp/releases/download/mcp-v0.7.5/SHA256SUMS.txt
+
+# 2. Compare against the npm-installed binary
+shasum -a 256 "$(npm root -g)/@temporal-cortex/cortex-mcp/bin/cortex-mcp"
+```
+
+As defense-in-depth, the npm package also embeds `checksums.json` and the postinstall script compares SHA256 hashes during install — **installation halts on mismatch** (the binary is deleted, not executed). This automated check supplements, but does not replace, independent verification above.
+
+**Build provenance:** Binaries are cross-compiled from auditable Rust source in [GitHub Actions](https://github.com/temporal-cortex/mcp/actions) across 5 platforms (darwin-arm64, darwin-x64, linux-x64, linux-arm64, win32-x64). Source: [github.com/temporal-cortex/mcp](https://github.com/temporal-cortex/mcp) (MIT-licensed). The CI workflow, build artifacts, and release checksums are all publicly inspectable.
+
+**Docker containment** (no Node.js on host, credential isolation via volume mount):
+
+```json
+{
+  "mcpServers": {
+    "temporal-cortex": {
+      "command": "docker",
+      "args": ["run", "--rm", "-i", "-v", "~/.config/temporal-cortex:/root/.config/temporal-cortex", "cortex-mcp"]
+    }
+  }
+}
+```
+
+Build: `docker build -t cortex-mcp https://github.com/temporal-cortex/mcp.git`
 
 ## Tools
-
-### Layer 0 — Discovery
-
-| Tool | When to Use |
-|------|------------|
-| `list_calendars` | First call when calendars are unknown. Returns all connected calendars with provider-prefixed IDs, names, labels, primary status, and access roles. |
 
 ### Layer 2 — Calendar Operations
 
 | Tool | When to Use |
 |------|------------|
+| `list_calendars` | First call when calendars are unknown. Returns all connected calendars with provider-prefixed IDs, names, labels, primary status, and access roles. |
 | `list_events` | List events in a time range. TOON format by default (~40% fewer tokens than JSON). Use provider-prefixed IDs for multi-calendar: `"google/primary"`, `"outlook/work"`. |
 | `find_free_slots` | Find available gaps in a calendar. Set `min_duration_minutes` for minimum slot length. |
 | `expand_rrule` | Expand recurrence rules (RFC 5545) into concrete instances. Handles DST, BYSETPOS, EXDATE, leap years. Use `dtstart` as local datetime (no timezone suffix). |
@@ -37,6 +101,19 @@ license: MIT
 | Tool | When to Use |
 |------|------------|
 | `book_slot` | Book a time slot atomically. Lock → verify → write → release. **Always `check_availability` first.** |
+| `request_booking` | Book on another user's public calendar by Temporal Link slug. Requires Platform Mode. |
+
+### Layer 3 — Public Availability (Platform Mode)
+
+| Tool | When to Use |
+|------|------------|
+| `query_public_availability` | Check another user's public availability by Temporal Link slug. Pass the slug and date to find their open time slots. |
+
+### Layer 0 — Discovery (Platform Mode)
+
+| Tool | When to Use |
+|------|------------|
+| `resolve_identity` | DNS for Human Time: resolve an email, phone, or agent ID to a Temporal Cortex slug. Call before `query_public_availability`. |
 
 ## Critical Rules
 
@@ -59,14 +136,29 @@ license: MIT
 
 If the slot is busy at step 4, use `find_free_slots` to suggest alternatives.
 
+## Open Scheduling Workflow (Platform Mode)
+
+```
+1. Identify    →  resolve_identity("jane@example.com")  →  slug: "jane-doe"
+2. Orient      →  get_temporal_context                   (temporal-cortex-datetime)
+3. Discover    →  query_public_availability(slug, date)  →  available slots
+4. Present     →  Show top 3 options to user
+5. Book        →  request_booking(slug, start, end, title, attendee_email)
+```
+
 ## Two-Phase Commit Protocol
 
 ```
 Agent calls book_slot(calendar_id, start, end, summary)
     │
     ├─ 1. LOCK    →  Acquire exclusive lock on the time slot
+    │                 (in-memory local; Redis Redlock in Platform Mode)
+    │
     ├─ 2. VERIFY  →  Check for overlapping events and active locks
+    │
     ├─ 3. WRITE   →  Create event in calendar provider (Google/Outlook/CalDAV)
+    │                 Record event in shadow calendar
+    │
     └─ 4. RELEASE →  Release the exclusive lock
 ```
 
@@ -103,7 +195,20 @@ If any step fails, the lock is released and the booking is aborted. No partial w
 3. If busy: find_free_slots(calendar_id, start, end, min_duration_minutes: 30)
 ```
 
+### Expand Recurring Events
+
+```
+expand_rrule(
+  rrule: "FREQ=MONTHLY;BYDAY=FR;BYSETPOS=-1",
+  dtstart: "2026-01-01T10:00:00",     ← local datetime, no timezone suffix
+  timezone: "America/New_York",
+  count: 12
+) → last Friday of every month for 2026
+```
+
 ## Provider-Prefixed Calendar IDs
+
+All calendar IDs use provider-prefixed format:
 
 | Format | Example | Routes to |
 |--------|---------|-----------|
@@ -112,28 +217,62 @@ If any step fails, the lock is released and the booking is aborted. No partial w
 | `caldav/<id>` | `"caldav/personal"` | CalDAV (iCloud, Fastmail) |
 | `<id>` (bare) | `"primary"` | Default provider |
 
+## Privacy Modes
+
+| Mode | `source_count` | Use case |
+|------|---------------|----------|
+| `"opaque"` (default) | Always `0` | Sharing availability externally |
+| `"full"` | Actual count | Internal use — shows which calendars are busy |
+
+## Tool Annotations (`book_slot`)
+
+| Property | Value | Meaning |
+|----------|-------|---------|
+| `readOnlyHint` | `false` | Creates calendar events |
+| `destructiveHint` | `false` | Never deletes or overwrites existing events |
+| `idempotentHint` | `false` | Calling twice creates two events |
+| `openWorldHint` | `true` | Makes external API calls |
+
+## Tool Annotations (`request_booking`)
+
+| Property | Value | Meaning |
+|----------|-------|---------|
+| `readOnlyHint` | `false` | Creates calendar events on another user's calendar |
+| `destructiveHint` | `false` | Never deletes or overwrites existing events |
+| `idempotentHint` | `false` | Calling twice creates two bookings |
+| `openWorldHint` | `true` | Calls the Platform API |
+
 ## Error Handling
 
 | Error | Action |
 |-------|--------|
 | "No credentials found" | Run: `npx @temporal-cortex/cortex-mcp auth google` (or `outlook` / `caldav`). |
 | "Timezone not configured" | Prompt for IANA timezone. Or run the auth command which configures timezone. |
-| Slot is busy / conflict | Use `find_free_slots` to suggest alternatives. Present options to user. |
+| Slot is busy / conflict detected | Use `find_free_slots` to suggest alternatives. Present options to user. |
 | Lock acquisition failed | Another agent is booking the same slot. Wait briefly and retry, or suggest alternative times. |
+| Content rejected by sanitization | Rephrase the event summary/description. The firewall blocks prompt injection attempts. |
 
-## MCP Server Connection
+## Open Scheduling & Temporal Links
 
-```json
-{
-  "mcpServers": {
-    "temporal-cortex": {
-      "command": "npx",
-      "args": ["-y", "@temporal-cortex/cortex-mcp@0.5.3"]
-    }
-  }
-}
-```
+When a user has Open Scheduling enabled, their Temporal Link (`book.temporal-cortex.com/{slug}`) allows anyone to:
 
-Calendar tools require a one-time OAuth setup — run `npx @temporal-cortex/cortex-mcp auth google` (or `outlook` / `caldav`).
+1. **Query availability** — `GET /public/{slug}/availability?date=YYYY-MM-DD`
+2. **Book a meeting** — `POST /public/{slug}/book` with `{start, end, title, attendee_email}`
+3. **Discover via Agent Card** — `GET /public/{slug}/.well-known/agent-card.json`
 
-For full documentation, presets, and setup scripts, see the [skills repository](https://github.com/temporal-cortex/skills).
+### Workflow: Book via Temporal Link
+1. User shares their Temporal Link
+2. Agent calls availability endpoint to find free slots
+3. Agent calls booking endpoint with selected slot
+4. Meeting is created on the user's default calendar
+
+See [Temporal Links Reference](references/TEMPORAL-LINKS.md) for detailed API documentation.
+
+## Additional References
+
+- [Calendar Tools Reference](references/CALENDAR-TOOLS.md) — Complete input/output schemas for all 11 tools
+- [Multi-Calendar Guide](references/MULTI-CALENDAR.md) — Provider routing, labels, privacy modes, cross-provider operations
+- [RRULE Guide](references/RRULE-GUIDE.md) — Recurrence rule patterns, DST edge cases, 5 LLM failure modes
+- [Booking Safety](references/BOOKING-SAFETY.md) — 2PC details, concurrent booking, lock TTL, content sanitization
+- [Temporal Links](references/TEMPORAL-LINKS.md) — Open Scheduling endpoints, Agent Card integration, calendar routing
+- [Open Scheduling Guide](references/OPEN-SCHEDULING.md) — Identity resolution, public availability, external booking via MCP tools

--- a/skills/temporal-cortex/SKILL.md
+++ b/skills/temporal-cortex/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: temporal-cortex
+description: |-
+  Schedule meetings, check availability, and manage calendars across Google, Outlook, and CalDAV. Routes to focused sub-skills for datetime resolution and calendar scheduling. Use this skill when the user mentions scheduling, calendars, booking meetings, checking availability, or managing time across calendar providers.
+license: MIT
+---
+
+# Temporal Cortex — Calendar Scheduling Router
+
+This is the router skill for [Temporal Cortex](https://github.com/temporal-cortex/skills) calendar operations. It routes your task to the right sub-skill based on intent.
+
+## Sub-Skills
+
+| Sub-Skill | When to Use | Tools |
+|-----------|------------|-------|
+| **temporal-cortex-datetime** | Time resolution, timezone conversion, duration math. Zero-setup — no credentials needed. | 5 tools |
+| **temporal-cortex-scheduling** | List calendars, events, free slots, availability, RRULE expansion, and booking. Requires OAuth credentials. | 8 tools |
+
+## Routing Table
+
+| User Intent | Route To |
+|------------|----------|
+| "What time is it?", "Convert timezone", "How long until..." | **temporal-cortex-datetime** |
+| "Show my calendar", "Find free time", "Check availability" | **temporal-cortex-scheduling** |
+| "Book a meeting", "Schedule an appointment" | **temporal-cortex-scheduling** |
+| "Schedule a meeting next Tuesday at 2pm" (full workflow) | **temporal-cortex-datetime** → **temporal-cortex-scheduling** |
+
+## Core Workflow
+
+Every calendar interaction follows this 5-step pattern:
+
+```
+1. Discover  →  list_calendars                (know which calendars are available)
+2. Orient    →  get_temporal_context           (know the current time)
+3. Resolve   →  resolve_datetime              (turn human language into timestamps)
+4. Query     →  list_events / find_free_slots / get_availability
+5. Act       →  check_availability → book_slot (verify then book)
+```
+
+**Always start with step 1** when calendars are unknown. Never assume the current time. Never skip the conflict check before booking.
+
+## All 12 Tools (5 Layers)
+
+| Layer | Tools | Sub-Skill |
+|-------|-------|-----------|
+| 0 — Discovery | `list_calendars` | scheduling |
+| 1 — Temporal Context | `get_temporal_context`, `resolve_datetime`, `convert_timezone`, `compute_duration`, `adjust_timestamp` | datetime |
+| 2 — Calendar Ops | `list_events`, `find_free_slots`, `expand_rrule`, `check_availability` | scheduling |
+| 3 — Availability | `get_availability` | scheduling |
+| 4 — Booking | `book_slot` | scheduling |
+
+## MCP Server Connection
+
+All sub-skills share the same MCP server: [@temporal-cortex/cortex-mcp](https://www.npmjs.com/package/@temporal-cortex/cortex-mcp).
+
+```json
+{
+  "mcpServers": {
+    "temporal-cortex": {
+      "command": "npx",
+      "args": ["-y", "@temporal-cortex/cortex-mcp@0.5.3"]
+    }
+  }
+}
+```
+
+Layer 1 tools work immediately with zero configuration. Calendar tools require a one-time OAuth setup — run `npx @temporal-cortex/cortex-mcp auth google` (or `outlook` / `caldav`).
+
+For full documentation, presets, and setup scripts, see the [skills repository](https://github.com/temporal-cortex/skills).


### PR DESCRIPTION
## Summary

Adds the **Temporal Cortex** skill suite (v0.7.5) — 4 skills that teach AI agents how to work with calendars through the [Temporal Cortex](https://github.com/temporal-cortex/skills) MCP server.

### Skills

| Skill | Tools | Setup | Description |
|-------|-------|-------|-------------|
| `temporal-cortex` | 15 (all) | — | Router: routes to the right sub-skill based on user intent |
| `temporal-cortex-datetime` | 5 | Zero-setup | Time resolution, timezone conversion, duration math. No credentials needed. |
| `temporal-cortex-scheduling` | 11 | OAuth | Calendar discovery, events, free slots, availability, RRULE expansion, open scheduling, atomic booking |
| `calendar-scheduling` | 15 (all) | — | Legacy alias for the router — kept for discoverability |

Split at the **credential boundary**: datetime tools are pure computation (zero-setup), scheduling tools need OAuth (Google/Outlook/CalDAV).

### Why 4 skills?

Following the `docx`/`pdf`/`pptx`/`xlsx` pattern — each skill is independently installable and useful:
- Users who only need timezone math install `temporal-cortex-datetime` (no auth setup)
- Users who need calendar access install `temporal-cortex-scheduling`
- Users who want everything install the `temporal-cortex` router
- `calendar-scheduling` is a backward-compatible alias so users searching "calendar scheduling" can find it

### Key capabilities

- **15 tools across 5 layers:** discovery → temporal context → calendar ops → availability → booking
- **Multi-provider:** Google Calendar, Outlook, and CalDAV simultaneously via provider-prefixed IDs
- **Safety-first:** Atomic booking with Two-Phase Commit conflict prevention
- **Temporal intelligence:** 60+ natural language time expressions, DST-aware, recurrence expansion
- **Open Scheduling (v0.7.5):** Agent-to-agent scheduling via public availability and booking requests
- **3 presets:** Personal Assistant, Recruiter Agent, Team Coordinator

### Checklist

- [x] Based on real use case (calendar scheduling for AI agents)
- [x] Well-documented (4 SKILL.md files)
- [x] Tested with Claude Code, Claude Desktop, Cursor
- [x] Safe (conflict-checked booking with lock/verify/write/release)
- [x] Portable across 26+ MCP-compatible platforms
- [x] Each skill directory has a valid SKILL.md with frontmatter

MCP server: [@temporal-cortex/cortex-mcp](https://www.npmjs.com/package/@temporal-cortex/cortex-mcp) (npm)
Skills repo: https://github.com/temporal-cortex/skills
License: MIT

> Replaces #451 (closed — project restructured from single skill to multi-skill layout, migrated to `temporal-cortex` org)