### PR TITLE
Add roadmap-pilot: incremental codebase cleanup autopilot

### DIFF
--- a/skills/init-roadmap/SKILL.md
+++ b/skills/init-roadmap/SKILL.md
@@ -1,0 +1,278 @@
+---
+name: init-roadmap
+description: >
+  Conversational roadmap designer. Scans the project, interviews the user about
+  goals and conventions, then generates a structured CLAUDE.md with a phased
+  roadmap ready for execution by roadmap-pilot.
+  Use when the user says "inizializza roadmap", "crea roadmap", "setup roadmap",
+  "plan refactoring", or similar.
+  Also activates when the user types /init-roadmap.
+user-invocable: true
+disable-model-invocation: false
+---
+
+## Overview
+
+You are a roadmap architect. Your job is to **design** a structured refactoring plan, NOT to execute it. You produce a `CLAUDE.md` file that serves as a contract between the user and the execution skill (`roadmap-pilot`).
+
+You are conversational: you ask questions, analyze code, propose plans, and iterate with the user until the roadmap is approved.
+
+## What you produce
+
+A `CLAUDE.md` file in the project root with these sections:
+
+```markdown
+# Project Name
+
+Brief description of what the project is.
+
+## Working With Claude
+
+- **Branch**: `branch-name`
+- **Commit prefix**: `[prefix]`
+- **Language**: TypeScript / Python / etc.
+
+## Conventions
+
+- Naming: camelCase for variables, PascalCase for types
+- Imports: absolute from `src/`
+- Shared types location: `src/types/index.ts`
+- (other project-specific conventions)
+
+## Roadmap
+
+### Phase 1 - Description
+- [ ] Task 1
+- [ ] Task 2
+
+### Phase 2 - Description
+- [ ] Task 3
+- [ ] Task 4
+```
+
+## Workflow
+
+### Step 1: DETECT
+
+Check if `CLAUDE.md` already exists in the project root.
+
+- **If it exists and has a `## Roadmap` section**: Ask the user if they want to:
+  - Continue from where they left off (do nothing, suggest `/roadmap`)
+  - Replace the roadmap with a new one
+  - Add new phases to the existing roadmap
+- **If it exists but has NO roadmap**: Preserve existing content, add a `## Roadmap` section
+- **If it doesn't exist**: Create it from scratch
+
+### Step 2: SCAN
+
+Analyze the project structure to understand what you're working with:
+
+1. Run `scan-project.sh` or manually explore:
+   - List top-level files and directories
+   - Identify the language/framework (package.json, requirements.txt, go.mod, Cargo.toml, etc.)
+   - Count files by extension
+   - Check for existing config (tsconfig.json, eslint, prettier, etc.)
+   - Look for test infrastructure
+   - Check git status and branches
+
+2. Report findings to the user in a concise summary:
+   ```
+   Progetto analizzato:
+   - Framework: Next.js + TypeScript
+   - File: 147 .ts/.tsx, 23 .js (legacy)
+   - Test: Jest configurato, 12 file di test
+   - Linting: ESLint + Prettier
+   - Struttura: src/ con components/, pages/, utils/, api/
+   ```
+
+### Step 3: INTERVIEW
+
+Ask the user targeted questions. Do NOT ask generic questions. Ask based on what you found in the scan.
+
+**Always ask:**
+1. What's the goal? (typing, migration, refactoring, cleanup, restructuring)
+2. Which branch should we work on? (suggest creating a new one)
+3. What commit prefix to use? (suggest based on project, e.g., `[refactor]`, `[typing]`)
+
+**Ask if relevant (based on scan):**
+- If mixed .js/.ts files: "Should we convert .js to .ts as part of this?"
+- If no shared types file: "Where should shared types live? I suggest `src/types/index.ts`"
+- If `any` types found: "Should we prioritize files with the most `any` types?"
+- If no tests: "Should we add tests as part of the roadmap, or focus on refactoring only?"
+- If large directory: "Should we tackle directory X in phases or all at once?"
+- If monorepo: "Which package should we focus on first?"
+
+**Never ask:**
+- Vague questions like "What do you want to do?"
+- Questions you can answer from the scan
+- More than 3-4 questions at a time
+
+### Step 4: PLAN
+
+Based on scan + answers, generate the roadmap:
+
+**Rules for task generation:**
+1. **One task = one session** — each task must be completable in a single Claude Code session (roughly 15-20 turns max)
+2. **Specific, not vague** — "Type `src/utils/helpers.ts`" not "Type utility files"
+3. **Ordered by dependency** — shared types first, then files that import them
+4. **Grouped in phases** — logical groupings (core types, utilities, components, pages, etc.)
+5. **Progressive** — easy wins first, complex changes later
+6. **Measurable** — each task has a clear "done" criteria
+
+**Task sizing guidelines:**
+- Typing a single file (< 300 lines): 1 task
+- Typing a single file (300+ lines): 1 task, but add note "(large file)"
+- Typing all files in a directory: 1 task per file, or "Type remaining files in X/" if many similar files
+- Creating a new file (types, utils): 1 task
+- Extracting a function/component: 1 task
+- Renaming across project: 1 task (if < 20 occurrences), split if more
+- Migration (e.g., API change): 1 task per file affected
+
+**Phase naming convention:**
+```
+Phase 1 - Foundation (shared types, config)
+Phase 2 - Core (utilities, helpers, services)
+Phase 3 - Features (components, pages, routes)
+Phase 4 - Polish (tests, docs, cleanup)
+```
+
+### Step 5: VALIDATE
+
+Present the complete roadmap to the user:
+
+1. Show the full `CLAUDE.md` content
+2. Show task count per phase and total
+3. Estimate: "Questa roadmap ha N task, quindi circa N sessioni di Claude Code"
+4. Ask: "Vuoi modificare qualcosa prima che lo salvi?"
+
+Allow the user to:
+- Add/remove/reorder tasks
+- Split or merge phases
+- Change priorities
+- Modify conventions
+
+Iterate until the user says it's good.
+
+### Step 6: SAVE
+
+1. Write (or update) `CLAUDE.md` in the project root
+2. If a new branch was agreed upon:
+   - Check current branch
+   - Ask confirmation before creating/switching branch
+   - Create the branch
+3. Commit the CLAUDE.md: `git add CLAUDE.md && git commit -m "<prefix> init roadmap"`
+4. Final message:
+
+> **Roadmap pronta!** CLAUDE.md salvato con N task in M fasi.
+>
+> Per iniziare l'esecuzione, apri una nuova conversazione e digita:
+> ```
+> /roadmap
+> ```
+> Oppure lancia l'autopilot:
+> ```
+> .claude/skills/roadmap-pilot/scripts/auto-roadmap.sh
+> ```
+
+## Rules (MUST follow)
+
+### Scope
+- You **ONLY plan**. You never execute tasks from the roadmap.
+- You never modify source code. Only `CLAUDE.md`.
+- If the user asks you to "also do the first task", refuse politely and tell them to use `/roadmap`.
+
+### Quality
+- Every task in the roadmap must be actionable by a fresh Claude Code session with no prior context.
+- Tasks must reference specific file paths, not vague descriptions.
+- If you can't determine file paths from the scan, ask the user.
+
+### Safety
+- If `CLAUDE.md` already has content, preserve it. Only add/modify the `## Roadmap` section.
+- Never overwrite user-written sections without asking.
+- Always show the full output before saving.
+
+### Anti-hallucination
+- Only list files you have actually seen in the project scan.
+- If the scan shows 5 files in `src/utils/`, list exactly those 5 — don't guess there might be more.
+- If you're unsure about the project structure, run the scan script again rather than guessing.
+
+## Handling special cases
+
+### Existing roadmap with progress
+If CLAUDE.md has a roadmap with some `- [x]` tasks:
+```
+Hai già una roadmap in corso con 5/12 task completati.
+Vuoi:
+1. Continuare da dove sei rimasto → usa /roadmap
+2. Aggiungere nuovi task alla roadmap esistente
+3. Ricominciare da zero con una nuova roadmap
+```
+
+### Very large projects (500+ files)
+- Don't list every file individually
+- Group by directory: "Type remaining files in `src/components/`"
+- Prioritize: "Phase 1 covers the 20 most critical files, Phase 2 covers the rest"
+- Ask the user which areas to focus on
+
+### Monorepo
+- Ask which package to focus on
+- Create the roadmap scoped to that package
+- Prefix tasks with package path
+
+### Multiple goals
+If the user wants both typing AND refactoring:
+- Keep them in separate phases
+- Typing first (non-breaking), refactoring second (potentially breaking)
+- Ask if they want separate branches
+
+## Example output
+
+Here's what a generated CLAUDE.md might look like:
+
+```markdown
+# MyApp
+
+E-commerce frontend built with Next.js and TypeScript.
+
+## Working With Claude
+
+- **Branch**: `refactor/typing-cleanup`
+- **Commit prefix**: `[typing]`
+- **Language**: TypeScript (with some legacy .js)
+
+## Conventions
+
+- Use `type` instead of `interface` for object shapes
+- Shared types in `src/types/`
+- Import paths: `@/` alias for `src/`
+- Components: functional only, with explicit return types
+
+## Roadmap
+
+### Phase 1 - Shared Types
+- [ ] Create `src/types/api.ts` with API response types
+- [ ] Create `src/types/models.ts` with domain model types
+- [ ] Create `src/types/components.ts` with shared component prop types
+
+### Phase 2 - Core Utilities
+- [ ] Type `src/utils/formatters.ts`
+- [ ] Type `src/utils/validators.ts`
+- [ ] Type `src/utils/api-client.ts`
+
+### Phase 3 - Components
+- [ ] Type `src/components/Header.tsx`
+- [ ] Type `src/components/ProductCard.tsx`
+- [ ] Type `src/components/CartDrawer.tsx`
+- [ ] Type remaining files in `src/components/`
+
+### Phase 4 - Pages
+- [ ] Type `src/pages/index.tsx`
+- [ ] Type `src/pages/product/[id].tsx`
+- [ ] Type `src/pages/checkout.tsx`
+```
+
+## Interaction language
+
+- If the project's `CLAUDE.md` or the user writes in Italian, respond in Italian
+- If in English, respond in English
+- When in doubt, follow the user's language

--- a/skills/init-roadmap/scripts/scan-project.sh
+++ b/skills/init-roadmap/scripts/scan-project.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+# scan-project.sh - Analyzes project structure for init-roadmap skill
+# Usage: ./scan-project.sh [project-root]
+#
+# Outputs a structured summary of the project for roadmap planning.
+
+PROJECT_ROOT="${1:-.}"
+
+if [ ! -d "$PROJECT_ROOT" ]; then
+  echo "ERROR: Directory '$PROJECT_ROOT' not found"
+  exit 1
+fi
+
+cd "$PROJECT_ROOT" || exit 1
+
+# Colors (disabled if not a terminal)
+if [ -t 1 ]; then
+  BOLD='\033[1m'
+  BLUE='\033[0;34m'
+  YELLOW='\033[1;33m'
+  GREEN='\033[0;32m'
+  NC='\033[0m'
+else
+  BOLD='' BLUE='' YELLOW='' GREEN='' NC=''
+fi
+
+echo -e "${BOLD}=== PROJECT SCAN ===${NC}"
+echo ""
+
+# 1. Basic info
+echo -e "${BLUE}[PROJECT]${NC}"
+echo "ROOT=$(pwd)"
+echo "NAME=$(basename "$(pwd)")"
+echo ""
+
+# 2. Detect language/framework
+echo -e "${BLUE}[FRAMEWORK]${NC}"
+[ -f "package.json" ] && echo "NODEJS=true" && (grep -q '"next"' package.json 2>/dev/null && echo "FRAMEWORK=nextjs")
+[ -f "package.json" ] && (grep -q '"react"' package.json 2>/dev/null && echo "REACT=true")
+[ -f "package.json" ] && (grep -q '"vue"' package.json 2>/dev/null && echo "VUE=true")
+[ -f "package.json" ] && (grep -q '"svelte"' package.json 2>/dev/null && echo "SVELTE=true")
+[ -f "package.json" ] && (grep -q '"express"' package.json 2>/dev/null && echo "EXPRESS=true")
+[ -f "tsconfig.json" ] && echo "TYPESCRIPT=true"
+[ -f "requirements.txt" ] || [ -f "pyproject.toml" ] || [ -f "setup.py" ] && echo "PYTHON=true"
+[ -f "go.mod" ] && echo "GO=true"
+[ -f "Cargo.toml" ] && echo "RUST=true"
+[ -f "pom.xml" ] || [ -f "build.gradle" ] && echo "JAVA=true"
+[ -f "Gemfile" ] && echo "RUBY=true"
+[ -f "composer.json" ] && echo "PHP=true"
+echo ""
+
+# 3. File count by extension
+echo -e "${BLUE}[FILES]${NC}"
+echo "TOTAL=$(find . -type f -not -path './.git/*' -not -path './node_modules/*' -not -path './.next/*' -not -path './dist/*' -not -path './build/*' -not -path './__pycache__/*' -not -path './venv/*' -not -path './.venv/*' | wc -l | tr -d ' ')"
+
+# Count by extension (top 10)
+find . -type f -not -path './.git/*' -not -path './node_modules/*' -not -path './.next/*' -not -path './dist/*' -not -path './build/*' -not -path './__pycache__/*' -not -path './venv/*' -not -path './.venv/*' \
+  | sed 's/.*\.//' | sort | uniq -c | sort -rn | head -10 | while read -r count ext; do
+    echo "  .${ext}=${count}"
+  done
+echo ""
+
+# 4. Directory structure (depth 2)
+echo -e "${BLUE}[STRUCTURE]${NC}"
+find . -maxdepth 2 -type d \
+  -not -path './.git*' \
+  -not -path './node_modules*' \
+  -not -path './.next*' \
+  -not -path './dist*' \
+  -not -path './build*' \
+  -not -path './__pycache__*' \
+  -not -path './venv*' \
+  -not -path './.venv*' \
+  | sort | head -40
+echo ""
+
+# 5. Config files
+echo -e "${BLUE}[CONFIG]${NC}"
+[ -f ".eslintrc" ] || [ -f ".eslintrc.js" ] || [ -f ".eslintrc.json" ] || [ -f "eslint.config.js" ] || [ -f "eslint.config.mjs" ] && echo "ESLINT=true"
+[ -f ".prettierrc" ] || [ -f ".prettierrc.js" ] || [ -f "prettier.config.js" ] && echo "PRETTIER=true"
+[ -f "jest.config.js" ] || [ -f "jest.config.ts" ] || [ -f "jest.config.mjs" ] && echo "JEST=true"
+[ -f "vitest.config.ts" ] || [ -f "vitest.config.js" ] && echo "VITEST=true"
+[ -f "cypress.config.ts" ] || [ -f "cypress.config.js" ] && echo "CYPRESS=true"
+[ -f "playwright.config.ts" ] && echo "PLAYWRIGHT=true"
+[ -f ".env" ] && echo "DOTENV=true"
+[ -f ".env.example" ] && echo "DOTENV_EXAMPLE=true"
+[ -f "docker-compose.yml" ] || [ -f "docker-compose.yaml" ] && echo "DOCKER_COMPOSE=true"
+[ -f "Dockerfile" ] && echo "DOCKERFILE=true"
+echo ""
+
+# 6. CLAUDE.md status
+echo -e "${BLUE}[CLAUDE_MD]${NC}"
+if [ -f "CLAUDE.md" ]; then
+  echo "EXISTS=true"
+  grep -c '^\- \[ \]' CLAUDE.md 2>/dev/null && echo "UNCHECKED_TASKS=$(grep -c '^\- \[ \]' CLAUDE.md)"
+  grep -c '^\- \[x\]' CLAUDE.md 2>/dev/null && echo "CHECKED_TASKS=$(grep -c '^\- \[x\]' CLAUDE.md)"
+  grep -q '## Roadmap' CLAUDE.md && echo "HAS_ROADMAP=true" || echo "HAS_ROADMAP=false"
+else
+  echo "EXISTS=false"
+fi
+echo ""
+
+# 7. Git status
+echo -e "${BLUE}[GIT]${NC}"
+if [ -d ".git" ]; then
+  echo "GIT=true"
+  echo "BRANCH=$(git branch --show-current 2>/dev/null)"
+  echo "CLEAN=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')"
+  echo "RECENT_COMMITS=$(git log --oneline -5 2>/dev/null)"
+else
+  echo "GIT=false"
+fi
+echo ""
+
+# 8. TypeScript-specific: count `any` types (if TS project)
+if [ -f "tsconfig.json" ]; then
+  echo -e "${BLUE}[TYPESCRIPT_ANALYSIS]${NC}"
+  ANY_COUNT=$(grep -r --include="*.ts" --include="*.tsx" -l ': any' . \
+    --exclude-dir=node_modules --exclude-dir=dist --exclude-dir=build --exclude-dir=.next 2>/dev/null | wc -l | tr -d ' ')
+  echo "FILES_WITH_ANY=${ANY_COUNT}"
+
+  if [ "$ANY_COUNT" -gt 0 ]; then
+    echo "TOP_FILES_WITH_ANY:"
+    grep -r --include="*.ts" --include="*.tsx" -c ': any' . \
+      --exclude-dir=node_modules --exclude-dir=dist --exclude-dir=build --exclude-dir=.next 2>/dev/null \
+      | grep -v ':0$' | sort -t: -k2 -rn | head -10 | while IFS=: read -r file count; do
+        echo "  ${file}=${count}"
+      done
+  fi
+  echo ""
+fi
+
+# 9. Python-specific: check for type hints
+if [ -f "requirements.txt" ] || [ -f "pyproject.toml" ]; then
+  echo -e "${BLUE}[PYTHON_ANALYSIS]${NC}"
+  PY_COUNT=$(find . -name "*.py" -not -path './venv/*' -not -path './.venv/*' -not -path './__pycache__/*' 2>/dev/null | wc -l | tr -d ' ')
+  echo "PYTHON_FILES=${PY_COUNT}"
+
+  # Files without type hints (rough heuristic: no -> in function defs)
+  NO_HINTS=$(grep -rL --include="*.py" '\->' . --exclude-dir=venv --exclude-dir=.venv --exclude-dir=__pycache__ 2>/dev/null | wc -l | tr -d ' ')
+  echo "FILES_WITHOUT_TYPE_HINTS=${NO_HINTS}"
+  echo ""
+fi
+
+echo -e "${GREEN}=== SCAN COMPLETE ===${NC}"

--- a/skills/roadmap-pilot/SKILL.md
+++ b/skills/roadmap-pilot/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: roadmap
+description: >
+  Roadmap-driven autopilot for incremental codebase cleanup. Reads the project
+  CLAUDE.md, finds the next unchecked task in the roadmap, executes it, marks it
+  done, commits, and hands off to a new session. Use when the user says
+  "continua la roadmap", "next task", "roadmap", or similar.
+  Also activates when the user types /roadmap.
+user-invocable: true
+argument-hint: "[--dry-run]"
+disable-model-invocation: true
+---
+
+## Overview
+
+You are a roadmap autopilot. You execute **ONE task per session** from a checklist defined in the project's `CLAUDE.md` file. You work incrementally, commit after each task, and hand off to the next session. This prevents context overflow and hallucinations.
+
+## Prerequisites
+
+Before starting, verify:
+
+1. `CLAUDE.md` exists in the project root and contains a `## Roadmap` section with checklist items (`- [ ]` and `- [x]`)
+2. A working branch is specified in `CLAUDE.md` under a "Branch" or "Working With Claude" section. Verify you are on that branch with `git branch --show-current`. If not specified, ask the user which branch to use.
+3. Shared types or conventions are defined in `CLAUDE.md`. Read them carefully before touching any code.
+
+If any prerequisite is missing, tell the user what's needed and **stop**.
+
+## Dry-Run Mode
+
+When the user says `/roadmap --dry-run` (or "dry run", "preview", "what's next"):
+
+1. **READ** → Read `CLAUDE.md` completely
+2. **FIND** → Find next unchecked `- [ ]` task in `## Roadmap` section
+3. **PLAN** → Read the target file(s), analyze what needs to change
+4. **REPORT** → Show the user:
+   - The task that would be executed
+   - The file(s) that would be modified
+   - A summary of planned changes (e.g., "12 `any` types to replace, will import from `src/types/`")
+   - Estimated complexity (simple / moderate / complex)
+5. **STOP** → Do NOT execute, do NOT commit, do NOT modify any files
+
+End with:
+> **Dry run complete. Run `/roadmap` to execute this task.**
+
+## Execution Flow
+
+```
+1. READ    → Read CLAUDE.md completely
+2. FIND    → Find first unchecked `- [ ]` task in the `## Roadmap` section ONLY
+             (ignore checkboxes in other sections like Test Flows, QA, etc.)
+3. PLAN    → Read the target file(s), understand what needs to change
+4. EXECUTE → Make the changes (type a file, create a file, extract, refactor)
+5. VERIFY  → Ensure no logic changed (diff review)
+6. UPDATE  → Mark task `- [x]` in CLAUDE.md
+7. COMMIT  → Commit code changes + updated CLAUDE.md together
+8. HANDOFF → Tell the user to open a new session
+```
+
+## Rules (MUST follow)
+
+### Scope
+
+- Execute exactly **ONE task** per session. Not two, not "just one more".
+- If a task is too large for one session (e.g., "Type remaining files in X/"), break it into sub-tasks: do ONE file, update the roadmap to reflect progress, commit, and hand off.
+
+### Safety
+
+- **NEVER** change logic. When typing or renaming, behavior must stay identical.
+- If unsure about a type or value, add a `// TODO: verify this type` comment rather than guessing wrong.
+- **NEVER** push to remote. Local commits only.
+- **NEVER** use `--no-verify` or skip hooks.
+- Always use the commit format specified in `CLAUDE.md`. If none specified, use: `[roadmap] <short description of what was done>`
+
+### Quality
+
+- Read the target file **BEFORE** making changes. Never edit blind.
+- If `CLAUDE.md` defines shared types or naming conventions, import from the specified location. Do NOT create local type aliases.
+- Do NOT rename Redux state keys, API response fields, or anything that crosses a module boundary — only local variables, params, and props.
+- Do NOT add features, refactor beyond scope, or "improve" surrounding code.
+
+### Anti-hallucination
+
+- Only reference files you have **actually read** in this session.
+- If you haven't read a file, don't assume its contents.
+- If a task requires understanding code you haven't seen, read it first.
+- When in doubt, commit what you have and hand off rather than guessing.
+
+## Handling "remaining files" tasks
+
+When the roadmap says "Type remaining files in DirectoryX/", follow this process:
+
+1. Run the `next-task.sh` script or list all files in the directory
+2. Check which files still have `any` types (or whatever the task targets)
+3. Pick the **ONE** file with the most occurrences
+4. Type that single file
+5. Update the roadmap: either mark the task done (if it was the last file) or add a note like `(3/12 files done)` next to the task
+6. Commit and hand off
+
+## Commit format
+
+```
+git commit -m "<prefix> <short description>"
+```
+
+- Use the prefix defined in `CLAUDE.md` (e.g., `[genius]`, `[auth]`, `[api]`)
+- If no prefix is defined, use `[roadmap]`
+- No Claude co-author tag unless the user explicitly wants it
+- Commit message in English
+- Always commit `CLAUDE.md` together with the code changes
+
+## Handoff message
+
+After committing, always end with:
+
+> **Fatto. Apri nuova conversazione e dimmi: continua la roadmap**
+
+Or in English if the project `CLAUDE.md` is in English:
+
+> **Done. Open a new conversation and say: continue the roadmap**
+
+## If roadmap is complete
+
+When no unchecked `- [ ]` tasks remain in the roadmap, tell the user:
+
+> 🎉 **Roadmap completata!** Tutti i task sono stati eseguiti.
+> Ecco un riepilogo di quello che è stato fatto:
+> <list of all phases and their tasks>
+
+## Edge cases
+
+- **No `CLAUDE.md` found**: Tell the user to create one with a `## Roadmap` section
+- **No unchecked tasks**: Report roadmap complete
+- **Task is ambiguous**: Ask the user to clarify before proceeding
+- **Session getting long (15+ turns)**: Stop, commit progress, update `CLAUDE.md`, hand off
+- **Build/lint errors after changes**: Fix them before committing. If you can't fix them, revert your changes and report the issue.
+- **Wrong branch**: Do NOT switch branches silently. Tell the user and stop.

--- a/skills/roadmap-pilot/scripts/auto-roadmap.sh
+++ b/skills/roadmap-pilot/scripts/auto-roadmap.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# auto-roadmap.sh - Autopilot: lancia sessioni Claude Code in loop
+# Ogni sessione = contesto fresco (come premere Cmd+N)
+# Si ferma quando la roadmap è completata o se Claude si blocca
+#
+# Usage: ./auto-roadmap.sh [path-to-claude-md] [max-sessions]
+# Example: ./auto-roadmap.sh CLAUDE.md 20
+
+set -e
+
+CLAUDE_MD="${1:-CLAUDE.md}"
+MAX_SESSIONS="${2:-50}"
+SESSION_COUNT=0
+STUCK_COUNT=0
+MAX_STUCK=3
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+echo -e "${BLUE}╔══════════════════════════════════════╗${NC}"
+echo -e "${BLUE}║     ROADMAP PILOT - AUTO MODE        ║${NC}"
+echo -e "${BLUE}╚══════════════════════════════════════╝${NC}"
+echo ""
+
+# Verify CLAUDE.md exists
+if [ ! -f "$CLAUDE_MD" ]; then
+  echo -e "${RED}ERROR: $CLAUDE_MD not found${NC}"
+  echo "Create a CLAUDE.md with a ## Roadmap section first."
+  exit 1
+fi
+
+# Verify claude CLI is available
+if ! command -v claude &> /dev/null; then
+  echo -e "${RED}ERROR: 'claude' CLI not found${NC}"
+  echo "Install Claude Code first: https://docs.anthropic.com/en/docs/claude-code"
+  exit 1
+fi
+
+# Count initial state
+TOTAL=$(grep -c '^\- \[.\]' "$CLAUDE_MD" 2>/dev/null || echo 0)
+DONE_INITIAL=$(grep -c '^\- \[x\]' "$CLAUDE_MD" 2>/dev/null || echo 0)
+REMAINING=$((TOTAL - DONE_INITIAL))
+
+echo -e "${YELLOW}Roadmap: ${DONE_INITIAL}/${TOTAL} completati, ${REMAINING} rimanenti${NC}"
+echo -e "${YELLOW}Max sessioni: ${MAX_SESSIONS}${NC}"
+echo ""
+
+if [ "$REMAINING" -eq 0 ]; then
+  echo -e "${GREEN}Roadmap gia' completata! Nessun task rimasto.${NC}"
+  exit 0
+fi
+
+# Main loop
+while [ "$SESSION_COUNT" -lt "$MAX_SESSIONS" ]; do
+  # Check remaining tasks
+  REMAINING_NOW=$(grep -c '^\- \[ \]' "$CLAUDE_MD" 2>/dev/null || echo 0)
+
+  if [ "$REMAINING_NOW" -eq 0 ]; then
+    echo ""
+    echo -e "${GREEN}╔══════════════════════════════════════╗${NC}"
+    echo -e "${GREEN}║     ROADMAP COMPLETATA!              ║${NC}"
+    echo -e "${GREEN}╚══════════════════════════════════════╝${NC}"
+    echo ""
+    echo -e "${GREEN}Sessioni usate: ${SESSION_COUNT}${NC}"
+    echo -e "${GREEN}Task completati: ${TOTAL}/${TOTAL}${NC}"
+    exit 0
+  fi
+
+  SESSION_COUNT=$((SESSION_COUNT + 1))
+  DONE_BEFORE=$(grep -c '^\- \[x\]' "$CLAUDE_MD" 2>/dev/null || echo 0)
+
+  # Show current task
+  NEXT_TASK=$(grep '^\- \[ \]' "$CLAUDE_MD" | head -1 | sed 's/^- \[ \] //')
+  echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+  echo -e "${BLUE}Sessione #${SESSION_COUNT}/${MAX_SESSIONS}${NC}"
+  echo -e "${YELLOW}Prossimo task: ${NEXT_TASK}${NC}"
+  echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+
+  # Launch Claude Code as a fresh session
+  claude -p "Leggi il file CLAUDE.md e esegui il prossimo task non completato dalla roadmap. Segui le istruzioni della skill roadmap-pilot: esegui UN solo task, spuntalo, committa, e fermati. Non pushare." \
+    --max-turns 25 \
+    2>&1 | while IFS= read -r line; do
+      echo "  $line"
+    done
+
+  # Check if progress was made
+  DONE_AFTER=$(grep -c '^\- \[x\]' "$CLAUDE_MD" 2>/dev/null || echo 0)
+
+  if [ "$DONE_AFTER" -gt "$DONE_BEFORE" ]; then
+    STUCK_COUNT=0
+    echo -e "${GREEN}Task completato! (${DONE_AFTER}/${TOTAL})${NC}"
+  else
+    STUCK_COUNT=$((STUCK_COUNT + 1))
+    echo -e "${RED}Nessun progresso in questa sessione (tentativo ${STUCK_COUNT}/${MAX_STUCK})${NC}"
+
+    if [ "$STUCK_COUNT" -ge "$MAX_STUCK" ]; then
+      echo ""
+      echo -e "${RED}╔══════════════════════════════════════╗${NC}"
+      echo -e "${RED}║  BLOCCATO: ${MAX_STUCK} sessioni senza progresso  ║${NC}"
+      echo -e "${RED}╚══════════════════════════════════════╝${NC}"
+      echo ""
+      echo -e "${RED}Prossimo task bloccante: ${NEXT_TASK}${NC}"
+      echo -e "${YELLOW}Intervieni manualmente e poi rilancia lo script.${NC}"
+      exit 2
+    fi
+  fi
+
+  echo ""
+  sleep 2
+done
+
+echo ""
+echo -e "${YELLOW}Raggiunto il limite di ${MAX_SESSIONS} sessioni.${NC}"
+DONE_FINAL=$(grep -c '^\- \[x\]' "$CLAUDE_MD" 2>/dev/null || echo 0)
+echo -e "${YELLOW}Progresso: ${DONE_FINAL}/${TOTAL} task completati.${NC}"
+exit 1

--- a/skills/roadmap-pilot/scripts/next-task.sh
+++ b/skills/roadmap-pilot/scripts/next-task.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Finds the next unchecked task in CLAUDE.md roadmap section ONLY
+# Usage: ./next-task.sh [path-to-claude-md]
+#
+# Only searches within the ## Roadmap section, ignoring other sections
+# like Test Flows, QA Checklists, etc. that may also contain checkboxes.
+
+CLAUDE_MD="${1:-CLAUDE.md}"
+
+if [ ! -f "$CLAUDE_MD" ]; then
+  echo "ERROR: $CLAUDE_MD not found"
+  exit 1
+fi
+
+# Extract only the ## Roadmap section
+# From "## Roadmap" until the next "## " heading (or end of file)
+# Uses awk for reliable section extraction
+ROADMAP_SECTION=$(awk '
+  /^## Roadmap/ { found=1; next }
+  found && /^## [^#]/ { exit }
+  found { print }
+' "$CLAUDE_MD")
+
+if [ -z "$ROADMAP_SECTION" ]; then
+  echo "ERROR: No '## Roadmap' section found in $CLAUDE_MD"
+  exit 1
+fi
+
+# Find next unchecked task within roadmap section only
+NEXT_TASK=$(echo "$ROADMAP_SECTION" | grep '^\- \[ \]' | head -1 | sed 's/^- \[ \] //')
+
+if [ -z "$NEXT_TASK" ]; then
+  echo "DONE: All roadmap tasks completed"
+  exit 0
+fi
+
+# Find the actual line number in the original file
+LINE_NUM=$(grep -n '^\- \[ \]' "$CLAUDE_MD" | while IFS=: read -r num line; do
+  # Verify this line is within the roadmap section by checking it appears
+  # after "## Roadmap" and before the next "## " section
+  ROADMAP_START=$(grep -n '^## Roadmap' "$CLAUDE_MD" | head -1 | cut -d: -f1)
+  NEXT_SECTION=$(awk "NR>$ROADMAP_START && /^## [^#]/{print NR; exit}" "$CLAUDE_MD")
+  if [ -z "$NEXT_SECTION" ]; then
+    NEXT_SECTION=999999
+  fi
+  if [ "$num" -gt "$ROADMAP_START" ] && [ "$num" -lt "$NEXT_SECTION" ]; then
+    echo "$num"
+    break
+  fi
+done)
+
+echo "NEXT_TASK_LINE=$LINE_NUM"
+echo "NEXT_TASK=$NEXT_TASK"
+
+# Count progress (roadmap section only)
+TOTAL=$(echo "$ROADMAP_SECTION" | grep -c '^\- \[.\]')
+DONE=$(echo "$ROADMAP_SECTION" | grep -c '^\- \[x\]')
+echo "PROGRESS=$DONE/$TOTAL"

--- a/skills/roadmap-pilot/scripts/rollback.sh
+++ b/skills/roadmap-pilot/scripts/rollback.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# rollback.sh - Safely revert the last roadmap commit
+# Usage: ./rollback.sh [--dry-run]
+#
+# Reverts the last commit if it was a roadmap commit (matches [prefix] pattern).
+# Also un-checks the task in CLAUDE.md that was marked done.
+
+set -e
+
+DRY_RUN=false
+if [ "$1" = "--dry-run" ]; then
+  DRY_RUN=true
+fi
+
+# Colors
+if [ -t 1 ]; then
+  BOLD='\033[1m'
+  GREEN='\033[0;32m'
+  YELLOW='\033[1;33m'
+  RED='\033[0;31m'
+  NC='\033[0m'
+else
+  BOLD='' GREEN='' YELLOW='' RED='' NC=''
+fi
+
+# Check we're in a git repo
+if ! git rev-parse --is-inside-work-tree &>/dev/null; then
+  echo -e "${RED}ERROR: Not a git repository${NC}"
+  exit 1
+fi
+
+# Check there are no uncommitted changes
+if [ -n "$(git status --porcelain)" ]; then
+  echo -e "${RED}ERROR: You have uncommitted changes. Commit or stash them first.${NC}"
+  exit 1
+fi
+
+# Get last commit info
+LAST_MSG=$(git log -1 --pretty=format:'%s')
+LAST_HASH=$(git log -1 --pretty=format:'%h')
+LAST_FILES=$(git diff-tree --no-commit-id --name-only -r HEAD)
+
+echo -e "${BOLD}Last commit:${NC}"
+echo -e "  ${YELLOW}${LAST_HASH}${NC} ${LAST_MSG}"
+echo ""
+echo -e "${BOLD}Files changed:${NC}"
+echo "$LAST_FILES" | while read -r f; do echo "  $f"; done
+echo ""
+
+# Verify it looks like a roadmap commit
+if ! echo "$LAST_MSG" | grep -qE '^\['; then
+  echo -e "${RED}WARNING: Last commit doesn't look like a roadmap commit (no [prefix]).${NC}"
+  echo -e "${RED}Commit message: ${LAST_MSG}${NC}"
+  echo ""
+  read -p "Revert anyway? (y/N): " CONFIRM
+  if [ "$CONFIRM" != "y" ] && [ "$CONFIRM" != "Y" ]; then
+    echo "Aborted."
+    exit 0
+  fi
+fi
+
+if [ "$DRY_RUN" = true ]; then
+  echo -e "${YELLOW}[DRY RUN] Would revert commit ${LAST_HASH}${NC}"
+  echo -e "${YELLOW}[DRY RUN] No changes made.${NC}"
+  exit 0
+fi
+
+# Revert
+echo -e "${BOLD}Reverting...${NC}"
+git revert HEAD --no-edit
+
+echo ""
+echo -e "${GREEN}Reverted successfully.${NC}"
+echo ""
+echo -e "${BOLD}What happened:${NC}"
+echo "  - Created a new revert commit (safe, preserves history)"
+echo "  - CLAUDE.md was restored to its previous state"
+echo "  - The task that was marked [x] is now back to [ ]"
+echo ""
+echo -e "${YELLOW}Next: open Claude Code and run /roadmap to retry the task.${NC}"

--- a/skills/roadmap-pilot/scripts/status.sh
+++ b/skills/roadmap-pilot/scripts/status.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# status.sh - Visual progress dashboard for roadmap section ONLY
+# Usage: ./status.sh [path-to-claude-md]
+#
+# Only parses the ## Roadmap section, ignoring Test Flows, QA, etc.
+
+CLAUDE_MD="${1:-CLAUDE.md}"
+
+if [ ! -f "$CLAUDE_MD" ]; then
+  echo "ERROR: $CLAUDE_MD not found"
+  exit 1
+fi
+
+# Colors
+if [ -t 1 ]; then
+  BOLD='\033[1m'
+  GREEN='\033[0;32m'
+  YELLOW='\033[1;33m'
+  BLUE='\033[0;34m'
+  DIM='\033[2m'
+  NC='\033[0m'
+  FILLED='█'
+  EMPTY='░'
+else
+  BOLD='' GREEN='' YELLOW='' BLUE='' DIM='' NC=''
+  FILLED='#'
+  EMPTY='-'
+fi
+
+BAR_WIDTH=20
+
+draw_bar() {
+  local done=$1
+  local total=$2
+  local filled=0
+
+  if [ "$total" -gt 0 ]; then
+    filled=$(( (done * BAR_WIDTH) / total ))
+  fi
+
+  local empty=$((BAR_WIDTH - filled))
+  local bar=""
+
+  for ((i=0; i<filled; i++)); do bar+="${FILLED}"; done
+  for ((i=0; i<empty; i++)); do bar+="${EMPTY}"; done
+
+  echo -n "$bar"
+}
+
+# Extract only the ## Roadmap section (awk for reliable extraction)
+ROADMAP_SECTION=$(awk '
+  /^## Roadmap/ { found=1; next }
+  found && /^## [^#]/ { exit }
+  found { print }
+' "$CLAUDE_MD")
+
+if [ -z "$ROADMAP_SECTION" ]; then
+  echo "ERROR: No '## Roadmap' section found in $CLAUDE_MD"
+  exit 1
+fi
+
+echo ""
+echo -e "${BOLD}  ROADMAP PROGRESS${NC}"
+echo -e "  ─────────────────────────────────────────────"
+echo ""
+
+# Parse phases within roadmap section only
+CURRENT_PHASE=""
+PHASE_DONE=0
+PHASE_TOTAL=0
+TOTAL_DONE=0
+TOTAL_ALL=0
+
+print_phase() {
+  if [ -n "$CURRENT_PHASE" ]; then
+    local bar=$(draw_bar "$PHASE_DONE" "$PHASE_TOTAL")
+    local pct=0
+    if [ "$PHASE_TOTAL" -gt 0 ]; then
+      pct=$(( (PHASE_DONE * 100) / PHASE_TOTAL ))
+    fi
+
+    local color="$YELLOW"
+    if [ "$PHASE_DONE" -eq "$PHASE_TOTAL" ]; then
+      color="$GREEN"
+    fi
+
+    printf "  ${color}%-28s %s %d/%d (%d%%)${NC}\n" "$CURRENT_PHASE" "$bar" "$PHASE_DONE" "$PHASE_TOTAL" "$pct"
+  fi
+}
+
+while IFS= read -r line; do
+  # Detect phase headers (### Phase N - Description)
+  if echo "$line" | grep -qE '^###\s+'; then
+    print_phase
+    CURRENT_PHASE=$(echo "$line" | sed 's/^###\s*//')
+    PHASE_DONE=0
+    PHASE_TOTAL=0
+  fi
+
+  # Count checked tasks
+  if echo "$line" | grep -qE '^\- \[x\]'; then
+    PHASE_DONE=$((PHASE_DONE + 1))
+    PHASE_TOTAL=$((PHASE_TOTAL + 1))
+    TOTAL_DONE=$((TOTAL_DONE + 1))
+    TOTAL_ALL=$((TOTAL_ALL + 1))
+  fi
+
+  # Count unchecked tasks
+  if echo "$line" | grep -qE '^\- \[ \]'; then
+    PHASE_TOTAL=$((PHASE_TOTAL + 1))
+    TOTAL_ALL=$((TOTAL_ALL + 1))
+  fi
+done <<< "$ROADMAP_SECTION"
+
+# Print last phase
+print_phase
+
+# Total
+echo ""
+echo -e "  ─────────────────────────────────────────────"
+
+TOTAL_BAR=$(draw_bar "$TOTAL_DONE" "$TOTAL_ALL")
+TOTAL_PCT=0
+if [ "$TOTAL_ALL" -gt 0 ]; then
+  TOTAL_PCT=$(( (TOTAL_DONE * 100) / TOTAL_ALL ))
+fi
+
+TOTAL_COLOR="$YELLOW"
+if [ "$TOTAL_DONE" -eq "$TOTAL_ALL" ] && [ "$TOTAL_ALL" -gt 0 ]; then
+  TOTAL_COLOR="$GREEN"
+fi
+
+printf "\n  ${BOLD}${TOTAL_COLOR}%-28s %s %d/%d (%d%%)${NC}\n" "TOTAL" "$TOTAL_BAR" "$TOTAL_DONE" "$TOTAL_ALL" "$TOTAL_PCT"
+
+# Show next task (from roadmap section only)
+NEXT=$(echo "$ROADMAP_SECTION" | grep '^\- \[ \]' | head -1 | sed 's/^- \[ \] //')
+if [ -n "$NEXT" ]; then
+  echo ""
+  echo -e "  ${BLUE}Next:${NC} $NEXT"
+fi
+
+echo ""


### PR DESCRIPTION
## Summary

Two skills for roadmap-driven incremental codebase cleanup:

- **roadmap-pilot** (`/roadmap`): Reads CLAUDE.md, executes ONE task per session, marks it done, commits. Prevents context overflow on large refactoring jobs.
- **init-roadmap** (`/init-roadmap`): Scans project, interviews user, generates phased CLAUDE.md roadmap.

Repo: https://github.com/antconsales/roadmap-pilot | License: MIT

## How it works

1. User runs `/init-roadmap` → Claude scans the project, asks targeted questions, generates a `CLAUDE.md` with a phased task checklist
2. User runs `/roadmap` → Claude picks the next unchecked task, executes it, marks it done, commits, and hands off to a new session
3. Repeat until roadmap is complete

This two-phase approach prevents context overflow and hallucinations on large refactoring jobs by keeping each session focused on a single task.

## Files added

- `skills/roadmap-pilot/SKILL.md` — autopilot execution skill
- `skills/roadmap-pilot/scripts/` — helper scripts (auto-roadmap, next-task, rollback, status)
- `skills/init-roadmap/SKILL.md` — roadmap planning skill  
- `skills/init-roadmap/scripts/` — project scanner script