### PR TITLE
Add pdf-signature skill for adding handwritten signatures to PDFs

### DIFF
--- a/skills/pdf-signature/LICENSE.txt
+++ b/skills/pdf-signature/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/pdf-signature/SKILL.md
+++ b/skills/pdf-signature/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: pdf-signature
+description: "Add handwritten signatures to PDF documents with automatic background removal and flexible positioning. Use when users need to: (1) add signatures to PDF files, (2) sign documents at specific positions (corners), (3) sign either all pages or only the last page, or (4) process signature images to remove backgrounds. Triggers include requests like 'sign this PDF', 'add my signature to all pages', 'sign the last page', or 'add signature to the bottom right'."
+license: Apache-2.0. LICENSE.txt has complete terms
+---
+
+# PDF Signature
+
+## Overview
+
+Automatically add handwritten signatures to PDF documents with intelligent image processing. The skill handles signature image preprocessing (background removal, cropping) and precise positioning on PDF pages.
+
+## Quick Start
+
+Basic usage - sign all pages at bottom right corner:
+
+```bash
+python scripts/add_pdf_signature.py <signature_image> <pdf_file>
+```
+
+The script will:
+1. Automatically detect and crop the signature from the image
+2. Remove the background to make it transparent
+3. Add the signature to every page at the bottom right corner
+4. Save output as `<original_filename>_已签名.pdf`
+
+## Workflow
+
+When a user requests PDF signing:
+
+1. **Gather inputs:**
+   - Signature image path (required)
+   - PDF file path (required)
+   - Position preference (optional, default: 右下角)
+   - Pages to sign (optional, default: 每页)
+   - Signature size (optional, default: 80 points)
+
+2. **Run the signature script:**
+   ```bash
+   python scripts/add_pdf_signature.py <signature_image> <pdf_file> \
+     --position <position> \
+     --pages <pages> \
+     --size <size>
+   ```
+
+3. **Verify output:**
+   - Output file is created with suffix `_已签名.pdf`
+   - Check that signature appears on expected pages
+
+## Parameters
+
+### Position Options
+- `右下角` (default) - Bottom right corner
+- `左下角` - Bottom left corner
+- `右上角` - Top right corner
+- `左上角` - Top left corner
+
+### Pages Options
+- `每页` (default) - Sign every page
+- `尾页` - Sign only the last page
+
+### Size
+- Integer value in points (default: 80)
+- Larger values create bigger signatures
+- Aspect ratio is automatically preserved
+
+## Examples
+
+**Sign every page at bottom right (most common):**
+```bash
+python scripts/add_pdf_signature.py signature.jpg document.pdf
+```
+
+**Sign only the last page at bottom left:**
+```bash
+python scripts/add_pdf_signature.py signature.jpg contract.pdf --position 左下角 --pages 尾页
+```
+
+**Custom signature size:**
+```bash
+python scripts/add_pdf_signature.py signature.jpg report.pdf --size 100
+```
+
+**Specify output location:**
+```bash
+python scripts/add_pdf_signature.py signature.jpg input.pdf --output /path/to/signed.pdf
+```
+
+## How It Works
+
+### Signature Image Processing
+
+The script automatically:
+
+1. **Detects signature region:** Uses pixel brightness analysis (threshold=80) to find dark ink strokes
+2. **Crops whitespace:** Removes empty margins around the signature
+3. **Removes background:** 
+   - Pixels with brightness > 150: Fully transparent
+   - Pixels with brightness 100-150: Semi-transparent
+   - Pixels with brightness < 100: Opaque (signature ink)
+4. **Preserves aspect ratio:** Signature is scaled proportionally
+
+### PDF Processing
+
+1. Reads the original PDF
+2. For each target page:
+   - Creates a transparent overlay with the signature
+   - Positions signature based on --position parameter
+   - Merges overlay onto the original page
+3. Saves all pages to output file
+
+## Dependencies
+
+Required Python packages:
+- `pypdf` - PDF manipulation
+- `pillow` - Image processing
+- `numpy` - Array operations for pixel analysis
+- `reportlab` - PDF canvas creation
+
+Install with:
+```bash
+pip install pypdf pillow numpy reportlab
+```
+
+## Troubleshooting
+
+**Signature not properly cropped:**
+- The script uses brightness threshold 80 to detect ink
+- Very light signatures may need manual adjustment
+- Edit `brightness_threshold` parameter in `process_signature_image()`
+
+**Background not fully transparent:**
+- Adjust threshold values in the background removal section
+- Light gray backgrounds may need higher threshold (>150)
+
+**Signature too large/small:**
+- Use `--size` parameter to adjust width in points
+- Default is 80 points (~1.1 inches)
+
+## Resources
+
+### scripts/add_pdf_signature.py
+
+Complete signature tool with command-line interface. Can be executed directly or read for understanding the implementation.

--- a/skills/pdf-signature/scripts/add_pdf_signature.py
+++ b/skills/pdf-signature/scripts/add_pdf_signature.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""
+PDF签名工具
+用法: python add_pdf_signature.py <签名图片> <PDF文件> [选项]
+
+选项:
+  --position: 签名位置 (右下角/左下角/右上角/左上角, 默认: 右下角)
+  --pages: 签名页面 (每页/尾页, 默认: 每页)
+  --size: 签名宽度，单位点 (默认: 80)
+  --output: 输出文件路径 (默认: 原文件名_已签名.pdf)
+"""
+
+import argparse
+import os
+import io
+import sys
+from PIL import Image
+import numpy as np
+from pypdf import PdfReader, PdfWriter
+from reportlab.pdfgen import canvas
+
+
+def process_signature_image(signature_path, brightness_threshold=80):
+    """
+    处理签名图片: 精确裁剪并去除背景
+    
+    Args:
+        signature_path: 签名图片路径
+        brightness_threshold: 亮度阈值，用于检测签名笔迹
+    
+    Returns:
+        PIL.Image: 处理后的签名图片(RGBA格式，透明背景)
+    """
+    print(f"处理签名图片: {signature_path}")
+    
+    # 打开图片
+    img = Image.open(signature_path)
+    original_size = img.size
+    print(f"  原始尺寸: {original_size}")
+    
+    # 转换为灰度图进行分析
+    gray = img.convert('L')
+    gray_array = np.array(gray)
+    
+    # 使用阈值检测签名笔迹
+    dark_pixels = gray_array < brightness_threshold
+    rows = np.any(dark_pixels, axis=1)
+    cols = np.any(dark_pixels, axis=0)
+    
+    if not (rows.any() and cols.any()):
+        print("  警告: 未能检测到签名区域，使用原始图片")
+        img_cropped = img
+    else:
+        # 找到签名边界
+        y_indices = np.where(rows)[0]
+        x_indices = np.where(cols)[0]
+        y_min, y_max = y_indices[0], y_indices[-1]
+        x_min, x_max = x_indices[0], x_indices[-1]
+        
+        # 添加边距
+        margin = 30
+        y_min = max(0, y_min - margin)
+        y_max = min(gray_array.shape[0], y_max + margin)
+        x_min = max(0, x_min - margin)
+        x_max = min(gray_array.shape[1], x_max + margin)
+        
+        # 裁剪
+        img_cropped = img.crop((x_min, y_min, x_max, y_max))
+        print(f"  裁剪后尺寸: {img_cropped.size}")
+    
+    # 转换为RGBA并处理背景
+    img_rgba = img_cropped.convert("RGBA")
+    datas = np.array(img_rgba)
+    
+    # 去除背景，保留签名笔迹
+    for i in range(datas.shape[0]):
+        for j in range(datas.shape[1]):
+            r, g, b, a = datas[i, j]
+            brightness = (int(r) + int(g) + int(b)) / 3
+            
+            if brightness > 150:  # 浅色背景 -> 透明
+                datas[i, j] = [255, 255, 255, 0]
+            elif brightness > 100:  # 中等亮度 -> 半透明
+                alpha = int((150 - brightness) / 50 * 255)
+                datas[i, j] = [r, g, b, alpha]
+            else:  # 深色笔迹 -> 不透明
+                datas[i, j] = [r, g, b, 255]
+    
+    img_final = Image.fromarray(datas, 'RGBA')
+    print(f"  ✓ 签名处理完成")
+    
+    return img_final
+
+
+def calculate_signature_position(page_width, page_height, sig_width, sig_height, position):
+    """
+    计算签名在页面上的位置
+    
+    Args:
+        page_width: 页面宽度
+        page_height: 页面高度
+        sig_width: 签名宽度
+        sig_height: 签名高度
+        position: 位置选项 (右下角/左下角/右上角/左上角)
+    
+    Returns:
+        tuple: (x, y) 坐标
+    """
+    margin = 40  # 边距
+    
+    position_map = {
+        '右下角': (page_width - sig_width - margin, margin),
+        '左下角': (margin, margin),
+        '右上角': (page_width - sig_width - margin, page_height - sig_height - margin),
+        '左上角': (margin, page_height - sig_height - margin),
+    }
+    
+    return position_map.get(position, position_map['右下角'])
+
+
+def add_signature_to_pdf(pdf_path, signature_img, output_path, position='右下角', 
+                         pages='每页', signature_width=80):
+    """
+    在PDF上添加签名
+    
+    Args:
+        pdf_path: PDF文件路径
+        signature_img: 处理后的签名图片(PIL.Image对象)
+        output_path: 输出文件路径
+        position: 签名位置
+        pages: 签名页面选项 (每页/尾页)
+        signature_width: 签名宽度(点)
+    """
+    print(f"\n处理PDF: {pdf_path}")
+    
+    # 保存临时签名图片
+    temp_sig_path = "/tmp/temp_signature.png"
+    signature_img.save(temp_sig_path, "PNG")
+    
+    # 读取PDF
+    reader = PdfReader(pdf_path)
+    writer = PdfWriter()
+    total_pages = len(reader.pages)
+    
+    print(f"  总页数: {total_pages}")
+    print(f"  签名选项: {pages}")
+    print(f"  签名位置: {position}")
+    
+    # 计算签名高度(保持宽高比)
+    aspect_ratio = signature_img.size[1] / signature_img.size[0]
+    signature_height = signature_width * aspect_ratio
+    
+    # 确定需要签名的页面
+    if pages == '尾页':
+        pages_to_sign = [total_pages - 1]
+    else:  # 每页
+        pages_to_sign = range(total_pages)
+    
+    # 处理每一页
+    for page_num, page in enumerate(reader.pages):
+        if page_num in pages_to_sign:
+            print(f"  签名第 {page_num + 1} 页...")
+            
+            # 获取页面尺寸
+            page_width = float(page.mediabox.width)
+            page_height = float(page.mediabox.height)
+            
+            # 创建签名水印
+            packet = io.BytesIO()
+            can = canvas.Canvas(packet, pagesize=(page_width, page_height))
+            
+            # 计算签名位置
+            x_pos, y_pos = calculate_signature_position(
+                page_width, page_height, 
+                signature_width, signature_height, 
+                position
+            )
+            
+            # 绘制签名
+            can.drawImage(temp_sig_path, 
+                          x_pos, y_pos,
+                          width=signature_width, 
+                          height=signature_height,
+                          mask='auto',
+                          preserveAspectRatio=True)
+            can.save()
+            
+            # 合并到原页面
+            packet.seek(0)
+            signature_pdf = PdfReader(packet)
+            page.merge_page(signature_pdf.pages[0])
+        
+        writer.add_page(page)
+    
+    # 保存输出文件
+    with open(output_path, "wb") as output_file:
+        writer.write(output_file)
+    
+    print(f"\n✓ 完成! 已签名 {len(pages_to_sign)} 页")
+    print(f"✓ 输出文件: {output_path}")
+    
+    # 清理临时文件
+    if os.path.exists(temp_sig_path):
+        os.remove(temp_sig_path)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='PDF签名工具 - 为PDF文档添加签名',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+示例:
+  # 在PDF每一页右下角添加签名
+  python add_pdf_signature.py signature.jpg document.pdf
+  
+  # 只在尾页左下角添加签名
+  python add_pdf_signature.py signature.jpg document.pdf --position 左下角 --pages 尾页
+  
+  # 自定义签名大小和输出文件
+  python add_pdf_signature.py signature.jpg document.pdf --size 100 --output signed.pdf
+        """
+    )
+    
+    parser.add_argument('signature', help='签名图片路径')
+    parser.add_argument('pdf', help='PDF文件路径')
+    parser.add_argument('--position', 
+                        choices=['右下角', '左下角', '右上角', '左上角'],
+                        default='右下角',
+                        help='签名位置 (默认: 右下角)')
+    parser.add_argument('--pages',
+                        choices=['每页', '尾页'],
+                        default='每页',
+                        help='签名页面 (默认: 每页)')
+    parser.add_argument('--size',
+                        type=int,
+                        default=80,
+                        help='签名宽度，单位点 (默认: 80)')
+    parser.add_argument('--output',
+                        help='输出文件路径 (默认: 原文件名_已签名.pdf)')
+    
+    args = parser.parse_args()
+    
+    # 验证输入文件
+    if not os.path.exists(args.signature):
+        print(f"错误: 签名图片不存在: {args.signature}")
+        sys.exit(1)
+    
+    if not os.path.exists(args.pdf):
+        print(f"错误: PDF文件不存在: {args.pdf}")
+        sys.exit(1)
+    
+    # 确定输出路径
+    if args.output:
+        output_path = args.output
+    else:
+        pdf_dir = os.path.dirname(args.pdf)
+        pdf_name = os.path.splitext(os.path.basename(args.pdf))[0]
+        output_path = os.path.join(pdf_dir, f"{pdf_name}_已签名.pdf")
+    
+    # 处理签名图片
+    signature_img = process_signature_image(args.signature)
+    
+    # 添加签名到PDF
+    add_signature_to_pdf(
+        args.pdf,
+        signature_img,
+        output_path,
+        position=args.position,
+        pages=args.pages,
+        signature_width=args.size
+    )
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
This PR adds a new `pdf-signature` skill that enables automatic addition of handwritten signatures to PDF documents.

## Features
- **Intelligent image processing**: Automatically detects signature region, crops whitespace, and removes backgrounds
- **Flexible positioning**: Supports 4 corner positions (top-left, top-right, bottom-left, bottom-right)
- **Configurable pages**: Sign all pages or only the last page
- **Transparent backgrounds**: Automatically removes backgrounds for seamless integration with PDFs
- **Aspect ratio preservation**: Maintains signature proportions when scaling

## Implementation
The skill includes a complete Python script (`scripts/add_pdf_signature.py`) that handles the entire workflow:
1. Signature image preprocessing (brightness analysis, cropping, transparency)
2. PDF page iteration and overlay creation
3. Signature positioning and merging

## Usage Example
```bash
# Sign all pages at bottom right corner (default)
python scripts/add_pdf_signature.py signature.jpg document.pdf

# Sign only last page at bottom left
python scripts/add_pdf_signature.py signature.jpg contract.pdf --position 左下角 --pages 尾页
```

## Testing
The skill has been tested with various signature images and PDF documents, successfully handling:
- Different image formats (JPG, PNG)
- Various background colors and lighting conditions
- Multi-page PDFs
- Different page sizes

## License
Apache 2.0 (same as other skills in this repository)