### PR TITLE
fix(pptx): add defusedxml and lxml to dependencies

### DIFF
--- a/skills/pptx/SKILL.md
+++ b/skills/pptx/SKILL.md
@@ -225,6 +225,7 @@ pdftoppm -jpeg -r 150 -f N -l N output.pdf slide-fixed
 
 ## Dependencies
 
+- `pip install defusedxml lxml` - XML parsing (required by unpack/pack scripts)
 - `pip install "markitdown[pptx]"` - text extraction
 - `pip install Pillow` - thumbnail grids
 - `npm install -g pptxgenjs` - creating from scratch


### PR DESCRIPTION
## Summary

- `unpack.py` and `pack.py` import `defusedxml` and `lxml` at the top level, causing immediate `ModuleNotFoundError` on first use
- Neither package is listed in the Dependencies section of `SKILL.md`, so users have no upfront warning
- Adds `pip install defusedxml lxml` to the Dependencies list

## Test plan

- [ ] Verify `unpack.py` and `pack.py` run without `ModuleNotFoundError` after installing the listed dependencies
- [ ] Confirm no other unlisted Python dependencies remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)