### PR TITLE
docs: use HTTPS for agentskills.io link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> **Note:** This repository contains Anthropic's implementation of skills for Claude. For information about the Agent Skills standard, see [agentskills.io](http://agentskills.io).
+> **Note:** This repository contains Anthropic's implementation of skills for Claude. For information about the Agent Skills standard, see [agentskills.io](https://agentskills.io).
 
 # Skills
 Skills are folders of instructions, scripts, and resources that Claude loads dynamically to improve performance on specialized tasks. Skills teach Claude how to complete specific tasks in a repeatable way, whether that's creating documents with your company's brand guidelines, analyzing data using your organization's specific workflows, or automating personal tasks.


### PR DESCRIPTION
README link update: switch agentskills.io from HTTP to HTTPS for secure default linking. Docs-only change.