### PR TITLE
Add Google Ads as a Partner Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,4 @@ The markdown content below contains the instructions, examples, and guidelines t
 Skills are a great way to teach Claude how to get better at using specific pieces of software. As we see awesome example skills from partners, we may highlight some of them here:
 
 - **Notion** - [Notion Skills for Claude](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0)
+- **Google Ads** - [Google Ads Skills for Claude](https://github.com/itallstartedwithaidea/google-ads-skills) — Campaign analysis, account auditing, safe write operations (CEP protocol), PPC math, and MCP server integration for live Google Ads API access. Install in Claude Code: `/plugin marketplace add itallstartedwithaidea/google-ads-skills`


### PR DESCRIPTION
## Summary

Adds **[Google Ads Skills for Claude](https://github.com/itallstartedwithaidea/google-ads-skills)** to the Partner Skills section of the README.

This skill set teaches Claude how to analyze, audit, optimize, and manage Google Ads accounts. It includes:

| Skill | Description |
|---|---|
| `google-ads-analysis` | Campaign performance analysis with GAQL query patterns, anomaly detection, wasted spend identification |
| `google-ads-audit` | Structured 7-dimension account audit with severity ratings and 30/60/90-day action plans |
| `google-ads-write` | Safe write operations using Confirm-Execute-Postcheck (CEP) protocol — pause, bid, budget, keywords, ads |
| `google-ads-math` | PPC calculations — CPA, ROAS, budget projections, impression share, break-even analysis (no API needed) |
| `google-ads-mcp` | MCP server setup for live Google Ads API access via [google-ads-mcp](https://github.com/itallstartedwithaidea/google-ads-mcp) (29 tools) |

### Claude Code Installation

```
/plugin marketplace add itallstartedwithaidea/google-ads-skills
/plugin install google-ads-full@google-ads-skills
```

### Key Features

- **Write safety**: All mutations use a two-step CEP protocol requiring explicit user confirmation
- **3 plugin bundles**: `google-ads-full` (all 5 skills), `google-ads-readonly` (no write access), `google-ads-mcp-only` (just MCP config)
- **Apache 2.0 licensed**
- **Production-tested**: Powers [googleadsagent.ai](https://googleadsagent.ai)

### Related Ecosystem

- [google-ads-mcp](https://github.com/itallstartedwithaidea/google-ads-mcp) — Python MCP server (29 tools)
- [google-ads-api-agent](https://github.com/itallstartedwithaidea/google-ads-api-agent) — Python agent with FastAPI deployment
- [google-ads-gemini-extension](https://github.com/itallstartedwithaidea/google-ads-gemini-extension) — Gemini CLI extension

## Test plan

- [ ] Verify README renders correctly with the new Partner Skills entry
- [ ] Confirm `itallstartedwithaidea/google-ads-skills` repo is publicly accessible
- [ ] Confirm marketplace.json follows the Claude Code plugin spec


Made with [Cursor](https://cursor.com)