### PR TITLE
Add consulting-opportunity skill

### DIFF
--- a/skills/consulting-opportunity/LICENSE.txt
+++ b/skills/consulting-opportunity/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/consulting-opportunity/SKILL.md
+++ b/skills/consulting-opportunity/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: consulting-opportunity
+description: Analyze a company's careers page for consulting opportunities. Scrapes job postings, identifies automation signals, and generates scoped engagement proposals.
+argument-hint: [careers-url]
+disable-model-invocation: true
+allowed-tools: Bash, WebSearch, WebFetch, Read, Write, Glob, Grep
+license: Complete terms in LICENSE.txt
+---
+
+# Analyze Company for Consulting Opportunities
+
+You are analyzing a company's careers page to identify consulting opportunities for building agents and automation. Job postings are companies broadcasting their pain points — roles heavy on coordination, data entry, reporting, and manual workflows signal where agent-based automation could replace or augment hiring.
+
+The user has provided a careers URL: `$ARGUMENTS`
+
+## Workflow
+
+### Step 1: Research the Company (DO THIS FIRST)
+
+Use WebSearch to find:
+- What the company does, who they serve
+- Size, funding stage, growth trajectory
+- **Key financials:** Customer count, ARR/revenue figures, growth rates (MoM/YoY), funding rounds and amounts, key investors
+- Recent news (acquisitions, expansions, new products)
+- Business model and key operational challenges
+
+Include specific numbers in the Company Context section — customer count, ARR, growth rates, team size, number of open roles. These figures are critical for assessing fit and framing opportunities.
+
+### Step 2: Scrape the Careers Page
+
+First, ensure Playwright is installed:
+```bash
+cd $SKILL_DIR/scripts && npm install && npx playwright install chromium 2>/dev/null || true
+```
+
+Then scrape the careers page:
+```bash
+node $SKILL_DIR/scripts/scrape.js "$ARGUMENTS"
+```
+
+This returns JSON with job listings. If the scraper doesn't find jobs automatically, use WebFetch to get the page content and parse it manually.
+
+For each job listing found, scrape the full job description:
+```bash
+node $SKILL_DIR/scripts/scrape.js --description "JOB_URL_HERE"
+```
+
+### Step 3: Smart Deduplication
+
+Before analyzing, deduplicate similar roles:
+1. Strip location suffixes (UK, France, EMEA, etc.)
+2. Strip seniority prefixes for grouping (Sr., Junior, Lead)
+3. Group by normalized title
+4. Keep one representative posting per group
+5. Note the count of similar roles (indicates team scale)
+
+Cap at 30 unique roles to analyze.
+
+### Step 4: Analyze for Automation Signals
+
+Read the `$SKILL_DIR/signals.md` file for the full signal detection reference.
+
+For each job description, look for:
+- **High-signal language:** "manage", "coordinate", "oversee" + process/workflow; "ensure", "maintain", "track" + data/records; "spreadsheet", "reporting", "reconciliation"
+- **High-signal role types:** Operations, Coordinator, Analyst with "reporting" emphasis, Implementation/Onboarding, Support with technical investigation
+- **Structural signals:** Multiple similar roles (scale problem), 24/7 coverage, cross-functional coordination, compliance/audit
+
+Identify 2-3 distinct opportunity areas. Each should be specific enough to pitch as a scoped engagement.
+
+### Step 5: Generate the Report
+
+Read the template at `$SKILL_DIR/templates/company-report.md` and use it to structure the output.
+
+Create the output directory and write the report:
+```bash
+mkdir -p data/companies
+```
+
+Write to `data/companies/{company-slug}.md`
+
+For each opportunity, frame it as a **quick-win engagement** (2-4 weeks):
+- **"The one thing it solves"** — a single, specific pain point
+- **What we'd build** — concrete agent/automation, not a vague platform
+- **Why now** — reference specific language from job postings
+- **Honest caveat** — be specific about what could make this not work: existing tools that solve this (name them), whether the team could build it themselves, market alternatives, timing risks. Don't just flag risk — explain why it might not land.
+- **Entry point** — who to pitch to
+- **Scope** — 2-4 week engagement with week-by-week breakdown
+- **Dependencies** — what access/APIs/data we'd need
+
+Include an **Overall Assessment** section with honest fit rating (Strong/Medium/Weak) and reasoning. For weak fits, include a **"When this might become a fit"** section with a specific re-check timeline (e.g., "worth re-checking in 6-12 months when they scale to X people and start hiring operations roles").
+
+### Step 6: Request Feedback
+
+After presenting the report, ask:
+1. Which opportunities resonate? Which don't?
+2. What's missing that you expected to see?
+3. Is the framing right for how you'd pitch this?
+
+If feedback is provided, save it to `data/feedback/{company-slug}_feedback.md` using the template at `$SKILL_DIR/templates/feedback.md`.
+
+## Positioning Context
+
+We're looking for projects involving:
+- **Primary:** Building agents to automate workflows (using Claude, etc.)
+- **Secondary:** General consulting on automation, process improvement
+
+Frame opportunities around what we can actually deliver as 2-4 week engagements, not generic "you should automate this."

--- a/skills/consulting-opportunity/scripts/package.json
+++ b/skills/consulting-opportunity/scripts/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "analyze-company-scraper",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "playwright": "^1.40.0"
+  }
+}

--- a/skills/consulting-opportunity/scripts/scrape.js
+++ b/skills/consulting-opportunity/scripts/scrape.js
@@ -1,0 +1,186 @@
+const { chromium } = require('playwright');
+
+/**
+ * Scrape job listings from a careers page
+ * Handles JavaScript-rendered pages (Ashby, Lever, Greenhouse, etc.)
+ */
+async function scrapeJobsPage(url) {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({
+    userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36'
+  });
+  const page = await context.newPage();
+
+  console.error(`Scraping: ${url}`);
+
+  try {
+    await page.goto(url, {
+      waitUntil: 'networkidle',
+      timeout: 30000
+    });
+
+    // Wait a bit for dynamic content
+    await page.waitForTimeout(2000);
+
+    // Get the full page content
+    const content = await page.content();
+
+    // Try to extract job listings based on common patterns
+    const jobs = await page.evaluate(() => {
+      const results = [];
+
+      // Ashby pattern
+      document.querySelectorAll('[data-testid="job-posting"]').forEach(el => {
+        const titleEl = el.querySelector('h3, [data-testid="job-posting-title"]');
+        const linkEl = el.querySelector('a');
+        const deptEl = el.querySelector('[data-testid="job-posting-department"]');
+        if (titleEl) {
+          results.push({
+            title: titleEl.textContent.trim(),
+            link: linkEl?.href || '',
+            department: deptEl?.textContent.trim() || ''
+          });
+        }
+      });
+
+      // Lever pattern
+      document.querySelectorAll('.posting').forEach(el => {
+        const titleEl = el.querySelector('.posting-title h5');
+        const linkEl = el.querySelector('a.posting-title');
+        const deptEl = el.querySelector('.posting-categories .sort-by-team');
+        if (titleEl) {
+          results.push({
+            title: titleEl.textContent.trim(),
+            link: linkEl?.href || '',
+            department: deptEl?.textContent.trim() || ''
+          });
+        }
+      });
+
+      // Greenhouse pattern
+      document.querySelectorAll('.opening').forEach(el => {
+        const titleEl = el.querySelector('a');
+        const deptEl = el.querySelector('.department');
+        if (titleEl) {
+          results.push({
+            title: titleEl.textContent.trim(),
+            link: titleEl.href || '',
+            department: deptEl?.textContent.trim() || ''
+          });
+        }
+      });
+
+      // Generic fallback - look for job-like links
+      if (results.length === 0) {
+        document.querySelectorAll('a').forEach(el => {
+          const href = el.href || '';
+          const text = el.textContent.trim();
+          // Look for links that seem like job postings
+          if (href.includes('/job') || href.includes('/position') ||
+              href.includes('/careers/') || href.includes('/opening')) {
+            if (text.length > 3 && text.length < 100) {
+              results.push({
+                title: text,
+                link: href,
+                department: ''
+              });
+            }
+          }
+        });
+      }
+
+      return results;
+    });
+
+    await browser.close();
+
+    return {
+      success: true,
+      url,
+      jobCount: jobs.length,
+      jobs
+    };
+
+  } catch (error) {
+    await browser.close();
+    return {
+      success: false,
+      url,
+      error: error.message,
+      jobs: []
+    };
+  }
+}
+
+/**
+ * Scrape a single job posting page for full description
+ */
+async function scrapeJobDescription(url) {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({
+    userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36'
+  });
+  const page = await context.newPage();
+
+  try {
+    await page.goto(url, {
+      waitUntil: 'networkidle',
+      timeout: 30000
+    });
+
+    await page.waitForTimeout(2000);
+
+    // Extract text content, focusing on main content area
+    const description = await page.evaluate(() => {
+      // Remove scripts, styles, nav, footer
+      const elementsToRemove = document.querySelectorAll('script, style, nav, footer, header');
+      elementsToRemove.forEach(el => el.remove());
+
+      // Try to find main content
+      const mainContent = document.querySelector('main, [role="main"], .job-description, .posting-description, article');
+      if (mainContent) {
+        return mainContent.textContent.replace(/\s+/g, ' ').trim();
+      }
+
+      // Fallback to body
+      return document.body.textContent.replace(/\s+/g, ' ').trim();
+    });
+
+    await browser.close();
+
+    return {
+      success: true,
+      url,
+      description
+    };
+
+  } catch (error) {
+    await browser.close();
+    return {
+      success: false,
+      url,
+      error: error.message,
+      description: ''
+    };
+  }
+}
+
+// CLI usage
+const args = process.argv.slice(2);
+
+if (args.length === 0) {
+  console.log('Usage:');
+  console.log('  node scrape.js <careers-url>              # Scrape job listings');
+  console.log('  node scrape.js --description <job-url>    # Scrape single job description');
+  process.exit(1);
+}
+
+if (args[0] === '--description') {
+  scrapeJobDescription(args[1]).then(result => {
+    console.log(JSON.stringify(result, null, 2));
+  });
+} else {
+  scrapeJobsPage(args[0]).then(result => {
+    console.log(JSON.stringify(result, null, 2));
+  });
+}

--- a/skills/consulting-opportunity/signals.md
+++ b/skills/consulting-opportunity/signals.md
@@ -1,0 +1,62 @@
+# Automation Signal Detection Reference
+
+## High-Signal Patterns (STRONG indicators)
+
+### Language patterns
+- "manage", "coordinate", "oversee" + process/workflow
+- "ensure", "maintain", "track" + data/records/compliance
+- "liaise between", "bridge", "connect" teams
+- "handle", "process", "review" + volume indicators
+- "manual", "repetitive" (rare but explicit)
+- "spreadsheet", "reporting", "reconciliation"
+
+### Role types
+- Operations roles (Ops Manager, Operations Specialist)
+- Coordinator roles (Project Coordinator, Sales Coordinator)
+- Analyst roles with "reporting" emphasis
+- "Specialist" roles that are really process executors
+- Integration/Implementation roles (onboarding customers)
+- Support roles with technical investigation components
+
+### Structural signals
+- Multiple similar roles = scale problem
+- 24/7 or shift coverage mentioned = automation candidate
+- Cross-functional coordination emphasized
+- Compliance/audit responsibilities
+
+## Medium-Signal Patterns
+
+- Customer Success with "onboarding" focus
+- Account Management with "support" emphasis
+- Data roles focused on "cleaning" or "validation"
+- QA roles with repetitive testing patterns
+
+## Low-Signal (Usually Skip)
+
+- Pure engineering roles (unless DevOps/SRE)
+- Executive/leadership roles
+- Creative roles (design, content)
+- Pure sales roles (AE, SDR without ops component)
+
+## Common ATS Selectors
+
+| Platform | Job List Selector | Job Link Pattern |
+|----------|------------------|------------------|
+| Ashby | `[data-testid="job-posting"]` | `jobs.ashbyhq.com/company/[id]` |
+| Lever | `.posting` | `jobs.lever.co/company/[id]` |
+| Greenhouse | `.opening` | `boards.greenhouse.io/company/jobs/[id]` |
+| Workday | `.css-19uc56f` | varies |
+
+## Smart Deduplication Rules
+
+1. Strip location suffixes (UK, France, EMEA, etc.)
+2. Strip seniority prefixes for grouping (Sr., Junior, Lead)
+3. Group by normalized title
+4. Keep one representative posting per group
+5. Note the count of similar roles (indicates team scale)
+
+Example:
+- "Account Executive - UK"
+- "Account Executive - France"
+- "Account Executive - DACH"
+-> Analyze ONE, note "3 similar roles = growing sales team"

--- a/skills/consulting-opportunity/templates/company-report.md
+++ b/skills/consulting-opportunity/templates/company-report.md
@@ -1,0 +1,67 @@
+# {Company Name}: Agent Consulting Opportunities
+
+**Generated:** {date}
+**Careers URL:** {url}
+**Status:** Draft
+
+## Company Context
+
+{2-3 paragraphs covering:}
+- What the company does, who they serve
+- Size, funding stage, growth trajectory
+- Key financials: customer count, ARR/revenue, growth rates, funding rounds and investors
+- Team size, number of open roles, and what the hiring push tells you
+- Key operational challenges implied by their business model
+
+## Signal Assessment: {Strong | Medium | Weak}
+
+{Why this company is or isn't a good fit for automation consulting}
+
+## Opportunity 1: {Descriptive Title}
+
+**Team:** {Department/Team name}
+**Scope:** {2-4} week build
+**The one thing it solves:** {Single sentence describing the core pain point}
+
+**What we'd build:** {Concrete description of the agent/automation — what it does, what inputs it takes, what outputs it produces}
+
+**Why now:** {Reference specific language from job postings that signals this need}
+
+**Honest caveat:** {Be specific: name competing tools/platforms, explain if the team could build this themselves, flag timing or market risks. Don't just note risk — explain why it might not land.}
+
+**Entry point:** {Who to pitch to — name/title}
+
+**Source postings:**
+- {Job title 1}
+- {Job title 2}
+
+## Opportunity 2: {Descriptive Title}
+
+{Same structure as above}
+
+## Opportunity 3: {Descriptive Title}
+
+{Same structure as above}
+
+---
+
+## Overall Assessment
+
+**Fit: {Strong | Medium | Weak}.**
+{2-3 sentences summarizing the overall opportunity and best angle if pursuing}
+
+**When this might become a fit:** {For weak/medium fits: specific re-check timeline and what would need to change, e.g. "Worth re-checking in 6-12 months if they scale to 50+ people and start hiring operations roles." Omit for strong fits.}
+
+**Best angle if we pursue:** {The single strongest opportunity and how to frame the pitch}
+
+---
+
+## Raw Data
+
+### Jobs Analyzed
+| Title | Team | Link |
+|-------|------|------|
+| ... | ... | ... |
+
+### Jobs Skipped (after dedup)
+- {title} — {reason}

--- a/skills/consulting-opportunity/templates/feedback.md
+++ b/skills/consulting-opportunity/templates/feedback.md
@@ -1,0 +1,17 @@
+# Feedback: {Company Name}
+
+**Date:** {date}
+
+## Opportunity Ratings
+- Opportunity 1: {Good/Meh/Bad} - "{brief reason}"
+- Opportunity 2: {Good/Meh/Bad} - "{brief reason}"
+- Opportunity 3: {Good/Meh/Bad} - "{brief reason}"
+
+## What Worked
+- {bullet points}
+
+## What to Improve
+- {bullet points}
+
+## Notes for Future
+- {any patterns to remember}


### PR DESCRIPTION
## Summary

- Adds a new `consulting-opportunity` skill that analyzes company careers pages to identify consulting opportunities for agent-based automation
- Scrapes job postings via Playwright (handles Ashby, Lever, Greenhouse, and generic JS-rendered ATS pages)
- Detects automation signals in job descriptions (operations, coordination, manual process patterns)
- Generates structured opportunity reports with scoped 2-4 week engagement proposals, honest caveats, and re-check timelines for weak fits

## Structure

```
skills/consulting-opportunity/
├── SKILL.md                    # Skill definition and workflow
├── LICENSE.txt                 # MIT license
├── signals.md                  # Automation signal detection reference
├── templates/
│   ├── company-report.md       # Output template
│   └── feedback.md             # Feedback template
└── scripts/
    ├── scrape.js               # Playwright scraping utilities
    └── package.json            # Script dependencies
```

## Usage

```
/consulting-opportunity https://jobs.ashbyhq.com/somecompany
```

## Test plan

- [x] Tested against YC companies and scale up companies — output matches quality of manually-crafted reports
- [x] No company-specific data included in the skill

## Repo details
https://github.com/abelOntrakk/consulting-opportunity-skill