### PR TITLE
fix(docx): prevent tracked change w:id collision with existing bookmarks

### DIFF
--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -463,16 +463,20 @@ Validates with auto-repair, condenses XML, and creates DOCX. Use `--validate fal
 
 ### Tracked Changes
 
+**CRITICAL — w:id allocation**: The `w:id` attribute shares a single ID space across bookmarks, tracked changes, comments, and move ranges. Before assigning IDs to new tracked changes, scan the document for the maximum existing `w:id` value across ALL element types (`w:bookmarkStart`, `w:bookmarkEnd`, `w:commentRangeStart`, `w:commentRangeEnd`, `w:ins`, `w:del`, etc.) and start numbering from `max + 1`. Never use hardcoded low IDs like 1, 2, 3 — existing bookmarks commonly use those, causing duplicate ID corruption that Word rejects.
+
+**CRITICAL — nesting level**: Tracked change elements (`w:ins`, `w:del`) must be placed at the `w:p` (paragraph) level as siblings of `w:r` elements. Never nest them inside `w:r` (run) or `w:t` (text) elements.
+
 **Insertion:**
 ```xml
-<w:ins w:id="1" w:author="Claude" w:date="2025-01-01T00:00:00Z">
+<w:ins w:id="100" w:author="Claude" w:date="2025-01-01T00:00:00Z">
   <w:r><w:t>inserted text</w:t></w:r>
 </w:ins>
 ```
 
 **Deletion:**
 ```xml
-<w:del w:id="2" w:author="Claude" w:date="2025-01-01T00:00:00Z">
+<w:del w:id="101" w:author="Claude" w:date="2025-01-01T00:00:00Z">
   <w:r><w:delText>deleted text</w:delText></w:r>
 </w:del>
 ```
@@ -481,12 +485,12 @@ Validates with auto-repair, condenses XML, and creates DOCX. Use `--validate fal
 
 **Minimal edits** - only mark what changes:
 ```xml
-<!-- Change "30 days" to "60 days" -->
+<!-- Change "30 days" to "60 days" — IDs must not collide with existing bookmarks/comments -->
 <w:r><w:t>The term is </w:t></w:r>
-<w:del w:id="1" w:author="Claude" w:date="...">
+<w:del w:id="100" w:author="Claude" w:date="...">
   <w:r><w:delText>30</w:delText></w:r>
 </w:del>
-<w:ins w:id="2" w:author="Claude" w:date="...">
+<w:ins w:id="101" w:author="Claude" w:date="...">
   <w:r><w:t>60</w:t></w:r>
 </w:ins>
 <w:r><w:t> days.</w:t></w:r>
@@ -498,10 +502,10 @@ Validates with auto-repair, condenses XML, and creates DOCX. Use `--validate fal
   <w:pPr>
     <w:numPr>...</w:numPr>  <!-- list numbering if present -->
     <w:rPr>
-      <w:del w:id="1" w:author="Claude" w:date="2025-01-01T00:00:00Z"/>
+      <w:del w:id="100" w:author="Claude" w:date="2025-01-01T00:00:00Z"/>
     </w:rPr>
   </w:pPr>
-  <w:del w:id="2" w:author="Claude" w:date="2025-01-01T00:00:00Z">
+  <w:del w:id="101" w:author="Claude" w:date="2025-01-01T00:00:00Z">
     <w:r><w:delText>Entire paragraph content being deleted...</w:delText></w:r>
   </w:del>
 </w:p>
@@ -510,8 +514,8 @@ Without the `<w:del/>` in `<w:pPr><w:rPr>`, accepting changes leaves an empty pa
 
 **Rejecting another author's insertion** - nest deletion inside their insertion:
 ```xml
-<w:ins w:author="Jane" w:id="5">
-  <w:del w:author="Claude" w:id="10">
+<w:ins w:author="Jane" w:id="50">
+  <w:del w:author="Claude" w:id="100">
     <w:r><w:delText>their inserted text</w:delText></w:r>
   </w:del>
 </w:ins>
@@ -519,10 +523,10 @@ Without the `<w:del/>` in `<w:pPr><w:rPr>`, accepting changes leaves an empty pa
 
 **Restoring another author's deletion** - add insertion after (don't modify their deletion):
 ```xml
-<w:del w:author="Jane" w:id="5">
+<w:del w:author="Jane" w:id="50">
   <w:r><w:delText>deleted text</w:delText></w:r>
 </w:del>
-<w:ins w:author="Claude" w:id="10">
+<w:ins w:author="Claude" w:id="100">
   <w:r><w:t>deleted text</w:t></w:r>
 </w:ins>
 ```
@@ -536,7 +540,7 @@ After running `comment.py` (see Step 2), add markers to document.xml. For replie
 ```xml
 <!-- Comment markers are direct children of w:p, never inside w:r -->
 <w:commentRangeStart w:id="0"/>
-<w:del w:id="1" w:author="Claude" w:date="2025-01-01T00:00:00Z">
+<w:del w:id="100" w:author="Claude" w:date="2025-01-01T00:00:00Z">
   <w:r><w:delText>deleted</w:delText></w:r>
 </w:del>
 <w:r><w:t> more text</w:t></w:r>

--- a/skills/docx/scripts/office/validators/base.py
+++ b/skills/docx/scripts/office/validators/base.py
@@ -17,25 +17,50 @@ class BaseSchemaValidator:
     ]
 
     UNIQUE_ID_REQUIREMENTS = {
-        "comment": ("id", "file"),  
-        "commentrangestart": ("id", "file"),  
-        "commentrangeend": ("id", "file"),  
-        "bookmarkstart": ("id", "file"),  
-        "bookmarkend": ("id", "file"),  
-        "sldid": ("id", "file"),  
-        "sldmasterid": ("id", "global"),  
-        "sldlayoutid": ("id", "global"),  
-        "cm": ("authorid", "file"),  
-        "sheet": ("sheetid", "file"),  
-        "definedname": ("id", "file"),  
-        "cxnsp": ("id", "file"),  
-        "sp": ("id", "file"),  
-        "pic": ("id", "file"),  
-        "grpsp": ("id", "file"),  
+        "comment": ("id", "file"),
+        "commentrangestart": ("id", "file"),
+        "commentrangeend": ("id", "file"),
+        "bookmarkstart": ("id", "file"),
+        "bookmarkend": ("id", "file"),
+        "ins": ("id", "file"),
+        "del": ("id", "file"),
+        "rprchange": ("id", "file"),
+        "pprchange": ("id", "file"),
+        "sectprchange": ("id", "file"),
+        "tblprchange": ("id", "file"),
+        "tcprchange": ("id", "file"),
+        "trprchange": ("id", "file"),
+        "cellins": ("id", "file"),
+        "celldel": ("id", "file"),
+        "cellmerge": ("id", "file"),
+        "numberingchange": ("id", "file"),
+        "sldid": ("id", "file"),
+        "sldmasterid": ("id", "global"),
+        "sldlayoutid": ("id", "global"),
+        "cm": ("authorid", "file"),
+        "sheet": ("sheetid", "file"),
+        "definedname": ("id", "file"),
+        "cxnsp": ("id", "file"),
+        "sp": ("id", "file"),
+        "pic": ("id", "file"),
+        "grpsp": ("id", "file"),
     }
 
     EXCLUDED_ID_CONTAINERS = {
-        "sectionlst",  
+        "sectionlst",
+    }
+
+    # OOXML elements that share a single w:id space within a file.
+    # Per the spec, w:id must be unique across bookmarks, tracked changes,
+    # comments, and move ranges. Duplicate IDs cause Word to reject the file.
+    SHARED_ID_SPACE_ELEMENTS = {
+        "bookmarkstart", "bookmarkend",
+        "commentrangestart", "commentrangeend",
+        "ins", "del",
+        "rprchange", "pprchange", "sectprchange",
+        "tblprchange", "tcprchange", "trprchange",
+        "cellins", "celldel", "cellmerge",
+        "numberingchange",
     }
 
     ELEMENT_RELATIONSHIP_TYPES = {}
@@ -257,19 +282,25 @@ class BaseSchemaValidator:
                                         tag,
                                     )
                             elif scope == "file":
-                                key = (tag, attr_name)
+                                # Elements in the shared ID space use a
+                                # common key so cross-type duplicates
+                                # (e.g. bookmark vs tracked change) are caught.
+                                if tag in self.SHARED_ID_SPACE_ELEMENTS:
+                                    key = ("__shared_w_id__", attr_name)
+                                else:
+                                    key = (tag, attr_name)
                                 if key not in file_ids:
                                     file_ids[key] = {}
 
                                 if id_value in file_ids[key]:
-                                    prev_line = file_ids[key][id_value]
+                                    prev_line, prev_tag = file_ids[key][id_value]
                                     errors.append(
                                         f"  {xml_file.relative_to(self.unpacked_dir)}: "
                                         f"Line {elem.sourceline}: Duplicate {attr_name}='{id_value}' in <{tag}> "
-                                        f"(first occurrence at line {prev_line})"
+                                        f"(first occurrence at line {prev_line} in <{prev_tag}>)"
                                     )
                                 else:
-                                    file_ids[key][id_value] = elem.sourceline
+                                    file_ids[key][id_value] = (elem.sourceline, tag)
 
             except (lxml.etree.XMLSyntaxError, Exception) as e:
                 errors.append(


### PR DESCRIPTION
## Summary

Fixes document corruption when the DOCX skill adds tracked changes to documents with existing bookmarks.

**Root cause**: In OOXML, `w:id` is a shared ID space across bookmarks, tracked changes, comments, and move ranges. The SKILL.md examples used hardcoded low IDs (1, 2, 3) which commonly collide with existing bookmark IDs, causing Word to reject the file as corrupt.

### Changes

**1. `skills/docx/SKILL.md`**
- Replace all hardcoded low `w:id` values in tracked change examples with high-offset IDs (100, 101, etc.)
- Add **CRITICAL** guidance: scan for max existing `w:id` across ALL element types before assigning new IDs
- Add **CRITICAL** nesting-level warning: `w:ins`/`w:del` must be at `w:p` level, never inside `w:r` or `w:t`

**2. `skills/docx/scripts/office/validators/base.py`**
- Add 12 tracked change element types to `UNIQUE_ID_REQUIREMENTS`: `ins`, `del`, `rPrChange`, `pPrChange`, `sectPrChange`, `tblPrChange`, `tcPrChange`, `trPrChange`, `cellIns`, `cellDel`, `cellMerge`, `numberingChange`
- Add `SHARED_ID_SPACE_ELEMENTS` set defining elements that share the `w:id` space
- Modify `validate_unique_ids()` to check cross-type ID uniqueness for shared-space elements (e.g., detect `bookmarkStart id="1"` conflicting with `ins id="1"`)

Closes #489

## Test plan

- [x] `base.py` compiles without syntax errors
- [x] All tracked change examples in SKILL.md use non-colliding high-offset IDs
- [x] Validator now detects cross-type ID duplicates (bookmark vs tracked change)
- [x] Non-shared-space elements (sp, pic, etc.) still validate independently as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)