### PR TITLE
Add Design Auditor skill

### DIFF
--- a/skills/design-auditor/SKILL.md
+++ b/skills/design-auditor/SKILL.md
@@ -1,0 +1,418 @@
+---
+name: design-auditor
+description: Audit and check designs against fundamental design rules and principles. Use this skill whenever the user wants to review, audit, validate, or improve a design — whether working with Figma files (via Figma MCP), code (HTML/CSS/React/Vue), screenshots, or written design descriptions. Trigger this skill for phrases like "check my design", "does this follow design rules", "review my UI", "audit my layout", "is this accessible", "design review", "design feedback", "check spacing", "typography check", "color contrast", "WCAG", "a11y", "accessibility check", or when a beginner says things like "I don't know if this looks right" or "does this look good?". Also trigger when the user is using Figma MCP or building UI in VS Code and asks for design guidance. This skill is especially valuable for developers and non-designers who need expert design validation without needing to know the rules themselves.
+---
+
+# Design Checker Skill
+
+You are an expert design reviewer. Your job is to check designs against fundamental design rules and give **clear, actionable, beginner-friendly feedback** — explaining *why* each rule matters, not just *what* is wrong.
+
+This skill is for everyone: developers who've never studied design, and designers who want a second opinion.
+
+---
+
+## Step 0: Language & Beginner Check (Always Do This First)
+
+### Language Detection
+Detect the language of the user's message and respond entirely in that language throughout the audit — including all issue labels, explanations, fix suggestions, and the final report. If the user writes in Korean, the full audit report must be in Korean. If in English, respond in English. Never mix languages in a single report.
+
+**Korean response note:** When auditing in Korean, use natural Korean UX/design terminology:
+- 타이포그래피 (typography), 색상 대비 (color contrast), 간격 (spacing)
+- 접근성 (accessibility), 시각적 계층 (visual hierarchy), 일관성 (consistency)
+- 🔴 심각한 문제 / 🟡 경고 / 🟢 팁
+- Overall score label: **디자인 감사 보고서** / 총점: X/100
+
+---
+
+## Step 0: Beginner Check
+
+Before anything else, gauge the user's familiarity with design from their message.
+
+**Signs they're a beginner:**
+- Vague requests: "does this look okay?", "is this good?"
+- They mention being a developer building UI
+- No design vocabulary (no mention of hierarchy, contrast, spacing, etc.)
+- They say things like "I'm not a designer but..."
+
+**If they seem like a beginner**, open with a friendly one-liner:
+> "No worries — I'll walk you through exactly what to look for and why each thing matters. Design has rules, and once you know them, it gets much easier!"
+
+Then **explain every term you use** inline (e.g., if you say "visual hierarchy", briefly say what that means in parentheses).
+
+**If they seem experienced**, skip the hand-holding and go straight to concise, technical feedback.
+
+---
+
+## Step 1: Gather the Design
+
+| Input Type | What to Do |
+|---|---|
+| **Figma URL or link** | Follow the **Figma MCP Workflow** below |
+| **Code (HTML/CSS/React/Vue)** | Read the file(s) directly |
+| **Screenshot or image** | Examine the attached image |
+| **Description only** | Ask for visuals — descriptions miss too much |
+
+If nothing shared yet, ask:
+> "Could you share a Figma link, paste your code, or upload a screenshot? I need to see the design to audit it properly."
+
+---
+
+## Figma MCP Workflow
+
+When a Figma file or URL is involved, follow these steps. Read `references/figma-mcp.md` for full details and safe editing patterns.
+
+### F1: Resolve the Link
+If given a Figma URL or shortlink → call `resolve_shortlink` first to get the node ID.
+
+### F2: Get Design Context
+Call `get_design_context` on the node. Returns: layer structure, component names, typography (font, size, weight, line-height), colors (fills, strokes, opacity), spacing (padding, gap, auto-layout), and component/style references.
+
+### F3: Get a Screenshot
+Call `get_screenshot` on the same node. Essential — context data alone misses visual issues like crowding, poor contrast, or bad hierarchy.
+
+### F4: Run the Audit
+With both context data and screenshot in hand, run the full audit below.
+
+### F5: Fix Directly in Figma (if requested)
+Offer to apply fixes using `perform_editing_operations`. Always target specific node IDs. Never bulk-edit without confirmation. See `references/figma-mcp.md` for safe patterns.
+
+---
+
+## Step 1.5: Set Confidence Level
+
+Before running the audit, declare your confidence level based on the input type:
+
+| Input Type | Confidence | What It Means |
+|---|---|---|
+| Figma file via MCP | 🟢 High | Full layer data + screenshot. Most accurate audit. |
+| Code (HTML/CSS/React) | 🟢 High | Direct access to values. Can catch all issues. |
+| Screenshot / image | 🟡 Medium | Visual only. Can't verify exact px values or token usage. |
+| Description only | 🔴 Low | Too abstract. Ask for visuals before auditing. |
+
+Always state this at the top of the report:
+> **Audit confidence: 🟢 High** (Figma MCP — full layer data + screenshot)
+> **Audit confidence: 🟡 Medium** (Screenshot — visual audit only, exact values estimated)
+
+---
+
+## Step 2: Run the Design Audit
+
+Check each category. Skip clearly inapplicable ones. Mark each issue:
+
+- 🔴 **Critical** — Breaks usability or accessibility. Must fix. **(-8 points each)**
+- 🟡 **Warning** — Weakens the design. Should fix. **(-4 points each)**
+- 🟢 **Tip** — Polish-level improvement. Nice to have. **(-1 point each)**
+
+---
+
+### CATEGORY 1: Typography
+*Full rules → `references/typography.md`*
+
+- [ ] **Hierarchy** — Clear visual difference between headings, subheadings, body? (Size, weight, or color should vary meaningfully.)
+- [ ] **Font count** — Max 2 font families. More = visual chaos.
+- [ ] **Body text size** — Min 14px, 16px preferred. Never below 12px for any visible text.
+- [ ] **Line height** — 1.4–1.6× the font size for body text.
+- [ ] **Line length** — 60–80 characters per line. Wide lines (100+ chars) tire the eyes.
+- [ ] **Text contrast** — WCAG AA: 4.5:1 for normal text, 3:1 for large text (18px+).
+- [ ] **Alignment** — Don't randomly mix left-aligned and center-aligned body text.
+
+---
+
+### CATEGORY 2: Color & Contrast
+*Full rules → `references/color.md`*
+
+- [ ] **WCAG contrast** — Normal text ≥ 4.5:1, large text ≥ 3:1, UI components ≥ 3:1.
+- [ ] **Color-only meaning** — Never use color as the *only* signal. Pair with icon or text.
+- [ ] **Palette size** — 1 primary + 1 accent + neutrals beats many colors.
+- [ ] **Color consistency** — Same color = same meaning everywhere.
+- [ ] **Low-contrast combos** — Light gray on white, yellow on white, white on light blue all commonly fail.
+
+---
+
+### CATEGORY 3: Spacing & Layout
+*Full rules → `references/spacing.md`*
+
+- [ ] **8-point grid** — Spacing/sizing should be multiples of 8 (or 4). Arbitrary values look accidental.
+- [ ] **Proximity** — Related items close together, unrelated far apart.
+- [ ] **Padding consistency** — Uniform padding inside cards/containers.
+- [ ] **Breathing room** — Enough whitespace? Dense UIs overwhelm.
+- [ ] **Alignment** — Elements align to a shared edge or center.
+- [ ] **Content margins** — Consistent left/right margins, not edge-to-edge.
+
+---
+
+### CATEGORY 4: Visual Hierarchy & Focus
+
+- [ ] **One primary action per screen** — One thing should be obviously most important.
+- [ ] **Reading patterns** — Users scan in F or Z patterns. Key info along those paths.
+- [ ] **Size = importance** — Bigger = more important. Check it maps correctly.
+- [ ] **Contrast = importance** — High contrast = foreground. Check it maps correctly.
+
+---
+
+### CATEGORY 5: Consistency
+*Corner radius full rules → `references/corner-radius.md`*
+
+- [ ] **Component reuse** — Buttons, inputs, cards identical throughout. No one-off styles.
+- [ ] **Icon family** — All icons from the same set (same style, same stroke weight).
+- [ ] **Corner radius scale** — Radii should come from a fixed set (e.g. 4, 8, 12, 16, 24px, full). Arbitrary values (7px, 11px) look accidental.
+- [ ] **Nested radius rule** — When an element sits inside another, outer radius = inner radius + padding. If the inner element has 8px radius and 12px padding, the outer must be ~20px. Mismatched nesting makes corners look "poking out."
+- [ ] **Size-proportional radius** — Larger elements need larger radii. A small badge with 12px radius looks right. A large modal with 4px radius looks barely rounded.
+- [ ] **Pill shapes are intentional** — border-radius ≥ 50% of height creates a pill. Should be deliberate (tags, toggles, badges) not accidental.
+- [ ] **Zero radius is a choice** — Sharp corners (0px) should be a design language decision, not a forgotten default.
+- [ ] **Contextual radius** — Modals/sheets anchored to screen edges should have rounded top corners, square bottom. Floating elements fully rounded.
+- [ ] **Interaction states** — Hover, active, disabled states all visually distinct.
+
+---
+
+### CATEGORY 6: Accessibility (A11y / WCAG)
+
+- [ ] **Touch targets** — Interactive elements ≥ 44×44px (iOS) or 48×48dp (Material).
+- [ ] **Focus states** — Visible focus ring on every keyboard-navigable element.
+- [ ] **Alt text readiness** — Meaningful images need alt text. Decorative = `aria-hidden`.
+- [ ] **Form labels** — Visible label on every input. Placeholder alone is not a label.
+- [ ] **Error messages** — Text description of errors, not just red border/color change.
+- [ ] **Reading order** — Visual order matches logical/DOM order for screen readers.
+- [ ] **Motion sensitivity** — Animations respect `prefers-reduced-motion`.
+- [ ] **Link clarity** — Links distinguishable from text by more than color alone.
+
+---
+
+### CATEGORY 7: Forms & Inputs
+
+- [ ] **Label placement** — Labels above inputs (not beside or inside). Fastest to scan.
+- [ ] **Input sizing** — Wide enough to show typical content.
+- [ ] **Required field marking** — Asterisk (*) with legend, or label optional fields instead.
+- [ ] **Validation timing** — Validate on blur (leaving field), not only on submit.
+- [ ] **Error placement** — Error messages directly below the relevant field.
+- [ ] **Field grouping** — Related fields visually grouped (less space within, more between groups).
+- [ ] **Submit button state** — Loading state while submitting. Disable after first click.
+
+---
+
+### CATEGORY 8: Motion & Animation
+
+- [ ] **Purpose** — Every animation orients, gives feedback, or shows a relationship. No pure decoration.
+- [ ] **Duration** — UI transitions: 150–300ms. Page transitions: 300–500ms. Longer feels sluggish.
+- [ ] **Easing** — Ease-out for entering elements, ease-in for exiting. Linear feels mechanical.
+- [ ] **Reduced motion** — Non-animated version for `prefers-reduced-motion` users.
+- [ ] **No infinite autoplay loops** — Distract and exhaust users. Pause after 3 loops or on hover.
+
+---
+
+### CATEGORY 9: Dark Mode (if applicable)
+
+- [ ] **Not just inverted** — Dark mode requires redesigned colors, not flipped ones.
+- [ ] **Background depth** — Lighter dark grays for elevated surfaces (cards, modals). Not pure black.
+- [ ] **Saturation** — Reduce vivid brand colors in dark mode — they look garish on dark.
+- [ ] **Shadow replacement** — Use lighter surface colors for elevation instead of shadows.
+- [ ] **Icon & image legibility** — Icons/images still readable on dark backgrounds.
+
+---
+
+### CATEGORY 10: Responsive & Adaptive
+
+- [ ] **Breakpoints** — Mobile (320–480px), tablet (768px), desktop (1024px+) considered.
+- [ ] **No overflow** — Long words or fixed-width containers don't break on small screens.
+- [ ] **Mobile touch targets** — Bigger targets and more spacing than desktop.
+- [ ] **Image scaling** — Images scale without awkward cropping or overflow.
+- [ ] **Type scaling** — Large desktop headings (48px) scaled down to 28–32px on mobile.
+
+---
+
+### CATEGORY 11: Loading, Empty & Error States
+*The forgotten 30% — most beginner UIs only design the "happy path." Read `references/states.md` for full guidance.*
+
+- [ ] **Loading state** — Every data fetch needs a loading indicator. Skeleton screens preferred over spinners for content-heavy layouts. Never show a blank screen.
+- [ ] **Empty state** — What does an empty list, inbox, or dashboard look like? Should include an illustration or icon, a friendly explanation, and a clear next action ("Create your first task →").
+- [ ] **Error state** — Network failures, server errors, and not-found pages need their own designed state. Not just a console error or blank screen.
+- [ ] **Partial failure** — What if only some data loads? Design for partial states, not just all-or-nothing.
+- [ ] **Success state** — After a form submission or action, confirm it worked. A toast, a green banner, or a state change — something must close the loop.
+- [ ] **Disabled state** — Disabled buttons and inputs should look visually distinct (reduced opacity, no pointer cursor) and ideally explain why they're disabled.
+- [ ] **Consistency** — Loading/empty/error states should match the overall visual style — not be plain browser defaults or unstyled fallbacks.
+
+---
+
+### CATEGORY 12: Content & Microcopy
+*The words inside a UI are part of the design. Read `references/microcopy.md` for full guidance.*
+
+- [ ] **Button labels are verbs** — Buttons should say what they *do*: "Save Changes", "Send Message", "Delete Account" — not "OK", "Submit", or "Yes".
+- [ ] **Error messages are human** — "Invalid input" is not helpful. "Please enter a valid email address" is. Errors should say what went wrong and how to fix it.
+- [ ] **Placeholder text is not a label** — Placeholders like "Enter your email" disappear on typing. They can hint at format (e.g., "name@example.com") but never replace a label.
+- [ ] **Destructive actions are explicit** — "Delete" dialogs should name what's being deleted: "Delete 'Project Alpha'? This can't be undone." Never just "Are you sure?"
+- [ ] **Consistent terminology** — Don't call the same thing "workspace", "project", and "board" interchangeably. Pick one word and use it everywhere.
+- [ ] **Tone consistency** — If the UI is friendly and casual in some places but cold and technical in others, it feels broken. Pick a tone and maintain it.
+- [ ] **No lorem ipsum in shipped designs** — Placeholder text must be replaced before handoff. Real content often reveals layout problems that lorem ipsum hides.
+- [ ] **Empty states have personality** — "No results found" is forgettable. "Looks like nothing's here yet — add your first task to get started!" is memorable and helpful.
+
+---
+
+### CATEGORY 13: Internationalization & RTL Support (if applicable)
+*Only audit this category if the product targets multiple languages or RTL locales (Arabic, Hebrew, Persian, Urdu). Read `references/i18n.md` for full guidance.*
+
+- [ ] **No hardcoded strings** — All visible text should come from a translation file, not be baked into the component. Check for any hardcoded labels, tooltips, or error messages.
+- [ ] **Text expansion budget** — German and Finnish can be 30–40% longer than English. Buttons, labels, and nav items must accommodate longer text without breaking layout. Test with a long string.
+- [ ] **RTL layout mirroring** — In RTL languages, the entire layout flips: left becomes right. Navigation, icons, progress indicators, and reading direction all reverse. Use `dir="rtl"` and CSS logical properties (`margin-inline-start` instead of `margin-left`).
+- [ ] **RTL-safe icons** — Directional icons (arrows, chevrons, back buttons) must flip in RTL. Non-directional icons (heart, star, trash) stay the same.
+- [ ] **Date, time & number formats** — These vary by locale. Don't hardcode formats like "MM/DD/YYYY" — use locale-aware formatting (e.g., `Intl.DateTimeFormat`).
+- [ ] **Currency & units** — Symbol position and decimal separators differ by locale (€1,234.56 vs 1.234,56 €). Never assume.
+- [ ] **No text in images** — Images with embedded text can't be translated. Use CSS overlays or separate text layers instead.
+- [ ] **Font support** — Does the chosen font support all target scripts? Latin fonts won't render Arabic or CJK characters — a system fallback font will kick in and look inconsistent.
+
+---
+
+
+### CATEGORY 14: Elevation & Shadows
+*Full rules → `references/elevation.md`*
+
+- [ ] **Shadow scale** — Shadows should come from a defined scale (e.g. sm, md, lg, xl) — not arbitrary values. Each level should be used consistently for the same type of element.
+- [ ] **Shadow = elevation** — Shadows communicate how high above the page an element floats. Cards sit low (subtle shadow), modals sit high (strong shadow), tooltips highest. Check the hierarchy makes sense.
+- [ ] **Shadow color** — Shadows should use a dark, slightly saturated color (e.g. `rgba(0,0,0,0.08)`) — never pure black. On colored backgrounds, tint the shadow with the surface color.
+- [ ] **No shadows in dark mode** — Shadows are invisible on dark backgrounds. Use lighter surface colors for elevation instead (e.g. a card is slightly lighter gray than the page background).
+- [ ] **No decorative shadows** — Shadows should only appear on elevated elements. Don't use shadows purely for decoration or emphasis on flat elements.
+- [ ] **Consistent blur & offset** — A consistent offset-to-blur ratio (e.g. offset-y = 1/3 of blur) makes shadows feel physically grounded. Mismatched values look amateur.
+- [ ] **Multiple light sources** — Don't combine a top-shadow and a bottom-shadow on the same element unless intentional. Pick one light source direction and stick to it.
+
+---
+
+### CATEGORY 15: Iconography
+*Full rules → `references/iconography.md`*
+
+- [ ] **Consistent icon family** — All icons from the same set (e.g. all Phosphor, all Lucide, all Material). Never mix outline icons from one library with filled icons from another.
+- [ ] **Consistent style within family** — Stick to one style: all outline, all filled, or all duotone. Mixing styles inside one library looks inconsistent.
+- [ ] **Optical sizing** — Icons should be sized at standard grid-friendly values: 16, 20, 24, 32, 40, 48px. Avoid 18px, 22px, 26px — they fall between optical grid lines.
+- [ ] **Stroke weight consistency** — Outline icons have a stroke weight. Don't use 1px icons next to 2px icons — they feel mismatched even when both are "outline."
+- [ ] **Touch target padding** — Icons used as interactive buttons need padding to reach 44×44px minimum. A 24px icon needs 10px padding on each side.
+- [ ] **Icon meaning consistency** — The same icon should mean the same thing everywhere. Don't use a star for both "favourite" and "rating" in the same product.
+- [ ] **Label pairing** — Icons without labels are ambiguous for non-expert users. Always pair with a visible label or tooltip. Exception: universally understood icons (✕ close, ☰ menu, ⌕ search).
+- [ ] **Optical alignment** — Icons often have invisible padding baked in. When aligning icons with text, align to optical center, not bounding box edge.
+
+---
+
+### CATEGORY 16: Navigation Patterns
+*Full rules → `references/navigation.md`*
+
+- [ ] **Clear current location** — Users should always know where they are. Active nav items must be visually distinct (color, weight, indicator bar) — not just slightly different.
+- [ ] **Tabs vs nav** — Tabs switch between views of the same content. Nav moves between different sections. Don't use tabs for top-level navigation or nav for in-page switching.
+- [ ] **Breadcrumbs for depth** — Any page more than 2 levels deep needs breadcrumbs. They should show the full path and every crumb should be clickable (except the current page).
+- [ ] **Back button behavior** — "Back" should always go to the previous screen, not the previous URL. In modals and flows, "Back" should not close the entire flow unexpectedly.
+- [ ] **Mobile navigation** — Bottom navigation bar for 3–5 primary destinations on mobile. Hamburger menu acceptable for secondary items but not primary navigation.
+- [ ] **Active state contrast** — Active/selected nav items must meet 3:1 contrast ratio against inactive items — not just a subtle color shift that's easy to miss.
+- [ ] **Overflow handling** — What happens when there are too many nav items? Tabs should scroll horizontally or collapse into a "More" dropdown. Never let them clip or wrap awkwardly.
+- [ ] **Navigation consistency** — The nav should look and behave identically on every page. Never change which items appear, their order, or their style between sections.
+
+---
+
+### CATEGORY 17: Design Tokens & Variables Health (if applicable)
+*Audit this when reviewing Figma files or codebases with a design system. Read `references/tokens.md` for full guidance.*
+
+- [ ] **Colors are tokenized** — No hardcoded hex values in components. Colors should reference a token (e.g. `color.primary.500`, `--color-brand`), not `#7c3aed` directly.
+- [ ] **Spacing is tokenized** — Spacing values reference a scale token, not arbitrary pixel values.
+- [ ] **Typography is tokenized** — Font size, weight, and line-height come from defined text style tokens, not ad-hoc values per component.
+- [ ] **Radius is tokenized** — Corner radius values reference the radius scale, not hardcoded numbers.
+- [ ] **Shadow is tokenized** — Box shadows reference elevation tokens, not custom values per element.
+- [ ] **Token naming is semantic** — Tokens should describe *purpose*, not appearance. `color.background.danger` is good. `color.red.500` used directly in a component is not — it breaks when you need to change the danger color.
+- [ ] **No magic numbers** — Any value that appears more than twice should be a token. Repeated one-off values are a sign the token system isn't being used.
+- [ ] **Dark mode uses the same tokens** — Dark mode should swap token values, not introduce new hardcoded colors. If dark mode components have their own hex values, the token system is broken.
+
+---
+## Step 3: Score & Report
+
+### Scoring Formula
+
+Start at **100 points**. Deduct for every issue found:
+
+| Severity | Deduction | Example |
+|---|---|---|
+| 🔴 Critical | **-8 points** | No text contrast, missing form labels, broken dark mode |
+| 🟡 Warning | **-4 points** | Off-grid spacing, inconsistent radius, unused prop |
+| 🟢 Tip | **-1 point** | Deprecated attribute, minor naming improvement |
+
+**Floor is 0** — score never goes negative.
+
+Scoring bands:
+- **90–100** → Production-ready
+- **70–89** → Solid, minor fixes needed
+- **50–69** → Needs work before shipping
+- **< 50** → Foundational issues, significant rework needed
+
+**Always show the maths:**
+> Score: 100 − (3 × 🔴 8pts) − (4 × 🟡 4pts) − (2 × 🟢 1pt) = 100 − 24 − 16 − 2 = **58/100**
+
+---
+
+### Strict Output Template
+
+Always use this exact structure — no exceptions:
+
+```
+## Design Audit Report
+
+**Audit confidence:** [🟢 High / 🟡 Medium / 🔴 Low] ([reason])
+
+### Overall Score: [X/100]
+[Score breakdown: 100 − (N × 🔴 8) − (N × 🟡 4) − (N × 🟢 1) = X]
+[One sentence rationale.]
+
+---
+
+### 🔴 Critical Issues (−8pts each)
+- **[Issue name]**: [What's wrong] → Fix: [Specific how-to] → Why: [One sentence]
+  *Want me to fix this now? I can edit the code/Figma directly.*
+
+### 🟡 Warnings (−4pts each)
+- **[Issue name]**: [What's wrong] → Fix: [Specific how-to] → Why: [One sentence]
+  *Want me to fix this now? I can edit the code/Figma directly.*
+
+### 🟢 Tips (−1pt each)
+- **[Issue name]**: [What's wrong] → Fix: [Specific how-to] → Why: [One sentence]
+
+---
+
+### ✅ What's Working Well
+[2–3 specific genuine positives. Builds design instincts.]
+
+### 🎯 Top 3 Priority Fixes
+1. [Highest impact — most points to recover]
+2. [Second]
+3. [Third]
+```
+
+---
+
+## Step 4: Offer to Fix
+
+After every report, offer:
+
+> "Want me to apply any of these fixes? I can edit the code directly, or if you're in Figma, I can make changes there too. Or if you'd rather learn how to do it yourself, I can walk you through it step by step."
+
+**In Figma**: `perform_editing_operations` → specific node IDs → see `references/figma-mcp.md`.  
+**In code**: Edit CSS/JSX/HTML directly, show before/after diff.  
+**Teaching mode**: Walk through the fix step by step instead of doing it for them.
+
+---
+
+## Tone Guidelines
+
+- **Never condescending.** They're smart — they just haven't learned this yet.
+- **Always explain the "why."** One sentence is enough.
+- **Avoid jargon** unless the user uses it first.
+- **Be genuinely encouraging.** Real praise, not filler.
+- **Match their energy.** Casual question → relaxed tone. Formal request → structured response.
+
+---
+
+## Reference Files
+
+- `references/typography.md` — Font rules, sizing, line height, hierarchy
+- `references/color.md` — Contrast ratios, WCAG, palette guidance
+- `references/spacing.md` — 8-point grid, layout, proximity rules
+- `references/figma-mcp.md` — Figma MCP workflow, safe editing patterns
+- `references/states.md` — Loading, empty, error, success & disabled state patterns
+- `references/microcopy.md` — Button labels, error messages, tone, terminology
+- `references/i18n.md` — Internationalization, RTL layout, locale-aware formatting
+- `references/corner-radius.md` — Nested radius rule, radius scale, size-proportional rounding
+- `references/elevation.md` — Shadow scale, elevation hierarchy, dark mode depth
+- `references/iconography.md` — Icon families, optical sizing, touch targets, meaning
+- `references/navigation.md` — Tabs, breadcrumbs, back buttons, mobile nav, active states
+- `references/tokens.md` — Design tokens, semantic naming, dark mode token swapping

--- a/skills/design-auditor/references/color.md
+++ b/skills/design-auditor/references/color.md
@@ -1,0 +1,180 @@
+# Color Rules Reference
+
+## The Basics: Palette Structure
+
+Every good UI color palette has these roles:
+
+| Role | Purpose | Count |
+|---|---|---|
+| **Primary** | Main brand color, primary actions (buttons, links) | 1 color + shades |
+| **Secondary / Accent** | Highlights, secondary CTAs, decorative | 1 color |
+| **Neutral** | Backgrounds, text, borders, surfaces | 1 grayscale ramp (5–9 shades) |
+| **Semantic: Success** | Confirmations, completed states | 1 green |
+| **Semantic: Warning** | Caution states | 1 yellow/orange |
+| **Semantic: Error** | Errors, destructive actions | 1 red |
+| **Semantic: Info** | Informational alerts | 1 blue |
+
+**Total**: Usually 3–5 distinct hues, with shades of each.
+
+### The Palette Size Problem
+- **Too few colors**: Flat, boring, hard to create hierarchy
+- **Too many colors**: Chaotic, inconsistent, unprofessional
+- **Sweet spot**: 2–3 brand colors + neutral ramp + semantic colors
+
+---
+
+## WCAG Contrast Ratios
+
+This is the most important thing to check. Failing contrast = failing accessibility.
+
+### Minimum Requirements (WCAG AA)
+
+| Situation | Minimum Contrast |
+|---|---|
+| Normal body text (< 18px or < 14px bold) | **4.5:1** |
+| Large text (≥ 18px or ≥ 14px bold) | **3:1** |
+| UI Components (buttons, inputs, icons) | **3:1** |
+| Decorative/disabled elements | None required |
+
+### Enhanced Requirements (WCAG AAA — aspirational)
+- Normal text: 7:1
+- Large text: 4.5:1
+
+### How Contrast Ratio Works
+- White on white = 1:1 (invisible)
+- Black on white = 21:1 (maximum)
+- The higher the number, the more readable
+
+### Common Contrast Failures
+| Combo | Approximate Ratio | Status |
+|---|---|---|
+| #999 gray on white | ~2.8:1 | ❌ Fails AA |
+| #767676 on white | 4.54:1 | ✅ Barely passes AA |
+| #555 on white | ~7:1 | ✅ Passes AAA |
+| Light blue on white | Often fails | ❌ Check carefully |
+| Yellow on white | ~1.07:1 | ❌ Completely invisible |
+| White on mid-blue (#4A90E2) | ~3.3:1 | ❌ Fails for small text |
+| White on dark blue (#1E5BB5) | ~6.2:1 | ✅ Passes |
+
+**Check tool**: https://webaim.org/resources/contrastchecker/ or Figma's built-in accessibility panel.
+
+---
+
+## Color Meaning & Semantics
+
+### Universal Associations
+- **Red** → Error, danger, delete, stop
+- **Green** → Success, confirmed, proceed, positive
+- **Yellow/Orange** → Warning, caution, pending
+- **Blue** → Information, links, interactive, trust
+- **Gray** → Disabled, secondary, neutral
+
+**Rule**: Be consistent. If blue means "clickable" on one screen, it must mean "clickable" everywhere. Never use blue for decorative non-interactive elements.
+
+### The Color-Only Problem
+**Never rely on color alone** to communicate meaning. Approximately 8% of men have color blindness.
+
+❌ Bad: A red border on an error input (with no other indicator)  
+✅ Good: A red border + ⚠ icon + error message text
+
+❌ Bad: A green dot = online, red dot = offline (for colorblind users, they look the same)  
+✅ Good: Green dot labeled "Online" + Red dot labeled "Offline"
+
+---
+
+## Color Harmony
+
+### Monochromatic
+One hue, many shades. Safe, cohesive, professional.
+Example: Light blue background, medium blue accent, dark blue text.
+
+### Complementary
+Two colors opposite on the color wheel. High contrast, energetic.
+Example: Blue + Orange, Purple + Yellow, Red + Teal.
+**Caution**: Can feel aggressive if both are saturated. Usually tone one down.
+
+### Analogous
+Colors adjacent on the wheel. Harmonious, natural.
+Example: Blue + Teal + Purple.
+
+### Triadic
+Three colors equally spaced on the wheel. Vibrant but tricky.
+Example: Red + Blue + Yellow. Usually keep one dominant, others as accents.
+
+---
+
+## Color in Dark Mode
+
+Dark mode ≠ just inverting colors. Rules change:
+
+- **Don't use pure black** (#000000) backgrounds — it creates harsh contrast. Use dark grays (#121212, #1A1A1A, #0F172A).
+- **Don't use pure white** (#FFFFFF) text on dark — slightly off-white (#E0E0E0, #F1F1F1) reduces eye strain.
+- **Reduce saturation** of brand colors slightly — very saturated colors on dark feel garish.
+- **Elevation uses lighter shades** (not shadows) — higher cards use slightly lighter dark gray.
+- **Semantic colors shift**: Greens and reds often need to be desaturated or their lighter variants to maintain contrast on dark backgrounds.
+
+---
+
+## Common Color Mistakes
+
+1. **Purple gradient on white** — The most clichéd "AI-generated" aesthetic. Avoid.
+2. **Too many accent colors** — Pick one accent, use it consistently.
+3. **Saturated background colors** — Very saturated colored backgrounds (not neutrals) make text hard to read and cause eye fatigue.
+4. **Inconsistent primary color usage** — If your primary is blue, don't put random blue decorative shapes that aren't interactive.
+5. **Low-contrast placeholders** — Placeholder text is often styled #999 or lighter. Check the contrast.
+6. **Brand color for body text** — Usually looks odd and reduces readability. Use it for headings and interactive elements, not long-form text.
+7. **White text on bright colors** — White on bright yellow, cyan, or light green almost always fails contrast.
+
+---
+
+## The 60-30-10 Rule
+
+A classic color proportion rule for balanced UI design:
+
+| Role | % of UI | What to Use |
+|---|---|---|
+| **60% — Dominant** | Background, large surfaces, whitespace | Neutral (white, light gray, dark gray) |
+| **30% — Secondary** | Cards, sidebars, nav, secondary elements | Slightly different neutral or soft brand tone |
+| **10% — Accent** | Buttons, links, highlights, CTAs | Primary brand color |
+
+### Why It Works
+- The 60% keeps the UI calm and readable
+- The 30% creates depth and separation
+- The 10% draws attention exactly where you want it — interactive elements
+
+### Common Violations
+- **Too much accent** (30%+): UI feels loud, overwhelming — everything is competing for attention
+- **Accent used decoratively**: Brand color on non-interactive elements trains users to ignore it
+- **No clear dominant neutral**: Multiple competing background colors create visual chaos
+
+### Example Application
+```
+60%: #F9FAFB (off-white page background)
+30%: #FFFFFF (white cards) + #E5E7EB (subtle borders)
+10%: #7C3AED (purple CTAs, active nav, links)
+```
+
+### Dark Mode Version
+```
+60%: #0F172A (dark navy background)
+30%: #1E293B (slightly lighter cards/panels)
+10%: #818CF8 (lighter purple — adjusted for dark bg contrast)
+```
+
+The accent color almost always needs adjusting for dark mode — the light-mode version is often too dark to pass contrast on dark backgrounds.
+
+---
+
+## Quick Reference: Accessible Dark Text on Colored Backgrounds
+
+These text colors have been checked against common background colors:
+
+| Background | Min text color for 4.5:1 | Notes |
+|---|---|---|
+| White #FFFFFF | #767676 | Medium gray threshold |
+| Light gray #F5F5F5 | #727272 | Slightly darker |
+| Light blue #E3F2FD | #5C6F7A | Teal-gray |
+| Brand blue #4A90E2 | White works, but check | ~4.0:1 — borderline for small text |
+| Dark blue #1E3A5F | White #FFFFFF | Clearly passes |
+
+**When in doubt, use a contrast checker tool.** Don't eyeball it.

--- a/skills/design-auditor/references/corner-radius.md
+++ b/skills/design-auditor/references/corner-radius.md
@@ -1,0 +1,240 @@
+# Corner Radius Rules Reference
+
+Corner radius is one of the most overlooked consistency systems in UI design. Most developers pick a radius value that "looks right" and apply it inconsistently — resulting in designs that feel subtly off without the viewer knowing why.
+
+---
+
+## The Nested Radius Rule (Most Important)
+
+**Outer radius = Inner radius + Padding**
+
+When one rounded element sits inside another rounded element, the outer element's radius must be *larger* than the inner element's radius — specifically, larger by the amount of padding between them.
+
+### Why This Matters
+If the inner element has the same or larger radius than the outer, its corners appear to "poke out" or clip through the outer container. The eye notices this as wrong even if the viewer can't articulate it.
+
+### The Formula
+```
+outer_radius = inner_radius + padding
+```
+
+### Examples
+
+**Card with a button inside:**
+```
+Card padding: 16px
+Button border-radius: 8px
+→ Card border-radius should be: 8 + 16 = 24px
+```
+
+**Input inside a form panel:**
+```
+Panel padding: 24px
+Input border-radius: 6px
+→ Panel border-radius should be: 6 + 24 = 30px
+```
+
+**Badge inside a chip:**
+```
+Chip padding: 8px
+Inner dot border-radius: 4px (full circle)
+→ Chip border-radius should be: 4 + 8 = 12px
+```
+
+### Visual Diagnosis
+If the inner element's corners look like they're touching or crossing the outer element's border, the outer radius is too small. Increase it.
+
+If the inner corners look like they're floating far from the outer corners with too much gap, the outer radius may be too large (though this is rarely a problem).
+
+---
+
+## Radius Scale
+
+Like spacing, corner radii should come from a **predefined scale** — not arbitrary values.
+
+### Recommended Scale
+
+| Token | Value | Use Case |
+|---|---|---|
+| `radius-xs` | 2px | Subtle rounding — tooltips, small tags |
+| `radius-sm` | 4px | Tight components — chips, badges, code blocks |
+| `radius-md` | 8px | Default — buttons, inputs, small cards |
+| `radius-lg` | 12px | Medium cards, dropdowns, popovers |
+| `radius-xl` | 16px | Large cards, panels |
+| `radius-2xl` | 24px | Modals, sheets, large containers |
+| `radius-full` | 9999px | Pills — toggles, tags, avatar badges |
+
+### Rules
+- **Stick to the scale.** Arbitrary values like 7px, 11px, 13px, 22px signal inconsistency.
+- **Use CSS variables or design tokens.** Define once, reference everywhere.
+- **The scale should feel geometric.** A ×2 progression works well (4 → 8 → 16 → 32).
+
+---
+
+## Size-Proportional Radius
+
+Corner radius should feel proportional to the element it's applied to. The same absolute radius value looks very different on small vs large elements.
+
+### The Rule of Thumb
+**radius ÷ height ≈ consistent visual weight across sizes**
+
+| Element Height | Feels Right | Too Small | Too Large |
+|---|---|---|---|
+| 24px (badge) | 4–6px | 1–2px | 12px+ (becomes pill) |
+| 40px (button) | 6–10px | 2–3px | 20px+ (becomes pill) |
+| 48px (input) | 6–12px | 2–3px | 24px+ |
+| 120px (card) | 12–20px | 2–4px | 48px+ |
+| 400px (modal) | 16–24px | 4–6px | 48px+ |
+
+### Signs of Size-Proportion Mismatch
+- A large modal or page card with 4px radius — barely looks rounded, feels flat
+- A small badge with 16px radius — looks unexpectedly blobby
+- All elements having the same 8px radius regardless of size — creates inconsistency in how "rounded" things feel at different scales
+
+---
+
+## Pill Shapes
+
+A **pill** shape occurs when `border-radius ≥ 50%` of the element's height. The corners fully curve, creating a stadium/capsule shape.
+
+### When to Use Pills
+- Tags and labels: `<span class="tag">Design</span>`
+- Toggle switches
+- Status badges ("Active", "Pending")
+- Avatar group indicators
+- Search bars (optional — matters for brand tone)
+- Progress bars
+
+### When NOT to Use Pills
+- Cards (looks toy-like)
+- Modals (doesn't feel stable)
+- Large containers (too bubbly)
+- Tables (inconsistent with data density)
+
+### The Pill Trap
+Applying `border-radius: 50%` to a non-square element creates a pill. Applying it to a *square* element creates a **circle**. Make sure you know which one you're creating.
+
+```css
+/* Square element → circle */
+width: 40px; height: 40px; border-radius: 50%;
+
+/* Wide element → pill */
+width: 120px; height: 40px; border-radius: 9999px; /* or 50% */
+```
+
+---
+
+## Zero Radius (Sharp Corners)
+
+`border-radius: 0` is a valid design choice — not a default or forgotten value.
+
+### When Sharp Corners Work
+- Flat/brutalist design languages
+- High-density data UIs (tables, spreadsheets, terminals)
+- Industrial or technical tools
+- When the brand deliberately avoids softness (fintech, security, enterprise)
+
+### When Sharp Corners Hurt
+- Consumer apps where warmth matters
+- Forms (sharp-cornered inputs feel cold and uninviting)
+- Cards in social or lifestyle contexts
+
+### The Rule
+If you're using 0px radius, it should be applied **consistently** and feel intentional. A mix of 0px and rounded elements with no system looks like an accident.
+
+---
+
+## Contextual Radius
+
+Some contexts have specific radius conventions that users have come to expect:
+
+### Bottom Sheets & Mobile Drawers
+```
+Top corners: rounded (16–24px)
+Bottom corners: 0px (flush with screen edge)
+```
+This signals the sheet is "attached" to the bottom of the screen.
+
+### Floating Modals & Dialogs
+```
+All four corners: rounded (16–24px)
+```
+Floating elements should feel detached from the screen — full rounding reinforces this.
+
+### Dropdown Menus
+```
+All corners rounded (8px), OR
+Top corners match the trigger button radius
+Bottom corners rounded
+```
+When a dropdown appears directly below a button, the top corners of the dropdown can be square (0px) to feel connected to the button.
+
+### Toast / Snackbar Notifications
+```
+All corners: rounded (8–12px)
+```
+Toasts float above content and should feel self-contained and friendly.
+
+### Table Cells
+```
+Typically 0px (sharp) inside the table
+First/last row corners may be rounded to match the table container
+```
+
+### Buttons Inside Inputs (Search, Inline Actions)
+```
+Button radius should match or be slightly less than the input radius
+They should feel like one connected unit
+```
+Example: Input with 8px radius + internal search icon button with 6px radius on the right side only.
+
+---
+
+## Common Mistakes
+
+| Mistake | Why It's Wrong | Fix |
+|---|---|---|
+| Same radius on all elements regardless of size | Large elements look barely rounded, small elements look blobby | Use size-proportional radius |
+| Inner element radius > outer element radius | Inner corners appear to poke through the outer border | Apply: outer = inner + padding |
+| Arbitrary values (7px, 11px, 13px) | Looks inconsistent and unintentional | Use a defined radius scale |
+| Mixing rounded and square corners with no system | Feels inconsistent, designed by accident | Pick a language: all rounded, all square, or a clear rule for when each is used |
+| Pills used everywhere | Looks playful/childish in serious contexts | Reserve pills for small, label-like elements |
+| Square corners on consumer-facing forms | Feels cold and uninviting | Use at least 4–8px on inputs in consumer products |
+| Forgetting to match radius in dark mode | Sometimes developers only update background colors in dark mode and forget border-radius context | Dark mode should use same radius system |
+
+---
+
+## CSS Reference
+
+```css
+/* Define your radius scale as variables */
+:root {
+  --radius-xs:   2px;
+  --radius-sm:   4px;
+  --radius-md:   8px;
+  --radius-lg:   12px;
+  --radius-xl:   16px;
+  --radius-2xl:  24px;
+  --radius-full: 9999px;
+}
+
+/* Nested radius example */
+.card {
+  padding: 16px;
+  border-radius: var(--radius-2xl); /* 24px = inner (8px) + padding (16px) */
+}
+
+.card .button {
+  border-radius: var(--radius-md); /* 8px inner element */
+}
+
+/* Contextual radius — bottom sheet */
+.bottom-sheet {
+  border-radius: var(--radius-2xl) var(--radius-2xl) 0 0; /* top-left top-right bottom-right bottom-left */
+}
+
+/* Pill */
+.tag {
+  border-radius: var(--radius-full);
+}
+```

--- a/skills/design-auditor/references/elevation.md
+++ b/skills/design-auditor/references/elevation.md
@@ -1,0 +1,168 @@
+# Elevation & Shadows Reference
+
+Shadows communicate depth — how high above the page surface an element sits. A consistent elevation system makes a UI feel physically grounded and helps users understand which elements are layered above others.
+
+---
+
+## The Elevation Hierarchy
+
+Think of your UI as having physical layers, like sheets of paper stacked on a table:
+
+| Level | Elements | Shadow Strength |
+|---|---|---|
+| **0 — Surface** | Page background, table rows | No shadow |
+| **1 — Raised** | Cards, panels, input fields | Very subtle |
+| **2 — Floating** | Sticky headers, FABs, sidebars | Soft, visible |
+| **3 — Overlay** | Dropdowns, popovers, tooltips | Medium |
+| **4 — Modal** | Dialogs, drawers, side sheets | Strong |
+| **5 — Maximum** | Notifications, critical alerts | Strongest |
+
+Higher = more prominent = stronger shadow. Elements at the same level should have the same shadow.
+
+---
+
+## Shadow Scale
+
+Define shadows as a scale, not per-element:
+
+```css
+:root {
+  --shadow-sm:   0 1px 2px rgba(0, 0, 0, 0.06);
+  --shadow-md:   0 4px 8px rgba(0, 0, 0, 0.08), 0 1px 3px rgba(0, 0, 0, 0.05);
+  --shadow-lg:   0 8px 24px rgba(0, 0, 0, 0.10), 0 2px 6px rgba(0, 0, 0, 0.06);
+  --shadow-xl:   0 16px 48px rgba(0, 0, 0, 0.12), 0 4px 12px rgba(0, 0, 0, 0.08);
+  --shadow-2xl:  0 24px 64px rgba(0, 0, 0, 0.14), 0 8px 20px rgba(0, 0, 0, 0.08);
+}
+```
+
+### Mapping to Elevation Levels
+
+| Level | Token |
+|---|---|
+| Cards | `--shadow-sm` |
+| Sticky header / FAB | `--shadow-md` |
+| Dropdowns / popovers | `--shadow-lg` |
+| Modals | `--shadow-xl` |
+| Critical overlays | `--shadow-2xl` |
+
+---
+
+## Shadow Anatomy
+
+A box shadow has four values: `offset-x offset-y blur spread color`
+
+```css
+box-shadow: 0 4px 8px rgba(0, 0, 0, 0.08);
+/*          ↑ ↑   ↑    ↑
+            | |   |    color (opacity = strength)
+            | |   blur radius
+            | offset-y (vertical — positive = shadow below)
+            offset-x (horizontal — 0 = centered light source)
+```
+
+### The Ratio Rule
+For a grounded, realistic shadow: **blur ≈ 2× offset-y**
+
+```
+offset-y: 4px → blur: 8px  ✅ grounded
+offset-y: 4px → blur: 40px ❌ looks like a glow, not a shadow
+offset-y: 4px → blur: 4px  ❌ looks harsh and pixelated
+```
+
+### Layered Shadows
+Professional shadows often combine two layers — one for ambient light, one for direct light:
+
+```css
+/* Ambient (wide, soft) + Direct (tight, stronger) */
+box-shadow:
+  0 8px 24px rgba(0, 0, 0, 0.08),   /* ambient */
+  0 2px 6px  rgba(0, 0, 0, 0.06);   /* direct */
+```
+
+This creates more realistic, nuanced depth than a single shadow.
+
+---
+
+## Shadow Color
+
+**Never use pure black** (`rgba(0,0,0,1)`) for shadows. Real shadows are:
+- Semi-transparent (typically 5–15% opacity)
+- Slightly warm or cool depending on the light source
+- Tinted by the surface color beneath
+
+### For Light Mode
+```css
+/* Standard: neutral dark */
+rgba(0, 0, 0, 0.08)
+
+/* Warmer feel */
+rgba(15, 10, 5, 0.10)
+
+/* Brand-tinted shadow (subtle) */
+rgba(124, 58, 237, 0.12) /* purple tint for purple brand */
+```
+
+### For Dark Mode
+Shadows don't work on dark backgrounds — a dark shadow on a dark surface is invisible.
+
+**Instead, use surface color elevation:**
+```css
+/* Dark mode elevation via lightness, not shadow */
+--surface-0: #121212;   /* base */
+--surface-1: #1e1e1e;   /* cards (+elevation 1) */
+--surface-2: #242424;   /* dropdowns (+elevation 2) */
+--surface-3: #2c2c2c;   /* modals (+elevation 3) */
+```
+
+Each elevated layer is slightly lighter. No shadows needed.
+
+---
+
+## Common Shadow Mistakes
+
+| Mistake | Why It's Wrong | Fix |
+|---|---|---|
+| Same shadow on all elements | Destroys elevation hierarchy — cards and modals look the same depth | Use different shadow levels per elevation |
+| Pure black shadow at 100% opacity | Looks harsh and fake | Use rgba with 5–15% opacity |
+| Very large blur with tiny offset | Looks like a glow, not a shadow | Match blur to ~2× offset-y |
+| Shadows in dark mode | Invisible — dark shadow on dark background does nothing | Use lighter surface colors instead |
+| Directional shadows inconsistency | Some elements shadow down, some shadow right — looks like multiple light sources | Always use offset-x: 0, offset-y: positive (light from above) |
+| Decorative shadow on flat elements | Shadows mean elevation — using them decoratively confuses the hierarchy | Only shadow actually elevated elements |
+| Shadow + border on same card | Double-defining the card boundary — usually one or the other is enough | Pick shadow OR subtle border, not both (unless intentional) |
+
+---
+
+## Interaction Shadows
+
+Shadows can also communicate interactive state changes:
+
+```css
+/* Button: resting → hovered → pressed */
+.button {
+  box-shadow: var(--shadow-sm);        /* resting */
+  transition: box-shadow 0.15s ease, transform 0.15s ease;
+}
+
+.button:hover {
+  box-shadow: var(--shadow-md);        /* rises on hover */
+  transform: translateY(-1px);         /* slight lift */
+}
+
+.button:active {
+  box-shadow: none;                    /* pressed flat */
+  transform: translateY(0);            /* back down */
+}
+```
+
+This creates a tactile, physical feel — the button lifts on hover and presses down on click.
+
+---
+
+## Figma Elevation Checklist
+
+When auditing a Figma file:
+- [ ] Are shadows applied via shared styles/variables? (not individual custom values)
+- [ ] Do cards all use the same shadow? Modals all use the same shadow?
+- [ ] Is there a defined shadow scale in the design system?
+- [ ] Are dark mode frames using surface colors instead of shadows?
+- [ ] Do interactive elements change shadow on hover/active?

--- a/skills/design-auditor/references/figma-mcp.md
+++ b/skills/design-auditor/references/figma-mcp.md
@@ -1,0 +1,199 @@
+# Figma MCP Workflow Reference
+
+## Overview
+
+The Figma MCP gives Claude direct read and write access to Figma files. This reference covers how to use it safely and effectively during design audits.
+
+---
+
+## Reading a Design
+
+### Tool: `resolve_shortlink`
+Use when the user shares a short Figma URL (e.g. `fig.com/abc123`).
+```
+input: { shortlink: "https://fig.com/abc123" }
+output: { nodeId: "123:456", fileKey: "AbCdEfGh" }
+```
+Use the returned nodeId for all subsequent calls.
+
+### Tool: `get_design_context`
+The primary tool for reading design data. Call on any frame, component, or layer.
+
+**What it returns:**
+- Layer tree (names, types, parent-child relationships)
+- Typography: fontFamily, fontSize, fontWeight, lineHeight, letterSpacing
+- Colors: fills (hex + opacity), strokes, background colors
+- Layout: width, height, x, y, padding (top/right/bottom/left), gap (auto-layout)
+- Component info: which components are used, their names, any overrides
+
+**Best practices:**
+- Start with the top-level frame, not individual layers
+- If the frame is very complex (100+ layers), request specific sections
+- Component names are a signal of design system health — look for names like "Button/Primary/Default" (good) vs "Rectangle 42" (bad)
+
+### Tool: `get_screenshot`
+Always call this alongside `get_design_context`. The visual rendering catches issues that data alone misses:
+- Visual density and crowding
+- Color contrast as it actually appears
+- Alignment issues
+- Overall hierarchy and balance
+
+```
+input: { nodeId: "123:456" }
+output: { imageUrl: "..." }
+```
+
+### Tool: `get_design_pages`
+Use to see all pages in a Figma file. Helpful if the user says "check my whole file" — you can list pages and ask which to audit.
+
+### Tool: `get_metadata`
+Returns file-level info: title, last modified, owner. Use to confirm you're in the right file.
+
+---
+
+## Auditing from Context Data
+
+When you have the `get_design_context` output, check these specific fields:
+
+### Typography Checks
+```
+Look for in context data:
+- fontFamily → Are there more than 2 distinct families?
+- fontSize → Any below 12? Body text below 14?
+- lineHeight → Calculate ratio: lineHeight / fontSize. Should be 1.4–1.6 for body.
+- fontWeight → Does weight vary meaningfully across hierarchy levels?
+- letterSpacing → Negative on body text? (bad)
+```
+
+### Color Checks
+```
+Look for:
+- fills[].color → Convert to hex, check contrast against background
+- opacity → Low opacity text is a common contrast failure
+- Multiple fills → Complex blending may affect contrast
+```
+
+### Spacing Checks
+```
+Look for:
+- paddingTop, paddingRight, paddingBottom, paddingLeft → Are they consistent? Multiples of 8?
+- itemSpacing (gap) → Multiple of 8?
+- x, y positions → Do sibling elements align to shared values?
+```
+
+### Component Health Checks
+```
+Look for:
+- Layer names like "Frame 12", "Group 7", "Rectangle" → Red flag: not using components
+- Layer names like "Button/Primary/Hover" → Green flag: proper component system
+- Detached instances → Components used inconsistently
+```
+
+---
+
+## Making Edits in Figma
+
+### Tool: `perform_editing_operations`
+Use this to fix issues directly. **Always follow the safety rules below.**
+
+### Safety Rules for Editing
+
+**Rule 1: Always confirm before editing**
+Never apply edits without asking:
+> "I can fix [specific issue] on the [element name] layer. Want me to go ahead?"
+
+**Rule 2: Target specific node IDs**
+Get node IDs from `get_design_context` output. Never guess or construct IDs.
+
+**Rule 3: One change at a time for critical properties**
+For risky changes (colors, layout, component swaps), do one edit and check the result before continuing.
+
+**Rule 4: Never bulk-edit without confirmation**
+Don't say "I'll fix all the spacing issues" and run 20 operations. List what you'll change, confirm, then execute.
+
+**Rule 5: Take a screenshot after editing**
+After each batch of edits, call `get_screenshot` to verify the result looks correct.
+
+---
+
+### Common Edit Patterns
+
+#### Fix a text color for contrast
+```
+operation: "SET_FILL_COLOR"
+nodeId: "[text layer node ID]"
+color: { r: 0.2, g: 0.2, b: 0.2, a: 1.0 }  // #333333 — passes 4.5:1 on white
+```
+
+#### Fix font size
+```
+operation: "SET_FONT_SIZE"
+nodeId: "[text layer node ID]"
+fontSize: 16
+```
+
+#### Fix padding on a frame
+```
+operation: "SET_PADDING"
+nodeId: "[frame node ID]"
+paddingTop: 16
+paddingRight: 16
+paddingBottom: 16
+paddingLeft: 16
+```
+
+#### Fix spacing between auto-layout items
+```
+operation: "SET_ITEM_SPACING"
+nodeId: "[auto-layout frame node ID]"
+itemSpacing: 8
+```
+
+#### Rename a layer (for component hygiene)
+```
+operation: "RENAME_LAYER"
+nodeId: "[layer node ID]"
+name: "Button/Primary/Default"
+```
+
+---
+
+## Reading Component Structure
+
+Well-structured Figma files use a naming convention like:
+```
+ComponentName/Variant/State
+Button/Primary/Default
+Button/Primary/Hover
+Button/Secondary/Disabled
+Icon/Arrow/Right
+```
+
+When auditing, note if components follow this pattern. If they don't, flag it as a 🟡 Warning — it means the design won't scale well and handoff to developers will be harder.
+
+---
+
+## Common Figma-Specific Issues to Flag
+
+| Issue | Figma Signal | Severity |
+|---|---|---|
+| No components used | All layers are "Frame", "Rectangle", "Group" | 🟡 |
+| Detached components | Layer shows "⚠ Detached" | 🟡 |
+| Inconsistent text styles | No shared text styles defined | 🟡 |
+| Inconsistent color styles | No shared color styles defined | 🟡 |
+| Missing auto-layout | Fixed-position elements that should flex | 🟢 |
+| No grids defined | Layout grid not applied to frames | 🟢 |
+| Unlabeled frames | Frames named "Frame 1", "Frame 2" | 🟢 |
+| Missing variants | Component has no hover/disabled states | 🟡 |
+| Images not masked | Raw image fills without mask shapes | 🟢 |
+
+---
+
+## When Figma MCP Isn't Available
+
+If Figma MCP tools aren't connected, ask the user to:
+1. Export a screenshot (PNG) and share it
+2. Or share specific values they see in Figma's right panel (colors, font sizes, spacing)
+3. Or copy-paste the CSS Figma generates (right panel → Inspect → CSS)
+
+The CSS export from Figma is particularly useful — it contains exact font sizes, colors, and spacing values that can be checked programmatically.

--- a/skills/design-auditor/references/i18n.md
+++ b/skills/design-auditor/references/i18n.md
@@ -1,0 +1,254 @@
+# Internationalization (i18n) & RTL Reference
+
+Internationalization is building a product that can be adapted for different languages and regions without engineering changes. Localization (l10n) is the actual adaptation for a specific locale.
+
+This reference focuses on what's visible in the design — the things that break or look wrong when a product goes multilingual.
+
+---
+
+## Text Expansion
+
+Different languages take up very different amounts of space than English. This is the most common i18n design failure.
+
+### Typical Expansion Rates vs English
+
+| Language | Expansion |
+|---|---|
+| German | +30–40% |
+| Finnish | +30–40% |
+| French | +15–25% |
+| Spanish | +15–25% |
+| Portuguese | +15–30% |
+| Russian | +15–25% |
+| Arabic | -20–25% (shorter but RTL) |
+| Chinese/Japanese/Korean | -30–50% (denser characters) |
+
+### How to Design for Text Expansion
+
+**Buttons:**
+- Don't use fixed-width buttons. Use `min-width` with horizontal padding, so the button grows with the text.
+- Test with a German or Finnish string — if the button wraps or overflows, the design isn't ready.
+- Avoid putting two buttons side by side in a tight space — one may grow and overlap the other.
+
+**Navigation:**
+- Horizontal nav bars are the most vulnerable — they clip or wrap when labels expand.
+- Test nav items with longer strings. Consider icon-only nav on mobile, with labels on desktop.
+
+**Labels & headings:**
+- Truncation (`text-overflow: ellipsis`) is acceptable for secondary content, never for critical labels.
+- Two-line truncation is safer than one-line for headings.
+
+**Cards & table cells:**
+- Fixed-height cards clip translated text. Use `min-height` not `height`.
+- Table cells should allow text wrapping, not fixed heights.
+
+### Testing for Expansion
+The quickest test: temporarily replace all strings with a string 40% longer than the original and scan for breakage.
+
+---
+
+## RTL (Right-to-Left) Languages
+
+RTL languages: **Arabic, Hebrew, Persian (Farsi), Urdu, Pashto, Sindhi**
+
+In RTL, the entire reading direction reverses — and the UI layout should mirror accordingly.
+
+### What Mirrors in RTL
+
+| Element | LTR | RTL |
+|---|---|---|
+| Text alignment | Left | Right |
+| Page layout direction | Left to right | Right to left |
+| Navigation | Logo left, actions right | Logo right, actions left |
+| Sidebar | Left | Right |
+| Form fields | Left-aligned | Right-aligned |
+| Progress bars | Fill left → right | Fill right → left |
+| Breadcrumbs | Home > Section > Page | Page < Section < Home |
+| List bullets/numbers | Left of text | Right of text |
+| Tooltips | Open right | Open left |
+| Scrollbar | Right side | Left side |
+| Back button icon | ← | → |
+
+### What Does NOT Mirror in RTL
+
+| Element | Stays the Same |
+|---|---|
+| Clock direction | Always clockwise |
+| Phone numbers | Always LTR |
+| Prices / currencies | Depends on locale standard |
+| Code snippets | Always LTR |
+| Non-directional icons | Heart, star, trash, settings |
+| Media controls | Play/pause buttons stay the same |
+| Logos | Unless specifically designed with RTL version |
+| Mathematical expressions | Always LTR |
+
+### Implementing RTL in Code
+
+**HTML level:**
+```html
+<html dir="rtl" lang="ar">
+```
+Or per section:
+```html
+<div dir="rtl">...</div>
+```
+
+**CSS — Use logical properties instead of directional ones:**
+
+| ❌ Directional (breaks in RTL) | ✅ Logical (works in both) |
+|---|---|
+| `margin-left` | `margin-inline-start` |
+| `margin-right` | `margin-inline-end` |
+| `padding-left` | `padding-inline-start` |
+| `padding-right` | `padding-inline-end` |
+| `border-left` | `border-inline-start` |
+| `left: 0` | `inset-inline-start: 0` |
+| `text-align: left` | `text-align: start` |
+| `text-align: right` | `text-align: end` |
+| `float: left` | `float: inline-start` |
+
+**CSS `transform` for directional icons:**
+```css
+/* Flip directional icons in RTL */
+[dir="rtl"] .icon-arrow,
+[dir="rtl"] .icon-chevron,
+[dir="rtl"] .icon-back {
+  transform: scaleX(-1);
+}
+```
+
+### RTL-Specific Design Checklist
+- [ ] `dir="rtl"` applied at html or section level
+- [ ] CSS uses logical properties (`inline-start/end`) not directional (`left/right`)
+- [ ] Directional icons (arrows, chevrons) flip in RTL
+- [ ] Layout mirrors (sidebar, nav, cards)
+- [ ] Progress bars and sliders fill from correct direction
+- [ ] Form fields are right-aligned
+- [ ] Text is right-aligned
+- [ ] Scrollbar moves to left side (handled by browser with `dir="rtl"`)
+
+---
+
+## Date, Time & Number Formats
+
+Never hardcode locale-specific formats. Use the browser's `Intl` API.
+
+### Date Formats by Region
+
+| Region | Format | Example |
+|---|---|---|
+| US | MM/DD/YYYY | 01/15/2025 |
+| UK / Australia | DD/MM/YYYY | 15/01/2025 |
+| ISO / Technical | YYYY-MM-DD | 2025-01-15 |
+| Germany | DD.MM.YYYY | 15.01.2025 |
+| Japan | YYYY年MM月DD日 | 2025年01月15日 |
+| Arabic | Right-to-left, varies | Locale-dependent |
+
+**Always use `Intl.DateTimeFormat`:**
+```javascript
+new Intl.DateTimeFormat('de-DE').format(new Date()) // 15.1.2025
+new Intl.DateTimeFormat('en-US').format(new Date()) // 1/15/2025
+new Intl.DateTimeFormat('ar-SA').format(new Date()) // Arabic numeral date
+```
+
+### Number Formats
+
+| Locale | Thousands separator | Decimal separator | Example |
+|---|---|---|---|
+| en-US | , | . | 1,234,567.89 |
+| de-DE | . | , | 1.234.567,89 |
+| fr-FR | (thin space) | , | 1 234 567,89 |
+| ar | (varies) | (varies) | Use Intl API |
+
+**Always use `Intl.NumberFormat`:**
+```javascript
+new Intl.NumberFormat('de-DE').format(1234567.89) // 1.234.567,89
+```
+
+### Currency
+
+- Symbol position varies: `$100` (US) vs `100 €` (Europe) vs `¥100` (Japan)
+- Always use `Intl.NumberFormat` with `style: 'currency'`
+- Never hardcode `$` prefix
+
+```javascript
+new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(1234)
+// → 1.234,00 €
+```
+
+---
+
+## Font Support for Non-Latin Scripts
+
+Most web fonts only support Latin characters. If you use a custom font and the user's OS language is Arabic, Chinese, Korean, etc., the browser will fall back to a system font — creating a jarring inconsistency.
+
+### Check Font Coverage
+
+| Script | Common Web Font Support |
+|---|---|
+| Latin (English, French, German...) | ✅ Most web fonts |
+| Cyrillic (Russian, Bulgarian...) | ✅ Many Google Fonts |
+| Greek | ✅ Many Google Fonts |
+| Arabic | ❌ Most Latin web fonts — needs dedicated Arabic font |
+| Hebrew | ❌ Most Latin web fonts — needs dedicated Hebrew font |
+| CJK (Chinese, Japanese, Korean) | ❌ Most Latin web fonts — system fonts usually |
+| Devanagari (Hindi) | ❌ Most Latin web fonts — Noto fonts or dedicated |
+
+### Recommended Universal Font: Noto
+
+Google's **Noto** font family is designed to support all scripts without "tofu" (□ characters). It's a safe fallback for multilingual products.
+
+### CSS Font Stack for Multilingual
+
+```css
+font-family: 'YourFont', 'Noto Sans', system-ui, sans-serif;
+```
+
+---
+
+## Text in Images
+
+**Never embed text inside images** if the product will be translated.
+
+- Images with text can't be localized without recreating the image
+- Screen readers can't read text in images
+- Text in images doesn't scale with browser font settings
+
+**Solution:** Use CSS text overlays on top of images. Keep the image as a background, text as a separate HTML element.
+
+---
+
+## Pluralization
+
+Languages handle plurals very differently. English has 2 forms (1 item, 2 items). Arabic has 6 plural forms. Russian has 3.
+
+**Never do this in code:**
+```javascript
+`${count} item${count === 1 ? '' : 's'}` // Only works for English
+```
+
+**Do this instead:**
+Use an i18n library that handles plural rules (i18next, react-intl, FormatJS):
+```javascript
+t('items', { count }) // Library handles the plural form per locale
+```
+
+### Design implication: Leave room for plural variations
+In designs, don't assume a short string stays short in all plural forms. "1 item" vs "1,234 items" is one thing — but in some languages, the word itself changes length significantly across plural forms.
+
+---
+
+## i18n Design Audit Checklist
+
+- [ ] No hardcoded strings visible in the UI (all from translation files)
+- [ ] Buttons use `min-width` not fixed width
+- [ ] Fixed-height containers use `min-height` to accommodate expansion
+- [ ] RTL layout tested with `dir="rtl"` (if targeting RTL languages)
+- [ ] Directional icons flip in RTL
+- [ ] Dates use `Intl.DateTimeFormat`
+- [ ] Numbers use `Intl.NumberFormat`
+- [ ] Currency uses `Intl.NumberFormat` with currency style
+- [ ] No text embedded in images
+- [ ] Pluralization handled by an i18n library, not string concatenation
+- [ ] Font stack includes multilingual fallback (Noto or system-ui)
+- [ ] Navigation tested with 40% longer strings

--- a/skills/design-auditor/references/iconography.md
+++ b/skills/design-auditor/references/iconography.md
@@ -1,0 +1,201 @@
+# Iconography Rules Reference
+
+Icons are a universal UI language — but only when used consistently and correctly. Inconsistent iconography is one of the most noticeable signs of an unpolished UI.
+
+---
+
+## Choosing an Icon Library
+
+### The One Library Rule
+Use exactly **one icon library** throughout the product. Mixing libraries creates visual inconsistency because each library has its own optical proportions, stroke weights, and corner rounding.
+
+### Popular Libraries & Their Character
+
+| Library | Style | Best For |
+|---|---|---|
+| **Lucide** | Clean outline, 2px stroke | Modern SaaS, developer tools |
+| **Phosphor** | Multi-weight, very versatile | Any product, highly flexible |
+| **Heroicons** | Outline + solid variants | Tailwind-based projects |
+| **Material Symbols** | Google's system | Android-adjacent, data-heavy UIs |
+| **Feather** | Minimal outline | Clean, minimal interfaces |
+| **Tabler Icons** | Outline, very complete | Enterprise tools |
+| **Radix Icons** | Compact, precise | UI components, design systems |
+
+### Picking a Style
+Each library usually offers multiple styles. Pick **one** and don't mix:
+- **Outline** — light, airy, modern
+- **Filled / Solid** — heavier, more assertive, better at small sizes
+- **Duotone** — two-tone, decorative, good for empty states and illustrations
+- **Bold / Thick** — accessible, high-contrast, punchy
+
+---
+
+## Icon Sizing
+
+### The Optical Grid
+Icons look best at sizes that align to the 4-point grid AND are optical grid-friendly:
+
+| Size | Use Case |
+|---|---|
+| 12px | Tiny inline indicators (status dots with label) |
+| 16px | Dense UI, inline with small text (12–13px) |
+| 20px | Default inline with body text (14–16px) |
+| 24px | Standard icon button, nav item, list row |
+| 32px | Feature icons, section headings |
+| 40px | Empty state icons, card decorations |
+| 48px | Large empty states, onboarding |
+| 64–96px | Hero illustrations (use SVG illustrations, not icons) |
+
+**Avoid:** 18px, 22px, 26px, 28px, 36px — these fall between optical grid lines and look slightly off.
+
+### Matching Icon Size to Text Size
+
+| Text Size | Paired Icon Size |
+|---|---|
+| 12px | 12–14px |
+| 14px | 16px |
+| 16px | 20px |
+| 18–20px | 24px |
+| 24px+ | 28–32px |
+
+---
+
+## Stroke Weight Consistency
+
+Outline icons have a stroke weight. Mixing stroke weights in the same UI feels inconsistent.
+
+| Context | Stroke Weight |
+|---|---|
+| Dense UI, small icons (16px) | 1.5px |
+| Standard UI (20–24px) | 2px |
+| Bold/accessible UI | 2.5px |
+| Large decorative icons (32px+) | 1.5–2px (lighter at large sizes) |
+
+**Rule:** If your icon library uses 2px strokes and you manually scale an icon up, the stroke doesn't scale — it stays 2px. At 48px, a 2px stroke looks too thin. Either use a bolder variant or adjust stroke weight.
+
+---
+
+## Optical Alignment
+
+Icons are not the same as text — they don't sit on the baseline. Aligning them to text requires care.
+
+### The Bounding Box Problem
+Most icons have invisible padding baked into their bounding box. The actual visual weight sits in the center, but the bounding box is square (24×24px). This means:
+
+```
+❌ Bad: align icon bounding box to text baseline → icon looks high
+✅ Good: align icon to optical center of adjacent text
+```
+
+In CSS, use `vertical-align: middle` or flexbox with `align-items: center`:
+
+```css
+.icon-with-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+```
+
+For inline icons inside text, `vertical-align: -0.125em` (shifting slightly below baseline) often gives the best optical result.
+
+### Optical Centering in Buttons
+When an icon is inside a button with a label, the icon + label combination should feel optically centered — not mathematically centered. Sometimes this means adding 1–2px more padding on one side.
+
+---
+
+## Touch Target Padding
+
+A 24px icon used as an interactive button is too small to tap comfortably. You need padding.
+
+```
+Icon size + padding = touch target
+
+24px icon + 10px padding each side = 44px touch target ✅
+16px icon + 14px padding each side = 44px touch target ✅
+```
+
+In CSS:
+```css
+.icon-button {
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  /* The icon inside is 20–24px; padding provides the rest */
+}
+```
+
+---
+
+## Icon Meaning & Consistency
+
+### Universal Icons (No label needed)
+These are understood cross-culturally and don't need a visible label (but a tooltip is still good practice):
+- ✕ or × — Close
+- ☰ — Menu / hamburger
+- ⌕ / 🔍 — Search
+- ⬆ ⬇ ← → — Directional arrows
+- + — Add
+- ✓ — Confirm / checked
+
+### Ambiguous Icons (Always need a label)
+These mean different things in different contexts and should always have a visible label:
+- ★ — Could mean favourite, rating, or featured
+- 🔔 — Could mean notifications, alerts, or reminders
+- ⚙ — Could mean settings, configuration, or preferences
+- 📁 — Could mean files, projects, or categories
+- 🏠 — Could mean home page, dashboard, or main menu
+
+### The Meaning Consistency Rule
+Once an icon has a meaning in your product, that meaning must be consistent everywhere.
+
+❌ Bad: Using ★ for "favourite" on the home page and ★ for "rating" in the review section  
+✅ Good: Using ★ for "favourite" everywhere, and a separate ⭐ filled style for ratings
+
+---
+
+## Icon + Label Patterns
+
+### When to Show Labels
+| Context | Label Required? |
+|---|---|
+| Primary navigation (desktop) | Recommended |
+| Primary navigation (mobile bottom bar) | Required |
+| Toolbar / action bar | Tooltip minimum, label preferred |
+| Inline with text | No (context is enough) |
+| Icon-only button | Tooltip required (`aria-label` always required) |
+| Empty state illustrations | Yes — with heading + body text |
+
+### Accessibility: aria-label
+Every icon used as a button or interactive element MUST have an `aria-label` even if it has a visual label:
+
+```html
+<!-- Icon-only button -->
+<button aria-label="Close dialog">
+  <XIcon size={20} />
+</button>
+
+<!-- Icon + visible label (aria-label still recommended) -->
+<button aria-label="Add new task">
+  <PlusIcon size={16} />
+  Add task
+</button>
+```
+
+---
+
+## Common Iconography Mistakes
+
+| Mistake | Fix |
+|---|---|
+| Mixing outline and filled icons in same UI | Pick one style and stick to it |
+| Using icons from 2+ different libraries | Pick one library |
+| Scaling icons to non-grid sizes (18px, 22px) | Use 16, 20, 24, 32px |
+| Using icon bounding box for alignment | Use optical/flex center alignment |
+| No label on ambiguous icons | Add visible label or tooltip |
+| No `aria-label` on icon buttons | Always add `aria-label` |
+| Icon touch target too small (under 44px) | Add padding to reach 44×44px |
+| Same icon, different meanings in same product | Pick one meaning per icon, use different icons for different meanings |
+| Decreasing icon size on mobile | Icons need to be the same or larger on mobile for touch |

--- a/skills/design-auditor/references/microcopy.md
+++ b/skills/design-auditor/references/microcopy.md
@@ -1,0 +1,186 @@
+# Microcopy Reference
+
+Microcopy is the small functional text throughout a UI — button labels, error messages, tooltips, placeholders, confirmations, and empty states. It's often written by developers as an afterthought, but it has an outsized impact on usability and user trust.
+
+---
+
+## Button Labels
+
+### The Verb Rule
+Buttons should always be a **verb** (or verb phrase) that describes the action:
+
+| ❌ Vague | ✅ Specific |
+|---|---|
+| OK | Got it / Save / Confirm |
+| Submit | Send Message / Create Account / Place Order |
+| Yes | Delete / Remove / Yes, cancel my plan |
+| Cancel | Keep editing / Go back |
+| Upload | Upload photo / Add file |
+| Continue | Next: Shipping / Continue to payment |
+
+### Rules
+- **Be specific about what happens.** "Save Changes" is better than "Save" when the user might not know what they're saving.
+- **Match the button to the outcome.** If clicking a button sends an email, say "Send Email" — not "Confirm."
+- **Destructive buttons should name the thing being destroyed.** "Delete Project" not just "Delete." "Cancel Subscription" not just "Cancel."
+- **Primary CTA should be 2–4 words max.** Longer labels don't scan well in buttons.
+- **Sentence case, not Title Case.** "Create account" not "Create Account" (unless your brand style is Title Case throughout).
+
+### Confirmation Dialogs
+A good destructive confirmation dialog has:
+```
+Title:   Delete "Project Alpha"?
+Body:    This will permanently delete the project and all its tasks.
+         This action cannot be undone.
+Buttons: [Cancel]  [Delete project]  ← specific, not just "Delete"
+```
+
+Never:
+```
+Title:   Are you sure?
+Body:    This action cannot be undone.
+Buttons: [No]  [Yes]
+```
+
+---
+
+## Error Messages
+
+### The Formula
+A good error message answers three questions:
+1. **What went wrong?**
+2. **Why did it go wrong?** (if not obvious)
+3. **How do I fix it?**
+
+| ❌ Bad | ✅ Good |
+|---|---|
+| Invalid input | Please enter a valid email address |
+| Error | We couldn't save your changes — check your connection and try again |
+| Password incorrect | That password doesn't match — try again or reset your password |
+| Required field | Please add a project name to continue |
+| 500 Internal Server Error | Something went wrong on our end. We're looking into it — try again in a moment |
+| File too large | This file is too large. Maximum size is 10MB |
+
+### Rules
+- **Don't blame the user.** Passive voice helps: "That email wasn't recognized" vs "You entered an invalid email."
+- **Be specific.** "Something went wrong" is a last resort, not a default.
+- **Tell them what to do next.** End with an action: "try again", "reset your password", "check your connection."
+- **Match your brand's tone.** A playful app can say "Oops! That didn't work." An enterprise tool should stay neutral and professional.
+- **Never expose technical details** to end users. No stack traces, no HTTP status codes, no "null pointer exception."
+- **Keep error messages short.** 1–2 sentences max. If it needs more explanation, link to a help article.
+
+### Validation Timing
+- **Validate on blur** (when leaving a field) for format errors (email, URL, phone).
+- **Validate on change** for things like password strength (give live feedback).
+- **Validate on submit** for required field checks — don't interrupt typing.
+- **Never validate on every keystroke** for format errors — showing "Invalid email" while the user is still typing is annoying.
+
+---
+
+## Placeholder Text
+
+Placeholders appear inside empty inputs and disappear when the user starts typing. They are **not labels**.
+
+### What Placeholders Are Good For
+- Showing the expected format: `name@example.com`, `(555) 000-0000`, `YYYY-MM-DD`
+- Giving a short hint: `Search by name or email`
+- Example values: `e.g. Project Alpha`, `e.g. San Francisco`
+
+### What Placeholders Are NOT Good For
+- Replacing labels (they disappear, users forget what goes there)
+- Long instructions (they get cut off)
+- Required information (users skip it)
+
+### Rules
+- **Always have a visible label** in addition to placeholder text.
+- **Keep placeholders short** — one phrase, max.
+- **Use "e.g." prefix** for example values to make clear it's an example, not a required format.
+- **Placeholder contrast** should be noticeably lighter than real input text — but still meet 3:1 contrast for readability.
+
+---
+
+## Tooltips & Helper Text
+
+### When to Use Tooltips
+- To explain an icon button with no label
+- To clarify a non-obvious field ("API keys are case-sensitive")
+- To explain why something is disabled ("You need admin access")
+
+### When NOT to Use Tooltips
+- For essential information — if it's critical, put it on the screen, not hidden in a hover
+- For mobile (tooltips don't work on touch — use inline helper text or a modal instead)
+- For long explanations — tooltips should be 1–2 sentences max
+
+### Helper Text (Below Input)
+Use static helper text below inputs for:
+- Format hints: "Use 8+ characters with at least one number"
+- Consequences: "This will be visible to everyone on your team"
+- Counts: "0/280 characters"
+
+Position: directly below the input, above where the error message will appear.
+
+---
+
+## Tone Guidelines
+
+### Pick One Tone and Stick to It
+
+| Tone | Best For | Example |
+|---|---|---|
+| **Friendly & casual** | Consumer apps, social, creative tools | "Looks great! Your changes are saved ✓" |
+| **Warm & professional** | SaaS, productivity, HR tools | "Your changes have been saved." |
+| **Neutral & clinical** | Finance, legal, healthcare, enterprise | "Transaction completed successfully." |
+| **Playful** | Games, kids apps, lifestyle | "Woohoo! You crushed it 🎉" |
+
+### Consistency Rules
+- If you use contractions ("you're", "we'll") in one place, use them everywhere.
+- If you use first person ("Your account") vs second person ("My account") — pick one.
+- If you address users casually in empty states, don't suddenly switch to formal language in error messages.
+- If your brand is friendly, never let technical/legal copy sneak in with a completely different voice.
+
+---
+
+## Terminology Consistency
+
+One of the most common microcopy mistakes is calling the same concept different things in different parts of the app.
+
+### How to Audit Terminology
+Search for synonyms being used for the same thing. Common traps:
+
+| Concept | Don't Mix These |
+|---|---|
+| The user's workspace | "workspace" / "project" / "team" / "organization" |
+| Content items | "task" / "item" / "card" / "ticket" / "to-do" |
+| Saving | "save" / "update" / "apply" / "confirm" |
+| Removing | "delete" / "remove" / "archive" / "clear" |
+| Members | "members" / "users" / "collaborators" / "teammates" |
+
+### Rule: Pick One Word Per Concept
+Create a short glossary and stick to it. Every button, label, confirmation, and error message should use the same word for the same thing.
+
+---
+
+## Numbers, Dates & Formatting
+
+- **Dates**: Use unambiguous formats. "Jan 15, 2025" or "15 January 2025" beats "01/15/25" (is that Jan 15 or the 1st of the 15th month?).
+- **Relative time**: "2 hours ago" is friendlier than a timestamp for recent events. But always show the full date on hover/focus.
+- **Large numbers**: Use commas: 1,000,000 not 1000000. Or abbreviate for dashboards: 1.2M, 45K.
+- **Percentages**: "You're 75% done" not "75% complete" — the possessive makes it feel personal.
+- **File sizes**: Show in the most readable unit. 1.4 MB not 1,400,000 bytes.
+
+---
+
+## Confirmation & Success Messages
+
+| Action | ✅ Good Confirmation |
+|---|---|
+| Saved | "Changes saved" or "Project saved" |
+| Sent | "Message sent to Jamie" |
+| Deleted | "Task deleted" + Undo option |
+| Copied | "Link copied to clipboard" |
+| Uploaded | "Photo uploaded successfully" |
+| Invited | "Invitation sent to alex@example.com" |
+
+### Rules
+- **Be specific** — name the thing that was acted on when possible.
+- **Offer undo** for destructive or hard-to-reverse actions.
+- **Don't celebrate too hard** — "🎉 Amazing! You saved a file!" is patronizing. Save enthusiasm for genuinely exciting moments (first project created, subscription upgraded).

--- a/skills/design-auditor/references/navigation.md
+++ b/skills/design-auditor/references/navigation.md
@@ -1,0 +1,202 @@
+# Navigation Patterns Reference
+
+Navigation is how users find their way through a product. Poor navigation is the single biggest cause of user confusion — not bad visual design, not slow performance, but not knowing where you are or how to get somewhere.
+
+---
+
+## The Core Navigation Question
+
+At any moment in the product, a user should be able to answer three questions instantly:
+1. **Where am I?** — Current location is clearly indicated
+2. **Where can I go?** — Available destinations are visible
+3. **How do I get back?** — Return path is clear
+
+If any of these fail, the navigation is broken.
+
+---
+
+## Navigation Types
+
+### Primary Navigation
+The main way to move between top-level sections of the product.
+
+| Pattern | Use When | Platform |
+|---|---|---|
+| **Top nav bar** | 3–7 primary destinations | Desktop |
+| **Side nav / sidebar** | 5–10 destinations, hierarchical | Desktop SaaS/tools |
+| **Bottom nav bar** | 3–5 primary destinations | Mobile |
+| **Hamburger menu** | Secondary items, overflow | Mobile (not primary) |
+| **Tab bar** | Switching views of same context | Both |
+
+### Secondary Navigation
+Deeper levels within a section.
+
+| Pattern | Use When |
+|---|---|
+| **Tabs** | Parallel views of same content (not different sections) |
+| **Breadcrumbs** | 3+ levels deep in hierarchy |
+| **Sidebar sub-nav** | Multi-level sections in desktop apps |
+| **Segmented control** | 2–4 closely related views |
+
+---
+
+## Active States
+
+The currently active nav item must be **unambiguously distinct** from inactive items.
+
+### What Works
+- **Filled background** on active item (most common, clearest)
+- **Bottom border indicator** (tab bar pattern)
+- **Left border indicator** (sidebar pattern)
+- **Bold weight** on active label
+- **Different color** for active icon + label
+
+### What Doesn't Work
+- Slightly different shade of the same color (too subtle)
+- Color alone with no weight/position change (fails for colorblind users)
+- Only the icon changes, not the label (too easy to miss)
+
+### Contrast Requirement
+Active nav item must have at least **3:1 contrast** against inactive items — not just visually "different."
+
+### Code Pattern
+```css
+.nav-item { color: #6b7280; }
+.nav-item.active {
+  color: #111827;
+  font-weight: 600;
+  background: #f3f4f6;
+  border-left: 3px solid #7c3aed; /* sidebar indicator */
+}
+```
+
+---
+
+## Tabs
+
+Tabs switch between **parallel views of the same content or context**. They are NOT for top-level navigation between different sections.
+
+### ✅ Correct Tab Usage
+- Profile page: Overview | Activity | Settings
+- Message thread: Messages | Files | Members
+- Dashboard: Daily | Weekly | Monthly
+
+### ❌ Incorrect Tab Usage
+- Home | Projects | Settings | Help (these are different sections — use nav)
+- Step 1 | Step 2 | Step 3 (these are sequential — use a stepper)
+
+### Tab Rules
+- **Tabs should be equal weight.** If one tab is visited 90% of the time, reconsider whether tabs are the right pattern.
+- **Always show the active tab clearly** — filled background, bottom border, or bold label.
+- **Don't use tabs for navigation that changes the URL** — tabs are within-page state changes. Use nav for page-level routing.
+- **Overflow handling** — If tabs overflow their container on mobile, scroll horizontally. Never wrap tabs to a second line.
+- **Tab content should be fast** — tab switching should feel instant. Don't put heavy data fetches behind tabs that only load on click.
+
+---
+
+## Breadcrumbs
+
+Breadcrumbs show the hierarchical path to the current page.
+
+### When to Use Breadcrumbs
+- Any page **3 or more levels** deep in a hierarchy
+- Products with complex nested navigation (CMS, file management, settings)
+- When users may arrive directly at a deep page (from search, email link)
+
+### When NOT to Use Breadcrumbs
+- Flat sites with only 1–2 levels
+- Single-page apps where URL doesn't reflect hierarchy
+- Mobile (too small — use a back button instead)
+
+### Breadcrumb Rules
+- **Every crumb is a link** — except the current page (last item)
+- **Current page is not a link** — it can be shown in muted color or without underline
+- **Separator character** — use `/` or `›` — avoid `>` (looks like code) or `→` (implies direction)
+- **Truncate long paths** — if the path is very deep, show first + last 2 levels: `Home / ... / Section / Current Page`
+- **Match the page title** — the last breadcrumb should exactly match the `<h1>` of the current page
+
+```html
+<nav aria-label="Breadcrumb">
+  <ol>
+    <li><a href="/">Home</a></li>
+    <li><a href="/projects">Projects</a></li>
+    <li><a href="/projects/alpha">Project Alpha</a></li>
+    <li aria-current="page">Settings</li>
+  </ol>
+</nav>
+```
+
+---
+
+## Back Buttons
+
+"Back" is a fundamental navigation primitive — and one of the most commonly broken patterns.
+
+### Rules
+- **Back goes to the previous screen, not the previous URL.** In a multi-step flow, pressing Back should go to the previous step, not the previous browser history entry.
+- **Back in a modal closes the modal to the page behind it** — not to the previous page in history.
+- **Back should not lose user data** — if the user has entered information, warn them before going back ("Go back? Your changes will be lost.") or auto-save.
+- **Back button label should name the destination** — iOS convention: "< Projects" tells the user where they're going. Just "< Back" is acceptable but less helpful.
+- **Always provide a way back** — any screen that can be reached should have an exit path. No dead ends.
+
+### When to Show a Back Button
+- Detail pages within a list (e.g. item detail → back to list)
+- Steps in a flow (step 3 → back to step 2)
+- Modals and drawers (close/back button in header)
+- Any screen without primary navigation visible
+
+---
+
+## Mobile Navigation
+
+### Bottom Navigation Bar
+- **3–5 destinations** maximum. More than 5 = too crowded.
+- **Always show labels** — icon-only bottom nav fails usability testing consistently.
+- **Active state must be clear** — filled icon, label color change, or indicator dot.
+- **Never use for secondary items** — keep primary destinations only.
+- **Safe area** — respect iOS/Android safe area insets so content isn't hidden behind home indicator.
+
+### Hamburger Menu
+- Acceptable for **secondary or overflow navigation**.
+- **Not acceptable** for primary navigation on mobile — it hides destinations, reducing discoverability by 50%+.
+- If you have 3–5 primary destinations, use a bottom nav bar instead.
+
+### Gestures
+- **Swipe back** — respect native back gestures (iOS swipe from left edge, Android back button).
+- Never intercept swipe gestures for something other than navigation without strong justification.
+
+---
+
+## Navigation Accessibility
+
+- **`aria-current="page"`** — mark the active nav item with this attribute for screen readers
+- **Skip navigation link** — provide a "Skip to main content" link as the first focusable element on each page. Essential for keyboard users who don't want to tab through the entire nav on every page.
+- **Keyboard navigation** — nav items must be reachable and activatable by keyboard (Tab + Enter)
+- **Focus management** — when a nav item opens a new section, move focus to the section heading or first interactive element
+
+```html
+<!-- Skip nav link (visually hidden until focused) -->
+<a href="#main-content" class="skip-link">Skip to main content</a>
+
+<!-- Active page indicator -->
+<nav>
+  <a href="/home">Home</a>
+  <a href="/projects" aria-current="page">Projects</a>
+  <a href="/settings">Settings</a>
+</nav>
+```
+
+---
+
+## Common Navigation Mistakes
+
+| Mistake | Fix |
+|---|---|
+| Tabs used for top-level section navigation | Use nav bar or sidebar instead |
+| No active state on current nav item | Add clear visual indicator (background, border, weight) |
+| Breadcrumbs with non-clickable intermediate items | All crumbs except current page must be links |
+| Back button goes to browser history, not app flow | Implement in-app back navigation in multi-step flows |
+| Hamburger menu for primary nav on mobile | Use bottom nav bar for 3–5 primary destinations |
+| Nav changes between sections (items appear/disappear) | Keep nav consistent on every page |
+| No skip navigation link | Add `<a href="#main">Skip to main content</a>` as first element |
+| Active nav item only differs by color | Add weight, background, or position indicator too |

--- a/skills/design-auditor/references/spacing.md
+++ b/skills/design-auditor/references/spacing.md
@@ -1,0 +1,238 @@
+# Spacing & Layout Rules Reference
+
+## The 8-Point Grid System
+
+The most widely-used spacing system in professional UI design. Every spacing and sizing value should be a **multiple of 8**.
+
+### The Scale
+4, 8, 12, 16, 24, 32, 40, 48, 64, 80, 96, 128px
+
+### Why 8?
+- Screens are divisible by 8 (common screen widths: 320, 360, 375, 390, 414, 768, 1024, 1280, 1440...)
+- 8px is small enough for fine-grained control, large enough to be meaningful
+- Values always divide cleanly across pixel densities (1×, 2×, 3×)
+
+### 4-Point Variant
+Some teams use a 4-point base instead. This gives you: 4, 8, 12, 16, 20, 24, 32, 40, 48, 64...
+Fine for dense/compact UIs. Still keep values as multiples of 4.
+
+### What to Put on the Grid
+- Spacing between components
+- Padding inside components
+- Component sizes (widths, heights)
+- Icon sizes (16, 20, 24, 32, 40, 48px)
+
+### Common Off-Grid Values (Red Flags)
+- 3px, 5px, 7px, 9px, 11px, 13px, 17px, 22px, 27px...
+If you see these, ask "why?" — they're usually accidental.
+
+---
+
+## Spacing Vocabulary
+
+| Term | Meaning |
+|---|---|
+| **Padding** | Space *inside* a container (between content and its border) |
+| **Margin** | Space *outside* a component (between it and adjacent things) |
+| **Gap** | Space between items in a flex or grid container |
+| **Gutter** | Space between columns in a grid layout |
+| **Inset** | Uniform padding on all sides |
+
+---
+
+## Content Margins (Page-Level)
+
+The space between the screen edge and the content:
+
+| Screen Size | Common Margin |
+|---|---|
+| Mobile (< 768px) | 16px or 20px |
+| Tablet (768–1024px) | 24px or 32px |
+| Desktop (1024–1440px) | 48px, 64px, or 80px |
+| Wide desktop (1440px+) | Content max-width + auto margins |
+
+**Max Content Width**: Most readable body content caps at **680–800px wide**. Full-width containers can go to 1200–1440px for dashboards/data-heavy layouts.
+
+---
+
+## Component Padding
+
+### Buttons
+
+| Size | Vertical Padding | Horizontal Padding |
+|---|---|---|
+| Small | 6–8px | 12–16px |
+| Medium (default) | 10–12px | 20–24px |
+| Large | 14–16px | 28–32px |
+
+**Touch target rule**: The entire button hit area should be at least **44×44px** (iOS) or **48×48dp** (Android/Material).
+
+### Cards & Panels
+
+| Size | Padding |
+|---|---|
+| Compact (dense dashboards) | 12–16px |
+| Default | 16–24px |
+| Spacious | 24–32px |
+
+Padding should be consistent on all four sides, or use a pattern like more top/bottom than left/right intentionally.
+
+### Form Inputs
+
+- **Height**: 36–40px (small), 44–48px (default), 52–56px (large)
+- **Horizontal padding**: 12–16px
+- **Vertical padding**: enough to center text within the height above
+- **Gap between fields**: 16–24px
+- **Label-to-input gap**: 4–8px
+
+---
+
+## The Law of Proximity
+
+**"Things that are related should be close together. Things that are unrelated should be far apart."**
+
+This is the most important spacing rule to internalize:
+
+✅ Good: A form label is 4–8px above its input. The next form field is 24px below.  
+❌ Bad: Equal spacing between the label and its input, and the label and the previous field.
+
+### Applying Proximity
+
+- Section title → content below: **8–12px gap**
+- Section → next section: **32–64px gap**
+- Card title → card body: **8–12px**
+- Unrelated elements: **32px+**
+
+If two groups of content have the same amount of space between them as within them, add more space between the groups.
+
+---
+
+## Alignment
+
+### Types of Alignment
+
+| Type | When to Use |
+|---|---|
+| **Left edge** | Most common. Body text, list items, form fields |
+| **Right edge** | Numbers in tables, secondary actions (right-side of nav) |
+| **Center** | Short headlines, icons, button labels, hero content |
+| **Baseline** | Text that sits next to each other in a line |
+
+### Grid Alignment
+Elements should align to a shared invisible grid. Things that aren't aligned to something look accidental.
+
+**Check by drawing invisible lines**: Do your left edges line up? Do your top edges line up? If not, it should be intentional, not accidental.
+
+---
+
+## White Space
+
+White space (negative space) is **not empty space** — it's an active design element.
+
+### Why White Space Matters
+- Makes content easier to scan
+- Creates focus on what matters
+- Communicates quality and confidence
+- Reduces cognitive load
+
+### Signs of Insufficient White Space
+- Text runs edge-to-edge in containers
+- Elements feel cramped or cluttered
+- Nothing has visual breathing room
+- Too many elements compete for attention
+
+### Signs of Too Much White Space
+- Content feels lost or disconnected
+- Scroll depth becomes excessive for simple content
+- Relationships between elements are unclear
+
+**Rule of thumb**: When in doubt, add more space than you think you need.
+
+---
+
+## Layout Patterns
+
+### The Column Grid
+
+Most layouts use a **12-column grid** (desktop). This divides evenly into 1, 2, 3, 4, 6, and 12 columns.
+
+Common desktop layouts:
+- **Full width**: 12 columns
+- **Wide content**: 10 columns, 1-column offset each side
+- **Article**: 8 columns (centered)
+- **Sidebar + Content**: 3 + 9 columns, or 4 + 8 columns
+
+Mobile: Usually **1 column** (stacked), or **2 columns** for grids.
+
+### Common Layout Patterns
+
+| Pattern | Use Case |
+|---|---|
+| **Holy Grail** | Header + sidebar + content + sidebar + footer |
+| **Card Grid** | Products, blog posts, gallery items |
+| **Dashboard** | Stats + charts + tables |
+| **Single Column** | Mobile, articles, forms |
+| **Split / Two-Pane** | Settings, email clients, sidebars |
+
+---
+
+## Z-Index & Layering
+
+When elements overlap, they need a clear layer hierarchy:
+
+| Layer | Z-index Range | Examples |
+|---|---|---|
+| Base content | 0–9 | Page content, images |
+| Floating elements | 10–99 | Sticky headers, floating buttons |
+| Dropdowns / tooltips | 100–199 | Dropdown menus, tooltips |
+| Modals / overlays | 200–299 | Modal dialogs, drawers |
+| Notifications / toasts | 300–399 | Toast messages, alerts |
+| Debug / dev tools | 9999+ | Dev tools, onboarding overlays |
+
+**Don't use arbitrary z-index values** like 9999 for normal components. It creates escalation wars.
+
+---
+
+## Common Spacing Mistakes
+
+1. **Inconsistent padding inside cards** — 12px on left, 16px on top. Pick one value and use it everywhere.
+2. **Elements touching the edge** — Content with no margin from the screen or container edge.
+3. **Equal spacing between unrelated items** — Everything looks like one undifferentiated blob.
+4. **Random spacing values** — 13px, 22px, 7px. Use the 8-point grid.
+5. **Overloaded screen density** — Too many things on screen at once. Consider splitting content across multiple screens or using progressive disclosure.
+6. **Missing whitespace in forms** — Fields jammed together with no breathing room between sections.
+7. **Ignoring mobile margins** — Desktop designs often use generous margins that collapse to nothing on mobile.
+
+---
+
+## When to Intentionally Break the 8-Point Grid
+
+The 8-point grid is a rule, not a law. There are legitimate cases where breaking it is the right call — but they should always be **intentional and documented**, never accidental.
+
+### Acceptable Reasons to Break the Grid
+
+**1. Optical correction**
+Sometimes mathematically correct spacing looks visually wrong. A common example: icons with built-in padding that makes them look off-center even when mathematically centered. Adjust by 1–2px to fix what the eye sees, not what the ruler says.
+
+**2. Border compensation**
+A 1px border adds to the total height/width of an element. If a button needs a 44px touch target and has a 1px border, the padding should be `(44 - 2) / 2 = 21px` — off-grid, but correct.
+
+**3. Dense data UIs**
+Tables, spreadsheets, and data grids sometimes need tighter vertical spacing (e.g. 6px or 10px row padding) to show more rows without scrolling. Acceptable when information density is the primary goal.
+
+**4. Line-height alignment**
+When aligning multi-line text with single-line text or icons, tiny spacing adjustments (1–3px) may be needed for optical baseline alignment.
+
+**5. External constraints**
+Third-party components, native platform guidelines (iOS HIG, Material Design), or specific browser rendering may impose constraints that conflict with your grid.
+
+### How to Handle Intentional Breaks
+- **Document it** — Add a comment in code: `/* 6px: optical correction for icon padding */`
+- **Keep it local** — Don't make a "6px" token. The break is specific to this context.
+- **Review it** — Off-grid values should be questioned in design reviews. If it doesn't have a reason, it's accidental.
+
+### The Key Test
+> "Can I explain why this value isn't on the grid?"
+
+If yes → intentional, acceptable.  
+If no → accidental, fix it.

--- a/skills/design-auditor/references/states.md
+++ b/skills/design-auditor/references/states.md
@@ -1,0 +1,159 @@
+# UI States Reference
+
+Most beginner UIs only design the "happy path" — data loads perfectly and the user does everything right. In reality, users spend a surprising amount of time in other states. Each needs its own design.
+
+## The 6 States Every UI Component Can Be In
+
+| State | When | Design Priority |
+|---|---|---|
+| **Default** | Nothing has happened yet | ✅ Always designed |
+| **Loading** | Waiting for data or an action to complete | ⚠️ Often forgotten |
+| **Empty** | No data exists yet | ⚠️ Often forgotten |
+| **Error** | Something went wrong | ⚠️ Often forgotten |
+| **Success** | Action completed | ⚠️ Often forgotten |
+| **Disabled** | Action not available | 🟡 Sometimes missing |
+
+---
+
+## Loading States
+
+### When to use what
+
+| Pattern | Best For |
+|---|---|
+| **Skeleton screen** | Content-heavy layouts (feeds, cards, tables) |
+| **Spinner** | Short, action-triggered waits (button click, form submit) |
+| **Progress bar** | Long operations where progress can be measured (upload, export) |
+| **Shimmer / pulse** | Image placeholders and text blocks |
+
+### Rules
+- **Never show a blank screen.** Even a spinner is better than nothing.
+- **Skeleton screens beat spinners** for perceived performance — the layout already exists, so content "appears" rather than "loading."
+- **Show loading state immediately** — don't wait 500ms before showing anything. Users click again if nothing happens.
+- **Skeleton shapes should match real content shapes.** A skeleton for a card should have lines where the title, description, and image will be — not generic rectangles.
+- **Don't show too many spinners at once.** If five components all have their own spinner, the page feels broken. Consolidate into a page-level or section-level loading state.
+
+### Loading State Checklist
+- [ ] Every data fetch has a visual loading indicator
+- [ ] Skeleton shapes match actual content layout
+- [ ] Loading state matches the overall visual style (not plain gray boxes in an otherwise polished UI)
+- [ ] Buttons show a loading state when clicked (spinner inside, disabled)
+- [ ] Long operations have a progress indicator
+
+---
+
+## Empty States
+
+Empty states are one of the most underdesigned parts of any product. They're the first thing a brand new user sees — and often the thing that determines whether they come back.
+
+### Anatomy of a Good Empty State
+
+```
+[Illustration or icon]
+
+[Friendly headline]
+"You haven't added any tasks yet"
+
+[Helpful context — optional]
+"Tasks help you track work and stay on schedule."
+
+[Clear call to action]
+[+ Create your first task]
+```
+
+### Rules
+- **Always include a CTA.** An empty state without an action leaves the user stranded.
+- **Be specific.** "Nothing here yet" is useless. "You haven't connected any integrations — connect Slack to get started" is actionable.
+- **Match the tone of the product.** A playful product can have a fun illustration. An enterprise tool should stay professional.
+- **Don't use sad/broken imagery** (broken robots, crying faces) — it implies the product failed, not that the user just needs to add something.
+- **Search empty states are different** — "No results for 'purple elephant'" needs different copy and a different CTA (clear search, refine filters) than a true empty state.
+
+### Types of Empty States
+
+| Type | Example | CTA |
+|---|---|---|
+| **First-use** | New user, no data created yet | Create first item |
+| **Cleared** | User deleted everything | Undo or create new |
+| **Search/filter** | No results match the query | Clear filters |
+| **Error-caused** | Data failed to load | Retry |
+| **Permission** | User can't see data | Request access |
+
+### Empty State Checklist
+- [ ] Every list, table, feed, or grid has a designed empty state
+- [ ] Empty states include an illustration/icon, headline, and CTA
+- [ ] Search/filter empty state is distinct from first-use empty state
+- [ ] Copy is specific and helpful, not generic
+
+---
+
+## Error States
+
+### Levels of Error
+
+| Level | Examples | How to Handle |
+|---|---|---|
+| **Field validation** | Invalid email, password too short | Inline message below the field |
+| **Form-level** | Missing required fields on submit | Summary at top + highlight fields |
+| **Action failure** | "Save failed — try again" | Toast or inline error near the action |
+| **Page-level** | 404, server error, network offline | Full error page with recovery action |
+| **Partial failure** | 3 of 5 items loaded | Inline error on failed items, rest still usable |
+
+### Rules
+- **Say what went wrong AND what to do.** "Something went wrong" with no next step is a dead end.
+- **Don't blame the user.** "You entered an invalid email" vs "The email address doesn't look right — check for typos." The second is kinder.
+- **Error messages should be specific.** "Error 500" means nothing to a user. "We couldn't save your changes — check your connection and try again" is helpful.
+- **Position errors close to the cause.** Field errors below the field. Form errors near the submit button. Don't show errors at the top of the page for a field at the bottom.
+- **Preserve user input.** If a form fails, never clear the fields. Force the user to retype everything = guaranteed frustration.
+- **Retry should be one click.** If something fails, a "Try again" button should be immediately available.
+
+### Error State Checklist
+- [ ] Field validation errors appear inline, below the field
+- [ ] Error messages say what's wrong and how to fix it
+- [ ] Failed actions have a retry option
+- [ ] Page-level errors (404, 500) have a designed state, not a browser default
+- [ ] Error messages never clear user's input
+- [ ] Errors use both color AND text/icon (not color alone)
+
+---
+
+## Success States
+
+Success states close the loop — they tell the user "yes, it worked." Without them, users click submit buttons twice, refresh pages, or simply don't know if their action completed.
+
+### Patterns
+
+| Pattern | Best For | Duration |
+|---|---|---|
+| **Toast / snackbar** | Non-critical confirmations ("Saved", "Copied") | 3–5 seconds, then auto-dismiss |
+| **Inline confirmation** | Form submission, settings saved | Until next user action |
+| **State change** | Button changes to "Saved ✓", item marked complete | Persistent until state changes |
+| **Full screen** | Payment completed, account created | One-time, then redirect |
+| **Email confirmation** | Account verification, order placed | The page becomes a holding state |
+
+### Rules
+- **Be specific.** "Saved" is fine. "Project 'Q4 Launch' saved" is better.
+- **Auto-dismiss toasts after 3–5 seconds.** Persistent toasts that require manual dismissal block the UI.
+- **Don't use green for everything.** Reserve green for genuine success. Confirmations that aren't "good news" (e.g., "Your account has been deleted") shouldn't be green.
+- **Success states need to be accessible.** Toasts that appear and disappear must be announced to screen readers (`role="status"` or `aria-live="polite"`).
+
+### Success State Checklist
+- [ ] Every form submission has a visible success confirmation
+- [ ] Toasts auto-dismiss and are screen-reader accessible
+- [ ] Destructive actions (delete, cancel) confirm completion without using green
+
+---
+
+## Disabled States
+
+### Rules
+- **Look clearly different from enabled.** Reduced opacity (50–60%) is the standard pattern.
+- **Never remove disabled elements entirely** — this is confusing. Show them, just make them unclickable.
+- **Explain why when possible.** A tooltip on hover: "You need admin access to do this" is vastly better than a greyed-out button with no context.
+- **Don't use color alone** to signal disabled — combine reduced opacity with `cursor: not-allowed` and `aria-disabled="true"`.
+- **Disabled inputs** should still be readable (contrast ≥ 3:1 even in disabled state).
+
+### Disabled State Checklist
+- [ ] Disabled elements are visually distinct (opacity + cursor)
+- [ ] Disabled state doesn't remove elements from the layout
+- [ ] Where possible, a tooltip explains why the element is disabled
+- [ ] `aria-disabled="true"` set for screen readers

--- a/skills/design-auditor/references/tokens.md
+++ b/skills/design-auditor/references/tokens.md
@@ -1,0 +1,286 @@
+# Design Tokens & Variables Health Reference
+
+Design tokens are the single source of truth for visual decisions — colors, spacing, typography, shadows, radii. A healthy token system means changing one value updates the entire product. A broken system means hunting through hundreds of files to change a brand color.
+
+---
+
+## What Are Design Tokens?
+
+Design tokens are named variables that store visual values:
+
+```
+color.primary.500 = #7c3aed
+spacing.4 = 16px
+font.size.body = 16px
+radius.md = 8px
+shadow.card = 0 4px 8px rgba(0,0,0,0.08)
+```
+
+Instead of using `#7c3aed` directly in a component, you reference `color.primary.500`. When the brand color changes, you update one token — everything updates automatically.
+
+---
+
+## Token Naming Systems
+
+### Anti-Pattern: Descriptive Names
+Naming tokens after their appearance breaks when values change:
+
+```
+❌ color.purple = #7c3aed   → What if purple becomes blue? The name is now wrong.
+❌ color.red-500 = #ef4444  → Is this always used for danger? Or sometimes for decoration?
+```
+
+### Best Practice: Semantic Names
+Name tokens by their **purpose**, not their **value**:
+
+```
+✅ color.brand.primary = #7c3aed     → The main brand color, whatever it is
+✅ color.feedback.danger = #ef4444   → Used for error states everywhere
+✅ color.text.secondary = #6b7280    → Secondary text color
+✅ color.background.surface = #f9fafb → Card/panel backgrounds
+```
+
+### Two-Tier Token System (Industry Best Practice)
+
+**Tier 1 — Primitive tokens** (raw values):
+```
+color.purple.500 = #7c3aed
+color.red.500 = #ef4444
+spacing.4 = 16px
+```
+
+**Tier 2 — Semantic tokens** (reference primitives):
+```
+color.brand.primary = color.purple.500
+color.feedback.danger = color.red.500
+color.interactive.default = color.purple.500
+```
+
+Components reference **semantic tokens only**. Primitives are never used directly in components. This allows you to remap semantic meaning without touching components (e.g. changing brand color from purple to blue: update one primitive reference).
+
+---
+
+## Token Categories
+
+### Color Tokens
+
+```
+color.brand.primary       — Primary brand color (buttons, links, highlights)
+color.brand.secondary     — Secondary brand color
+color.brand.accent        — Accent/pop color
+
+color.text.primary        — Main body text
+color.text.secondary      — Supporting text, captions
+color.text.disabled       — Disabled state text
+color.text.inverse        — Text on dark/colored backgrounds
+color.text.link           — Hyperlink color
+
+color.background.page     — Base page/app background
+color.background.surface  — Cards, panels, containers
+color.background.elevated — Dropdowns, modals, tooltips
+color.background.overlay  — Modal backdrop scrim
+
+color.border.default      — Standard borders
+color.border.subtle       — Dividers, faint borders
+color.border.focus        — Focus ring color
+color.border.danger       — Error state border
+
+color.feedback.success    — Success states
+color.feedback.warning    — Warning states
+color.feedback.danger     — Error states
+color.feedback.info       — Informational states
+```
+
+### Spacing Tokens
+```
+spacing.1  = 4px
+spacing.2  = 8px
+spacing.3  = 12px
+spacing.4  = 16px
+spacing.6  = 24px
+spacing.8  = 32px
+spacing.10 = 40px
+spacing.12 = 48px
+spacing.16 = 64px
+```
+
+### Typography Tokens
+```
+font.family.sans    = 'Figtree', sans-serif
+font.family.mono    = 'JetBrains Mono', monospace
+
+font.size.xs   = 11px
+font.size.sm   = 13px
+font.size.md   = 15px
+font.size.base = 16px
+font.size.lg   = 18px
+font.size.xl   = 20px
+font.size.2xl  = 24px
+font.size.3xl  = 30px
+font.size.4xl  = 36px
+
+font.weight.regular    = 400
+font.weight.medium     = 500
+font.weight.semibold   = 600
+font.weight.bold       = 700
+
+line.height.tight   = 1.2
+line.height.snug    = 1.35
+line.height.normal  = 1.5
+line.height.relaxed = 1.6
+```
+
+---
+
+## Dark Mode Token Architecture
+
+The most important benefit of a semantic token system is clean dark mode support.
+
+### How It Works
+Instead of creating separate dark mode components, you remap semantic token values:
+
+```css
+/* Light mode */
+:root {
+  --color-background-page: #ffffff;
+  --color-text-primary: #111827;
+  --color-background-surface: #f9fafb;
+  --color-border-default: #e5e7eb;
+}
+
+/* Dark mode — same tokens, different values */
+[data-theme="dark"] {
+  --color-background-page: #0f172a;
+  --color-text-primary: #f1f5f9;
+  --color-background-surface: #1e293b;
+  --color-border-default: #334155;
+}
+```
+
+Components use `var(--color-background-page)` — they don't need to know which mode they're in. The theme switch happens at one level.
+
+### Signs the Token System is Broken for Dark Mode
+- Components have hardcoded hex values that don't change in dark mode
+- Dark mode overrides are scattered across individual component files
+- Dark mode colors are new hardcoded values, not remapped tokens
+- Some components adapt to dark mode but others don't
+
+---
+
+## Auditing Token Health in a Codebase
+
+### Signs of a Healthy Token System
+- All colors in components reference CSS variables or JS tokens
+- No hardcoded hex values (`#abc123`) in component styles
+- Spacing values are multiples of the base unit (4 or 8)
+- Typography uses a defined text style system
+- Dark mode works by swapping a theme class, not editing components
+
+### Signs of a Broken Token System
+
+**Red flags in CSS/code:**
+```css
+/* ❌ Hardcoded values — no token */
+color: #7c3aed;
+margin: 13px;
+font-size: 15px;
+border-radius: 7px;
+box-shadow: 0 3px 7px rgba(0,0,0,0.11);
+```
+
+```css
+/* ✅ Tokenized */
+color: var(--color-brand-primary);
+margin: var(--spacing-3);
+font-size: var(--font-size-md);
+border-radius: var(--radius-md);
+box-shadow: var(--shadow-sm);
+```
+
+**Red flags in Figma:**
+- Components use local styles instead of shared library styles
+- Colors show as hex values in the inspector, not style names
+- "Detached" text styles (no linked text style)
+- Different teams using different color values for the same UI element
+
+### Token Coverage Audit
+
+Run a search for hardcoded values in your codebase:
+```bash
+# Find hardcoded hex colors (not in token definition files)
+grep -r "#[0-9a-fA-F]\{3,6\}" src/components/
+
+# Find hardcoded pixel spacing
+grep -rE "margin|padding|gap" src/components/ | grep -v "var(--"
+
+# Find hardcoded font sizes
+grep -rE "font-size:\s*[0-9]" src/components/ | grep -v "var(--"
+```
+
+Any hits in component files (not token definition files) are candidates for tokenization.
+
+---
+
+## Token System Maturity Levels
+
+| Level | Description | Signs |
+|---|---|---|
+| **0 — No system** | All values hardcoded | Hex values everywhere, no variables |
+| **1 — Basic variables** | CSS variables exist but naming is inconsistent | Mix of `--purple`, `--color-primary`, `#7c3aed` |
+| **2 — Consistent naming** | Variables follow a naming convention | All components use tokens, names are meaningful |
+| **3 — Semantic + primitive** | Two-tier system in place | Components only use semantic tokens |
+| **4 — Multi-theme** | Token system supports light/dark/brand themes | Theme switching works by swapping one class |
+| **5 — Cross-platform** | Tokens shared between web, iOS, Android | Single source of truth across platforms |
+
+---
+
+## Common Token Mistakes
+
+| Mistake | Fix |
+|---|---|
+| Naming tokens by value (`--red`, `--purple-500`) | Name by purpose (`--color-danger`, `--color-brand-primary`) |
+| Using primitive tokens directly in components | Create semantic tokens; components reference semantic only |
+| Hardcoding hex values in components | Replace with token references |
+| Different tokens for same concept in different parts of codebase | Audit and consolidate — one token per concept |
+| Dark mode via per-component overrides | Remap semantic tokens at theme level |
+| Tokens defined but not used consistently | Enforce via linting (stylelint, custom ESLint rules) |
+| Spacing that doesn't follow the token scale | Replace with scale tokens, remove magic numbers |
+
+---
+
+## Token Health Score
+
+Use this formula to quickly assess the health of a token system during an audit:
+
+### How to Score
+
+Check 5 areas, each worth 20 points:
+
+| Area | 20pts (Full) | 10pts (Partial) | 0pts (Missing) |
+|---|---|---|---|
+| **Color** | All colors are tokens, semantic naming | Mix of tokens + hardcoded | Mostly hardcoded hex |
+| **Spacing** | All spacing uses scale tokens | Some tokens, some arbitrary | Mostly arbitrary px values |
+| **Typography** | Font size/weight/line-height tokenized | Partial tokenization | All hardcoded |
+| **Dark Mode** | Single theme swap, no new hex values | Some components adapt | Per-component overrides or no dark mode |
+| **Naming** | Semantic (purpose-based) naming throughout | Mix of semantic + descriptive | Descriptive or no naming convention |
+
+### Token Health Score Bands
+
+| Score | Health Level | What It Means |
+|---|---|---|
+| **90–100** | ✅ Excellent | System is production-grade, scalable, and maintainable |
+| **70–89** | 🟡 Good | Minor gaps, easy to clean up |
+| **50–69** | 🟠 Needs Work | Significant hardcoding, inconsistent adoption |
+| **< 50** | 🔴 Broken | Tokens exist in name only — no real system |
+
+### Quick Audit Command
+Run this to get a rough hardcoded value count in a codebase:
+```bash
+# Count hardcoded hex colors in component files
+grep -rE "#[0-9a-fA-F]{3,6}" src/components/ | grep -v "token\|variable\|\.tokens\." | wc -l
+
+# Count hardcoded px spacing (not in token files)
+grep -rE "(margin|padding|gap):\s*[0-9]+px" src/components/ | grep -v "var(--" | wc -l
+```
+
+A healthy codebase returns **0** for both. Every non-zero hit is a token debt item.

--- a/skills/design-auditor/references/typography.md
+++ b/skills/design-auditor/references/typography.md
@@ -1,0 +1,182 @@
+# Typography Rules Reference
+
+## Font Hierarchy
+
+A well-structured type system has 3–4 levels:
+
+| Level | Purpose | Typical Size | Weight |
+|---|---|---|---|
+| Display / H1 | Hero titles, page names | 32–72px | Bold or Black |
+| H2 / Section | Section headings | 24–36px | SemiBold or Bold |
+| H3 / Subsection | Sub-groupings | 18–24px | Medium or SemiBold |
+| Body | Main reading content | 14–16px | Regular |
+| Caption / Label | Supporting info, metadata | 11–13px | Regular or Medium |
+
+**Rule**: Each level should be visually distinct from adjacent levels. If H2 and H3 look the same, one of them is doing nothing.
+
+---
+
+## Font Pairing
+
+### The 2-Font Rule
+Use a maximum of **2 typefaces** in one design:
+- One for **headings** (display, expressive)
+- One for **body** (readable, neutral)
+
+Optionally, use one font family with different weights (Bold for headings, Regular for body). This always looks cohesive.
+
+### Good Pairing Patterns
+- **Serif heading + Sans-serif body** — Classic, trustworthy (e.g., Playfair + Inter... wait, avoid Inter. Try Playfair + Source Sans)
+- **Sans-serif heading + Sans-serif body** — Clean, modern (different weights of the same family)
+- **Display/decorative heading + Simple body** — Expressive but readable
+
+### Font Families to Avoid (Overused / Generic)
+- Inter (massively overused in AI-generated UIs)
+- Roboto (Android default, feels generic)
+- Arial / Helvetica (system fallback, no personality)
+- Times New Roman (dated unless intentionally retro)
+
+### Better Alternatives
+**For body text**: Source Sans 3, DM Sans, Nunito, Lato, Figtree, Plus Jakarta Sans
+**For headings**: Fraunces, Syne, Clash Display, Cabinet Grotesk, Satoshi, Bricolage Grotesque
+**For monospace/code**: JetBrains Mono, Fira Code, IBM Plex Mono
+
+---
+
+## Size Scale
+
+Use a **modular scale** — sizes based on a ratio, not arbitrary numbers:
+
+### Major Third Scale (1.25×)
+12 → 15 → 19 → 24 → 30 → 38 → 48 → 60px
+
+### Perfect Fourth Scale (1.333×)
+12 → 16 → 21 → 28 → 37 → 50px
+
+### Practical Scale (Most Common)
+12, 14, 16, 18, 20, 24, 28, 32, 36, 48, 60, 72px
+
+**Minimum sizes**:
+- Body text: **16px** (14px acceptable, 12px only for captions)
+- Mobile body: **16px** minimum (browsers auto-zoom below this)
+- Tiny labels: **11px** minimum, never smaller
+
+---
+
+## Line Height (Leading)
+
+| Text Type | Line Height Multiplier |
+|---|---|
+| Large headings (40px+) | 1.1–1.2× |
+| Medium headings (24–40px) | 1.2–1.35× |
+| Body text | 1.4–1.6× |
+| Captions / small text | 1.3–1.5× |
+
+**Example**: 16px body text → line-height: 24px (1.5×)
+
+**Never use line-height: 1** for multi-line text. It's unreadable.
+
+---
+
+## Line Length (Measure)
+
+- **Optimal**: 60–75 characters per line (~550–680px at 16px)
+- **Acceptable**: 45–90 characters
+- **Too wide**: 100+ characters (eye has to travel too far)
+- **Too narrow**: Under 40 characters (too many line breaks, choppy)
+
+In CSS: `max-width: 65ch` is a great rule for body text containers.
+
+---
+
+## Letter Spacing (Tracking)
+
+- **Body text**: 0 or very slightly positive (0–0.01em)
+- **Small caps / all caps**: Always add letter spacing (0.05–0.1em). All-caps with no tracking looks cramped.
+- **Large display text**: Often slightly negative (-0.02 to -0.04em). Tighter feels more premium.
+- **Never**: Negative letter spacing on body text (hurts readability)
+
+---
+
+## Text Contrast (WCAG)
+
+| Text Type | Minimum Contrast Ratio |
+|---|---|
+| Normal text (under 18px regular / 14px bold) | 4.5:1 |
+| Large text (18px+ regular or 14px+ bold) | 3:1 |
+| UI components (borders, icons) | 3:1 |
+| Decorative text | No requirement |
+
+**How to check**: Use a contrast checker. Common tools: Figma's built-in accessibility checker, WebAIM Contrast Checker, or browser devtools.
+
+**Common failures**:
+- Light gray body text on white (#999 on white = ~2.8:1 — fails!)
+- Yellow or light green text on white
+- Any low-opacity text overlay on images without a dark scrim
+
+---
+
+## Alignment Rules
+
+- **Left-align body text** in most Western/LTR languages. It's the most readable.
+- **Center-align** only for short text: headlines, CTAs, hero text, labels.
+- **Never center-align** long body paragraphs. It's exhausting to read.
+- **Right-align** numbers in tables (so decimal points align).
+- **Avoid justified text** on the web (creates uneven word spacing, looks bad without hyphenation).
+
+---
+
+## Common Typography Mistakes
+
+1. **Using too many font sizes** — Pick 4–5 and stick to them. Designers call this a "type ramp."
+2. **All caps body text** — Extremely hard to read in long form. Reserve for labels and buttons only.
+3. **Bold everything** — If everything is bold, nothing is bold. Bold = emphasis, use sparingly.
+4. **Underlining non-links** — Users will click underlined text expecting it to be a link.
+5. **Low-contrast text** — The single most common accessibility failure. Always check.
+6. **Inconsistent alignment** — Some centered, some left-aligned, some right-aligned with no system = chaos.
+7. **No hierarchy** — Everything the same size = wall of text.
+
+---
+
+## Fluid Typography (clamp())
+
+Static type sizes break at breakpoints. Fluid typography scales smoothly between a minimum and maximum size based on viewport width.
+
+### How clamp() Works
+
+```css
+font-size: clamp(MIN, PREFERRED, MAX);
+```
+
+- **MIN** — smallest the text should ever be (e.g. on narrow mobile)
+- **PREFERRED** — fluid value using `vw` (viewport width) units
+- **MAX** — largest the text should ever be (e.g. on wide desktop)
+
+### Common Fluid Type Values
+
+```css
+/* Body text: 16px → 18px */
+font-size: clamp(1rem, 0.9rem + 0.5vw, 1.125rem);
+
+/* H2: 24px → 36px */
+font-size: clamp(1.5rem, 1.2rem + 1.5vw, 2.25rem);
+
+/* H1: 32px → 60px */
+font-size: clamp(2rem, 1.5rem + 2.5vw, 3.75rem);
+
+/* Display: 48px → 80px */
+font-size: clamp(3rem, 2rem + 5vw, 5rem);
+```
+
+### When to Use Fluid Typography
+- Headings and display text — biggest win
+- Hero sections and large callouts
+- Any text that appears at very different sizes across breakpoints
+
+### When NOT to Use It
+- Body text (usually fine staying at 16px)
+- Labels, captions, small UI text (should stay fixed and readable)
+- When you need pixel-perfect control at specific breakpoints
+
+### The Rule
+Fluid type should never drop below its minimum readable size. Always test `clamp()` values at the narrowest viewport you support.


### PR DESCRIPTION
Adds Design Auditor — a Claude skill that audits designs against 17 
professional rules with a scored, actionable report.

**What it does:**
- Scores designs out of 100 (deterministic: 🔴 −8pts, 🟡 −4pts, 🟢 −1pt)
- Audits 17 categories: typography, WCAG contrast, spacing, accessibility,
  iconography, navigation, design tokens + more
- Declares audit confidence level per report (High/Medium/Low)
- Works with Figma MCP, HTML/CSS/React/Vue, and screenshots
- Supports English and Korean
- Offers to fix issues directly in code or Figma after the audit

**Files added:**
- `skills/design-auditor/SKILL.md`
- `skills/design-auditor/references/` (12 reference files)

GitHub: https://github.com/Ashutos1997/claude-design-auditor-skill