### PR TITLE
fix(pdf): correct case-sensitive file references in SKILL.md

### DIFF
--- a/skills/pdf/SKILL.md
+++ b/skills/pdf/SKILL.md
@@ -8,7 +8,7 @@ license: Proprietary. LICENSE.txt has complete terms
 
 ## Overview
 
-This guide covers essential PDF processing operations using Python libraries and command-line tools. For advanced features, JavaScript libraries, and detailed examples, see REFERENCE.md. If you need to fill out a PDF form, read FORMS.md and follow its instructions.
+This guide covers essential PDF processing operations using Python libraries and command-line tools. For advanced features, JavaScript libraries, and detailed examples, see reference.md. If you need to fill out a PDF form, read forms.md and follow its instructions.
 
 ## Quick Start
 
@@ -304,11 +304,11 @@ with open("encrypted.pdf", "wb") as output:
 | Create PDFs | reportlab | Canvas or Platypus |
 | Command line merge | qpdf | `qpdf --empty --pages ...` |
 | OCR scanned PDFs | pytesseract | Convert to image first |
-| Fill PDF forms | pdf-lib or pypdf (see FORMS.md) | See FORMS.md |
+| Fill PDF forms | pdf-lib or pypdf (see forms.md) | See forms.md |
 
 ## Next Steps
 
-- For advanced pypdfium2 usage, see REFERENCE.md
-- For JavaScript libraries (pdf-lib), see REFERENCE.md
-- If you need to fill out a PDF form, follow the instructions in FORMS.md
-- For troubleshooting guides, see REFERENCE.md
+- For advanced pypdfium2 usage, see reference.md
+- For JavaScript libraries (pdf-lib), see reference.md
+- If you need to fill out a PDF form, follow the instructions in forms.md
+- For troubleshooting guides, see reference.md


### PR DESCRIPTION
## Summary

- Fix 8 case-sensitivity mismatches in `skills/pdf/SKILL.md`
- `REFERENCE.md` → `reference.md` (4 occurrences)
- `FORMS.md` → `forms.md` (4 occurrences)

The actual files are lowercase (`forms.md`, `reference.md`), but SKILL.md references them in uppercase. This breaks on case-sensitive filesystems (Linux, macOS APFS case-sensitive) where the skill may fail to resolve these references.

Closes #375

## Test plan

- [x] Verified actual filenames are lowercase: `forms.md`, `reference.md`
- [x] All 8 references updated to match actual filenames
- [x] No other files affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)