### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## What does this change?
+
+<!-- A short description of your change and why it's useful. -->
+
+## Type
+
+<!-- Check one. -->
+
+- [ ] Bug fix (to an existing skill or script)
+- [ ] Documentation improvement
+- [ ] Improvement to an existing skill
+- [ ] New skill
+
+## For new skills or skill improvements
+
+<!-- Skip this section for bug fixes and doc changes. -->
+
+- [ ] One skill per PR
+- [ ] Tested against realistic prompts
+- [ ] SKILL.md has valid frontmatter (`name`, `description`)
+- [ ] Self-contained in `skills/your-skill-name/`
+
+## Related issue
+
+<!-- Link to the issue this addresses, if any. New skills should have an approved issue first. -->
+
+Closes #


### PR DESCRIPTION
## What

Adds a `.github/PULL_REQUEST_TEMPLATE.md` — a lightweight PR template that gives contributors structure without adding friction.

Suggested by @hesreallyhim in [#509 (comment)](https://github.com/anthropics/skills/pull/509#issuecomment-3993638385) as a natural companion to the CONTRIBUTING.md in #509.

## What it does

When a contributor opens a PR, GitHub pre-fills the description with:

1. **What does this change?** — free-text description
2. **Type** — checkbox to classify (bug fix, docs, skill improvement, new skill)
3. **Checklist for new skills** — one skill per PR, tested, valid frontmatter, self-contained folder
4. **Related issue** — nudges linking to an issue

## Why this helps

Looking at the open PR queue, the most common patterns that slow review are:

- Multiple skills bundled in a single PR
- No description of what the skill does or why
- No evidence of testing
- No link to a related issue

The template addresses all four by making the right thing the easy thing. Contributors who fill it in produce reviewable PRs. Contributors who ignore it signal low effort — which is also useful information.

## Design choices

- **27 lines** — short enough that contributors actually read it
- **Checkboxes, not prose requirements** — lower friction, scannable
- **"Skip this section" note** — bug fixes and doc changes aren't burdened with the new-skill checklist
- **No enforcement** — GitHub templates are advisory. Contributors can delete the template. This is intentional — the goal is guidance, not gatekeeping.