### PR TITLE
fix(skill-creator): warn on unquoted description with YAML special characters

### DIFF
--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -30,6 +30,18 @@ def validate_skill(skill_path):
 
     frontmatter_text = match.group(1)
 
+    # Warn about unquoted description containing YAML special characters
+    desc_match = re.search(r'^description:\s*(["\']?)(.+?)\1\s*$', frontmatter_text, re.MULTILINE)
+    if desc_match:
+        quote_char = desc_match.group(1)
+        desc_value = desc_match.group(2)
+        if not quote_char and ':' in desc_value:
+            return False, (
+                "Description contains ':' but is not quoted. "
+                "Wrap in quotes to avoid YAML parsing issues. "
+                "Example: description: \"Use when: gmail, inbox\""
+            )
+
     # Parse YAML frontmatter
     try:
         frontmatter = yaml.safe_load(frontmatter_text)


### PR DESCRIPTION
## Summary

- Add pre-parse validation in `quick_validate.py` to detect unquoted `description` fields containing `:` 
- Prevents silent YAML parsing failures where description is truncated or split into multiple keys
- Checks raw frontmatter text before `yaml.safe_load()` to catch the issue early

## Example

```yaml
# ❌ Now caught by validator
description: Use when: gmail, inbox

# ✅ Passes validation
description: "Use when: gmail, inbox"
```

Closes #338

## Test plan

- [x] Existing valid skills (`pdf`, `frontend-design`) still pass validation
- [x] Unquoted description with `:` correctly returns error with fix suggestion
- [x] Quoted description with `:` passes validation (both single and double quotes)
- [x] Description without `:` passes validation as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)