### PR TITLE
Add webpilot skill — CDP-free browser automation

### DIFF
--- a/skills/webpilot/SKILL.md
+++ b/skills/webpilot/SKILL.md
@@ -9,6 +9,16 @@ Use Webpilot as a browser tool.
 
 It gives you a local browser runtime, a CLI, and a WebSocket command surface. Your job is not to guess. Your job is to inspect page state, choose a safe action, run it, and verify the result.
 
+**Do not default to screenshots.** Webpilot exposes the live DOM directly. Screenshots are slow, expensive, and unnecessary for most tasks. Use `html`, `discover`, and `q` to read page state. Reserve `ss` for cases where layout or visual rendering is the actual question.
+
+Start every session by running:
+
+```bash
+npx h17-webpilot -c '.help'
+```
+
+This lists all available commands. Use it to orient before acting.
+
 ## Runtime
 
 ```bash
@@ -37,24 +47,24 @@ Do not skip the inspect step unless you already have fresh page state from the i
 
 Use these first:
 
-- `npx webpilot -c 'html'`: read the current page DOM, title, and URL
-- `npx webpilot -c 'discover'`: list interactive elements and their handles
-- `npx webpilot -c 'q <selector>'`: query specific elements
-- `npx webpilot -c 'wait <selector>'`: wait for a known state change
-- `npx webpilot -c 'ss'`: take a screenshot when visual context matters
+- `npx h17-webpilot -c 'html'`: read the current page DOM, title, and URL
+- `npx h17-webpilot -c 'discover'`: list interactive elements and their handles
+- `npx h17-webpilot -c 'q <selector>'`: query specific elements
+- `npx h17-webpilot -c 'wait <selector>'`: wait for a known state change
+- `npx h17-webpilot -c 'ss'`: last resort — only when layout or visual rendering is the actual question, not DOM structure
 
 ## Act
 
 Use the safest matching action:
 
-- `npx webpilot -c 'click <selector|handleId>'`
-- `npx webpilot -c 'type [selector] <text>'`
-- `npx webpilot -c 'clear <selector>'`
-- `npx webpilot -c 'key <name>'`
-- `npx webpilot -c 'sd [px] [selector]'`
-- `npx webpilot -c 'su [px] [selector]'`
-- `npx webpilot -c 'go <url>'`
-- `npx webpilot -c 'cookies load ./cookies.json'` when the task requires restoring an existing session
+- `npx h17-webpilot -c 'click <selector|handleId>'`
+- `npx h17-webpilot -c 'type [selector] <text>'`
+- `npx h17-webpilot -c 'clear <selector>'`
+- `npx h17-webpilot -c 'key <name>'`
+- `npx h17-webpilot -c 'sd [px] [selector]'`
+- `npx h17-webpilot -c 'su [px] [selector]'`
+- `npx h17-webpilot -c 'go <url>'`
+- `npx h17-webpilot -c 'cookies load ./cookies.json'` when the task requires restoring an existing session
 
 `click` goes through the human action pipeline. If the runtime refuses the action, respect the refusal and re-inspect the page.
 
@@ -62,11 +72,11 @@ Use the safest matching action:
 
 After navigation or interaction, confirm the new state:
 
-- `npx webpilot -c 'wait <selector>'`
-- `npx webpilot -c 'url'`
-- `npx webpilot -c 'title'`
-- `npx webpilot -c 'html'`
-- `npx webpilot -c 'q <selector>'`
+- `npx h17-webpilot -c 'wait <selector>'`
+- `npx h17-webpilot -c 'url'`
+- `npx h17-webpilot -c 'title'`
+- `npx h17-webpilot -c 'html'`
+- `npx h17-webpilot -c 'q <selector>'`
 
 ## Safe Usage Rules
 
@@ -81,15 +91,15 @@ After navigation or interaction, confirm the new state:
 If you need a protocol action that the shorthand CLI does not expose directly, send it through raw mode:
 
 ```bash
-npx webpilot -c 'dom.queryAllInfo {"selector": "a[href]"}'
-npx webpilot -c 'human.scroll {"selector": ".feed", "direction": "down"}'
-npx webpilot -c 'framework.getConfig {}'
+npx h17-webpilot -c 'dom.queryAllInfo {"selector": "a[href]"}'
+npx h17-webpilot -c 'human.scroll {"selector": ".feed", "direction": "down"}'
+npx h17-webpilot -c 'framework.getConfig {}'
 ```
 
 You can also send a full JSON message:
 
 ```bash
-npx webpilot -c '{"action": "tabs.navigate", "params": {"url": "https://example.com"}}'
+npx h17-webpilot -c '{"action": "tabs.navigate", "params": {"url": "https://example.com"}}'
 ```
 
 ## Strategy Notes
@@ -117,7 +127,7 @@ Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_conf
 }
 ```
 
-The MCP server connects to the same WebSocket runtime (`ws://localhost:7331`). Start the runtime first with `npx webpilot start`, then the MCP tools become available in the host application automatically.
+The MCP server connects to the same WebSocket runtime (`ws://localhost:7331`). Start the runtime first with `npx h17-webpilot start`, then the MCP tools become available in the host application automatically.
 
 ## Limits
 

--- a/skills/webpilot/SKILL.md
+++ b/skills/webpilot/SKILL.md
@@ -12,14 +12,13 @@ It gives you a local browser runtime, a CLI, and a WebSocket command surface. Yo
 ## Runtime
 
 ```bash
-npm install -g h17-webpilot
-npx webpilot start
-npx webpilot start -d
+npx h17-webpilot start
+npx h17-webpilot start -d
 ```
 
-If the runtime is already running, use `npx webpilot -c '...'` directly.
+If the runtime is already running, use `npx h17-webpilot -c '...'` directly.
 
-Use `npx webpilot start -d` when you want an append-only session log.
+Use `npx h17-webpilot start -d` when you want an append-only session log.
 
 - default path: `~/h17-webpilot/webpilot.log`
 - config override: `framework.debug.sessionLogPath`
@@ -104,12 +103,6 @@ npx webpilot -c '{"action": "tabs.navigate", "params": {"url": "https://example.
 ## MCP Server
 
 An MCP adapter is available for environments that support the Model Context Protocol (e.g. Claude Desktop, Cursor, Windsurf).
-
-Install:
-
-```bash
-npm install -g webpilot-mcp
-```
 
 Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
 

--- a/skills/webpilot/SKILL.md
+++ b/skills/webpilot/SKILL.md
@@ -12,22 +12,36 @@ It gives you a local browser runtime, a CLI, and a WebSocket command surface. Yo
 
 **Do not default to screenshots.** Webpilot exposes the live DOM directly. Screenshots are slow, expensive, and unnecessary for most tasks. Use `html`, `discover`, and `q` to read page state. Reserve `ss` for cases where layout or visual rendering is the actual question.
 
+## Setup
+
+Verify the package is installed before doing anything else:
+
+```bash
+webpilot --help
+```
+
+If `webpilot` is not found, install it first:
+
+```bash
+npm install -g h17-webpilot
+```
+
+Then run `.help` to list all available commands:
+
+```bash
+webpilot -c '.help'
+```
+
 ## Runtime
 
 ```bash
-npx h17-webpilot start
-npx h17-webpilot start -d
+webpilot start
+webpilot start -d
 ```
 
-If the runtime is already running, use `npx h17-webpilot -c '...'` directly.
+If the runtime is already running, use `webpilot -c '...'` directly.
 
-Once the runtime is running, list all available commands:
-
-```bash
-npx h17-webpilot -c '.help'
-```
-
-Use `npx h17-webpilot start -d` when you want an append-only session log.
+Use `webpilot start -d` when you want an append-only session log.
 
 - default path: `~/h17-webpilot/webpilot.log`
 - config override: `framework.debug.sessionLogPath`
@@ -46,24 +60,24 @@ Do not skip the inspect step unless you already have fresh page state from the i
 
 Use these first:
 
-- `npx h17-webpilot -c 'html'`: read the current page DOM, title, and URL
-- `npx h17-webpilot -c 'discover'`: list interactive elements and their handles
-- `npx h17-webpilot -c 'q <selector>'`: query specific elements
-- `npx h17-webpilot -c 'wait <selector>'`: wait for a known state change
-- `npx h17-webpilot -c 'ss'`: last resort — only when layout or visual rendering is the actual question, not DOM structure
+- `webpilot -c 'html'`: read the current page DOM, title, and URL
+- `webpilot -c 'discover'`: list interactive elements and their handles
+- `webpilot -c 'q <selector>'`: query specific elements
+- `webpilot -c 'wait <selector>'`: wait for a known state change
+- `webpilot -c 'ss'`: last resort — only when layout or visual rendering is the actual question, not DOM structure
 
 ## Act
 
 Use the safest matching action:
 
-- `npx h17-webpilot -c 'click <selector|handleId>'`
-- `npx h17-webpilot -c 'type [selector] <text>'`
-- `npx h17-webpilot -c 'clear <selector>'`
-- `npx h17-webpilot -c 'key <name>'`
-- `npx h17-webpilot -c 'sd [px] [selector]'`
-- `npx h17-webpilot -c 'su [px] [selector]'`
-- `npx h17-webpilot -c 'go <url>'`
-- `npx h17-webpilot -c 'cookies load ./cookies.json'` when the task requires restoring an existing session
+- `webpilot -c 'click <selector|handleId>'`
+- `webpilot -c 'type [selector] <text>'`
+- `webpilot -c 'clear <selector>'`
+- `webpilot -c 'key <name>'`
+- `webpilot -c 'sd [px] [selector]'`
+- `webpilot -c 'su [px] [selector]'`
+- `webpilot -c 'go <url>'`
+- `webpilot -c 'cookies load ./cookies.json'` when the task requires restoring an existing session
 
 `click` goes through the human action pipeline. If the runtime refuses the action, respect the refusal and re-inspect the page.
 
@@ -71,11 +85,11 @@ Use the safest matching action:
 
 After navigation or interaction, confirm the new state:
 
-- `npx h17-webpilot -c 'wait <selector>'`
-- `npx h17-webpilot -c 'url'`
-- `npx h17-webpilot -c 'title'`
-- `npx h17-webpilot -c 'html'`
-- `npx h17-webpilot -c 'q <selector>'`
+- `webpilot -c 'wait <selector>'`
+- `webpilot -c 'url'`
+- `webpilot -c 'title'`
+- `webpilot -c 'html'`
+- `webpilot -c 'q <selector>'`
 
 ## Safe Usage Rules
 
@@ -90,15 +104,15 @@ After navigation or interaction, confirm the new state:
 If you need a protocol action that the shorthand CLI does not expose directly, send it through raw mode:
 
 ```bash
-npx h17-webpilot -c 'dom.queryAllInfo {"selector": "a[href]"}'
-npx h17-webpilot -c 'human.scroll {"selector": ".feed", "direction": "down"}'
-npx h17-webpilot -c 'framework.getConfig {}'
+webpilot -c 'dom.queryAllInfo {"selector": "a[href]"}'
+webpilot -c 'human.scroll {"selector": ".feed", "direction": "down"}'
+webpilot -c 'framework.getConfig {}'
 ```
 
 You can also send a full JSON message:
 
 ```bash
-npx h17-webpilot -c '{"action": "tabs.navigate", "params": {"url": "https://example.com"}}'
+webpilot -c '{"action": "tabs.navigate", "params": {"url": "https://example.com"}}'
 ```
 
 ## Strategy Notes
@@ -126,7 +140,7 @@ Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_conf
 }
 ```
 
-The MCP server connects to the same WebSocket runtime (`ws://localhost:7331`). Start the runtime first with `npx h17-webpilot start`, then the MCP tools become available in the host application automatically.
+The MCP server connects to the same WebSocket runtime (`ws://localhost:7331`). Start the runtime first with `webpilot start`, then the MCP tools become available in the host application automatically.
 
 ## Limits
 

--- a/skills/webpilot/SKILL.md
+++ b/skills/webpilot/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: webpilot
 description: Skill for LLM agents to drive a real browser through the Webpilot CLI and shared WebSocket runtime.
-license: LICENSE.txt
+license: Complete terms in LICENSE.txt
 ---
 
 # Webpilot Skill
@@ -12,14 +12,6 @@ It gives you a local browser runtime, a CLI, and a WebSocket command surface. Yo
 
 **Do not default to screenshots.** Webpilot exposes the live DOM directly. Screenshots are slow, expensive, and unnecessary for most tasks. Use `html`, `discover`, and `q` to read page state. Reserve `ss` for cases where layout or visual rendering is the actual question.
 
-Start every session by running:
-
-```bash
-npx h17-webpilot -c '.help'
-```
-
-This lists all available commands. Use it to orient before acting.
-
 ## Runtime
 
 ```bash
@@ -28,6 +20,12 @@ npx h17-webpilot start -d
 ```
 
 If the runtime is already running, use `npx h17-webpilot -c '...'` directly.
+
+Once the runtime is running, list all available commands:
+
+```bash
+npx h17-webpilot -c '.help'
+```
 
 Use `npx h17-webpilot start -d` when you want an append-only session log.
 

--- a/skills/webpilot/SKILL.md
+++ b/skills/webpilot/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: webpilot
 description: Skill for LLM agents to drive a real browser through the Webpilot CLI and shared WebSocket runtime.
+license: LICENSE.txt
 ---
 
 # Webpilot Skill

--- a/skills/webpilot/SKILL.md
+++ b/skills/webpilot/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: webpilot
+description: Skill for LLM agents to drive a real browser through the Webpilot CLI and shared WebSocket runtime.
+---
+
+# Webpilot Skill
+
+Use Webpilot as a browser tool.
+
+It gives you a local browser runtime, a CLI, and a WebSocket command surface. Your job is not to guess. Your job is to inspect page state, choose a safe action, run it, and verify the result.
+
+## Runtime
+
+```bash
+npm install -g h17-webpilot
+npx webpilot start
+npx webpilot start -d
+```
+
+If the runtime is already running, use `npx webpilot -c '...'` directly.
+
+Use `npx webpilot start -d` when you want an append-only session log.
+
+- default path: `~/h17-webpilot/webpilot.log`
+- config override: `framework.debug.sessionLogPath`
+
+## Operating Loop
+
+Use this order every time:
+
+1. Inspect.
+2. Act.
+3. Verify.
+
+Do not skip the inspect step unless you already have fresh page state from the immediately preceding command.
+
+## Inspect
+
+Use these first:
+
+- `npx webpilot -c 'html'`: read the current page DOM, title, and URL
+- `npx webpilot -c 'discover'`: list interactive elements and their handles
+- `npx webpilot -c 'q <selector>'`: query specific elements
+- `npx webpilot -c 'wait <selector>'`: wait for a known state change
+- `npx webpilot -c 'ss'`: take a screenshot when visual context matters
+
+## Act
+
+Use the safest matching action:
+
+- `npx webpilot -c 'click <selector|handleId>'`
+- `npx webpilot -c 'type [selector] <text>'`
+- `npx webpilot -c 'clear <selector>'`
+- `npx webpilot -c 'key <name>'`
+- `npx webpilot -c 'sd [px] [selector]'`
+- `npx webpilot -c 'su [px] [selector]'`
+- `npx webpilot -c 'go <url>'`
+- `npx webpilot -c 'cookies load ./cookies.json'` when the task requires restoring an existing session
+
+`click` goes through the human action pipeline. If the runtime refuses the action, respect the refusal and re-inspect the page.
+
+## Verify
+
+After navigation or interaction, confirm the new state:
+
+- `npx webpilot -c 'wait <selector>'`
+- `npx webpilot -c 'url'`
+- `npx webpilot -c 'title'`
+- `npx webpilot -c 'html'`
+- `npx webpilot -c 'q <selector>'`
+
+## Safe Usage Rules
+
+- Never guess selectors when `html` or `discover` can tell you the real ones.
+- Never assume a click worked. Verify it.
+- Never treat `{ "clicked": false }` as something to brute-force through.
+- Never confuse DOM reading with interaction. Read first, then act.
+- Re-query stale handles instead of reusing them blindly.
+
+## Raw Protocol
+
+If you need a protocol action that the shorthand CLI does not expose directly, send it through raw mode:
+
+```bash
+npx webpilot -c 'dom.queryAllInfo {"selector": "a[href]"}'
+npx webpilot -c 'human.scroll {"selector": ".feed", "direction": "down"}'
+npx webpilot -c 'framework.getConfig {}'
+```
+
+You can also send a full JSON message:
+
+```bash
+npx webpilot -c '{"action": "tabs.navigate", "params": {"url": "https://example.com"}}'
+```
+
+## Strategy Notes
+
+- Prefer `html`, `discover`, and `q` over `eval` when DOM inspection is enough.
+- Use `wait` after page-changing actions.
+- Use handle IDs when you already have a fresh element from `discover` or `q`.
+- Use screenshots when layout or visibility is the uncertainty, not HTML structure.
+- If the task needs a preloaded authenticated session, load cookies first or use config boot commands.
+
+## MCP Server
+
+An MCP adapter is available for environments that support the Model Context Protocol (e.g. Claude Desktop, Cursor, Windsurf).
+
+Install:
+
+```bash
+npm install -g webpilot-mcp
+```
+
+Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "webpilot": {
+      "command": "npx",
+      "args": ["webpilot-mcp"]
+    }
+  }
+}
+```
+
+The MCP server connects to the same WebSocket runtime (`ws://localhost:7331`). Start the runtime first with `npx webpilot start`, then the MCP tools become available in the host application automatically.
+
+## Limits
+
+- Public defaults are generic and uncalibrated.
+- This tool does not give you task strategy, retries, route doctrine, or tuned behavior profiles.
+- Advanced outcomes depend on how well you choose selectors, waits, verification steps, and configuration.


### PR DESCRIPTION
## Summary

- Adds the **webpilot** skill for Claude Code and compatible agent platforms
- Webpilot is a CDP-free browser automation framework — no Playwright, no Puppeteer, no detectable debugging port
- Drives a real browser through a Chrome extension + WebSocket bridge, giving any LLM a human-like browser surface
- Ships two npm packages: `h17-webpilot` (runtime + CLI) and `webpilot-mcp` (MCP adapter for Claude Desktop, Cursor, Windsurf)

## What the skill does

- Teaches Claude the inspect → act → verify operating loop
- Documents the full CLI shorthand surface (`click`, `type`, `html`, `discover`, `ss`, etc.)
- Documents the raw WebSocket protocol for advanced use
- Includes MCP server setup for Claude Desktop

## Install

```bash
npx h17-webpilot start
```

MCP: `npm install -g webpilot-mcp`

GitHub: https://github.com/hugopalma17/webpilot
npm: https://www.npmjs.com/package/h17-webpilot