### PR TITLE
Add ios-localization skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -38,7 +38,8 @@
         "./skills/slack-gif-creator",
         "./skills/theme-factory",
         "./skills/web-artifacts-builder",
-        "./skills/webapp-testing"
+        "./skills/webapp-testing",
+        "./skills/ios-localization"
       ]
     }
   ]

--- a/skills/ios-localization/LICENSE.txt
+++ b/skills/ios-localization/LICENSE.txt
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/skills/ios-localization/SKILL.md
+++ b/skills/ios-localization/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: ios-localization
+description: This skill should be used when the user asks to "translate iOS app", "localize xcstrings", "add translations to Localizable.xcstrings", "translate strings to multiple languages", or mentions iOS localization, xcstrings files, or app translation workflows.
+---
+
+# iOS Localization Skill
+
+Translate `Localizable.xcstrings` files in iOS projects efficiently using haiku agents for each target language.
+
+## Overview
+
+This skill provides a workflow for translating iOS app strings to multiple languages:
+1. Extract strings needing translation
+2. Mark non-translatable strings (aspect ratios, brands, etc.)
+3. Launch sequential haiku agents for each language
+4. Verify completion and fix gaps
+
+## Script Location
+
+All helper scripts are located in `./scripts/` relative to this skill's install directory. Determine the skill's installed path and use it to reference scripts. For example, if installed at `$SKILL_DIR`, run scripts as `python3 $SKILL_DIR/scripts/<script>.py`.
+
+## Quick Start Workflow
+
+### Step 1: Locate the xcstrings File
+
+Find the `Localizable.xcstrings` file in the iOS project:
+```bash
+find . -name "*.xcstrings" -type f
+```
+
+### Step 2: Mark Non-Translatable Strings
+
+Identify and mark strings that should not be translated:
+
+```bash
+python3 $SKILL_DIR/scripts/mark_non_translatable.py path/to/Localizable.xcstrings \
+  "1:2" "2:3" "3:4" "4:3" "9:16" "16:9" \
+  "A4" "A5" "OK" "PDF" \
+  "FB Cover" "IG 5:4"
+```
+
+Common non-translatable strings:
+- Aspect ratios: `1:2`, `16:9`, `4:3`
+- Paper sizes: `A4`, `A5`
+- Universal terms: `OK`, `PDF`, `USB`
+- Brand names: Product names, company names
+- Social media formats: `FB Cover`, `IG Post`
+
+### Step 3: Verify Current State
+
+Check translation completion status:
+```bash
+python3 $SKILL_DIR/scripts/verify_translations.py path/to/Localizable.xcstrings
+```
+
+Or specify target languages:
+```bash
+python3 $SKILL_DIR/scripts/verify_translations.py path/to/Localizable.xcstrings fr,de,es,ja,ko,zh-Hans
+```
+
+### Step 4: Launch Translation Agents
+
+For each target language, launch a haiku agent sequentially:
+
+```
+Use the Task tool with:
+- subagent_type: "general-purpose"
+- model: "haiku"
+- prompt: Translation instructions (see below)
+```
+
+**Translation Agent Prompt Template:**
+
+```
+Translate iOS app strings from English to [LANGUAGE] ([LANG_CODE]).
+
+## Instructions
+
+1. Extract strings needing translation:
+   python3 $SKILL_DIR/scripts/extract_strings.py path/to/Localizable.xcstrings [LANG_CODE]
+
+2. Translate ALL strings to [LANGUAGE]. Rules:
+   - Preserve format specifiers (%lld, %@, %d) exactly
+   - Keep & symbol in strings like "& BACKGROUND"
+   - Use natural [LANGUAGE] phrasing for a photo editing app
+
+3. Save translations and update:
+   cat > /tmp/translations_[LANG_CODE].json << 'EOF'
+   { "English key": "Translation", ... }
+   EOF
+   python3 $SKILL_DIR/scripts/update_translations.py path/to/Localizable.xcstrings [LANG_CODE] /tmp/translations_[LANG_CODE].json
+
+Complete ALL translations. Do not skip any strings.
+```
+
+### Step 5: Verify Completion
+
+After all agents complete, verify:
+```bash
+python3 $SKILL_DIR/scripts/verify_translations.py path/to/Localizable.xcstrings
+```
+
+Fix any gaps by launching targeted agents for incomplete languages.
+
+## Helper Scripts
+
+All scripts are located at `./scripts/` relative to this skill's install directory.
+
+### extract_strings.py
+
+Extract strings needing translation for a language:
+```bash
+python3 $SKILL_DIR/scripts/extract_strings.py <xcstrings_path> <lang_code>
+# Output: JSON with {"key": "english_value", ...}
+```
+
+### update_translations.py
+
+Update xcstrings with translations:
+```bash
+python3 $SKILL_DIR/scripts/update_translations.py <xcstrings_path> <lang_code> <translations.json>
+```
+
+### verify_translations.py
+
+Check translation completion:
+```bash
+python3 $SKILL_DIR/scripts/verify_translations.py <xcstrings_path> [lang1,lang2,...]
+```
+
+### mark_non_translatable.py
+
+Mark strings as non-translatable:
+```bash
+python3 $SKILL_DIR/scripts/mark_non_translatable.py <xcstrings_path> "key1" "key2" ...
+```
+
+## Common Target Languages
+
+| Priority | Languages |
+|----------|-----------|
+| Tier 1 | en, zh-Hans, zh-Hant, ja, ko, es, fr, de |
+| Tier 2 | pt-BR, it, nl, pl, ru, tr, ar |
+| Tier 3 | vi, th, id, ms, cs, da, sv, no, fi |
+
+## Translation Rules
+
+### Always Preserve
+
+- Format specifiers: `%lld`, `%@`, `%d`, `%f`
+- Positional arguments: `%1$@`, `%2$d`
+- Special symbols in context: `&`, `+`
+- Newlines: `\n`
+
+### Keep As-Is (shouldTranslate: false)
+
+- Technical identifiers
+- Aspect ratios and dimensions
+- Brand and product names
+- Universal abbreviations
+
+### Translate
+
+- UI labels and buttons
+- Status and error messages
+- Feature names and descriptions
+- Settings and preferences
+- Onboarding text
+
+## Sequential Agent Execution
+
+Launch agents **one at a time** to avoid file conflicts:
+
+```
+Order: zh-Hans -> zh-Hant -> ja -> ko -> es -> fr -> de -> ...
+```
+
+Each agent:
+1. Reads current file state
+2. Extracts untranslated strings
+3. Translates all strings
+4. Updates file with translations
+
+## Troubleshooting
+
+### JSON Parse Errors
+
+If xcstrings file becomes corrupted:
+```bash
+python3 -m json.tool Localizable.xcstrings > /dev/null
+```
+
+### Missing Translations After Agent
+
+Re-run extract to check:
+```bash
+python3 $SKILL_DIR/scripts/extract_strings.py Localizable.xcstrings <lang_code> | jq 'keys | length'
+```
+
+If count > 0, translations are missing. Re-run agent.
+
+### Format Specifier Mismatch
+
+Verify format specifiers match between source and translation. Common issues:
+- `%lld` changed to `%d`
+- `%@` removed or duplicated
+- Positional arguments reordered incorrectly
+
+## Additional Resources
+
+### Reference Files
+
+- **`references/xcstrings-format.md`** - Detailed xcstrings format documentation
+
+### Scripts
+
+- **`scripts/extract_strings.py`** - Extract untranslated strings
+- **`scripts/update_translations.py`** - Update xcstrings with translations
+- **`scripts/verify_translations.py`** - Verify translation completion
+- **`scripts/mark_non_translatable.py`** - Mark non-translatable strings

--- a/skills/ios-localization/references/xcstrings-format.md
+++ b/skills/ios-localization/references/xcstrings-format.md
@@ -1,0 +1,207 @@
+# Localizable.xcstrings Format Reference
+
+## File Structure
+
+The `.xcstrings` file is a JSON-based localization format introduced in Xcode 15.
+
+```json
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "Hello": {
+      "localizations": {
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bonjour"
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}
+```
+
+## Key Properties
+
+### String Entry Structure
+
+```json
+"String Key": {
+  "comment": "Optional developer comment",
+  "extractionState": "manual|extracted_with_value|stale",
+  "shouldTranslate": true|false,
+  "localizations": {
+    "<lang_code>": {
+      "stringUnit": {
+        "state": "translated|needs_review|new",
+        "value": "Translated text"
+      }
+    }
+  }
+}
+```
+
+### Translation States
+
+| State | Description |
+|-------|-------------|
+| `translated` | Translation is complete and verified |
+| `needs_review` | Translation exists but needs review |
+| `new` | New string, not yet translated |
+
+### shouldTranslate Flag
+
+Set `shouldTranslate: false` for strings that should not be translated:
+- Technical identifiers (aspect ratios: "16:9", "4:3")
+- Universal symbols ("OK", "PDF", "USB")
+- Brand names ("iPhone", "Kodak")
+- Format specifiers used alone ("%lld", "%@")
+
+## Common Language Codes
+
+| Code | Language | Code | Language |
+|------|----------|------|----------|
+| ar | Arabic | ko | Korean |
+| ca | Catalan | ms | Malay |
+| zh-Hans | Chinese (Simplified) | nl | Dutch |
+| zh-Hant | Chinese (Traditional) | pl | Polish |
+| cs | Czech | pt-BR | Portuguese (Brazil) |
+| da | Danish | pt-PT | Portuguese (Portugal) |
+| de | German | ro | Romanian |
+| el | Greek | ru | Russian |
+| es | Spanish | sk | Slovak |
+| fi | Finnish | sv | Swedish |
+| fr | French | th | Thai |
+| he | Hebrew | tr | Turkish |
+| hi | Hindi | uk | Ukrainian |
+| hr | Croatian | vi | Vietnamese |
+| hu | Hungarian | | |
+| id | Indonesian | | |
+| it | Italian | | |
+| ja | Japanese | | |
+
+## Format Specifiers
+
+Preserve these exactly in translations:
+
+| Specifier | Type | Example |
+|-----------|------|---------|
+| `%@` | String/Object | "Hello %@" |
+| `%d`, `%i` | Integer | "%d items" |
+| `%lld` | Long integer | "%lld photos" |
+| `%f` | Float | "%.2f MB" |
+| `%%` | Literal % | "100%%" |
+
+### Positional Arguments
+
+For reordering in translations:
+```
+English: "Move %1$@ to %2$@"
+German: "Verschiebe %1$@ nach %2$@"
+Japanese: "%2$@に%1$@を移動"
+```
+
+## Pluralization
+
+For plural forms, use `stringUnit` with `variations`:
+
+```json
+"%lld items": {
+  "localizations": {
+    "en": {
+      "variations": {
+        "plural": {
+          "one": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "%lld item"
+            }
+          },
+          "other": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "%lld items"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Plural Categories by Language
+
+| Category | Languages |
+|----------|-----------|
+| one, other | English, German, Italian, Spanish, Portuguese |
+| one, few, many, other | Russian, Polish, Ukrainian |
+| one, two, few, many, other | Arabic |
+| other only | Chinese, Japanese, Korean, Vietnamese, Thai |
+
+## Device Variations
+
+For device-specific strings:
+
+```json
+"Welcome": {
+  "localizations": {
+    "en": {
+      "variations": {
+        "device": {
+          "iphone": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Welcome to iPhone"
+            }
+          },
+          "ipad": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Welcome to iPad"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Best Practices
+
+### String Keys
+
+- Use English text as the key (acts as fallback)
+- Keep keys consistent and descriptive
+- Avoid special characters in keys when possible
+
+### Comments
+
+Add comments for context:
+```json
+"Save": {
+  "comment": "Button title for saving document",
+  "localizations": { ... }
+}
+```
+
+### Grouping
+
+The xcstrings format doesn't support groups, but use consistent naming:
+```
+"settings.title"
+"settings.privacy"
+"editor.brush"
+"editor.eraser"
+```
+
+## Validation
+
+Check for common issues:
+1. Missing translations for target languages
+2. Mismatched format specifiers
+3. Empty translation values
+4. Inconsistent plural forms

--- a/skills/ios-localization/scripts/extract_strings.py
+++ b/skills/ios-localization/scripts/extract_strings.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""
+Extract translatable strings from Localizable.xcstrings for a specific language.
+Outputs JSON with strings that need translation.
+
+Usage: python extract_strings.py <xcstrings_path> <lang_code>
+Example: python extract_strings.py ./Localizable.xcstrings fr
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+def extract_strings(xcstrings_path: str, lang_code: str) -> dict:
+    """Extract strings needing translation for the given language."""
+    with open(xcstrings_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    strings = data.get("strings", {})
+    to_translate = {}
+
+    for key, value in strings.items():
+        # Skip strings marked as shouldTranslate: false
+        if value.get("shouldTranslate") is False:
+            continue
+
+        # Check if already translated for this language
+        localizations = value.get("localizations", {})
+        if lang_code in localizations:
+            lang_data = localizations[lang_code]
+            if lang_data.get("stringUnit", {}).get("state") == "translated":
+                continue
+
+        # This string needs translation
+        to_translate[key] = key
+
+    return to_translate
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("Usage: python extract_strings.py <xcstrings_path> <lang_code>", file=sys.stderr)
+        print("Example: python extract_strings.py ./Localizable.xcstrings fr", file=sys.stderr)
+        sys.exit(1)
+
+    xcstrings_path = sys.argv[1]
+    lang_code = sys.argv[2]
+
+    if not Path(xcstrings_path).exists():
+        print(f"Error: File not found: {xcstrings_path}", file=sys.stderr)
+        sys.exit(1)
+
+    strings = extract_strings(xcstrings_path, lang_code)
+    print(json.dumps(strings, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/ios-localization/scripts/mark_non_translatable.py
+++ b/skills/ios-localization/scripts/mark_non_translatable.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""
+Mark strings as shouldTranslate: false in Localizable.xcstrings.
+Removes existing localizations for marked strings.
+
+Usage: python mark_non_translatable.py <xcstrings_path> <key1> [key2] [key3] ...
+Example: python mark_non_translatable.py ./Localizable.xcstrings "1:2" "16:9" "A4" "OK"
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+def mark_non_translatable(xcstrings_path: str, keys: list) -> int:
+    """
+    Mark specified keys as shouldTranslate: false.
+    Returns the number of keys updated.
+    """
+    with open(xcstrings_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    strings = data.get("strings", {})
+    updated = 0
+
+    for key in keys:
+        if key in strings:
+            # Remove any existing localizations
+            if "localizations" in strings[key]:
+                del strings[key]["localizations"]
+            strings[key]["shouldTranslate"] = False
+            updated += 1
+            print(f"Marked: {key}")
+        else:
+            print(f"Warning: Key not found: {key}", file=sys.stderr)
+
+    # Write back to file preserving Xcode's formatting (" : " separator)
+    with open(xcstrings_path, "w", encoding="utf-8") as f:
+        content = json.dumps(data, ensure_ascii=False, indent=2)
+        # Xcode uses " : " (space before colon) for key-value separators
+        import re
+        content = re.sub(r'": ', '" : ', content)
+        f.write(content)
+        f.write("\n")
+
+    return updated
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Usage: python mark_non_translatable.py <xcstrings_path> <key1> [key2] ...", file=sys.stderr)
+        print('Example: python mark_non_translatable.py ./Localizable.xcstrings "1:2" "16:9"', file=sys.stderr)
+        sys.exit(1)
+
+    xcstrings_path = sys.argv[1]
+    keys = sys.argv[2:]
+
+    if not Path(xcstrings_path).exists():
+        print(f"Error: File not found: {xcstrings_path}", file=sys.stderr)
+        sys.exit(1)
+
+    count = mark_non_translatable(xcstrings_path, keys)
+    print(f"\nTotal: {count} strings marked as shouldTranslate: false")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/ios-localization/scripts/update_translations.py
+++ b/skills/ios-localization/scripts/update_translations.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""
+Update Localizable.xcstrings with translations for a specific language.
+Merges translations from a JSON file into the xcstrings file.
+
+Usage: python update_translations.py <xcstrings_path> <lang_code> <translations.json>
+Example: python update_translations.py ./Localizable.xcstrings fr translations_fr.json
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+def update_translations(xcstrings_path: str, lang_code: str, translations: dict) -> int:
+    """
+    Update xcstrings file with translations for the given language.
+    Returns the number of strings updated.
+    """
+    with open(xcstrings_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    strings = data.get("strings", {})
+    updated_count = 0
+
+    for key, translated_value in translations.items():
+        if key not in strings:
+            print(f"Warning: Key '{key}' not found in xcstrings", file=sys.stderr)
+            continue
+
+        # Initialize localizations dict if needed
+        if "localizations" not in strings[key]:
+            strings[key]["localizations"] = {}
+
+        # Add or update the translation
+        strings[key]["localizations"][lang_code] = {
+            "stringUnit": {
+                "state": "translated",
+                "value": translated_value
+            }
+        }
+        updated_count += 1
+
+    # Write back to file preserving Xcode's formatting (" : " separator)
+    with open(xcstrings_path, "w", encoding="utf-8") as f:
+        content = json.dumps(data, ensure_ascii=False, indent=2)
+        # Xcode uses " : " (space before colon) for key-value separators
+        import re
+        content = re.sub(r'": ', '" : ', content)
+        f.write(content)
+        f.write("\n")
+
+    return updated_count
+
+
+def main():
+    if len(sys.argv) != 4:
+        print("Usage: python update_translations.py <xcstrings_path> <lang_code> <translations.json>", file=sys.stderr)
+        print("Example: python update_translations.py ./Localizable.xcstrings fr translations_fr.json", file=sys.stderr)
+        sys.exit(1)
+
+    xcstrings_path = sys.argv[1]
+    lang_code = sys.argv[2]
+    translations_file = sys.argv[3]
+
+    if not Path(xcstrings_path).exists():
+        print(f"Error: File not found: {xcstrings_path}", file=sys.stderr)
+        sys.exit(1)
+
+    # Read translations from file or stdin
+    if translations_file == "-":
+        translations = json.load(sys.stdin)
+    else:
+        with open(translations_file, "r", encoding="utf-8") as f:
+            translations = json.load(f)
+
+    count = update_translations(xcstrings_path, lang_code, translations)
+    print(f"Updated {count} translations for '{lang_code}'")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/ios-localization/scripts/verify_translations.py
+++ b/skills/ios-localization/scripts/verify_translations.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+Verify that all translations are complete in Localizable.xcstrings.
+Reports completion percentage per language and lists missing translations.
+
+Usage: python verify_translations.py <xcstrings_path> [lang1,lang2,...]
+Example: python verify_translations.py ./Localizable.xcstrings
+Example: python verify_translations.py ./Localizable.xcstrings fr,de,es
+"""
+
+import json
+import sys
+from pathlib import Path
+
+# Common iOS app target languages
+DEFAULT_LANGUAGES = [
+    "ar", "ca", "zh-Hans", "zh-Hant", "hr", "cs", "da", "nl",
+    "fr", "de", "id", "it", "ja", "ko", "ms", "pl",
+    "pt-PT", "pt-BR", "sk", "es", "th", "tr", "vi", "ru",
+    "uk", "he", "hi", "bn", "sv", "no", "fi", "el", "ro", "hu"
+]
+
+LANGUAGE_NAMES = {
+    "ar": "Arabic", "ca": "Catalan", "zh-Hans": "Chinese (Simplified)",
+    "zh-Hant": "Chinese (Traditional)", "hr": "Croatian", "cs": "Czech",
+    "da": "Danish", "nl": "Dutch", "fr": "French", "de": "German",
+    "id": "Indonesian", "it": "Italian", "ja": "Japanese", "ko": "Korean",
+    "ms": "Malay", "pl": "Polish", "pt-PT": "Portuguese (Portugal)",
+    "pt-BR": "Portuguese (Brazil)", "sk": "Slovak", "es": "Spanish",
+    "th": "Thai", "tr": "Turkish", "vi": "Vietnamese", "ru": "Russian",
+    "uk": "Ukrainian", "he": "Hebrew", "hi": "Hindi", "bn": "Bengali",
+    "sv": "Swedish", "no": "Norwegian", "fi": "Finnish", "el": "Greek",
+    "ro": "Romanian", "hu": "Hungarian"
+}
+
+
+def detect_languages(data: dict) -> list:
+    """Detect languages that have at least one translation in the file."""
+    languages = set()
+    strings = data.get("strings", {})
+
+    for key, value in strings.items():
+        localizations = value.get("localizations", {})
+        languages.update(localizations.keys())
+
+    # Filter to known languages and sort
+    known = [lang for lang in DEFAULT_LANGUAGES if lang in languages]
+    unknown = sorted([lang for lang in languages if lang not in DEFAULT_LANGUAGES])
+    return known + unknown
+
+
+def verify_translations(xcstrings_path: str, target_languages: list = None) -> dict:
+    """
+    Verify translations and return stats.
+    Returns dict with completion stats and missing translations per language.
+    """
+    with open(xcstrings_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    strings = data.get("strings", {})
+
+    # Auto-detect languages if not specified
+    if not target_languages:
+        target_languages = detect_languages(data)
+        if not target_languages:
+            print("No translations found. Specify target languages.", file=sys.stderr)
+            sys.exit(1)
+
+    # Get list of translatable strings
+    translatable = []
+    for key, value in strings.items():
+        if value.get("shouldTranslate") is False:
+            continue
+        translatable.append(key)
+
+    total = len(translatable)
+    results = {}
+
+    for lang in target_languages:
+        missing = []
+        translated = 0
+
+        for key in translatable:
+            localizations = strings.get(key, {}).get("localizations", {})
+            lang_data = localizations.get(lang, {})
+
+            if lang_data.get("stringUnit", {}).get("state") == "translated":
+                translated += 1
+            else:
+                missing.append(key)
+
+        percentage = (translated / total * 100) if total > 0 else 0
+        results[lang] = {
+            "translated": translated,
+            "total": total,
+            "percentage": percentage,
+            "missing": missing
+        }
+
+    return results, target_languages
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python verify_translations.py <xcstrings_path> [lang1,lang2,...]", file=sys.stderr)
+        print("Example: python verify_translations.py ./Localizable.xcstrings", file=sys.stderr)
+        print("Example: python verify_translations.py ./Localizable.xcstrings fr,de,es", file=sys.stderr)
+        sys.exit(1)
+
+    xcstrings_path = sys.argv[1]
+    target_languages = None
+
+    if len(sys.argv) >= 3:
+        target_languages = sys.argv[2].split(",")
+
+    if not Path(xcstrings_path).exists():
+        print(f"Error: File not found: {xcstrings_path}", file=sys.stderr)
+        sys.exit(1)
+
+    results, languages = verify_translations(xcstrings_path, target_languages)
+    all_complete = True
+
+    print("=" * 60)
+    print("TRANSLATION VERIFICATION REPORT")
+    print("=" * 60)
+    print()
+
+    # Summary table
+    print(f"{'Language':<25} {'Translated':<12} {'Percentage':<12}")
+    print("-" * 49)
+
+    for lang in languages:
+        stats = results[lang]
+        name = LANGUAGE_NAMES.get(lang, lang)
+        translated = stats["translated"]
+        total = stats["total"]
+        pct = stats["percentage"]
+
+        status = "COMPLETE" if pct == 100 else ""
+        print(f"{name:<25} {translated:>4}/{total:<6} {pct:>6.1f}%  {status}")
+
+        if pct < 100:
+            all_complete = False
+
+    print()
+
+    # Missing translations detail
+    if not all_complete:
+        print("=" * 60)
+        print("MISSING TRANSLATIONS")
+        print("=" * 60)
+
+        for lang in languages:
+            stats = results[lang]
+            if stats["missing"]:
+                name = LANGUAGE_NAMES.get(lang, lang)
+                print(f"\n{name} ({lang}) - {len(stats['missing'])} missing:")
+                for key in stats["missing"][:10]:
+                    print(f"  - {key}")
+                if len(stats["missing"]) > 10:
+                    print(f"  ... and {len(stats['missing']) - 10} more")
+
+    print()
+    if all_complete:
+        print("All translations complete!")
+        sys.exit(0)
+    else:
+        print("Some translations are missing.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds a new `ios-localization` skill for translating `Localizable.xcstrings` files in iOS projects
- Includes 4 helper Python scripts for extracting, updating, verifying, and marking non-translatable strings
- Includes xcstrings format reference documentation
- Registers the skill in the example-skills plugin in marketplace.json

## Test plan
- [ ] Install the skill via `/plugin install` and verify it appears in the skill list
- [ ] Run the skill against an iOS project with a `Localizable.xcstrings` file
- [ ] Verify helper scripts work: `extract_strings.py`, `update_translations.py`, `verify_translations.py`, `mark_non_translatable.py`