### PR TITLE
Add enzyme skill — semantic search for Obsidian vaults

### DIFF
--- a/skills/enzyme/LICENSE.txt
+++ b/skills/enzyme/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Joshua Pham
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/enzyme/SKILL.md
+++ b/skills/enzyme/SKILL.md
@@ -5,7 +5,7 @@ description: >
   find latent patterns across notes. Use when the user wants to explore their
   thinking, draw connections, or search their vault by concept rather than keyword.
 license: MIT
-compatibility: Requires the enzyme CLI (brew install jshph/enzyme/enzyme-cli). Designed for agents with shell access.
+compatibility: Requires the enzyme CLI (curl -fsSL enzyme.garden/install.sh | bash). Designed for agents with shell access.
 allowed-tools: Bash Read Glob Grep
 metadata:
   author: jshph
@@ -32,10 +32,10 @@ Content retrieval works by **resonance with catalyst questions**, not keyword ma
 Install the `enzyme` CLI:
 
 ```bash
-brew install jshph/enzyme/enzyme-cli
+curl -fsSL enzyme.garden/install.sh | bash
 ```
 
-Or download from [GitHub releases](https://github.com/jshph/enzyme/releases). For a self-contained version with bundled binary and model, see [enzyme-skill](https://github.com/jshph/enzyme-skill).
+Or via Homebrew (`brew install jshph/enzyme/enzyme-cli`) or [GitHub releases](https://github.com/jshph/enzyme/releases). For a self-contained version with bundled binary and model, see [enzyme-skill](https://github.com/jshph/enzyme-skill).
 
 Enzyme resolves the vault path in this order: `-p` flag > `ENZYME_VAULT_ROOT` env var > current directory. If `ENZYME_VAULT_ROOT` is set (check with `echo $ENZYME_VAULT_ROOT`), all commands automatically target the right vault.
 

--- a/skills/enzyme/SKILL.md
+++ b/skills/enzyme/SKILL.md
@@ -5,7 +5,7 @@ description: >
   find latent patterns across notes. Use when the user wants to explore their
   thinking, draw connections, or search their vault by concept rather than keyword.
 license: MIT
-compatibility: Requires the enzyme CLI (brew install jshph/tap/enzyme). Designed for agents with shell access.
+compatibility: Requires the enzyme CLI (brew install jshph/enzyme/enzyme-cli). Designed for agents with shell access.
 allowed-tools: Bash Read Glob Grep
 metadata:
   author: jshph
@@ -32,7 +32,7 @@ Content retrieval works by **resonance with catalyst questions**, not keyword ma
 Install the `enzyme` CLI:
 
 ```bash
-brew install jshph/tap/enzyme
+brew install jshph/enzyme/enzyme-cli
 ```
 
 Or download from [GitHub releases](https://github.com/jshph/enzyme/releases). For a self-contained version with bundled binary and model, see [enzyme-skill](https://github.com/jshph/enzyme-skill).

--- a/skills/enzyme/SKILL.md
+++ b/skills/enzyme/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: enzyme
+description: >
+  Explore an Obsidian vault using Enzyme — surface connections between ideas,
+  find latent patterns across notes. Use when the user wants to explore their
+  thinking, draw connections, or search their vault by concept rather than keyword.
+license: MIT
+compatibility: Requires the enzyme CLI (brew install jshph/tap/enzyme). Designed for agents with shell access.
+allowed-tools: Bash Read Glob Grep
+metadata:
+  author: jshph
+  version: "0.3.2"
+  homepage: https://enzyme.garden
+---
+
+# Enzyme — Vault Exploration Skill
+
+## What Enzyme Is
+
+Enzyme turns your Obsidian vault into something you can converse with. It works through three concepts:
+
+**Entities** are the tags (`#travel`), wikilinks (`[[open questions]]`), and folders (`/people`) in your vault. Each one is a semantic cluster — a gathering of content you've already organized by how you think. Hierarchical tags like `#travel/pyrenees` create nested clusters.
+
+**Catalysts** are AI-generated questions anchored to each entity. They probe what's latent in that cluster. A catalyst for `#travel` might be: *"What kept pulling you forward when something was asking you to stay?"* — and content surfaces because it **speaks to the question**, not because it contains matching words. The same entity explored through different catalysts reveals different material.
+
+**Petri** is the live readout of what's growing in your vault — which entities are active, what catalysts have formed around them, where the thinking is heading. Each entity carries temporal metadata: when you last engaged it, how frequently, whether it's active or dormant. Dormant entities are often the most interesting — they surface threads you've stopped noticing.
+
+Content retrieval works by **resonance with catalyst questions**, not keyword matching. The catalysts encode the vault's own vocabulary for its themes — they're handles the vault has grown. Reaching for them connects you to content that generic search terms won't find.
+
+## Prerequisites
+
+Install the `enzyme` CLI:
+
+```bash
+brew install jshph/tap/enzyme
+```
+
+Or download from [GitHub releases](https://github.com/jshph/enzyme/releases). For a self-contained version with bundled binary and model, see [enzyme-skill](https://github.com/jshph/enzyme-skill).
+
+Enzyme resolves the vault path in this order: `-p` flag > `ENZYME_VAULT_ROOT` env var > current directory. If `ENZYME_VAULT_ROOT` is set (check with `echo $ENZYME_VAULT_ROOT`), all commands automatically target the right vault.
+
+### Check vault initialization
+
+```bash
+ls ${ENZYME_VAULT_ROOT:-.}/.enzyme/enzyme.db
+```
+
+- If `.enzyme/enzyme.db` exists: vault is ready. Run `enzyme petri` to begin.
+- If it doesn't exist: run `enzyme init` to initialize the vault.
+
+## Commands
+
+### `enzyme petri` — See what's growing
+
+Returns JSON with trending entities and their catalysts.
+
+```bash
+enzyme petri                  # Default: top 10 entities
+enzyme petri -n 5             # Top 5 entities
+```
+
+### `enzyme catalyze "query"` — Search by concept
+
+Activates the vault's catalysts to surface resonant content. Returns JSON with matched excerpts, file paths, and contributing catalysts.
+
+```bash
+enzyme catalyze "feeling stuck"
+enzyme catalyze "tension between efficiency and presence" -n 20
+```
+
+### `enzyme init` — Initialize a vault
+
+```bash
+enzyme init                           # Initialize current directory
+enzyme init -p /path/to/vault
+enzyme init --guide "vault guide content"
+```
+
+### `enzyme refresh` — Update the index
+
+Lightweight update that only re-runs if content has changed. Use `--full` to force a complete re-index if results seem off.
+
+```bash
+enzyme refresh                        # Incremental update
+enzyme refresh --full                 # Force full re-index
+```
+
+### `--quiet` mode (agent/headless use)
+
+Both `enzyme init --quiet` and `enzyme refresh --quiet` output compact JSON to stdout that includes full petri data. **Do not follow up with a separate `enzyme petri` call** — it's already in the response under the `petri` key.
+
+When `refresh --quiet` detects the vault is fresh (nothing to do), the output is `{ "fresh": true, "petri": ... }`. When stale, the full output includes indexing stats, capabilities, warnings, entity changes, and petri.
+
+### `enzyme apply <target>` — Project catalysts onto external content
+
+Indexes an external directory using the current vault's catalysts. After applying, search the target with `enzyme catalyze "query" --vault <target>`.
+
+```bash
+enzyme apply ./research-papers           # Apply current vault's catalysts
+enzyme apply ./papers --source ~/vault   # Explicit source vault
+```
+
+### When to use `catalyze` vs text search
+
+**Use text search (grep) when you have a concrete anchor** — something that exists verbatim in the vault:
+- People: "Sarah", `[[Dr. Chen]]`
+- Tags: `#productivity`, `#enzyme/pmf`
+- Links/titles: `[[On Writing Well]]`, `[[meeting notes]]`
+- Files: `Readwise/Articles/...`, book titles, paper names
+- Proper nouns: places, companies, projects
+
+**Use `catalyze` when you only have a theme/concept** — no anchor to grep:
+- "What have I written about feeling stuck?" (no name, no tag, no title)
+- "cost of care in algorithmic interfaces" (academic framing — vault won't use these words)
+- "tension between efficiency and presence" (conceptual, not anchored)
+
+The test: would these exact words appear in their notes? Names and tags always do. Abstract/academic language rarely does — vaults use personal, concrete phrasing.
+
+### Reading JSON output
+
+Enzyme commands return JSON. Read the output directly — do not pipe through Python or jq.
+
+**`enzyme petri`** — each entity object has:
+- `name`, `type`, `frequency`, `activity_trend`, `days_since_last_seen`
+- `catalysts`: array of `{ text, context }`
+
+**`enzyme catalyze`** — response has:
+- `results`: array of `{ file_path, content, similarity }`
+- `top_contributing_catalysts`: array of `{ text, entity, contribution_count }`
+
+## Workflow
+
+1. **Discover vault context.** Scan for structural files that reveal the vault's shape:
+   - Look for `**/MOC.md`, `**/Index.md`, `**/agents.md`, `**/guide.md`, `**/ENZYME_GUIDE.md`, and `**/_index.md`
+   - Read any discovered files to understand vault structure, conventions, and user preferences
+   - If the vault is **not initialized** (no `.enzyme/enzyme.db`), build a guide by stacking the files with context headers describing what each one is, then pipe to `enzyme init --guide`. Example:
+     ```bash
+     enzyme init --guide "$(printf '=== guide.md (entity weights) ===\n'; cat guide.md; printf '\n\n=== CLAUDE.md (vault workflow instructions) ===\n'; cat CLAUDE.md)"
+     ```
+   - If the vault **is initialized**, use this context to orient your petri reading
+
+2. **Start with petri.** Run `enzyme petri` to see the landscape — what's active, what's dormant, what catalysts have formed. (If you just ran `init --quiet` or `refresh --quiet`, petri is already in the JSON output — skip this step.)
+
+3. **Ground in evidence.** Before making observations, use catalysts from the petri to run `enzyme catalyze` searches. Look across entities for patterns — what the user keeps returning to, avoiding, or circling.
+
+4. **Open with a question.** Synthesize a single 10-20 word question that names something the user is *doing* across their vault — then ground it with their words. Follow [petri-guide.md](references/petri-guide.md).
+
+5. **Follow threads.** Use catalysts from petri results to drive searches based on what the user responds to. A catalyst for one entity often surfaces content connecting to another.
+
+6. **Present search results** following [search-guide.md](references/search-guide.md). Lead with their words from matched excerpts, notice tensions across results, suggest specific next searches using catalyst language.

--- a/skills/enzyme/references/petri-guide.md
+++ b/skills/enzyme/references/petri-guide.md
@@ -1,0 +1,152 @@
+# Presenting Petri Results
+
+## Posture
+
+You are returning something the user left behind.
+
+Open with what you found — "You wrote..." then their words. After that, notice something small: a word choice, a sentiment, a tension. Don't rush to make it legible. Wonder about it with them.
+
+"There's something about how you used 'reserves' here..." is better than "So the pattern is X."
+
+The gift is in what you noticed and how you held it — not in how quickly you connected the dots.
+
+## Opening Well
+
+**After grounding with catalyze, craft a single opening question (10-20 words) that invites the user in.** This is the most important move — it's what gives them a way into their own vault.
+
+The question should name something the user is *doing* across their vault — saving, returning to, avoiding, circling, protecting — not list topics. Draw from patterns you noticed across entities in the petri, grounded in the excerpts you retrieved. Personal phrasing, direct.
+
+Avoid: "connect", "intersect", "relate", "explore", "resonate". These are observer words. Use action words that name what the user is up to.
+
+Good opening questions:
+- "Why do you keep saving things you've already decided against?"
+- "You stop writing about X right when it gets personal — what's there?"
+- "Is the thirst about being seen, or about proving you were here?"
+
+Bad opening questions:
+- "How do these themes connect in your thinking?" (observer framing, topic-listing)
+- "What's the relationship between X and Y?" (academic, not personal)
+- "Would you like to explore the tension between A and B?" (generic invitation)
+
+**After the question, ground it.** Show the excerpts that led you there — their words, with attribution. Then notice something small: a word choice, a sentiment, a contradiction between two entries. Don't rush to make it legible. Wonder about it with them.
+
+> "what i'm noticing is that increased capacity and reach through ai comes with increased thirst for connection" — 2024-11-18
+>
+> You used "thirst" here — not "need" or "desire." There's something about that word. It shows up again in your notes about enzyme as a way to "prove" human attention.
+
+**Don't do these:**
+- Rushing to adjacency: "You wrote X. And here's Y. So the pattern is Z." (Too fast — no space to wonder)
+- Energy assessment: "Your vault is absolutely buzzing right now..." (Characterizing, not noticing)
+- Making it legible too fast: "So it's really about hospitality as receiving — that's the thread connecting all three." (Resolving too quickly)
+
+**The gift is in what you noticed and how you held it — not in how quickly you made it legible.**
+
+## Guardrails (non-negotiable)
+
+- Never expose tool names (catalyze, petri, start_exploring_vault) to the user
+- Never say "available via..." or "ready to explore through..."
+- Never open with energy assessments of the vault
+
+## Grounding with Evidence (DO THIS FIRST)
+
+Before presenting observations, retrieve concrete excerpts using `enzyme catalyze`.
+
+The catalysts are where the vault has found language for things — convergences around certain framings. They're keys that unlock semantic territory the vault has already mapped. Generic terms work against this grain; the catalyst vocabulary follows it.
+
+Open with excerpts from their notes. Their words first. Then you speak.
+
+## Reading the Petri
+
+The petri contains trending entities with their catalysts. Each entity has:
+- **Temporal metadata**: first_seen, last_seen, total_mentions, recency_score
+- **Catalysts**: convergences where the vault's language has gathered — handles that reach content generic terms won't find
+
+The catalysts encode the vault's own vocabulary for these themes. They're the entry points the vault has grown; reaching for them connects you to what the vault has already mapped.
+
+Reference specifics when grounding observations:
+- "folder:inbox — 1,019 notes, active through last week"
+- "#enzyme/pmf — 263 mentions over 6 months"
+- "[[ecology of technology]] — 375 mentions since March"
+
+## Expandable Folders (Hierarchical Entities)
+
+Some folders contain **individually meaningful entities** — people, concepts, or notes that get `[[wikilinked]]` throughout the vault. These appear in the petri with `expandable: true` and include:
+
+- **total_children**: How many files are in the folder
+- **sampled_children**: Top children by reference count, each with:
+  - `entity`: The child as a wikilink (e.g., `[[Person Name]]`)
+  - `reference_count`: How often this child is referenced elsewhere
+  - `last_seen`: When this child was last modified
+- **catalyzed_children**: The explicit children that have catalysts generated for them
+- **additional_children_available**: How many more exist beyond the sample
+
+**How to present expandable folders:**
+
+1. **Acknowledge the scope**: Reference the total (e.g., "across N relationships...")
+2. **Incorporate active children into your response**: The sampled children are the most-referenced entities — weave them naturally into observations about patterns, connections, or themes
+3. **Signal depth**: The `additional_children_available` count indicates there's more to explore if the user wants
+
+**The children are already surfaced** — your job is to make meaning from them, not to offer to look them up. Reference specific children when they connect to other themes in the petri.
+
+**Do NOT:**
+- List all sampled children mechanically as a bulleted list
+- Offer to "drill down" or "explore further" using tools — the data is already here
+- Treat expandable folders the same as regular folders
+
+## Presenting Catalysts
+
+**Distill long catalysts into sharp versions:**
+
+| Long | Sharp |
+|------|-------|
+| "Given that X, and considering Y, how does Z complicate Q in context of R?" | "I keep thinking about Z — how does it actually relate to Q?" |
+| "Considering the tension between AI's reliability of data and the need for editorial human voice..." | "I need AI's reliability, but I also need the human voice. How do I hold both?" |
+| "If technology 'flattens the world into what can be indexed and summoned,' what does this mean for preserving meaning that resists optimization?" | "Technology flattens everything into the searchable. What about meaning that shouldn't be indexed?" |
+
+**Keep it to 1-2 sentences. Preserve first-person voice. Strip preambles.**
+
+## Ending Well
+
+**Always end with a specific direction, not a generic invitation.**
+
+Good:
+- "The tension between X and Y feels live — want to follow that thread?"
+- "Your notes on Z keep circling back to this question — shall we dig in?"
+
+Bad:
+- "What would you like to explore?" (too generic)
+- "Which thread do you want to follow?" (puts work on user)
+- "Ready to organize this?" (premature)
+
+## Mattering vs. Sycophancy
+
+Sycophancy affirms the person with generic praise.
+Mattering engages the work with specificity.
+
+- Name the specific note, phrase, or connection that shifted your reading
+- Engage what's unresolved rather than affirming what's concluded
+- Follow threads across their notes and show what you found
+
+Bad: "You're so thoughtful about this topic"
+Good: "This thread keeps surfacing in unexpected places — it's doing more work than the tag suggests."
+
+## Cross-Index Connections
+
+If `applied_targets` is non-empty, the vault's catalysts have been projected onto
+external directories. Each target has a `path`, `doc_count`, and `applied_at`.
+
+**How to present:**
+- Mention applied targets naturally when relevant: "Your catalysts have also been
+  applied to research-papers (1,189 docs) — want me to search there too?"
+- Don't list them mechanically. Only surface when the current theme plausibly
+  spans the external content.
+- Use `enzyme catalyze "query" --vault <path>` to search an applied target.
+
+**When to suggest:**
+- The user asks about a topic that could exist in the external corpus
+- A petri theme bridges domains (e.g., vault has #research, target is papers/)
+- The user explicitly mentions the external content
+
+**When NOT to suggest:**
+- The user's question is clearly vault-internal
+- The applied target is stale or irrelevant to the current thread

--- a/skills/enzyme/references/search-guide.md
+++ b/skills/enzyme/references/search-guide.md
@@ -1,0 +1,59 @@
+# Presenting Search Results
+
+## Presenting Results
+
+Lead with the content, not the metadata. Quote their words directly — use blockquotes with attribution.
+
+Don't open with "I found 12 results across 4 catalysts." Open with the most resonant excerpt and what you notice about it. The search metadata (file paths, scores, catalyst IDs) is scaffolding — the user doesn't need to see it.
+
+## Using Contributing Catalysts
+
+The `top_contributing_catalysts` field shows which questions drove results. Each has:
+- `text`: the catalyst question
+- `entity`: which entity it belongs to
+- `contribution_count`: how many results it surfaced
+
+Use these to frame **why** content surfaced: "This came up because your vault has language around X" or "The catalyst asking about Y pulled this in — it's a different angle than you might expect."
+
+Don't list the catalysts mechanically. Weave them into your reading of the results.
+
+## Connecting Across Results
+
+When multiple results touch the same tension from different angles, notice that. Don't just list results sequentially.
+
+Instead of:
+> "Result 1 is about X. Result 2 is about Y. Result 3 is about Z."
+
+Try:
+> "Two of these come at the same question from opposite directions — one from your notes on [topic A], another from [topic B]. The first treats it as a problem to solve; the second seems to sit with it."
+
+Look for:
+- The same word appearing in different contexts
+- Contradictions between entries (one confident, one uncertain)
+- Time gaps — the same idea revisited months apart with different framing
+- Unexpected connections across domains (a work note and a reading highlight touching the same nerve)
+
+## Cross-Index Connections
+
+If search results span multiple indexes (main vault, Readwise, applied external content), notice when threads cross boundaries. A journal entry and a book highlight touching the same tension is worth calling out — but be selective. Only flag cross-index connections when the bridge is genuine, not forced.
+
+## Follow-up
+
+After presenting results, suggest specific next searches based on what surfaced. Use catalyst language rather than generic terms.
+
+Good:
+- "The word 'reserves' keeps showing up — want to pull on that thread specifically?"
+- "There's a tension between X and Y here that your #productivity catalysts might also reach — worth checking?"
+
+Bad:
+- "Would you like to search for anything else?"
+- "Let me know if you want to explore further."
+
+Suggest 1-2 concrete next directions. Use language from the results themselves — words the user actually wrote — as seeds for follow-up searches.
+
+## When Nothing Surfaces
+
+If results are sparse or low-relevance:
+- The vault may not have content in this area yet. Say so directly.
+- Suggest trying a different framing — abstract queries sometimes miss when the vault uses concrete, personal language. Offer a more grounded alternative.
+- Don't apologize. Absence of results is information too — it tells you something about where the vault's attention has and hasn't been.


### PR DESCRIPTION
## Summary

Adds an [Enzyme](https://enzyme.garden) skill that teaches agents how to explore Obsidian vaults by concept rather than keyword.

Enzyme indexes a vault's tags, wikilinks, and folders, generates AI-driven "catalyst" questions anchored to each entity, then uses those questions to drive semantic retrieval. The skill instructs agents on:

- **`enzyme petri`** — see trending entities and their catalysts
- **`enzyme catalyze "query"`** — search by concept/theme
- **`enzyme refresh`** / **`enzyme init`** — index management
- When to use semantic search vs grep
- How to present results (reference guides for petri and search output)

### Structure

```
skills/enzyme/
├── SKILL.md              # Main instructions
├── LICENSE.txt            # MIT
└── references/
    ├── petri-guide.md     # How to present vault overview results
    └── search-guide.md    # How to present search results
```

### Prerequisites

Requires the `enzyme` CLI (`curl -fsSL enzyme.garden/install.sh | bash` or `brew install jshph/enzyme/enzyme-cli`). A [self-contained version](https://github.com/jshph/enzyme-skill) with bundled binary and embedding model is also available.

- [enzyme.garden](https://enzyme.garden)
- [GitHub (CLI)](https://github.com/jshph/enzyme)
- [GitHub (self-contained skill)](https://github.com/jshph/enzyme-skill)