### PR TITLE
fix(pptx): normalize source path and fix duplicate slide IDs in add_slide.py

### DIFF
--- a/skills/pptx/scripts/add_slide.py
+++ b/skills/pptx/scripts/add_slide.py
@@ -15,7 +15,8 @@ Examples:
 
 To see available layouts: ls unpacked/ppt/slideLayouts/
 
-Prints the <p:sldId> element to add to presentation.xml.
+The new slide is appended to the end of <p:sldIdLst> in presentation.xml.
+To reorder slides, edit presentation.xml directly after running this script.
 """
 
 import re
@@ -81,15 +82,17 @@ def create_slide_from_layout(unpacked_dir: Path, layout_file: str) -> None:
 
     rid = _add_to_presentation_rels(unpacked_dir, dest)
 
-    next_slide_id = _get_next_slide_id(unpacked_dir)
+    next_slide_id = _add_to_presentation_sldidlst(unpacked_dir, rid)
 
-    print(f"Created {dest} from {layout_file}")
-    print(f'Add to presentation.xml <p:sldIdLst>: <p:sldId id="{next_slide_id}" r:id="{rid}"/>')
+    print(f"Created {dest} from {layout_file} (sldId={next_slide_id}, {rid})")
 
 
 def duplicate_slide(unpacked_dir: Path, source: str) -> None:
     slides_dir = unpacked_dir / "ppt" / "slides"
     rels_dir = slides_dir / "_rels"
+
+    # Accept bare filename, relative path, or absolute path — use only the filename.
+    source = Path(source).name
 
     source_slide = slides_dir / source
 
@@ -121,10 +124,9 @@ def duplicate_slide(unpacked_dir: Path, source: str) -> None:
 
     rid = _add_to_presentation_rels(unpacked_dir, dest)
 
-    next_slide_id = _get_next_slide_id(unpacked_dir)
+    next_slide_id = _add_to_presentation_sldidlst(unpacked_dir, rid)
 
-    print(f"Created {dest} from {source}")
-    print(f'Add to presentation.xml <p:sldIdLst>: <p:sldId id="{next_slide_id}" r:id="{rid}"/>')
+    print(f"Created {dest} from {source} (sldId={next_slide_id}, {rid})")
 
 
 def _add_to_content_types(unpacked_dir: Path, dest: str) -> None:
@@ -160,6 +162,23 @@ def _get_next_slide_id(unpacked_dir: Path) -> int:
     pres_content = pres_path.read_text(encoding="utf-8")
     slide_ids = [int(m) for m in re.findall(r'<p:sldId[^>]*id="(\d+)"', pres_content)]
     return max(slide_ids) + 1 if slide_ids else 256
+
+
+def _add_to_presentation_sldidlst(unpacked_dir: Path, rid: str) -> int:
+    """Append a <p:sldId> to <p:sldIdLst> in presentation.xml.
+
+    Writing directly ensures consecutive calls produce unique slide IDs.
+    Returns the assigned slide id.
+    """
+    next_id = _get_next_slide_id(unpacked_dir)
+    pres_path = unpacked_dir / "ppt" / "presentation.xml"
+    pres_content = pres_path.read_text(encoding="utf-8")
+    new_entry = f'    <p:sldId id="{next_id}" r:id="{rid}"/>'
+    pres_content = pres_content.replace(
+        "</p:sldIdLst>", f"{new_entry}\n  </p:sldIdLst>"
+    )
+    pres_path.write_text(pres_content, encoding="utf-8")
+    return next_id
 
 
 def parse_source(source: str) -> tuple[str, str | None]:


### PR DESCRIPTION
## Summary

Two bugs fixed in `add_slide.py`:

**1. Path normalization in `duplicate_slide()`**

`duplicate_slide()` constructs `slides_dir / source` directly. If source is passed as a relative or absolute path (e.g., `unpacked/ppt/slides/slide15.xml`) instead of a bare filename (`slide15.xml`), the resulting path is invalid (`unpacked/ppt/slides/unpacked/ppt/slides/slide15.xml`). Fix: extract the filename with `Path(source).name`.

**2. Duplicate slide IDs when adding multiple slides**

`_get_next_slide_id()` reads `presentation.xml` to find `max(sldId) + 1`, but the script never writes back to `presentation.xml` — it only prints the `<p:sldId>` entry for manual insertion. When called in a loop to add N slides, every invocation computes the same max and returns the same ID, producing N duplicate IDs.

Fix: add `_add_to_presentation_sldidlst()` that calls `_get_next_slide_id()` then writes the entry directly to `presentation.xml`. Both callers now use the new function. `_get_next_slide_id()` is preserved unchanged for backward compatibility.

New slides are appended to the end of `<p:sldIdLst>`. Users can reorder by editing `presentation.xml` after running the script.

## Test plan

- [ ] `add_slide.py unpacked/ slide15.xml` works with a bare filename (existing behavior)
- [ ] `add_slide.py unpacked/ ppt/slides/slide15.xml` works with a relative path (was broken)
- [ ] Run `add_slide.py` 3 times in succession — verify each new slide gets a unique `id` in `<p:sldIdLst>`
- [ ] Verify the resulting PPTX opens correctly in PowerPoint/LibreOffice after `pack.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)