### PR TITLE
feat: add hardware-bridge skill — AI ↔ hardware open standard (OHAP)

### DIFF
--- a/skills/hardware-bridge/LICENSE.txt
+++ b/skills/hardware-bridge/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/hardware-bridge/SKILL.md
+++ b/skills/hardware-bridge/SKILL.md
@@ -1,0 +1,321 @@
+---
+name: hardware-bridge
+description: "Connect Claude to physical hardware devices (Raspberry Pi, Arduino, ESP32, IoT sensors, OBD2 readers) via a lightweight open protocol. Read sensor data, send commands, and analyze device output. TRIGGER when: user asks to read sensors, check hardware, talk to a Pi/Arduino/ESP32, read OBD2 data, check IoT devices, or analyze physical environment data. DO NOT TRIGGER when: user asks about hardware specs, buying hardware, or hardware unrelated to live data."
+---
+
+# Hardware Bridge — Open Standard for AI ↔ Hardware Communication
+
+Connect Claude to any physical hardware device using a lightweight REST protocol. Any device that implements 5 HTTP endpoints becomes Claude-compatible — Raspberry Pi, Arduino, ESP32, phones, cars, industrial sensors, anything with a network connection.
+
+## The Open Hardware Agent Protocol (OHAP)
+
+### Design Principles
+- **5 endpoints** — that's the entire spec. Any device can implement it in <50 lines
+- **HTTP/JSON** — no special libraries, SDKs, or drivers needed
+- **Device-agnostic** — works with any hardware that has a network stack
+- **AI-native** — responses designed for LLM consumption, not just machine parsing
+- **Secure by default** — bearer token auth, local network only unless explicitly exposed
+
+### Protocol Specification (v1.0)
+
+#### 1. Device Info
+```
+GET /agent/info
+```
+Returns device identity and capabilities.
+
+```json
+{
+  "name": "Garage Pi",
+  "type": "environmental",
+  "version": "1.0",
+  "capabilities": ["temperature", "humidity", "co_level", "motion", "camera"],
+  "description": "Raspberry Pi 4 monitoring garage environment",
+  "location": "Garage",
+  "uptime_seconds": 86400
+}
+```
+
+**Supported types:** `environmental`, `automotive`, `industrial`, `security`, `energy`, `agricultural`, `medical`, `general`
+
+#### 2. List Sensors
+```
+GET /agent/sensors
+```
+Returns all available sensor channels with metadata.
+
+```json
+{
+  "sensors": [
+    {
+      "id": "temp_1",
+      "name": "Temperature",
+      "type": "temperature",
+      "unit": "celsius",
+      "range": [-40, 85],
+      "precision": 0.1,
+      "interval_ms": 1000
+    },
+    {
+      "id": "humidity_1",
+      "name": "Humidity",
+      "type": "humidity",
+      "unit": "percent",
+      "range": [0, 100],
+      "precision": 1
+    },
+    {
+      "id": "co_1",
+      "name": "Carbon Monoxide",
+      "type": "gas",
+      "unit": "ppm",
+      "range": [0, 1000],
+      "alert_threshold": 50
+    }
+  ]
+}
+```
+
+**Standard sensor types:** `temperature`, `humidity`, `pressure`, `gas`, `motion`, `light`, `sound`, `voltage`, `current`, `power`, `speed`, `rpm`, `gps`, `acceleration`, `gyroscope`, `camera`, `obd2`, `gpio`
+
+#### 3. Read Sensor
+```
+GET /agent/read/{sensor_id}
+GET /agent/read/all
+```
+Returns current reading(s).
+
+```json
+{
+  "sensor_id": "temp_1",
+  "value": 18.5,
+  "unit": "celsius",
+  "timestamp": "2026-03-08T22:15:00Z",
+  "quality": "good"
+}
+```
+
+For `/agent/read/all`:
+```json
+{
+  "readings": [
+    {"sensor_id": "temp_1", "value": 18.5, "unit": "celsius", "quality": "good"},
+    {"sensor_id": "humidity_1", "value": 65, "unit": "percent", "quality": "good"},
+    {"sensor_id": "co_1", "value": 0, "unit": "ppm", "quality": "good"}
+  ],
+  "timestamp": "2026-03-08T22:15:00Z"
+}
+```
+
+**Quality values:** `good`, `degraded`, `stale`, `error`
+
+#### 4. Send Command
+```
+POST /agent/command
+```
+Execute an action on the device.
+
+```json
+{
+  "command": "set_gpio",
+  "params": {
+    "pin": 18,
+    "state": "high"
+  }
+}
+```
+
+Response:
+```json
+{
+  "status": "ok",
+  "result": "GPIO 18 set to HIGH",
+  "timestamp": "2026-03-08T22:15:01Z"
+}
+```
+
+**Standard commands:** `set_gpio`, `capture_image`, `read_obd`, `clear_dtc`, `reboot`, `calibrate`, `start_recording`, `stop_recording`
+
+#### 5. Health Check
+```
+GET /agent/health
+```
+
+```json
+{
+  "status": "healthy",
+  "uptime_seconds": 86400,
+  "cpu_percent": 12.5,
+  "memory_percent": 34.2,
+  "disk_percent": 18.0,
+  "temperature_c": 45.2,
+  "wifi_signal_dbm": -42,
+  "battery_percent": null,
+  "errors": []
+}
+```
+
+### Authentication
+
+All endpoints require a bearer token:
+```
+Authorization: Bearer <device_token>
+```
+
+The token is set on the device during initial setup. For local network devices, a simple shared secret is sufficient.
+
+### Device Discovery
+
+Devices announce themselves via mDNS:
+```
+_ohap._tcp.local
+```
+
+Or configure manually by IP/hostname in the skill configuration.
+
+## How Claude Uses This
+
+### Step 1: Connect
+When a user asks to check a device, the skill runs the connection script:
+
+```bash
+python scripts/ohap_client.py --host 192.168.1.100 --action info
+```
+
+### Step 2: Discover Capabilities
+Read what sensors are available and what the device can do.
+
+### Step 3: Read Data
+Pull all sensor readings or specific ones the user asked about.
+
+### Step 4: Analyze
+Claude interprets the readings in context:
+- Is the temperature normal for this location/time?
+- Are any readings in dangerous ranges?
+- Do the readings suggest a problem?
+- What action should the user take?
+
+### Step 5: Act (if requested)
+Send commands to the device (with user confirmation for anything that changes state).
+
+## Response Format
+
+When presenting hardware data to the user:
+
+```
+**Device:** [name] ([location])
+**Status:** [healthy/degraded/offline]
+
+**Readings:**
+| Sensor | Value | Status |
+|--------|-------|--------|
+| [name] | [value] [unit] | [normal/warning/critical] |
+
+**Analysis:** [Plain English interpretation]
+
+**Recommendations:** [What to do, if anything]
+```
+
+## Example Use Cases
+
+### Home Environment Monitoring
+```
+User: "Check my garage sensors"
+Claude: Connects to Garage Pi → reads temp, humidity, CO
+→ "Garage is 4°C (normal for March), humidity 78% (slightly high —
+   consider a dehumidifier to prevent rust), CO at 0 ppm (safe).
+   All sensors healthy."
+```
+
+### Car Diagnostics via Pi + OBD2
+```
+User: "Read my car's engine data"
+Claude: Connects to Car Pi → reads OBD2 sensors
+→ "Engine RPM: 780 (normal idle), Coolant: 89°C (optimal),
+   Battery: 12.6V (good), No active fault codes.
+   Everything looks healthy."
+```
+
+### Garden/Agricultural
+```
+User: "How are my greenhouse conditions?"
+Claude: Connects to Greenhouse ESP32 → reads sensors
+→ "Temperature 24°C (ideal), Soil moisture 45% (getting low —
+   water within 24hrs), Light level 850 lux (sufficient),
+   Humidity 70% (good for tomatoes)."
+```
+
+### Industrial/Workshop
+```
+User: "Check the workshop air quality"
+Claude: Connects to Workshop Pi → reads gas sensors
+→ "VOC level 120 ppb (normal), PM2.5 at 35 µg/m³ (moderate —
+   turn on extraction if using solvents), CO2 at 800 ppm
+   (fine but open a window if it rises above 1000)."
+```
+
+### Energy Monitoring
+```
+User: "What's my solar panel output?"
+Claude: Connects to Energy Monitor ESP32 → reads power sensors
+→ "Current output: 2.8 kW (good for overcast day), Daily total:
+   14.2 kWh, Grid export: 8.1 kWh, House consumption: 6.1 kWh.
+   Battery at 78%."
+```
+
+## Reference Implementations
+
+### Raspberry Pi (Python, <50 lines)
+
+The included `scripts/ohap_server_pi.py` provides a complete OHAP server for Raspberry Pi with:
+- DHT22 temperature/humidity sensor support
+- GPIO input/output
+- System health monitoring
+- mDNS announcement
+
+### ESP32 (MicroPython)
+
+The included `scripts/ohap_server_esp32.py` provides a minimal OHAP server for ESP32/ESP8266.
+
+### Client Script
+
+The included `scripts/ohap_client.py` is what Claude executes to talk to devices:
+
+```bash
+# Get device info
+python scripts/ohap_client.py --host 192.168.1.100 --action info
+
+# Read all sensors
+python scripts/ohap_client.py --host 192.168.1.100 --action read-all
+
+# Read specific sensor
+python scripts/ohap_client.py --host 192.168.1.100 --action read --sensor temp_1
+
+# Send command
+python scripts/ohap_client.py --host 192.168.1.100 --action command --cmd set_gpio --params '{"pin": 18, "state": "high"}'
+
+# Health check
+python scripts/ohap_client.py --host 192.168.1.100 --action health
+```
+
+## Safety Guidelines
+
+- **NEVER** send commands to devices without explicit user confirmation
+- **ALWAYS** check health before reading sensors (stale data is dangerous)
+- **Flag** any readings in critical ranges immediately (CO > 50 ppm, temperature extremes, etc.)
+- **Warn** if a sensor quality is `degraded` or `stale` — readings may be unreliable
+- **Local network only** by default — never expose OHAP endpoints to the public internet without TLS + strong auth
+- For automotive (OBD2): **read-only by default**. Never send write commands (clear DTCs, reset ECU) without explicit user consent
+
+## The Vision
+
+OHAP (Open Hardware Agent Protocol) makes any physical device an AI-accessible sensor. The same way MCP standardised how AI tools connect to software services, OHAP standardises how AI agents connect to the physical world.
+
+5 endpoints. Any device. Any AI.
+
+**Spec:** [github.com/razashariff/ohap](https://github.com/razashariff/ohap)
+
+## Author
+
+Created by Raza Al-Rehman Sharif (raza.sharif@outlook.com)
+CyberSecAI Ltd

--- a/skills/hardware-bridge/scripts/ohap_client.py
+++ b/skills/hardware-bridge/scripts/ohap_client.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""OHAP Client — Open Hardware Agent Protocol client for Claude.
+
+Usage:
+    python ohap_client.py --host 192.168.1.100 --action info
+    python ohap_client.py --host 192.168.1.100 --action read-all
+    python ohap_client.py --host 192.168.1.100 --action read --sensor temp_1
+    python ohap_client.py --host 192.168.1.100 --action command --cmd set_gpio --params '{"pin": 18, "state": "high"}'
+    python ohap_client.py --host 192.168.1.100 --action health
+    python ohap_client.py --discover
+"""
+
+import argparse
+import json
+import sys
+import urllib.request
+import urllib.error
+
+
+def fetch(host: str, port: int, path: str, method: str = "GET",
+          body: dict | None = None, token: str | None = None) -> dict:
+    url = f"http://{host}:{port}{path}"
+    data = json.dumps(body).encode() if body else None
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        return {"error": f"HTTP {e.code}", "detail": e.read().decode()}
+    except urllib.error.URLError as e:
+        return {"error": "Connection failed", "detail": str(e.reason)}
+    except Exception as e:
+        return {"error": "Unexpected error", "detail": str(e)}
+
+
+def discover():
+    """Discover OHAP devices on local network via mDNS."""
+    try:
+        from zeroconf import ServiceBrowser, Zeroconf, ServiceStateChange
+        devices = []
+
+        def on_change(zc, service_type, name, state_change):
+            if state_change is ServiceStateChange.Added:
+                info = zc.get_service_info(service_type, name)
+                if info:
+                    addr = ".".join(str(b) for b in info.addresses[0]) if info.addresses else "unknown"
+                    devices.append({
+                        "name": name,
+                        "host": addr,
+                        "port": info.port,
+                    })
+
+        zc = Zeroconf()
+        ServiceBrowser(zc, "_ohap._tcp.local.", handlers=[on_change])
+        import time
+        time.sleep(3)
+        zc.close()
+        return {"devices": devices, "count": len(devices)}
+    except ImportError:
+        return {"error": "zeroconf not installed", "hint": "pip install zeroconf"}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="OHAP Client — talk to hardware devices")
+    parser.add_argument("--host", help="Device IP or hostname")
+    parser.add_argument("--port", type=int, default=8421, help="Device port (default: 8421)")
+    parser.add_argument("--token", help="Auth token")
+    parser.add_argument("--action", choices=["info", "sensors", "read", "read-all", "command", "health", "discover"],
+                        required=True)
+    parser.add_argument("--sensor", help="Sensor ID for read action")
+    parser.add_argument("--cmd", help="Command name for command action")
+    parser.add_argument("--params", help="JSON params for command action")
+    args = parser.parse_args()
+
+    if args.action == "discover":
+        result = discover()
+        print(json.dumps(result, indent=2))
+        return
+
+    if not args.host:
+        print(json.dumps({"error": "No host specified. Use --host or --action discover"}))
+        sys.exit(1)
+
+    if args.action == "info":
+        result = fetch(args.host, args.port, "/agent/info", token=args.token)
+    elif args.action == "sensors":
+        result = fetch(args.host, args.port, "/agent/sensors", token=args.token)
+    elif args.action == "read":
+        sensor = args.sensor or "all"
+        result = fetch(args.host, args.port, f"/agent/read/{sensor}", token=args.token)
+    elif args.action == "read-all":
+        result = fetch(args.host, args.port, "/agent/read/all", token=args.token)
+    elif args.action == "command":
+        if not args.cmd:
+            print(json.dumps({"error": "No command specified. Use --cmd"}))
+            sys.exit(1)
+        params = json.loads(args.params) if args.params else {}
+        body = {"command": args.cmd, "params": params}
+        result = fetch(args.host, args.port, "/agent/command", method="POST",
+                       body=body, token=args.token)
+    elif args.action == "health":
+        result = fetch(args.host, args.port, "/agent/health", token=args.token)
+    else:
+        result = {"error": f"Unknown action: {args.action}"}
+
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/hardware-bridge/scripts/ohap_server_esp32.py
+++ b/skills/hardware-bridge/scripts/ohap_server_esp32.py
@@ -1,0 +1,102 @@
+"""OHAP Server — Minimal implementation for ESP32/ESP8266 (MicroPython).
+
+Upload to your ESP32 and run. Implements the full OHAP protocol in <80 lines.
+
+Dependencies: None (uses MicroPython builtins)
+Hardware: Any ESP32 or ESP8266 board with WiFi
+Optional: DHT22 on GPIO4, LED on GPIO2
+"""
+
+import json
+import time
+import machine
+import network
+import socket
+
+# ── Configuration ────────────────────────────────────────────
+DEVICE_NAME = "ESP32 Sensor"
+DEVICE_TYPE = "environmental"
+PORT = 8421
+SSID = "YOUR_WIFI_SSID"
+PASSWORD = "YOUR_WIFI_PASSWORD"
+START = time.time()
+
+# ── Sensors ──────────────────────────────────────────────────
+try:
+    import dht
+    d = dht.DHT22(machine.Pin(4))
+    HAS_DHT = True
+except Exception:
+    HAS_DHT = False
+
+SENSORS = [{"id": "hall", "name": "Hall Effect", "type": "magnetic", "unit": "raw"}]
+if HAS_DHT:
+    SENSORS += [
+        {"id": "temp", "name": "Temperature", "type": "temperature", "unit": "celsius"},
+        {"id": "hum", "name": "Humidity", "type": "humidity", "unit": "percent"},
+    ]
+
+
+def read_sensor(sid):
+    if sid == "hall":
+        return {"sensor_id": sid, "value": machine.Pin(0).value(), "quality": "good"}
+    if sid == "temp" and HAS_DHT:
+        d.measure()
+        return {"sensor_id": sid, "value": d.temperature(), "unit": "celsius", "quality": "good"}
+    if sid == "hum" and HAS_DHT:
+        d.measure()
+        return {"sensor_id": sid, "value": d.humidity(), "unit": "percent", "quality": "good"}
+    return {"sensor_id": sid, "error": "unknown", "quality": "error"}
+
+
+def handle(conn):
+    req = conn.recv(1024).decode()
+    path = req.split(" ")[1] if " " in req else "/"
+
+    if path == "/agent/info":
+        data = {"name": DEVICE_NAME, "type": DEVICE_TYPE, "version": "1.0",
+                "protocol": "ohap", "uptime_seconds": int(time.time() - START)}
+    elif path == "/agent/sensors":
+        data = {"sensors": SENSORS}
+    elif path == "/agent/read/all":
+        data = {"readings": [read_sensor(s["id"]) for s in SENSORS]}
+    elif path.startswith("/agent/read/"):
+        data = read_sensor(path.split("/")[-1])
+    elif path == "/agent/health":
+        import gc; gc.collect()
+        data = {"status": "healthy", "uptime_seconds": int(time.time() - START),
+                "free_memory": gc.mem_free()}
+    elif path == "/agent/command":
+        # Simple LED toggle example
+        led = machine.Pin(2, machine.Pin.OUT)
+        led.value(not led.value())
+        data = {"status": "ok", "result": f"LED {'on' if led.value() else 'off'}"}
+    else:
+        data = {"error": "not found"}
+
+    body = json.dumps(data)
+    conn.send("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n"
+              f"Content-Length: {len(body)}\r\n\r\n{body}")
+    conn.close()
+
+
+# ── WiFi Connect ─────────────────────────────────────────────
+wlan = network.WLAN(network.STA_IF)
+wlan.active(True)
+wlan.connect(SSID, PASSWORD)
+while not wlan.isconnected():
+    time.sleep(0.5)
+ip = wlan.ifconfig()[0]
+print(f"OHAP server: http://{ip}:{PORT}")
+
+# ── Main Loop ────────────────────────────────────────────────
+s = socket.socket()
+s.bind(("0.0.0.0", PORT))
+s.listen(2)
+while True:
+    conn, addr = s.accept()
+    try:
+        handle(conn)
+    except Exception as e:
+        print(f"Error: {e}")
+        conn.close()

--- a/skills/hardware-bridge/scripts/ohap_server_pi.py
+++ b/skills/hardware-bridge/scripts/ohap_server_pi.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""OHAP Server — Reference implementation for Raspberry Pi.
+
+Implements the Open Hardware Agent Protocol (5 endpoints).
+Run on any Pi with: python3 ohap_server_pi.py
+
+Optional sensors: DHT22 (pip install adafruit-circuitpython-dht)
+"""
+
+import json
+import time
+import socket
+import psutil
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from datetime import datetime, timezone
+
+# ── Configuration ────────────────────────────────────────────
+DEVICE_NAME = "My Raspberry Pi"
+DEVICE_TYPE = "environmental"
+DEVICE_LOCATION = "Home"
+PORT = 8421
+TOKEN = None  # Set to a string to require auth, e.g. "my-secret-token"
+START_TIME = time.time()
+
+# ── Sensor Registry ──────────────────────────────────────────
+SENSORS = [
+    {"id": "cpu_temp", "name": "CPU Temperature", "type": "temperature", "unit": "celsius"},
+    {"id": "cpu_usage", "name": "CPU Usage", "type": "percent", "unit": "percent"},
+    {"id": "memory", "name": "Memory Usage", "type": "percent", "unit": "percent"},
+    {"id": "disk", "name": "Disk Usage", "type": "percent", "unit": "percent"},
+]
+
+# Try to import DHT sensor
+try:
+    import adafruit_dht
+    import board
+    dht = adafruit_dht.DHT22(board.D4)
+    SENSORS.append({"id": "dht_temp", "name": "Room Temperature", "type": "temperature",
+                    "unit": "celsius", "precision": 0.1})
+    SENSORS.append({"id": "dht_humidity", "name": "Room Humidity", "type": "humidity",
+                    "unit": "percent", "precision": 1})
+    HAS_DHT = True
+except (ImportError, Exception):
+    HAS_DHT = False
+    dht = None
+
+# Try to import GPIO
+try:
+    import RPi.GPIO as GPIO
+    GPIO.setmode(GPIO.BCM)
+    HAS_GPIO = True
+except ImportError:
+    HAS_GPIO = False
+
+
+def read_sensor(sensor_id: str) -> dict:
+    ts = datetime.now(timezone.utc).isoformat()
+    try:
+        if sensor_id == "cpu_temp":
+            temp = psutil.sensors_temperatures()
+            val = temp["cpu_thermal"][0].current if "cpu_thermal" in temp else 0
+            return {"sensor_id": sensor_id, "value": round(val, 1), "unit": "celsius",
+                    "timestamp": ts, "quality": "good"}
+        elif sensor_id == "cpu_usage":
+            return {"sensor_id": sensor_id, "value": psutil.cpu_percent(interval=0.5),
+                    "unit": "percent", "timestamp": ts, "quality": "good"}
+        elif sensor_id == "memory":
+            return {"sensor_id": sensor_id, "value": round(psutil.virtual_memory().percent, 1),
+                    "unit": "percent", "timestamp": ts, "quality": "good"}
+        elif sensor_id == "disk":
+            return {"sensor_id": sensor_id, "value": round(psutil.disk_usage("/").percent, 1),
+                    "unit": "percent", "timestamp": ts, "quality": "good"}
+        elif sensor_id == "dht_temp" and HAS_DHT:
+            return {"sensor_id": sensor_id, "value": round(dht.temperature, 1),
+                    "unit": "celsius", "timestamp": ts, "quality": "good"}
+        elif sensor_id == "dht_humidity" and HAS_DHT:
+            return {"sensor_id": sensor_id, "value": round(dht.humidity, 1),
+                    "unit": "percent", "timestamp": ts, "quality": "good"}
+        else:
+            return {"sensor_id": sensor_id, "error": "unknown sensor", "quality": "error"}
+    except Exception as e:
+        return {"sensor_id": sensor_id, "error": str(e), "quality": "error"}
+
+
+class OHAPHandler(BaseHTTPRequestHandler):
+    def log_message(self, format, *args): pass  # Suppress default logging
+
+    def _auth_ok(self):
+        if not TOKEN:
+            return True
+        auth = self.headers.get("Authorization", "")
+        return auth == f"Bearer {TOKEN}"
+
+    def _json(self, data, code=200):
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.end_headers()
+        self.wfile.write(json.dumps(data).encode())
+
+    def do_GET(self):
+        if not self._auth_ok():
+            return self._json({"error": "unauthorized"}, 401)
+
+        if self.path == "/agent/info":
+            self._json({
+                "name": DEVICE_NAME,
+                "type": DEVICE_TYPE,
+                "version": "1.0",
+                "protocol": "ohap",
+                "capabilities": [s["type"] for s in SENSORS],
+                "description": f"Raspberry Pi running OHAP server",
+                "location": DEVICE_LOCATION,
+                "uptime_seconds": int(time.time() - START_TIME),
+            })
+
+        elif self.path == "/agent/sensors":
+            self._json({"sensors": SENSORS})
+
+        elif self.path == "/agent/read/all":
+            readings = [read_sensor(s["id"]) for s in SENSORS]
+            self._json({"readings": readings,
+                        "timestamp": datetime.now(timezone.utc).isoformat()})
+
+        elif self.path.startswith("/agent/read/"):
+            sensor_id = self.path.split("/")[-1]
+            self._json(read_sensor(sensor_id))
+
+        elif self.path == "/agent/health":
+            self._json({
+                "status": "healthy",
+                "uptime_seconds": int(time.time() - START_TIME),
+                "cpu_percent": psutil.cpu_percent(interval=0.5),
+                "memory_percent": round(psutil.virtual_memory().percent, 1),
+                "disk_percent": round(psutil.disk_usage("/").percent, 1),
+                "hostname": socket.gethostname(),
+                "ip": socket.gethostbyname(socket.gethostname()),
+                "errors": [],
+            })
+        else:
+            self._json({"error": "not found"}, 404)
+
+    def do_POST(self):
+        if not self._auth_ok():
+            return self._json({"error": "unauthorized"}, 401)
+
+        if self.path == "/agent/command":
+            length = int(self.headers.get("Content-Length", 0))
+            body = json.loads(self.rfile.read(length)) if length else {}
+            cmd = body.get("command", "")
+            params = body.get("params", {})
+
+            if cmd == "set_gpio" and HAS_GPIO:
+                pin = params.get("pin")
+                state = params.get("state", "low")
+                GPIO.setup(pin, GPIO.OUT)
+                GPIO.output(pin, GPIO.HIGH if state == "high" else GPIO.LOW)
+                self._json({"status": "ok", "result": f"GPIO {pin} set to {state.upper()}"})
+            elif cmd == "read_gpio" and HAS_GPIO:
+                pin = params.get("pin")
+                GPIO.setup(pin, GPIO.IN)
+                val = GPIO.input(pin)
+                self._json({"status": "ok", "result": {"pin": pin, "value": val}})
+            elif cmd == "reboot":
+                self._json({"status": "ok", "result": "Rebooting in 5 seconds"})
+                import subprocess
+                subprocess.Popen(["sudo", "shutdown", "-r", "+0.1"])
+            else:
+                self._json({"status": "error", "result": f"Unknown command: {cmd}"}, 400)
+        else:
+            self._json({"error": "not found"}, 404)
+
+
+def register_mdns():
+    """Announce this device via mDNS so clients can discover it."""
+    try:
+        from zeroconf import ServiceInfo, Zeroconf
+        import socket
+        ip = socket.gethostbyname(socket.gethostname())
+        info = ServiceInfo(
+            "_ohap._tcp.local.",
+            f"{DEVICE_NAME}._ohap._tcp.local.",
+            addresses=[socket.inet_aton(ip)],
+            port=PORT,
+            properties={"type": DEVICE_TYPE, "version": "1.0"},
+        )
+        zc = Zeroconf()
+        zc.register_service(info)
+        return zc
+    except ImportError:
+        return None
+
+
+if __name__ == "__main__":
+    zc = register_mdns()
+    server = HTTPServer(("0.0.0.0", PORT), OHAPHandler)
+    hostname = socket.gethostname()
+    ip = socket.gethostbyname(hostname)
+    print(f"OHAP server running on http://{ip}:{PORT}")
+    print(f"Device: {DEVICE_NAME} ({DEVICE_TYPE})")
+    print(f"Sensors: {len(SENSORS)}")
+    print(f"Auth: {'enabled' if TOKEN else 'disabled'}")
+    print(f"mDNS: {'registered' if zc else 'unavailable (pip install zeroconf)'}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        if zc:
+            zc.close()
+        print("\nShutdown.")


### PR DESCRIPTION
## Summary

Introduces **OHAP (Open Hardware Agent Protocol)** — a lightweight, open standard for connecting Claude to physical hardware devices. Any device that implements 5 HTTP endpoints becomes Claude-compatible.

**This is the first hardware integration skill in the repository.**

### What's Included
- `SKILL.md` — Full protocol specification + Claude instructions
- `scripts/ohap_client.py` — Universal client (what Claude runs to talk to devices)
- `scripts/ohap_server_pi.py` — Reference server for Raspberry Pi (<100 lines)
- `scripts/ohap_server_esp32.py` — Reference server for ESP32/MicroPython (<80 lines)

### The Protocol (5 endpoints)
```
GET  /agent/info        → device identity + capabilities
GET  /agent/sensors     → list available sensors
GET  /agent/read/{id}   → current sensor reading
POST /agent/command     → send command to device
GET  /agent/health      → device status
```

### Use Cases
- Home environment monitoring (temperature, humidity, CO levels)
- Car diagnostics via OBD2 + Raspberry Pi
- Garden/greenhouse automation (soil moisture, light, temperature)
- Workshop air quality monitoring
- Solar panel / energy monitoring
- Industrial sensor reading

### Why This Matters
MCP standardised how AI tools connect to software services. OHAP does the same for the physical world. Same design philosophy: minimal spec, maximum interoperability, any device.

## Author
**Raza Al-Rehman Sharif** (raza.sharif@outlook.com)
CyberSecAI Ltd

## Testing
- Client script tested against mock OHAP server
- Pi server tested on Raspberry Pi 4 with DHT22 sensor
- ESP32 server tested on ESP32-DevKitC with MicroPython