### PR TITLE
Add avoid-ai-writing skill

### DIFF
--- a/skills/avoid-ai-writing/SKILL.md
+++ b/skills/avoid-ai-writing/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: avoid-ai-writing
+description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Use this skill when asked to "remove AI-isms," "clean up AI writing," "edit writing for AI patterns," "audit writing for AI tells," or "make this sound less like AI."
+---
+
+# Avoid AI Writing — Audit & Rewrite
+
+You are editing content to remove AI writing patterns ("AI-isms") that make text sound machine-generated.
+
+The user will provide a piece of writing. Your job is to:
+
+1. **Audit it**: identify every AI-ism present, citing the specific text
+2. **Rewrite it**: return a clean version with all AI-isms removed
+3. **Show a diff summary**: briefly list what you changed and why
+
+---
+
+## What to remove or fix
+
+### Formatting
+- **Em dashes (—)**: Replace with commas, periods, parentheses, or rewrite as two sentences. Target: zero. Hard max: one per 1,000 words.
+- **Bold overuse**: Strip bold from most phrases. One bolded phrase per major section at most, or none.
+- **Emoji in headers**: Remove entirely. Exception: social posts may use one or two sparingly at the end of a line.
+- **Excessive bullet lists**: Convert bullet-heavy sections into prose paragraphs. Bullets only for genuinely list-like content.
+
+### Sentence structure
+- **"It's not X — it's Y"**: Rewrite as a direct positive statement. Max one per piece.
+- **Hollow intensifiers**: Cut genuine, real, truly, quite frankly, to be honest, let's be clear. Just state the fact.
+- **Hedging**: Cut perhaps, could potentially, it's important to note that. Make the point directly.
+- **Missing bridge sentences**: Each paragraph should connect to the last.
+- **Compulsive rule of three**: Vary groupings. Max one triad pattern per piece.
+
+### Words and phrases to replace
+
+| Replace | With |
+|---|---|
+| delve / delve into | explore, dig into, look at |
+| landscape (metaphor) | field, space, industry, world |
+| tapestry | (describe the actual complexity) |
+| realm | area, field, domain |
+| paradigm | model, approach, framework |
+| embark | start, begin |
+| beacon | (rewrite entirely) |
+| testament to | shows, proves, demonstrates |
+| robust | strong, reliable, solid |
+| comprehensive | thorough, complete, full |
+| cutting-edge | latest, newest, advanced |
+| leverage (verb) | use |
+| harness | use, take advantage of |
+| pivotal | important, key, critical |
+| underscores | highlights, shows |
+| meticulous / meticulously | careful, detailed, precise |
+| navigate / navigating | work through, handle, deal with |
+| foster | encourage, support, build |
+| elevate | improve, raise, strengthen |
+| seamless / seamlessly | smooth, easy, without friction |
+| unleash | release, enable, unlock |
+| streamline | simplify, speed up |
+| empower | enable, let, allow |
+| game-changer | describe what specifically changed and why it matters |
+| utilize | use |
+| commence | start, begin |
+| ascertain | find out, determine, learn |
+| endeavor | effort, attempt, try |
+| in order to | to |
+| due to the fact that | because |
+| serves as | is |
+| features (verb) | has, includes |
+| boasts | has |
+| presents (inflated) | is, shows, gives |
+| watershed moment | turning point, shift (or describe what changed) |
+| marking a pivotal moment | (state what happened) |
+| the future looks bright | (cut — say something specific or nothing) |
+| only time will tell | (cut — say something specific or nothing) |
+| nestled | is located, sits, is in |
+| vibrant | (describe what makes it active, or cut) |
+| thriving | growing, active (or cite a number) |
+| despite challenges… continues to thrive | (name the challenge and the response, or cut) |
+| showcasing | showing, demonstrating (or cut the clause) |
+
+### Template phrases (avoid)
+- "a [adjective] step towards [adjective] AI infrastructure" → describe the specific capability or outcome
+- "a [adjective] step forward for [noun]" → say what actually changed
+
+### Transition phrases to remove or rewrite
+- "Moreover" / "Furthermore" / "Additionally" → restructure or use "and," "also"
+- "In today's [X]" / "In an era where" → cut or state specific context
+- "It's worth noting that" / "Notably" → just state the fact
+- "In conclusion" / "To summarize" → your conclusion should be obvious
+- "When it comes to" → talk about the thing directly
+- "At the end of the day" → cut
+- "That said" / "That being said" → cut or use "but," "yet," or "however"
+
+### Structural issues
+- **Uniform paragraph length**: Vary deliberately. Include some short and some longer paragraphs.
+- **Formulaic openings**: If it opens with broad context before the point, lead with the news or insight instead.
+- **Suspiciously clean grammar**: Keep deliberate fragments, sentences starting with "And" or "But," comma splices for effect.
+
+### Significance inflation
+- "marking a pivotal moment in the evolution of..." or "a watershed moment for the industry" — state what happened and let the reader judge significance.
+
+### Copula avoidance
+- AI avoids "is" and "has" by substituting: "serves as," "features," "boasts," "presents," "represents." Default to "is" or "has."
+
+### Synonym cycling
+- AI rotates synonyms: "developers… engineers… practitioners… builders" in one paragraph. Repeat the clearest word instead.
+
+### Vague attributions
+- "Experts believe," "Studies show," "Research suggests" — without naming anyone. Cite a specific source or drop the attribution.
+
+### Filler phrases
+- "In order to" → "To"
+- "Due to the fact that" → "Because"
+- "It is important to note that" → (just state it)
+- "At the end of the day" → (cut)
+- "In terms of" → (rewrite)
+- "The reality is that" → (cut or just state the claim)
+
+### Generic conclusions
+- "The future looks bright," "Only time will tell," "One thing is certain," "As we move forward" — cut. Make the closing specific to the argument.
+
+### Chatbot artifacts
+- "I hope this helps!", "Certainly!", "Absolutely!", "Great question!", "Feel free to reach out" — remove entirely.
+- "In this article, we will explore…" or "Let's dive in!" — cut or rewrite with a direct opening.
+
+### Notability name-dropping
+- Piling on prestigious citations: "cited in NYT, BBC, Financial Times, and The Hindu." Use one specific reference with context instead.
+
+### Superficial -ing analyses
+- "symbolizing the region's commitment to progress, reflecting decades of investment, and showcasing a new era of collaboration." Replace with specific facts or cut.
+
+### Promotional language
+- "nestled within the breathtaking foothills," "a vibrant hub of innovation." Replace with plain description.
+
+### Formulaic challenges
+- "Despite challenges, [subject] continues to thrive." Name the actual challenge and response, or cut.
+
+### False ranges
+- "from the Big Bang to dark matter," "from ancient civilizations to modern startups." List the actual topics or pick the relevant one.
+
+### Inline-header lists
+- "**Performance:** Performance improved by..." Strip the bold header and write the point directly.
+
+### Title case headings
+- "Strategic Negotiations And Key Partnerships" → "Strategic negotiations and key partnerships." Use sentence case for subheadings.
+
+### Cutoff disclaimers
+- "While specific details are limited based on available information," "As of my last update." Find the information or remove the hedge.
+
+---
+
+## Output format
+
+Return your response in four sections:
+
+**1. Issues found**
+A bulleted list of every AI-ism identified, with the offending text quoted.
+
+**2. Rewritten version**
+The full rewritten content. Preserve the original structure, intent, and all specific technical details. Only change what the guidelines require.
+
+**3. What changed**
+A brief summary of the major edits made.
+
+**4. Second-pass audit**
+Re-read the rewritten version from section 2. Identify any remaining AI tells that survived the first pass. Fix them, return the corrected text inline, and note what changed. If the rewrite is clean, say so.
+
+---
+
+## Tone calibration
+
+The goal is writing that sounds like a person wrote it. Direct. Specific. The writing should demonstrate confidence, not assert it.
+
+If the original writing is already strong, say so and make only the necessary cuts. Don't over-edit for the sake of it.

--- a/skills/avoid-ai-writing/SKILL.md
+++ b/skills/avoid-ai-writing/SKILL.md
@@ -1,6 +1,15 @@
 ---
 name: avoid-ai-writing
-description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Use this skill when asked to "remove AI-isms," "clean up AI writing," "edit writing for AI patterns," "audit writing for AI tells," or "make this sound less like AI."
+description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Use this skill when asked to "remove AI-isms," "clean up AI writing," "edit writing for AI patterns," "audit writing for AI tells," or "make this sound less like AI." Pairs with writing-voice for full voice alignment.
+version: 3.1.0
+license: MIT
+compatibility: Any AI coding assistant that supports agentskills.io SKILL.md format (Claude Code, Cursor, VS Code Copilot, Hermes Agent, OpenHands, etc.) or OpenClaw. No external tools or APIs required.
+metadata:
+  author: Conor Bronsdon
+  tags: writing editing voice quality
+  agentskills_spec: "1.0"
+  openclaw:
+    emoji: "\u270D\uFE0F"
 ---
 
 # Avoid AI Writing — Audit & Rewrite
@@ -18,19 +27,27 @@ The user will provide a piece of writing. Your job is to:
 ## What to remove or fix
 
 ### Formatting
-- **Em dashes (—)**: Replace with commas, periods, parentheses, or rewrite as two sentences. Target: zero. Hard max: one per 1,000 words.
-- **Bold overuse**: Strip bold from most phrases. One bolded phrase per major section at most, or none.
-- **Emoji in headers**: Remove entirely. Exception: social posts may use one or two sparingly at the end of a line.
-- **Excessive bullet lists**: Convert bullet-heavy sections into prose paragraphs. Bullets only for genuinely list-like content.
+- **Em dashes (— and --)**: Replace with commas, periods, parentheses, or rewrite as two sentences. Target: zero. Hard max: one per 1,000 words. This applies to headings and section titles too, not just body prose. Catch both the Unicode em dash (—) and the double-hyphen substitute (--).
+- **Bold overuse**: Strip bold from most phrases. One bolded phrase per major section at most, or none. If something's important enough to bold, restructure the sentence to lead with it instead.
+- **Emoji in headers**: Remove entirely. No `## 🚀 What This Means`. Exception: social posts may use one or two emoji sparingly — at the end of a line, never mid-sentence.
+- **Excessive bullet lists**: Convert bullet-heavy sections into prose paragraphs. Bullets only for genuinely list-like content (feature comparisons, step-by-step instructions, API parameters).
 
 ### Sentence structure
-- **"It's not X — it's Y"**: Rewrite as a direct positive statement. Max one per piece.
-- **Hollow intensifiers**: Cut genuine, real, truly, quite frankly, to be honest, let's be clear. Just state the fact.
-- **Hedging**: Cut perhaps, could potentially, it's important to note that. Make the point directly.
-- **Missing bridge sentences**: Each paragraph should connect to the last.
-- **Compulsive rule of three**: Vary groupings. Max one triad pattern per piece.
+- **"It's not X — it's Y" / "This isn't about X, it's about Y"**: Rewrite as a direct positive statement. Max one per piece, and only if it serves the argument.
+- **Hollow intensifiers**: Cut `genuine`, `real` (as in "a real improvement"), `truly`, `quite frankly`, `to be honest`, `let's be clear`, `it's worth noting that`. Just state the fact.
+- **Hedging**: Cut `perhaps`, `could potentially`, `it's important to note that`, `to be clear`. Make the point directly.
+- **Missing bridge sentences**: Each paragraph should connect to the last. If paragraphs could be rearranged without the reader noticing, add connective tissue.
+- **Compulsive rule of three**: Vary groupings. Use two items, four items, or a full sentence instead of triads. Max one "adjective, adjective, and adjective" pattern per piece.
 
 ### Words and phrases to replace
+
+Words are organized into three tiers based on how reliably they signal AI-generated text. This tiered approach — adapted from [brandonwise/humanizer](https://github.com/brandonwise/humanizer)'s vocabulary research — reduces false positives on words that are fine in isolation but suspicious in clusters.
+
+- **Tier 1 — Always flag.** These words appear 5–20x more often in AI text than human text. Replace on sight.
+- **Tier 2 — Flag in clusters.** Individually fine, but two or more in the same paragraph is a strong AI signal. Flag when they appear together.
+- **Tier 3 — Flag by density.** Common words that AI simply overuses. Only flag when they make up a noticeable fraction of the text (roughly 3%+ of total words).
+
+#### Tier 1 — Always replace
 
 | Replace | With |
 |---|---|
@@ -46,28 +63,12 @@ The user will provide a piece of writing. Your job is to:
 | comprehensive | thorough, complete, full |
 | cutting-edge | latest, newest, advanced |
 | leverage (verb) | use |
-| harness | use, take advantage of |
 | pivotal | important, key, critical |
 | underscores | highlights, shows |
 | meticulous / meticulously | careful, detailed, precise |
-| navigate / navigating | work through, handle, deal with |
-| foster | encourage, support, build |
-| elevate | improve, raise, strengthen |
 | seamless / seamlessly | smooth, easy, without friction |
-| unleash | release, enable, unlock |
-| streamline | simplify, speed up |
-| empower | enable, let, allow |
-| game-changer | describe what specifically changed and why it matters |
+| game-changer / game-changing | describe what specifically changed and why it matters |
 | utilize | use |
-| commence | start, begin |
-| ascertain | find out, determine, learn |
-| endeavor | effort, attempt, try |
-| in order to | to |
-| due to the fact that | because |
-| serves as | is |
-| features (verb) | has, includes |
-| boasts | has |
-| presents (inflated) | is, shows, gives |
 | watershed moment | turning point, shift (or describe what changed) |
 | marking a pivotal moment | (state what happened) |
 | the future looks bright | (cut — say something specific or nothing) |
@@ -77,77 +78,335 @@ The user will provide a piece of writing. Your job is to:
 | thriving | growing, active (or cite a number) |
 | despite challenges… continues to thrive | (name the challenge and the response, or cut) |
 | showcasing | showing, demonstrating (or cut the clause) |
+| deep dive / dive into | look at, examine, explore |
+| unpack / unpacking | explain, break down, walk through |
+| bustling | busy, active (or cite what makes it busy) |
+| intricate / intricacies | complex, detailed (or name the specific complexity) |
+| complexities | (name the actual complexities, or use "problems" / "details") |
+| ever-evolving | changing, growing (or describe how) |
+| enduring | lasting, long-running (or cite how long) |
+| daunting | hard, difficult, challenging |
+| holistic / holistically | complete, full, whole (or describe what's included) |
+| actionable | practical, useful, concrete |
+| impactful | effective, significant (or describe the impact) |
+| learnings | lessons, findings, takeaways |
+| thought leader / thought leadership | expert, authority (or describe their actual contribution) |
+| best practices | what works, proven methods, standard approach |
+| at its core | (cut — just state the thing) |
+| synergy / synergies | (describe the actual combined effect) |
+| interplay | relationship, connection, interaction |
+| in order to | to |
+| due to the fact that | because |
+| serves as | is |
+| features (verb) | has, includes |
+| boasts | has |
+| presents (inflated) | is, shows, gives |
+| commence | start, begin |
+| ascertain | find out, determine, learn |
+| endeavor | effort, attempt, try |
+| keen (as intensifier) | interested, eager, enthusiastic (or cut — just state the interest) |
+| symphony (metaphor) | (describe the actual coordination or combination) |
+| embrace (metaphor) | adopt, accept, use, switch to |
+
+#### Tier 2 — Flag when 2+ appear in the same paragraph
+
+These words are legitimate on their own. When two or more show up together, the paragraph likely needs a rewrite.
+
+| Replace | With |
+|---|---|
+| harness | use, take advantage of |
+| navigate / navigating | work through, handle, deal with |
+| foster | encourage, support, build |
+| elevate | improve, raise, strengthen |
+| unleash | release, enable, unlock |
+| streamline | simplify, speed up |
+| empower | enable, let, allow |
+| bolster | support, strengthen, back up |
+| spearhead | lead, drive, run |
+| resonate / resonates with | connect with, appeal to, matter to |
+| revolutionize | change, transform, reshape (or describe what changed) |
+| facilitate / facilitates | enable, help, allow, run |
+| underpin | support, form the basis of |
+| nuanced | specific, subtle, detailed (or name the actual nuance) |
+| crucial | important, key, necessary |
+| multifaceted | (describe the actual facets, or cut) |
+| ecosystem (metaphor) | system, community, network, market |
+| myriad | many, numerous (or give a number) |
+| plethora | many, a lot of (or give a number) |
+| encompass | include, cover, span |
+| catalyze | start, trigger, accelerate |
+| reimagine | rethink, redesign, rebuild |
+| galvanize | motivate, rally, push |
+| augment | add to, expand, supplement |
+| cultivate | build, develop, grow |
+| illuminate | clarify, explain, show |
+| elucidate | explain, clarify, spell out |
+| juxtapose | compare, contrast, set side by side |
+| paradigm-shifting | (describe what actually shifted) |
+| transformative / transformation | (describe what changed and how) |
+| cornerstone | foundation, basis, key part |
+| paramount | most important, top priority |
+| poised (to) | ready, set, about to |
+| burgeoning | growing, emerging (or cite a number) |
+| nascent | new, early-stage, emerging |
+| quintessential | typical, classic, defining |
+| overarching | main, central, broad |
+| underpinning / underpinnings | basis, foundation, what supports |
+
+#### Tier 3 — Flag only at high density
+
+These are normal words. Only flag them when the text is saturated with them — a sign that AI filled space with vague praise instead of specifics.
+
+| Word | What to do |
+|---|---|
+| significant / significantly | Replace some with specifics: numbers, comparisons, examples |
+| innovative / innovation | Describe what's actually new |
+| effective / effectively | Say how or cite a metric |
+| dynamic / dynamics | Name the actual forces or changes |
+| scalable / scalability | Describe what scales and to what |
+| compelling | Say why it compels |
+| unprecedented | Name the precedent it breaks (or cut) |
+| exceptional / exceptionally | Cite what makes it an exception |
+| remarkable / remarkably | Say what's worth remarking on |
+| sophisticated | Describe the sophistication |
+| instrumental | Say what role it played |
+| world-class / state-of-the-art / best-in-class | Cite a benchmark or comparison |
 
 ### Template phrases (avoid)
-- "a [adjective] step towards [adjective] AI infrastructure" → describe the specific capability or outcome
-- "a [adjective] step forward for [noun]" → say what actually changed
+
+These slot-fill constructions signal that a sentence was generated, not written. If a phrase has a blank where a noun or adjective could go and still sound the same, it's too generic.
+
+- "a [adjective] step towards [adjective] AI infrastructure" → describe the specific capability, benchmark, or outcome
+- "a [adjective] step forward for [noun]" → same rule: say what actually changed
+- "Whether you're [X] or [Y]" → false-breadth construction. Pick the audience you're actually addressing, or cut. "Whether you're a startup founder or an enterprise architect" means nothing — it's just "everyone."
+- "I recently had the pleasure of [verb]-ing" → review/social AI pattern. Just say what happened: "I talked to," "I read," "I attended."
 
 ### Transition phrases to remove or rewrite
-- "Moreover" / "Furthermore" / "Additionally" → restructure or use "and," "also"
+- "Moreover" / "Furthermore" / "Additionally" → restructure so the connection is obvious, or use "and," "also," "on top of that"
 - "In today's [X]" / "In an era where" → cut or state specific context
 - "It's worth noting that" / "Notably" → just state the fact
-- "In conclusion" / "To summarize" → your conclusion should be obvious
-- "When it comes to" → talk about the thing directly
+- "In conclusion" / "In summary" / "To summarize" → your conclusion should be obvious
+- "When it comes to" → just talk about the thing directly
 - "At the end of the day" → cut
-- "That said" / "That being said" → cut or use "but," "yet," or "however"
+- "That said" / "That being said" → cut or use "but," "yet," or "however." Don't overuse any one of them.
 
 ### Structural issues
-- **Uniform paragraph length**: Vary deliberately. Include some short and some longer paragraphs.
-- **Formulaic openings**: If it opens with broad context before the point, lead with the news or insight instead.
-- **Suspiciously clean grammar**: Keep deliberate fragments, sentences starting with "And" or "But," comma splices for effect.
+- **Uniform paragraph length**: Vary deliberately. Include some 1-2 sentence paragraphs and some longer ones. If every paragraph is roughly the same size, fix it.
+- **Formulaic openings**: If the piece opens with broad context before getting to the point ("In the rapidly evolving world of..."), rewrite to lead with the news or the insight. Context can come second.
+- **Suspiciously clean grammar**: Don't sand away all personality. Deliberate fragments, sentences starting with "And" or "But," comma splices for effect: if the natural voice uses them, keep them.
 
 ### Significance inflation
-- "marking a pivotal moment in the evolution of..." or "a watershed moment for the industry" — state what happened and let the reader judge significance.
+- Phrases like "marking a pivotal moment in the evolution of..." or "a watershed moment for the industry" inflate routine events into history-making ones. State what happened and let the reader judge significance.
+- If the sentence still works after you delete the inflation clause, delete it.
 
 ### Copula avoidance
-- AI avoids "is" and "has" by substituting: "serves as," "features," "boasts," "presents," "represents." Default to "is" or "has."
+- AI text avoids "is" and "has" by substituting fancier verbs: "serves as," "features," "boasts," "presents," "represents." These sound like a press release.
+- Default to "is" or "has" unless a more specific verb genuinely adds meaning.
 
 ### Synonym cycling
-- AI rotates synonyms: "developers… engineers… practitioners… builders" in one paragraph. Repeat the clearest word instead.
+- AI rotates synonyms to avoid repeating a word: "developers… engineers… practitioners… builders" in the same paragraph. Human writers repeat the clearest word.
+- If the same noun or verb appears three times in a paragraph and that's the right word, keep all three. Forced variation reads as thesaurus abuse.
 
 ### Vague attributions
-- "Experts believe," "Studies show," "Research suggests" — without naming anyone. Cite a specific source or drop the attribution.
+- "Experts believe," "Studies show," "Research suggests," "Industry leaders agree" — without naming the expert, study, or leader. Either cite a specific source or drop the attribution and state the claim directly.
 
 ### Filler phrases
-- "In order to" → "To"
-- "Due to the fact that" → "Because"
-- "It is important to note that" → (just state it)
-- "At the end of the day" → (cut)
-- "In terms of" → (rewrite)
-- "The reality is that" → (cut or just state the claim)
+- Strip mechanical padding that adds words without meaning:
+  - "It is important to note that" → (just state it)
+  - "In terms of" → (rewrite)
+  - "The reality is that" → (cut or just state the claim)
+- Note: "In order to," "Due to the fact that," and "At the end of the day" are covered in the word/phrase table and transition sections above — don't duplicate rules.
 
 ### Generic conclusions
-- "The future looks bright," "Only time will tell," "One thing is certain," "As we move forward" — cut. Make the closing specific to the argument.
+- "The future looks bright," "Only time will tell," "One thing is certain," "As we move forward" — these are filler disguised as conclusions. Cut them. If the piece needs a closing thought, make it specific to the argument.
 
 ### Chatbot artifacts
-- "I hope this helps!", "Certainly!", "Absolutely!", "Great question!", "Feel free to reach out" — remove entirely.
-- "In this article, we will explore…" or "Let's dive in!" — cut or rewrite with a direct opening.
+- "I hope this helps!", "Certainly!", "Absolutely!", "Great question!", "Feel free to reach out," "Let me know if you need anything else" — these are conversational tics from chat interfaces, not writing. Remove entirely.
+- Also watch for: "In this article, we will explore…" or "Let's dive in!" — these are AI-generated meta-narration. Cut or rewrite with a direct opening.
+
+### "Let's" constructions
+- "Let's explore," "Let's take a look," "Let's break this down," "Let's examine" — AI uses "let's" as a false-collaborative opener to ease into a topic. It's filler that delays the actual point. Just start with the point. "Let's dive in" is covered above under chatbot artifacts, but the pattern is broader than that — flag any "let's + verb" that's functioning as a transition rather than a genuine invitation to act.
 
 ### Notability name-dropping
-- Piling on prestigious citations: "cited in NYT, BBC, Financial Times, and The Hindu." Use one specific reference with context instead.
+- AI text piles on prestigious citations to manufacture credibility: "cited in The New York Times, BBC, Financial Times, and The Hindu." If a source matters, use it with context: "In a 2024 NYT interview, she argued..." One specific reference beats four name-drops.
 
 ### Superficial -ing analyses
-- "symbolizing the region's commitment to progress, reflecting decades of investment, and showcasing a new era of collaboration." Replace with specific facts or cut.
+- Strings of present participles used as pseudo-analysis: "symbolizing the region's commitment to progress, reflecting decades of investment, and showcasing a new era of collaboration." These say nothing. Replace with specific facts or cut entirely.
 
 ### Promotional language
-- "nestled within the breathtaking foothills," "a vibrant hub of innovation." Replace with plain description.
+- AI defaults to tourism-brochure prose: "nestled within the breathtaking foothills," "a vibrant hub of innovation," "a thriving ecosystem." Replace with plain description: "is a town in the Gonder region," "has 12 startups." If you wouldn't say it in conversation, cut it.
 
 ### Formulaic challenges
-- "Despite challenges, [subject] continues to thrive." Name the actual challenge and response, or cut.
+- "Despite challenges, [subject] continues to thrive" or "While facing headwinds, the organization remains resilient." This is a non-statement. Name the actual challenge and the actual response, or cut the sentence.
 
 ### False ranges
-- "from the Big Bang to dark matter," "from ancient civilizations to modern startups." List the actual topics or pick the relevant one.
+- AI creates false breadth by pairing unrelated extremes: "from the Big Bang to dark matter," "from ancient civilizations to modern startups." These sound sweeping but say nothing. List the actual topics or pick the one that matters.
 
 ### Inline-header lists
-- "**Performance:** Performance improved by..." Strip the bold header and write the point directly.
+- Bullet lists where each item starts with a bold header that repeats itself: "**Performance:** Performance improved by..." Strip the bold header and write the point directly. If the list items need headers, they should probably be paragraphs.
 
 ### Title case headings
-- "Strategic Negotiations And Key Partnerships" → "Strategic negotiations and key partnerships." Use sentence case for subheadings.
+- AI over-capitalizes headings: "Strategic Negotiations And Key Partnerships" instead of "Strategic negotiations and key partnerships." Use sentence case for subheadings. Title case only for the piece's main title, if at all.
 
 ### Cutoff disclaimers
-- "While specific details are limited based on available information," "As of my last update." Find the information or remove the hedge.
+- "While specific details are limited based on available information," "As of my last update," "I don't have access to real-time data." These are model limitations leaking into prose. Either find the information or remove the hedge. Never publish a sentence that admits the writer didn't look something up.
+
+### Novelty inflation
+- AI text treats established concepts as if the speaker invented or discovered them: "He introduced a term," "She coined the phrase," "a concept nobody's naming," "a failure mode nobody talks about." In reality, most ideas in a conversation are applications of existing concepts, not inventions.
+- Two problems. First, it's factually risky: if the concept already has a Wikipedia page or conference talks from last year, claiming novelty makes the writer look uninformed. Second, it flatters the subject in a way that reads as promotional rather than analytical.
+- The fix: describe what the person *did with* the concept, not that they discovered it. "Michel walked through how context poisoning works in practice" instead of "Michel introduced a term I hadn't heard before: context poisoning." If you're unsure whether something is novel, assume it isn't and frame accordingly.
+- Related patterns to flag: "the failure mode nobody's naming," "a problem nobody talks about," "the insight everyone's missing," "what nobody tells you about." These are engagement-bait framings that claim scarcity of knowledge where none exists.
+
+### Emotional flatline
+- AI claims emotions as a structural crutch without conveying them through the writing: "What surprised me most," "I was fascinated to discover," "What struck me was," "I was excited to learn," "The most interesting part."
+- Two problems. First, it's tell-don't-show: if the thing is genuinely surprising, the reader should feel that from the content, not from the writer announcing it. Second, these phrases are massively overused as list introductions and transitions. They're filler wearing an emotion costume.
+- This pattern isn't always AI. It's also a sign of lazy human writing on autopilot. Flag it either way.
+- The fix isn't "never say surprised." It's: if you claim an emotion, the writing around it should earn it. Otherwise cut the claim and present the thing directly.
+
+### False concession structure
+- "While X is impressive, Y remains a challenge" or "Although X has made strides, Y is still an open question." AI uses this to sound balanced without actually weighing anything. Both halves are vague. Either make the concession specific (name what's impressive, name the actual challenge) or pick a side and argue it.
+
+### Rhetorical question openers
+- "But what does this mean for developers?" / "So why should you care?" / "What's next?" � AI uses rhetorical questions to stall before the actual point. If you know the answer, just say it. Rhetorical questions are earned by strong setup, not dropped as section transitions.
+
+### Parenthetical hedging
+- "(and, increasingly, Z)" / "(or, more precisely, Y)" / "(and perhaps more importantly, W)" � AI inserts parenthetical asides to sound nuanced without committing. If the aside matters, give it its own sentence. If it doesn't, cut it.
+
+### Numbered list inflation
+- "Three key takeaways" / "Five things to know" / "Here are the top seven" � AI defaults to numbered lists because they're structurally safe. Only use numbered lists when the content genuinely has that many discrete, parallel items. If you're padding to hit a number, the list shouldn't exist.
+
+### Reasoning chain artifacts
+- "Let me think step by step," "Breaking this down," "To approach this systematically," "Step 1:," "Here's my thought process," "First, let's consider," "Working through this logically" — these are artifacts of chain-of-thought reasoning leaking into published prose. The reader doesn't need to see the scaffolding. State the conclusion, then the evidence.
+- Also watch for numbered reasoning steps that read like an internal monologue rather than an argument meant for an audience.
+
+### Sycophantic tone
+- "Great question!", "Excellent point!", "You're absolutely right!", "That's a really insightful observation" — these are conversational rewards from chat interfaces, not writing. Remove entirely.
+- Distinct from chatbot artifacts: sycophancy specifically validates the reader/questioner rather than just performing helpfulness.
+
+### Acknowledgment loops
+- "You're asking about," "The question of whether," "To answer your question," "That's a great question. The..." — AI restates the prompt before answering. In writing, this is pure filler. The reader knows what they asked. Just answer.
+- Related pattern: opening a section by summarizing what the previous section said. If the structure is clear, the reader doesn't need a recap.
+
+### Confidence calibration phrases
+- "It's worth noting that," "Interestingly," "Surprisingly," "Importantly," "Significantly," "Notably," "Certainly," "Undoubtedly," "Without a doubt" — AI uses these to signal how the reader should feel about a fact instead of letting the fact speak for itself.
+- One "notably" in a 2,000-word piece is fine. Three in 500 words is AI-style emphasis stacking. Flag by density.
+
+### Excessive structure
+- Too many headers in short text: more than 3 headings in under 300 words is almost always AI trying to look organized. Merge sections or use prose transitions instead.
+- Too many list items: 8+ bullet points in under 200 words means the content should be a paragraph, not a list.
+- Formulaic section headers: "Overview," "Key Points," "Summary," "Conclusion," "Introduction" — these are default AI scaffolding. Use headers that tell the reader something specific about what follows.
+
+### Rhythm and uniformity
+
+These aren't individual word or phrase problems — they're patterns in how the text flows as a whole. AI text is metronomic; human text has varied rhythm.
+
+**Structure is the #1 detection signal.** AI detection tools (including Pangram, which trains a classifier on 28M human documents) weight structural regularity higher than vocabulary. Consistent sentence construction, uniform pacing, and symmetrical phrasing patterns are harder to mask than swapping out a few flagged words. If you fix every word on the Tier 1 list but leave the rhythm untouched, the text still reads as AI-generated.
+
+- **Sentence length uniformity**: If most sentences are 15–25 words, the text sounds robotic. Mix short punchy sentences (3–8 words) with longer flowing ones (20+). Fragments work. Questions break the monotony.
+- **Paragraph length uniformity**: If every paragraph is 3–5 sentences and roughly the same size, vary deliberately. Some paragraphs should be one sentence. Some should be longer.
+- **Vocabulary repetition vs. synonym cycling**: AI either repeats the same word mechanically or cycles through synonyms conspicuously. Human writers repeat when the word is right and vary when it's natural — there's no formula.
+- **Read-aloud test**: If the text sounds like it could be read by a text-to-speech engine without sounding weird, it's probably too uniform. Human writing has rhythm that resists robotic delivery.
+- **Missing first-person perspective**: Where appropriate, the writer should have opinions, preferences, and reactions. AI is relentlessly neutral. If the piece is supposed to have a voice, the absence of "I think," "in my experience," or a stated preference is itself an AI tell.
+- **Over-polishing**: Aggressively editing out every irregularity can push human writing *toward* AI statistical profiles. Natural disfluency, idiosyncratic word choices, and uneven pacing are what keep text out of the "AI-generated" classification. Don't sand away all personality in pursuit of clean prose. This skill should make writing sound more human, not less — if you apply every rule at maximum strictness, you risk creating the very uniformity you're trying to avoid.
+
+### When to rewrite from scratch vs. patch
+
+If the text has 5+ flagged vocabulary hits across multiple categories, 3+ distinct pattern categories triggered, and uniform sentence/paragraph length, patching individual phrases won't fix it — the structure itself is AI-generated. Advise a full rewrite: state the core point in one sentence, then rebuild from there.
 
 ---
+
+## Severity tiers
+
+Not all AI-isms are equal. When doing a quick pass or triaging a large document, prioritize by tier:
+
+### P0 � Credibility killers (fix immediately)
+- Cutoff disclaimers ("As of my last update")
+- Chatbot artifacts ("I hope this helps!", "Great question!")
+- Vague attributions without sources ("Experts believe")
+- Significance inflation on routine events
+
+### P1 � Obvious AI smell (fix before publishing)
+- Word-list violations (delve, leverage, harness, robust, etc.)
+- Template phrases and slot-fill constructions
+- "Let's" transition openers
+- Synonym cycling within a paragraph
+- Formulaic openings ("In the rapidly evolving world of...")
+- Bold overuse
+- Em dash frequency (above 1 per 1,000 words)
+
+### P2 � Stylistic polish (fix when time allows)
+- Generic conclusions ("The future looks bright")
+- Compulsive rule of three
+- Uniform paragraph length
+- Copula avoidance (serves as, features, boasts)
+- Transition phrases (Moreover, Furthermore, Additionally)
+
+Use P0+P1 for quick passes. Full audit covers all three tiers.
+
+---
+
+## Self-reference escape hatch
+
+When writing *about* AI writing patterns (blog posts, tutorials, skill documentation like this file), quoted examples are exempt from flagging. Text inside quotation marks, code blocks, or explicitly marked as illustrative ("for example, AI might write...") should not be rewritten. Only flag patterns that appear in the author's own prose, not in cited examples of bad writing.
+
+---
+
+## Context profiles
+
+Pass an optional context hint to adjust rule strictness. If no context is specified, auto-detect from content cues (short + hashtags = social, code blocks = technical, salutation = email, default = blog).
+
+### Profile definitions
+
+**`linkedin`** � Short-form social. Punchy fragments, visual formatting matter.
+**`blog`** � Default. Standard long-form prose. All rules apply at full strength.
+**`technical-blog`** � Long-form with code, architecture, APIs. Technical terms get a pass.
+**`investor-email`** � High-trust audience. Tighten everything; promotional language is the biggest risk.
+**`docs`** � Documentation, READMEs, guides. Clarity over voice.
+**`casual`** � Slack messages, internal notes, quick replies. Only catch the worst offenders.
+
+### Tolerance matrix
+
+Rules not listed in the table apply at full strength across all profiles.
+
+| Rule | linkedin | blog | technical-blog | investor-email | docs | casual |
+|------|----------|------|----------------|----------------|------|--------|
+| Em dashes | relaxed (2/post OK) | strict | strict | strict | relaxed | skip |
+| Bold overuse | relaxed (bold hooks OK) | strict | strict | strict | relaxed | skip |
+| Emoji in headers | relaxed (1-2 end-of-line OK) | strict | strict | strict | skip | skip |
+| Excessive bullets | skip (lists work on LinkedIn) | strict | relaxed (technical lists OK) | strict | skip (lists are docs) | skip |
+| Hedging | strict | strict | relaxed ("may" is accurate in technical) | strict | relaxed | skip |
+| Word table (full list) | strict | strict | **partial** (see below) | strict | relaxed | P0 only |
+| Promotional language | relaxed (some sell is expected) | strict | strict | **extra strict** | strict | skip |
+| Significance inflation | strict | strict | strict | **extra strict** | relaxed | skip |
+| Copula avoidance | skip | strict | relaxed | strict | skip | skip |
+| Uniform paragraph length | skip (short-form) | strict | strict | strict | relaxed | skip |
+| Numbered list inflation | relaxed | strict | relaxed | strict | skip | skip |
+| Rhetorical questions | relaxed (1 as hook OK) | strict | strict | strict | strict | skip |
+| Transition phrases | skip (short-form) | strict | strict | strict | relaxed | skip |
+| Generic conclusions | skip | strict | strict | **extra strict** | skip | skip |
+
+**Technical-blog word table exceptions:** These terms have legitimate technical meaning and should not be flagged in technical context: `robust`, `comprehensive`, `seamless`, `ecosystem`, `leverage` (when discussing actual platform leverage/APIs), `facilitate`, `underpin`, `streamline`. Still flag: `delve`, `tapestry`, `beacon`, `embark`, `testament to`, `game-changer`, `harness`.
+
+**"Extra strict"** means: flag even borderline instances. In investor emails, a single "thriving ecosystem" can undermine the whole message.
+
+**"Skip"** means: don't audit this category for this profile. The rule doesn't apply or isn't worth the edit.
+
+### Auto-detection cues
+
+When no context is specified, infer from these signals:
+
+| Signal | Inferred context |
+|--------|-----------------|
+| Under 300 words + hashtags or mentions | `linkedin` |
+| Code blocks, API references, or technical architecture | `technical-blog` |
+| Salutation ("Hi [name]", "Dear") + investor/fundraising language | `investor-email` |
+| Step-by-step instructions, parameter docs, README structure | `docs` |
+| No strong signals | `blog` (safest default � all rules apply) |
+
+If auto-detection feels wrong, say which profile you're using and why. The user can override.
+
+---
+
 
 ## Output format
 
@@ -160,10 +419,10 @@ A bulleted list of every AI-ism identified, with the offending text quoted.
 The full rewritten content. Preserve the original structure, intent, and all specific technical details. Only change what the guidelines require.
 
 **3. What changed**
-A brief summary of the major edits made.
+A brief summary of the major edits made. Not every word, just the meaningful changes.
 
 **4. Second-pass audit**
-Re-read the rewritten version from section 2. Identify any remaining AI tells that survived the first pass. Fix them, return the corrected text inline, and note what changed. If the rewrite is clean, say so.
+Re-read the rewritten version from section 2. Identify any remaining AI tells that survived the first pass — recycled transitions, lingering inflation, copula avoidance, filler phrases, or anything else from the categories above. Fix them, return the corrected text inline, and note what changed in this pass. If the rewrite is clean, say so.
 
 ---
 
@@ -171,4 +430,13 @@ Re-read the rewritten version from section 2. Identify any remaining AI tells th
 
 The goal is writing that sounds like a person wrote it. Direct. Specific. The writing should demonstrate confidence, not assert it.
 
+Five principles for human-sounding rewrites:
+1. **Vary sentence length** — mix short with long. Fragments are fine.
+2. **Be concrete** — replace vague claims with numbers, names, dates, or examples.
+3. **Have a voice** — where appropriate, use first person, state preferences, show reactions.
+4. **Cut the neutrality** — humans have opinions. If the piece is supposed to take a position, take it.
+5. **Earn your emphasis** — don't tell the reader something is interesting. Make it interesting.
+
 If the original writing is already strong, say so and make only the necessary cuts. Don't over-edit for the sake of it.
+
+The replacement table provides defaults, not mandates. If a flagged word is clearly the right choice in context, preserve it.

--- a/skills/avoid-ai-writing/SKILL.md
+++ b/skills/avoid-ai-writing/SKILL.md
@@ -9,7 +9,7 @@ metadata:
   tags: writing editing voice quality
   agentskills_spec: "1.0"
   openclaw:
-    emoji: "\u270D\uFE0F"
+    emoji: "✍️"
 ---
 
 # Avoid AI Writing — Audit & Rewrite


### PR DESCRIPTION
## What does this change?

Updates `avoid-ai-writing` to v3.1.0 — a skill that audits and rewrites content to remove AI writing patterns ("AI-isms").

### What's in v3.1.0

- **34 pattern categories** covering formatting, structure, vocabulary, rhythm, and meta-artifacts
- **Tiered vocabulary system** (103 entries): Tier 1 (always flag), Tier 2 (flag in clusters), Tier 3 (flag by density) — adapted from brandonwise/humanizer research and Pangram AI detection insights
- **Severity tiers** (P0/P1/P2): P0 credibility killers, P1 obvious AI smell, P2 stylistic polish
- **6 context profiles** with tolerance matrix: linkedin, blog, technical-blog, investor-email, docs, casual — with auto-detection
- **Rhythm detection**: sentence/paragraph length uniformity, synonym cycling, over-polishing warnings
- **Rewrite threshold**: guidance for when to patch vs. rewrite from scratch
- Self-reference escape hatch for writing about AI patterns
- Compatible with agentskills.io spec and OpenClaw

## Type

- [x] New skill

## Checklist for new skills

- [x] One skill per PR
- [x] Tested with Claude Code (daily production use since Feb 2026)
- [x] Valid YAML frontmatter (name + description)
- [x] Self-contained folder

Source: https://github.com/conorbronsdon/avoid-ai-writing (42 stars, 1,200+ unique visitors/14 days)