### PR TITLE
fix(docx): avoid w:id collision with existing bookmarks in tracked changes

### DIFF
--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -448,8 +448,9 @@ Validates with auto-repair, condenses XML, and creates DOCX. Use `--validate fal
 
 ### Common Pitfalls
 
-- **Replace entire `<w:r>` elements**: When adding tracked changes, replace the whole `<w:r>...</w:r>` block with `<w:del>...<w:ins>...` as siblings. Don't inject tracked change tags inside a run.
+- **Replace entire `<w:r>` elements**: When adding tracked changes, replace the whole `<w:r>...</w:r>` block with `<w:del>...<w:ins>...` as siblings at `<w:p>` level. Never inject tracked change tags inside a `<w:r>` or `<w:t>` element.
 - **Preserve `<w:rPr>` formatting**: Copy the original run's `<w:rPr>` block into your tracked change runs to maintain bold, font size, etc.
+- **Use high `w:id` values (90001+)**: The `w:id` attribute is a shared namespace across bookmarks, tracked changes, comments, and move ranges. Starting from low numbers (0, 1, 2) collides with existing bookmark IDs and corrupts the file.
 
 ---
 
@@ -463,16 +464,36 @@ Validates with auto-repair, condenses XML, and creates DOCX. Use `--validate fal
 
 ### Tracked Changes
 
+**CRITICAL: `w:id` is a shared ID space.** In OOXML, `w:id` attributes must be unique across ALL of: bookmarks (`w:bookmarkStart`/`w:bookmarkEnd`), tracked changes (`w:ins`, `w:del`, `w:rPrChange`), comments (`w:commentRangeStart`/`w:commentRangeEnd`), and move ranges. Documents commonly have bookmarks using low IDs (0, 1, 2...). **Always use IDs starting from 90001** for tracked changes to avoid collisions with existing IDs. Duplicate `w:id` values cause Microsoft Word to reject the file as corrupt (macOS Preview is more lenient and may hide this issue).
+
+**CRITICAL: Tracked changes must be at paragraph (`w:p`) level.** `w:ins` and `w:del` elements are siblings of `w:r` inside `w:p`. Never nest them inside `w:r` or `w:t` elements. When modifying text in an existing run, split the run and place tracked change elements between the parts.
+
+```xml
+<!-- WRONG: tracked change nested inside w:r or w:t — produces corrupt file -->
+<w:r>
+  <w:t>some text<w:del w:id="1" w:author="Claude">
+    <w:r><w:t>deleted</w:t></w:r>
+  </w:del>more text</w:t>
+</w:r>
+
+<!-- CORRECT: tracked changes as siblings of w:r inside w:p -->
+<w:r><w:t>some text</w:t></w:r>
+<w:del w:id="90001" w:author="Claude" w:date="2025-01-01T00:00:00Z">
+  <w:r><w:delText>deleted</w:delText></w:r>
+</w:del>
+<w:r><w:t>more text</w:t></w:r>
+```
+
 **Insertion:**
 ```xml
-<w:ins w:id="1" w:author="Claude" w:date="2025-01-01T00:00:00Z">
+<w:ins w:id="90001" w:author="Claude" w:date="2025-01-01T00:00:00Z">
   <w:r><w:t>inserted text</w:t></w:r>
 </w:ins>
 ```
 
 **Deletion:**
 ```xml
-<w:del w:id="2" w:author="Claude" w:date="2025-01-01T00:00:00Z">
+<w:del w:id="90002" w:author="Claude" w:date="2025-01-01T00:00:00Z">
   <w:r><w:delText>deleted text</w:delText></w:r>
 </w:del>
 ```
@@ -483,10 +504,10 @@ Validates with auto-repair, condenses XML, and creates DOCX. Use `--validate fal
 ```xml
 <!-- Change "30 days" to "60 days" -->
 <w:r><w:t>The term is </w:t></w:r>
-<w:del w:id="1" w:author="Claude" w:date="...">
+<w:del w:id="90001" w:author="Claude" w:date="...">
   <w:r><w:delText>30</w:delText></w:r>
 </w:del>
-<w:ins w:id="2" w:author="Claude" w:date="...">
+<w:ins w:id="90002" w:author="Claude" w:date="...">
   <w:r><w:t>60</w:t></w:r>
 </w:ins>
 <w:r><w:t> days.</w:t></w:r>
@@ -498,10 +519,10 @@ Validates with auto-repair, condenses XML, and creates DOCX. Use `--validate fal
   <w:pPr>
     <w:numPr>...</w:numPr>  <!-- list numbering if present -->
     <w:rPr>
-      <w:del w:id="1" w:author="Claude" w:date="2025-01-01T00:00:00Z"/>
+      <w:del w:id="90001" w:author="Claude" w:date="2025-01-01T00:00:00Z"/>
     </w:rPr>
   </w:pPr>
-  <w:del w:id="2" w:author="Claude" w:date="2025-01-01T00:00:00Z">
+  <w:del w:id="90002" w:author="Claude" w:date="2025-01-01T00:00:00Z">
     <w:r><w:delText>Entire paragraph content being deleted...</w:delText></w:r>
   </w:del>
 </w:p>
@@ -511,7 +532,7 @@ Without the `<w:del/>` in `<w:pPr><w:rPr>`, accepting changes leaves an empty pa
 **Rejecting another author's insertion** - nest deletion inside their insertion:
 ```xml
 <w:ins w:author="Jane" w:id="5">
-  <w:del w:author="Claude" w:id="10">
+  <w:del w:author="Claude" w:id="90001">
     <w:r><w:delText>their inserted text</w:delText></w:r>
   </w:del>
 </w:ins>
@@ -522,7 +543,7 @@ Without the `<w:del/>` in `<w:pPr><w:rPr>`, accepting changes leaves an empty pa
 <w:del w:author="Jane" w:id="5">
   <w:r><w:delText>deleted text</w:delText></w:r>
 </w:del>
-<w:ins w:author="Claude" w:id="10">
+<w:ins w:author="Claude" w:id="90001">
   <w:r><w:t>deleted text</w:t></w:r>
 </w:ins>
 ```
@@ -536,7 +557,7 @@ After running `comment.py` (see Step 2), add markers to document.xml. For replie
 ```xml
 <!-- Comment markers are direct children of w:p, never inside w:r -->
 <w:commentRangeStart w:id="0"/>
-<w:del w:id="1" w:author="Claude" w:date="2025-01-01T00:00:00Z">
+<w:del w:id="90001" w:author="Claude" w:date="2025-01-01T00:00:00Z">
   <w:r><w:delText>deleted</w:delText></w:r>
 </w:del>
 <w:r><w:t> more text</w:t></w:r>


### PR DESCRIPTION
## Summary

Fixes #489

When the DOCX skill adds tracked changes (`w:ins`, `w:del`) to existing documents, two types of corruption can occur:

1. **Duplicate `w:id` values**: The examples used low IDs (1, 2, 10) which collide with bookmark IDs already present in the document. In OOXML, `w:id` is a shared namespace across bookmarks, tracked changes, comments, and move ranges. Microsoft Word rejects files with duplicate IDs as corrupt (macOS Preview is more lenient and hides this).

2. **Structural nesting violations**: Tracked change elements sometimes get placed inside `w:r` or `w:t` elements instead of at `w:p` (paragraph) level, which violates the OOXML spec.

## Changes

- Updated all tracked change example IDs from low numbers (1, 2, 10) to high numbers (90001, 90002) to avoid collisions with existing document bookmark IDs
- Added a **CRITICAL** note explaining the shared `w:id` namespace requirement across bookmarks, tracked changes, comments, and move ranges
- Added a **CRITICAL** note with wrong/correct XML examples showing that `w:ins`/`w:del` must be siblings of `w:r` at `w:p` level, never nested inside `w:r` or `w:t`
- Reinforced both rules in the Common Pitfalls section

## Test plan

- [ ] Create a DOCX with existing bookmarks (IDs 0-10), apply tracked changes using the skill, verify Word opens without corruption
- [ ] Verify tracked change elements are placed at `w:p` level in generated XML, not nested inside `w:r` or `w:t`
- [ ] Run `python scripts/office/validate.py` on output files to confirm schema compliance

🤖 Generated with [Claude Code](https://claude.com/claude-code)