### PR TITLE
fix: prevent Zip Slip path traversal in Office document extraction (CWE-22)

### DIFF
--- a/skills/docx/scripts/office/unpack.py
+++ b/skills/docx/scripts/office/unpack.py
@@ -14,6 +14,7 @@ Examples:
 """
 
 import argparse
+import os
 import sys
 import zipfile
 from pathlib import Path
@@ -22,6 +23,20 @@ import defusedxml.minidom
 
 from helpers.merge_runs import merge_runs as do_merge_runs
 from helpers.simplify_redlines import simplify_redlines as do_simplify_redlines
+
+
+def _safe_extractall(zf, target_dir):
+    """Extract zip contents safely, preventing Zip Slip path traversal."""
+    target = os.path.realpath(target_dir)
+    for info in zf.infolist():
+        member_path = os.path.realpath(os.path.join(target, info.filename))
+        if not member_path.startswith(target + os.sep) and member_path != target:
+            raise ValueError(
+                f"Zip entry {info.filename!r} would escape target directory"
+            )
+    _safe_extractall(zf, target_dir)
+
+
 
 SMART_QUOTE_REPLACEMENTS = {
     "\u201c": "&#x201C;",  
@@ -51,7 +66,7 @@ def unpack(
         output_path.mkdir(parents=True, exist_ok=True)
 
         with zipfile.ZipFile(input_path, "r") as zf:
-            zf.extractall(output_path)
+            _safe_extractall(zf, output_path)
 
         xml_files = list(output_path.rglob("*.xml")) + list(output_path.rglob("*.rels"))
         for xml_file in xml_files:

--- a/skills/docx/scripts/office/validate.py
+++ b/skills/docx/scripts/office/validate.py
@@ -14,12 +14,27 @@ Auto-repair fixes:
 """
 
 import argparse
+import os
 import sys
 import tempfile
 import zipfile
 from pathlib import Path
 
 from validators import DOCXSchemaValidator, PPTXSchemaValidator, RedliningValidator
+
+
+def _safe_extractall(zf, target_dir):
+    """Extract zip contents safely, preventing Zip Slip path traversal."""
+    target = os.path.realpath(target_dir)
+    for info in zf.infolist():
+        member_path = os.path.realpath(os.path.join(target, info.filename))
+        if not member_path.startswith(target + os.sep) and member_path != target:
+            raise ValueError(
+                f"Zip entry {info.filename!r} would escape target directory"
+            )
+    _safe_extractall(zf, target_dir)
+
+
 
 
 def main():
@@ -71,7 +86,7 @@ def main():
     if path.is_file() and path.suffix.lower() in [".docx", ".pptx", ".xlsx"]:
         temp_dir = tempfile.mkdtemp()
         with zipfile.ZipFile(path, "r") as zf:
-            zf.extractall(temp_dir)
+            _safe_extractall(zf, temp_dir)
         unpacked_dir = Path(temp_dir)
     else:
         assert path.is_dir(), f"Error: {path} is not a directory or Office file"

--- a/skills/docx/scripts/office/validators/base.py
+++ b/skills/docx/scripts/office/validators/base.py
@@ -3,10 +3,25 @@ Base validator with common validation logic for document files.
 """
 
 import re
+import os
 from pathlib import Path
 
 import defusedxml.minidom
 import lxml.etree
+
+
+def _safe_extractall(zf, target_dir):
+    """Extract zip contents safely, preventing Zip Slip path traversal."""
+    target = os.path.realpath(target_dir)
+    for info in zf.infolist():
+        member_path = os.path.realpath(os.path.join(target, info.filename))
+        if not member_path.startswith(target + os.sep) and member_path != target:
+            raise ValueError(
+                f"Zip entry {info.filename!r} would escape target directory"
+            )
+    _safe_extractall(zf, target_dir)
+
+
 
 
 class BaseSchemaValidator:
@@ -799,7 +814,7 @@ class BaseSchemaValidator:
             temp_path = Path(temp_dir)
 
             with zipfile.ZipFile(self.original_file, "r") as zip_ref:
-                zip_ref.extractall(temp_path)
+                _safe_extractall(zip_ref, temp_path)
 
             original_xml_file = temp_path / relative_path
 

--- a/skills/docx/scripts/office/validators/docx.py
+++ b/skills/docx/scripts/office/validators/docx.py
@@ -3,6 +3,7 @@ Validator for Word document XML files against XSD schemas.
 """
 
 import random
+import os
 import re
 import tempfile
 import zipfile
@@ -11,6 +12,20 @@ import defusedxml.minidom
 import lxml.etree
 
 from .base import BaseSchemaValidator
+
+
+def _safe_extractall(zf, target_dir):
+    """Extract zip contents safely, preventing Zip Slip path traversal."""
+    target = os.path.realpath(target_dir)
+    for info in zf.infolist():
+        member_path = os.path.realpath(os.path.join(target, info.filename))
+        if not member_path.startswith(target + os.sep) and member_path != target:
+            raise ValueError(
+                f"Zip entry {info.filename!r} would escape target directory"
+            )
+    _safe_extractall(zf, target_dir)
+
+
 
 
 class DOCXSchemaValidator(BaseSchemaValidator):
@@ -186,7 +201,7 @@ class DOCXSchemaValidator(BaseSchemaValidator):
         try:
             with tempfile.TemporaryDirectory() as temp_dir:
                 with zipfile.ZipFile(original, "r") as zip_ref:
-                    zip_ref.extractall(temp_dir)
+                    _safe_extractall(zip_ref, temp_dir)
 
                 doc_xml_path = temp_dir + "/word/document.xml"
                 root = lxml.etree.parse(doc_xml_path).getroot()

--- a/skills/docx/scripts/office/validators/redlining.py
+++ b/skills/docx/scripts/office/validators/redlining.py
@@ -3,9 +3,24 @@ Validator for tracked changes in Word documents.
 """
 
 import subprocess
+import os
 import tempfile
 import zipfile
 from pathlib import Path
+
+
+def _safe_extractall(zf, target_dir):
+    """Extract zip contents safely, preventing Zip Slip path traversal."""
+    target = os.path.realpath(target_dir)
+    for info in zf.infolist():
+        member_path = os.path.realpath(os.path.join(target, info.filename))
+        if not member_path.startswith(target + os.sep) and member_path != target:
+            raise ValueError(
+                f"Zip entry {info.filename!r} would escape target directory"
+            )
+    _safe_extractall(zf, target_dir)
+
+
 
 
 class RedliningValidator:
@@ -61,7 +76,7 @@ class RedliningValidator:
 
             try:
                 with zipfile.ZipFile(self.original_docx, "r") as zip_ref:
-                    zip_ref.extractall(temp_path)
+                    _safe_extractall(zip_ref, temp_path)
             except Exception as e:
                 print(f"FAILED - Error unpacking original docx: {e}")
                 return False

--- a/skills/pptx/scripts/office/unpack.py
+++ b/skills/pptx/scripts/office/unpack.py
@@ -14,6 +14,7 @@ Examples:
 """
 
 import argparse
+import os
 import sys
 import zipfile
 from pathlib import Path
@@ -22,6 +23,20 @@ import defusedxml.minidom
 
 from helpers.merge_runs import merge_runs as do_merge_runs
 from helpers.simplify_redlines import simplify_redlines as do_simplify_redlines
+
+
+def _safe_extractall(zf, target_dir):
+    """Extract zip contents safely, preventing Zip Slip path traversal."""
+    target = os.path.realpath(target_dir)
+    for info in zf.infolist():
+        member_path = os.path.realpath(os.path.join(target, info.filename))
+        if not member_path.startswith(target + os.sep) and member_path != target:
+            raise ValueError(
+                f"Zip entry {info.filename!r} would escape target directory"
+            )
+    _safe_extractall(zf, target_dir)
+
+
 
 SMART_QUOTE_REPLACEMENTS = {
     "\u201c": "&#x201C;",  
@@ -51,7 +66,7 @@ def unpack(
         output_path.mkdir(parents=True, exist_ok=True)
 
         with zipfile.ZipFile(input_path, "r") as zf:
-            zf.extractall(output_path)
+            _safe_extractall(zf, output_path)
 
         xml_files = list(output_path.rglob("*.xml")) + list(output_path.rglob("*.rels"))
         for xml_file in xml_files:

--- a/skills/pptx/scripts/office/validate.py
+++ b/skills/pptx/scripts/office/validate.py
@@ -14,12 +14,27 @@ Auto-repair fixes:
 """
 
 import argparse
+import os
 import sys
 import tempfile
 import zipfile
 from pathlib import Path
 
 from validators import DOCXSchemaValidator, PPTXSchemaValidator, RedliningValidator
+
+
+def _safe_extractall(zf, target_dir):
+    """Extract zip contents safely, preventing Zip Slip path traversal."""
+    target = os.path.realpath(target_dir)
+    for info in zf.infolist():
+        member_path = os.path.realpath(os.path.join(target, info.filename))
+        if not member_path.startswith(target + os.sep) and member_path != target:
+            raise ValueError(
+                f"Zip entry {info.filename!r} would escape target directory"
+            )
+    _safe_extractall(zf, target_dir)
+
+
 
 
 def main():
@@ -71,7 +86,7 @@ def main():
     if path.is_file() and path.suffix.lower() in [".docx", ".pptx", ".xlsx"]:
         temp_dir = tempfile.mkdtemp()
         with zipfile.ZipFile(path, "r") as zf:
-            zf.extractall(temp_dir)
+            _safe_extractall(zf, temp_dir)
         unpacked_dir = Path(temp_dir)
     else:
         assert path.is_dir(), f"Error: {path} is not a directory or Office file"

--- a/skills/pptx/scripts/office/validators/base.py
+++ b/skills/pptx/scripts/office/validators/base.py
@@ -3,10 +3,25 @@ Base validator with common validation logic for document files.
 """
 
 import re
+import os
 from pathlib import Path
 
 import defusedxml.minidom
 import lxml.etree
+
+
+def _safe_extractall(zf, target_dir):
+    """Extract zip contents safely, preventing Zip Slip path traversal."""
+    target = os.path.realpath(target_dir)
+    for info in zf.infolist():
+        member_path = os.path.realpath(os.path.join(target, info.filename))
+        if not member_path.startswith(target + os.sep) and member_path != target:
+            raise ValueError(
+                f"Zip entry {info.filename!r} would escape target directory"
+            )
+    _safe_extractall(zf, target_dir)
+
+
 
 
 class BaseSchemaValidator:
@@ -799,7 +814,7 @@ class BaseSchemaValidator:
             temp_path = Path(temp_dir)
 
             with zipfile.ZipFile(self.original_file, "r") as zip_ref:
-                zip_ref.extractall(temp_path)
+                _safe_extractall(zip_ref, temp_path)
 
             original_xml_file = temp_path / relative_path
 

--- a/skills/pptx/scripts/office/validators/docx.py
+++ b/skills/pptx/scripts/office/validators/docx.py
@@ -3,6 +3,7 @@ Validator for Word document XML files against XSD schemas.
 """
 
 import random
+import os
 import re
 import tempfile
 import zipfile
@@ -11,6 +12,20 @@ import defusedxml.minidom
 import lxml.etree
 
 from .base import BaseSchemaValidator
+
+
+def _safe_extractall(zf, target_dir):
+    """Extract zip contents safely, preventing Zip Slip path traversal."""
+    target = os.path.realpath(target_dir)
+    for info in zf.infolist():
+        member_path = os.path.realpath(os.path.join(target, info.filename))
+        if not member_path.startswith(target + os.sep) and member_path != target:
+            raise ValueError(
+                f"Zip entry {info.filename!r} would escape target directory"
+            )
+    _safe_extractall(zf, target_dir)
+
+
 
 
 class DOCXSchemaValidator(BaseSchemaValidator):
@@ -186,7 +201,7 @@ class DOCXSchemaValidator(BaseSchemaValidator):
         try:
             with tempfile.TemporaryDirectory() as temp_dir:
                 with zipfile.ZipFile(original, "r") as zip_ref:
-                    zip_ref.extractall(temp_dir)
+                    _safe_extractall(zip_ref, temp_dir)
 
                 doc_xml_path = temp_dir + "/word/document.xml"
                 root = lxml.etree.parse(doc_xml_path).getroot()

--- a/skills/pptx/scripts/office/validators/redlining.py
+++ b/skills/pptx/scripts/office/validators/redlining.py
@@ -3,9 +3,24 @@ Validator for tracked changes in Word documents.
 """
 
 import subprocess
+import os
 import tempfile
 import zipfile
 from pathlib import Path
+
+
+def _safe_extractall(zf, target_dir):
+    """Extract zip contents safely, preventing Zip Slip path traversal."""
+    target = os.path.realpath(target_dir)
+    for info in zf.infolist():
+        member_path = os.path.realpath(os.path.join(target, info.filename))
+        if not member_path.startswith(target + os.sep) and member_path != target:
+            raise ValueError(
+                f"Zip entry {info.filename!r} would escape target directory"
+            )
+    _safe_extractall(zf, target_dir)
+
+
 
 
 class RedliningValidator:
@@ -61,7 +76,7 @@ class RedliningValidator:
 
             try:
                 with zipfile.ZipFile(self.original_docx, "r") as zip_ref:
-                    zip_ref.extractall(temp_path)
+                    _safe_extractall(zip_ref, temp_path)
             except Exception as e:
                 print(f"FAILED - Error unpacking original docx: {e}")
                 return False

--- a/skills/xlsx/scripts/office/unpack.py
+++ b/skills/xlsx/scripts/office/unpack.py
@@ -14,6 +14,7 @@ Examples:
 """
 
 import argparse
+import os
 import sys
 import zipfile
 from pathlib import Path
@@ -22,6 +23,20 @@ import defusedxml.minidom
 
 from helpers.merge_runs import merge_runs as do_merge_runs
 from helpers.simplify_redlines import simplify_redlines as do_simplify_redlines
+
+
+def _safe_extractall(zf, target_dir):
+    """Extract zip contents safely, preventing Zip Slip path traversal."""
+    target = os.path.realpath(target_dir)
+    for info in zf.infolist():
+        member_path = os.path.realpath(os.path.join(target, info.filename))
+        if not member_path.startswith(target + os.sep) and member_path != target:
+            raise ValueError(
+                f"Zip entry {info.filename!r} would escape target directory"
+            )
+    _safe_extractall(zf, target_dir)
+
+
 
 SMART_QUOTE_REPLACEMENTS = {
     "\u201c": "&#x201C;",  
@@ -51,7 +66,7 @@ def unpack(
         output_path.mkdir(parents=True, exist_ok=True)
 
         with zipfile.ZipFile(input_path, "r") as zf:
-            zf.extractall(output_path)
+            _safe_extractall(zf, output_path)
 
         xml_files = list(output_path.rglob("*.xml")) + list(output_path.rglob("*.rels"))
         for xml_file in xml_files:

--- a/skills/xlsx/scripts/office/validate.py
+++ b/skills/xlsx/scripts/office/validate.py
@@ -14,12 +14,27 @@ Auto-repair fixes:
 """
 
 import argparse
+import os
 import sys
 import tempfile
 import zipfile
 from pathlib import Path
 
 from validators import DOCXSchemaValidator, PPTXSchemaValidator, RedliningValidator
+
+
+def _safe_extractall(zf, target_dir):
+    """Extract zip contents safely, preventing Zip Slip path traversal."""
+    target = os.path.realpath(target_dir)
+    for info in zf.infolist():
+        member_path = os.path.realpath(os.path.join(target, info.filename))
+        if not member_path.startswith(target + os.sep) and member_path != target:
+            raise ValueError(
+                f"Zip entry {info.filename!r} would escape target directory"
+            )
+    _safe_extractall(zf, target_dir)
+
+
 
 
 def main():
@@ -71,7 +86,7 @@ def main():
     if path.is_file() and path.suffix.lower() in [".docx", ".pptx", ".xlsx"]:
         temp_dir = tempfile.mkdtemp()
         with zipfile.ZipFile(path, "r") as zf:
-            zf.extractall(temp_dir)
+            _safe_extractall(zf, temp_dir)
         unpacked_dir = Path(temp_dir)
     else:
         assert path.is_dir(), f"Error: {path} is not a directory or Office file"

--- a/skills/xlsx/scripts/office/validators/base.py
+++ b/skills/xlsx/scripts/office/validators/base.py
@@ -3,10 +3,25 @@ Base validator with common validation logic for document files.
 """
 
 import re
+import os
 from pathlib import Path
 
 import defusedxml.minidom
 import lxml.etree
+
+
+def _safe_extractall(zf, target_dir):
+    """Extract zip contents safely, preventing Zip Slip path traversal."""
+    target = os.path.realpath(target_dir)
+    for info in zf.infolist():
+        member_path = os.path.realpath(os.path.join(target, info.filename))
+        if not member_path.startswith(target + os.sep) and member_path != target:
+            raise ValueError(
+                f"Zip entry {info.filename!r} would escape target directory"
+            )
+    _safe_extractall(zf, target_dir)
+
+
 
 
 class BaseSchemaValidator:
@@ -799,7 +814,7 @@ class BaseSchemaValidator:
             temp_path = Path(temp_dir)
 
             with zipfile.ZipFile(self.original_file, "r") as zip_ref:
-                zip_ref.extractall(temp_path)
+                _safe_extractall(zip_ref, temp_path)
 
             original_xml_file = temp_path / relative_path
 

--- a/skills/xlsx/scripts/office/validators/docx.py
+++ b/skills/xlsx/scripts/office/validators/docx.py
@@ -3,6 +3,7 @@ Validator for Word document XML files against XSD schemas.
 """
 
 import random
+import os
 import re
 import tempfile
 import zipfile
@@ -11,6 +12,20 @@ import defusedxml.minidom
 import lxml.etree
 
 from .base import BaseSchemaValidator
+
+
+def _safe_extractall(zf, target_dir):
+    """Extract zip contents safely, preventing Zip Slip path traversal."""
+    target = os.path.realpath(target_dir)
+    for info in zf.infolist():
+        member_path = os.path.realpath(os.path.join(target, info.filename))
+        if not member_path.startswith(target + os.sep) and member_path != target:
+            raise ValueError(
+                f"Zip entry {info.filename!r} would escape target directory"
+            )
+    _safe_extractall(zf, target_dir)
+
+
 
 
 class DOCXSchemaValidator(BaseSchemaValidator):
@@ -186,7 +201,7 @@ class DOCXSchemaValidator(BaseSchemaValidator):
         try:
             with tempfile.TemporaryDirectory() as temp_dir:
                 with zipfile.ZipFile(original, "r") as zip_ref:
-                    zip_ref.extractall(temp_dir)
+                    _safe_extractall(zip_ref, temp_dir)
 
                 doc_xml_path = temp_dir + "/word/document.xml"
                 root = lxml.etree.parse(doc_xml_path).getroot()

--- a/skills/xlsx/scripts/office/validators/redlining.py
+++ b/skills/xlsx/scripts/office/validators/redlining.py
@@ -3,9 +3,24 @@ Validator for tracked changes in Word documents.
 """
 
 import subprocess
+import os
 import tempfile
 import zipfile
 from pathlib import Path
+
+
+def _safe_extractall(zf, target_dir):
+    """Extract zip contents safely, preventing Zip Slip path traversal."""
+    target = os.path.realpath(target_dir)
+    for info in zf.infolist():
+        member_path = os.path.realpath(os.path.join(target, info.filename))
+        if not member_path.startswith(target + os.sep) and member_path != target:
+            raise ValueError(
+                f"Zip entry {info.filename!r} would escape target directory"
+            )
+    _safe_extractall(zf, target_dir)
+
+
 
 
 class RedliningValidator:
@@ -61,7 +76,7 @@ class RedliningValidator:
 
             try:
                 with zipfile.ZipFile(self.original_docx, "r") as zip_ref:
-                    zip_ref.extractall(temp_path)
+                    _safe_extractall(zip_ref, temp_path)
             except Exception as e:
                 print(f"FAILED - Error unpacking original docx: {e}")
                 return False


### PR DESCRIPTION
## Security Fix

Prevent Zip Slip path traversal vulnerability (CWE-22) across all Office document processing skills.

## Problem

All 15 instances of `zipfile.extractall()` in docx/pptx/xlsx skills extract user-supplied Office documents without validating archive entry paths. A maliciously crafted .docx/.pptx/.xlsx file containing entries with path traversal sequences (e.g., `../../etc/cron.d/malicious`) could write files outside the intended directory.

## Solution

Add `_safe_extractall()` helper that validates every archive member's resolved path stays within the target directory before extraction. Applied to all 15 affected locations across 3 skills:

- `skills/docx/scripts/office/` (5 files)
- `skills/pptx/scripts/office/` (5 files)  
- `skills/xlsx/scripts/office/` (5 files)

## Severity

HIGH — allows arbitrary file write via crafted Office documents.

Fixes #540