### PR TITLE
Add obsidian skill for MCP-Obsidian vault access

### DIFF
--- a/skills/obsidian/SKILL.md
+++ b/skills/obsidian/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: obsidian
+description: >
+  Activate when the user mentions their Obsidian vault, notes, tags,
+  frontmatter, or daily notes. Teaches sharp edges and error recovery
+  for the MCP-Obsidian server that tool descriptions alone don't cover.
+metadata:
+  version: "2.0"
+  author: bitbonsai
+---
+
+# Obsidian Skill
+
+## Gotchas
+
+1. **patch_note rejects multi-match by default.** With `replaceAll: false`, if `oldString` appears more than once the call fails and returns `matchCount`. Set `replaceAll: true` only when you mean it, or add surrounding context to make the match unique.
+
+2. **patch_note matches inside frontmatter.** The replacement runs against the full file including the YAML block. A generic string like `title:` will match frontmatter fields. Include enough context to target the right occurrence.
+
+3. **patch_note forbids empty strings.** Both `oldString` and `newString` must be non-empty and non-whitespace. To delete text, use `newString` with a single space or restructure the note with `write_note`.
+
+4. **search_notes returns minified JSON.** Fields are abbreviated: `p` (path), `t` (title), `ex` (excerpt), `mc` (matchCount), `ln` (lineNumber), `uri` (obsidianUri). Hard cap of 20 results regardless of `limit`.
+
+5. **search_notes multi-word queries score terms individually AND as a phrase.** Each term is OR-matched, so a document matching any term appears in results. The full phrase gets an additional scoring boost.
+
+6. **write_note auto-creates directories.** Parent folders are created recursively. In `append`/`prepend` mode, if the note doesn't exist it's created. Frontmatter is merged (new keys override) in append/prepend; replaced entirely in overwrite.
+
+7. **delete_note requires exact path confirmation.** `confirmPath` must be character-identical to `path`. No normalization, no trailing-slash tolerance. Mismatch silently fails with `success: false`.
+
+8. **move_file needs double confirmation.** Both `confirmOldPath` and `confirmNewPath` must exactly match their counterparts. Use `move_note` for markdown renames (text-aware, no confirmation needed); use `move_file` only for binary files or when you need binary-safe moves.
+
+9. **manage_tags reads from two sources but writes to one.** `list` merges frontmatter tags + inline `#hashtags`. `add`/`remove` only modify the frontmatter `tags` array. Inline tags are never touched.
+
+10. **read_multiple_notes never rejects.** Uses `allSettled` internally. Failed files appear in the `err` array; successful ones in `ok`. Always check both. Hard limit of 10 paths per call.
+
+## Error Recovery
+
+| Error | Next step |
+|-------|-----------|
+| patch_note "Found N occurrences" | Add surrounding lines to `oldString` to make it unique, or set `replaceAll: true` |
+| delete_note / move_file confirmation mismatch | Re-read the note path with `read_note` or `list_directory`, then retry with the exact string |
+| search_notes returns 0 results | Try single keywords instead of phrases, toggle `searchFrontmatter`, or broaden with partial terms |
+| read_multiple_notes partial `err` | Verify failed paths with `list_directory`, fix typos or missing extensions, retry only failed ones |
+
+## Resources
+
+Load these only when needed, not on every invocation.
+
+- [Tool Patterns](resources/tool-patterns.md) - read when you need a tool's response shape, mode details, or the move_note vs move_file decision
+- [Obsidian Conventions](resources/obsidian-conventions.md) - read when creating/writing note content (link syntax, frontmatter fields, daily note format, template variables)

--- a/skills/obsidian/resources/obsidian-conventions.md
+++ b/skills/obsidian/resources/obsidian-conventions.md
@@ -1,0 +1,110 @@
+# Obsidian Conventions
+
+Knowledge about Obsidian's data model and conventions that the MCP server doesn't enforce but agents should follow.
+
+## Vault Structure
+
+A vault is a plain directory of markdown files. No database, no proprietary format.
+
+```
+my-vault/
+  .obsidian/          # App config (plugins, themes, hotkeys), not accessible via MCP
+  Daily Notes/        # Common convention, configurable in app
+  Templates/          # Template files, also configurable
+  Attachments/        # Images, PDFs, often set in app settings
+  Projects/
+    project-a.md
+  README.md
+```
+
+`.obsidian/` is blocked by the MCP server's path sandbox. You cannot read or write app config files.
+
+## Internal Links
+
+Obsidian uses `[[wikilinks]]`, not standard markdown links. When writing or patching note content, prefer wikilink syntax.
+
+| Syntax | Result |
+|--------|--------|
+| `[[Note Name]]` | Link to note |
+| `[[Note Name|Display Text]]` | Link with alias (pipe separates name from display text) |
+| `[[Note Name#Heading]]` | Link to heading |
+| `[[Note Name#^block-id]]` | Link to block |
+| `![[Note Name]]` | Embed (transclude) entire note |
+| `![[image.png]]` | Embed image |
+| `![[Note Name#Heading]]` | Embed specific section |
+
+Standard `[markdown](links)` work but won't participate in Obsidian's graph view, backlinks, or rename refactoring.
+
+## Daily Notes
+
+Common convention: one note per day in a `Daily Notes/` folder. Default filename format: `YYYY-MM-DD` (e.g., `2024-03-15.md`). The folder name and date format are configurable per-vault in `.obsidian/daily-notes.json`.
+
+When creating daily notes via MCP, use the `YYYY-MM-DD.md` format unless the user specifies otherwise.
+
+## Frontmatter
+
+YAML block delimited by `---` at the top of the file. Common standard fields:
+
+```yaml
+---
+title: Note Title
+tags:
+  - project
+  - status/active
+aliases:
+  - alternate name
+date: 2024-03-15
+cssclasses:
+  - custom-class
+---
+```
+
+- `tags`: array of strings, supports nested tags (`parent/child`)
+- `aliases`: alternative names for wikilink resolution
+- `cssclasses`: Obsidian-specific styling
+- `date`, `created`, `modified`: no enforced format, but ISO 8601 is conventional
+
+The MCP server validates frontmatter before writing (no functions, no symbols, string keys only).
+
+## Tags
+
+Two sources, both valid in Obsidian:
+
+1. **Frontmatter tags**: `tags: [foo, bar]` in YAML block
+2. **Inline tags**: `#foo` anywhere in the body text
+
+Nested tags use `/`: `#project/active`, `#status/done`. The MCP `manage_tags` tool merges both sources for `list` but only modifies frontmatter for `add`/`remove`.
+
+## Templates
+
+Obsidian's core Templates plugin uses these variables:
+
+| Variable | Expands to |
+|----------|-----------|
+| `{{title}}` | Note title (filename without extension) |
+| `{{date}}` | Current date (format configurable in settings) |
+| `{{time}}` | Current time (format configurable in settings) |
+| `{{date:FORMAT}}` | Date with custom Moment.js format, e.g. `{{date:YYYY-MM-DD}}` |
+| `{{time:FORMAT}}` | Time with custom format |
+
+**The MCP server does not expand template variables.** If you write `{{date}}` via `write_note`, it stays as literal text. Template expansion only happens when inserting templates through the Obsidian app.
+
+## Obsidian URIs
+
+Format: `obsidian://open?vault=VaultName&file=path/to/note`
+
+The MCP server includes `obsidianUri` in search results and read responses. These URIs only work when the Obsidian desktop app is running. They open the note in the app's editor.
+
+URL encoding rules apply: spaces become `%20`, special characters are percent-encoded.
+
+## Common Folder Patterns
+
+| Pattern | Usage |
+|---------|-------|
+| `Daily Notes/` | One note per day |
+| `Templates/` | Template files for new notes |
+| `Attachments/` or `assets/` | Images, PDFs, other media |
+| `Archive/` | Completed or inactive notes |
+| `Inbox/` | Quick capture, unsorted notes |
+
+These are conventions, not requirements. Every vault is different. Use `list_directory` to discover the actual structure before assuming folder names.

--- a/skills/obsidian/resources/tool-patterns.md
+++ b/skills/obsidian/resources/tool-patterns.md
@@ -1,0 +1,108 @@
+# Tool Patterns
+
+Per-tool behavioral knowledge beyond what tool descriptions provide.
+
+## read_note
+
+Response includes `content` (full markdown body) and `frontmatter` (parsed YAML object). `prettyPrint: true` indents the JSON response for readability but costs extra tokens.
+
+## write_note
+
+**Modes:**
+- `overwrite` (default): replaces entire file; frontmatter is set to exactly what you pass (or omitted if null)
+- `append`: adds content after existing body; merges frontmatter (new keys override existing)
+- `prepend`: adds content before existing body; same frontmatter merge as append
+
+Auto-creates parent directories recursively. In append/prepend, creates the file if it doesn't exist.
+
+**Frontmatter validation** runs before writing. Functions, symbols, and non-string keys are rejected. Invalid dates produce warnings but don't block the write.
+
+## patch_note
+
+**Response shape:**
+```json
+{ "success": bool, "path": str, "message": str, "matchCount": int }
+```
+
+- Rejects if `oldString === newString`
+
+**Recipe, safe single replacement:** Include the line before and after your target text in `oldString` to guarantee uniqueness.
+
+## search_notes
+
+**Response fields (minified):**
+- `p`: path
+- `t`: title (filename without `.md`)
+- `ex`: excerpt (context around first match, truncated with `...`)
+- `mc`: matchCount (total occurrences across all terms + filename)
+- `ln`: lineNumber (1-based, position of first match)
+- `uri`: Obsidian URI
+
+**Scoring:** BM25 with k1=1.2, b=0.75. Multi-word queries score each term individually plus the full phrase as a bonus term.
+
+**Limits:** Default 5, hard cap 20. `caseSensitive: false` by default (both query and corpus lowercased).
+
+**Frontmatter/content toggle:**
+- `searchContent: true` + `searchFrontmatter: false` (default): strips frontmatter before searching
+- `searchFrontmatter: true`: includes YAML block in searchable text
+- Both false: no results
+
+## delete_note
+
+**Response:** `{ "success": bool, "path": str, "message": str }`
+
+`confirmPath` must be character-identical to `path`. No undo. Files only; directories return "Cannot delete: path is not a file."
+
+## move_note
+
+Text-aware move for markdown files. Reads source as UTF-8, writes to destination with `wx` flag (fails if target exists unless `overwrite: true`), then deletes source. No confirmation parameters needed.
+
+**Response:** `{ "success": bool, "oldPath": str, "newPath": str, "message": str }`
+
+## move_file
+
+Binary-safe move. Requires double confirmation: `confirmOldPath === oldPath` AND `confirmNewPath === newPath`. Rejects directories. Falls back to copy+unlink for cross-filesystem moves.
+
+**When to use which:**
+- Renaming/moving `.md` files → `move_note`
+- Moving images, PDFs, attachments → `move_file`
+
+## read_multiple_notes
+
+**Response:** `{ "ok": [...], "err": [...] }`
+
+Hard limit: 10 paths. Uses `Promise.allSettled`, so it never throws on individual failures. Each `ok` entry has `path`, `obsidianUri`, and optionally `frontmatter`/`content` based on include flags. Each `err` entry has `path` and `error` message.
+
+## manage_tags
+
+**Operations:**
+- `list`: returns merged set of frontmatter `tags` array + inline `#hashtags` (deduplicated)
+- `add`: appends to frontmatter `tags` array only
+- `remove`: removes from frontmatter `tags` array only; if no tags remain, deletes the `tags` field
+
+Inline `#hashtag` occurrences in the note body are never modified.
+
+**Response:** `{ "path": str, "operation": str, "tags": [str], "success": bool }`
+
+## update_frontmatter
+
+- `merge: true` (default): spreads existing frontmatter first, new values override: `{...existing, ...new}`
+- `merge: false`: complete replacement of frontmatter
+
+Content body is always preserved. Validates resulting frontmatter before writing. File must already exist.
+
+## get_vault_stats
+
+Metadata-only. Returns total notes, folders, vault size, and recently modified files. No file content read. Use this for vault overview before batch operations.
+
+## get_notes_info
+
+Metadata-only alternative to reading notes. Returns `path`, `size` (bytes), `modified` (ms timestamp), `hasFrontmatter` (heuristic: checks if file starts with `---\n`), and `obsidianUri`. Failed reads are silently omitted from results.
+
+## list_directory
+
+Returns files and directories. Non-note filenames (images, PDFs) are included. Hidden directories (`.obsidian/`, `.git/`) are filtered out.
+
+## get_frontmatter
+
+Extracts parsed frontmatter without reading body content. Lighter than `read_note` when you only need YAML fields.


### PR DESCRIPTION
## Summary

- Adds an **obsidian** skill for [MCP-Obsidian](https://github.com/bitbonsai/mcp-obsidian), an open-source MCP server that gives AI assistants safe access to Obsidian vaults
- Teaches agents behavioral sharp edges and error recovery that tool descriptions alone don't cover
- Includes two resource files: `tool-patterns.md` (per-tool response shapes and recipes) and `obsidian-conventions.md` (wikilinks, daily notes, frontmatter, templates)

## What the skill covers

- 10 gotchas (patch_note multi-match rejection, search minified fields, confirmation parameter exactness, etc.)
- Error recovery table with actionable next steps
- Per-tool behavioral knowledge beyond tool descriptions
- Obsidian-specific conventions agents wouldn't know (wikilink syntax, template variables not expanding via MCP, dual-source tags)

## Install

```
npx skills add bitbonsai/mcp-obsidian
```

## Links

- Server repo: https://github.com/bitbonsai/mcp-obsidian
- Website: https://mcp-obsidian.org/skill
- npm: https://www.npmjs.com/package/@mauricio.wolff/mcp-obsidian