### PR TITLE
Add TestDino Playwright Testing Skill to Partner Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,4 @@ The markdown content below contains the instructions, examples, and guidelines t
 Skills are a great way to teach Claude how to get better at using specific pieces of software. As we see awesome example skills from partners, we may highlight some of them here:
 
 - **Notion** - [Notion Skills for Claude](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0)
+- **TestDino** - [Playwright Testing Skill](https://github.com/testdino-hq/playwright-skill) - 70+ structured Playwright testing skill for AI agents, covering end-to-end tests, page object models, CI/CD setup, Cypress/Selenium migration, and CLI automation.


### PR DESCRIPTION
Adds [testdino-hq/playwright-skill](https://github.com/testdino-hq/playwright-skill) to the Partner Skills section.

70+ structured Playwright testing skill for AI agents, covering end-to-end tests, page object models, CI/CD setup, Cypress/Selenium migration, and CLI automation.