### PR TITLE
Add polyflow skill: parallel multi-model AI workflows

### DIFF
--- a/skills/polyflow/SKILL.md
+++ b/skills/polyflow/SKILL.md
@@ -82,7 +82,7 @@ Any [OpenRouter model ID](https://openrouter.ai/models) works in the `model` fie
 ## GitHub Actions integration
 
 ```yaml
-- uses: celesteimnskirakira/polyflow@v1
+- uses: celesteimnskirakira/polyflow-ai@v1
   with:
     workflow: code-review-multi-model
     input: ${{ steps.diff.outputs.content }}

--- a/skills/polyflow/SKILL.md
+++ b/skills/polyflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: polyflow
-description: Use when running multi-model AI workflows where Claude, Gemini, and GPT-4 should analyze the same task in parallel — code review, security audit, cross-validation, or any task where consensus across models is more reliable than a single model's answer. Invoke when the user says "run polyflow", "multi-model review", "parallel AI analysis", "compare models", or wants multiple AI perspectives on the same input.
+description: Use when running parallel multi-model AI workflows — code review, security audit, cross-validation, or any task where consensus across models is more reliable than a single model's answer. Invoke when the user says "run polyflow", "multi-model review", "parallel AI analysis", "compare models", or wants multiple AI perspectives on the same input.
 ---
 
 Run parallel multi-model AI workflows using the `polyflow` CLI. Three models check the same thing simultaneously — consensus findings are more reliable than any single model's output. Describe what you want in plain English, or use one of 22 built-in workflows.

--- a/skills/polyflow/SKILL.md
+++ b/skills/polyflow/SKILL.md
@@ -24,6 +24,10 @@ polyflow run cross-validate -i "your design or problem statement"
 # Run headlessly — no prompts, auto-approve all checkpoints
 polyflow run <workflow> --ci -i "..."
 
+# Generate a custom workflow from natural language
+polyflow new "three models review my API design, vote on findings" -o api-review.yaml
+polyflow new "claude and gemini cross-validate my code, diff mode"
+
 # Browse 22 built-in workflows
 polyflow list
 polyflow list --tag security

--- a/skills/polyflow/SKILL.md
+++ b/skills/polyflow/SKILL.md
@@ -3,70 +3,56 @@ name: polyflow
 description: Use when running parallel multi-model AI workflows — code review, security audit, cross-validation, or any task where consensus across models is more reliable than a single model's answer. Invoke when the user says "run polyflow", "multi-model review", "parallel AI analysis", "compare models", or wants multiple AI perspectives on the same input.
 ---
 
-Run parallel multi-model AI workflows using the `polyflow` CLI. Multiple models check the same thing simultaneously — consensus findings are more reliable than any single model's output. Describe what you want in plain English, or use one of 22 built-in workflows.
+Run parallel multi-model AI workflows using the `polyflow` CLI. Multiple models check the same thing simultaneously — consensus is more reliable than any single model's output.
 
 ## Setup
 
 ```bash
 pip install polyflow-ai
-export OPENROUTER_API_KEY=sk-or-...   # one key covers Claude + Gemini + GPT-4
+export OPENROUTER_API_KEY=sk-or-...   # openrouter.ai — 290+ models, one key
 polyflow doctor                        # verify setup
 ```
 
 ## Key commands
 
 ```bash
-# Describe what you want — Polyflow generates the workflow
+# Generate a workflow from natural language
 polyflow new "multiple models audit my API for security issues, vote on findings" -o audit.yaml
 polyflow run ./audit.yaml -i "$(cat src/api.py)"
 
-# Or use a built-in workflow directly
+# Or use a built-in workflow
 polyflow run code-review-multi-model -i "$(git diff HEAD~1)"
 polyflow run security-audit -i "$(cat src/auth.py)"
 polyflow run cross-validate -i "your design or problem statement"
 
-# Run headlessly — no prompts, auto-approve all checkpoints
+# Run headlessly in CI/CD
 polyflow run <workflow> --ci -i "..."
 
 # Browse 22 built-in workflows
 polyflow list
 polyflow list --tag security
-
-# Validate a custom workflow file
-polyflow validate my-workflow.yaml
 ```
 
-## Workflow selection guide
+## Workflow selection
 
 | Task | Workflow |
 |---|---|
-| Review a code diff or PR | `code-review-multi-model` |
-| Security vulnerability scan | `security-audit` |
-| Cross-validate a plan or design | `cross-validate` |
-| Triage a bug report | `bug-triage` |
-| Generate unit tests | `test-generation` |
-| Write a PR description | `pr-description` |
-| Architecture decision record | `adr-generator` |
+| Code review | `code-review-multi-model` |
+| Security scan | `security-audit` |
+| Cross-validate a plan | `cross-validate` |
+| Bug triage | `bug-triage` |
+| Generate tests | `test-generation` |
+| PR description | `pr-description` |
 
-## How multi-model consensus works
+## How consensus works
 
-Each `type: parallel` step sends the same prompt to multiple models at the same time. The `aggregate` block synthesizes results:
+Each `type: parallel` step sends the same prompt to multiple models simultaneously. The `aggregate` block synthesizes results:
 
-- `mode: vote` — surfaces findings all models agree on (high confidence)
-- `mode: diff` — highlights where models disagree (needs human review)
-- `mode: summary` — one model synthesizes all outputs into a single report
+- `mode: vote` — only findings all models agree on (high confidence)
+- `mode: diff` — where models disagree (needs review)
+- `mode: summary` — one model synthesizes all outputs
 
-This is not about humans being smarter than AI. It's about models checking each other — the same principle behind ensemble methods in ML.
-
-## Write a custom consensus workflow
-
-**From natural language (recommended):**
-
-```bash
-polyflow new "claude and gemini cross-validate my code logic, diff mode" -o review.yaml
-```
-
-**Or write YAML directly:**
+## Custom workflow example
 
 ```yaml
 name: my-consensus-review
@@ -80,27 +66,20 @@ steps:
       - id: gemini_view
         model: gemini
         prompt: "Review this and list issues: {{input}}"
-      - id: gpt4_view
-        model: gpt-4
-        prompt: "Review this and list issues: {{input}}"
     aggregate:
-      mode: vote            # high-confidence: all models agree
-      model: claude         # Claude synthesizes the final report
+      mode: vote
+      model: claude
       prompt: |
         Multiple models independently reviewed this.
-        Synthesize findings. Mark items all models flagged as HIGH CONFIDENCE.
+        Mark items all models flagged as HIGH CONFIDENCE.
         {{aggregated}}
-
-output:
-  format: markdown
-  save_to: review.md
 ```
 
 Run it: `polyflow run ./my-consensus-review.yaml -i "your input"`
 
-## GitHub Actions integration
+Any [OpenRouter model ID](https://openrouter.ai/models) works in the `model` field — 290+ models available.
 
-Add multi-model consensus to any repo:
+## GitHub Actions integration
 
 ```yaml
 - uses: celesteimnskirakira/polyflow@main
@@ -109,5 +88,3 @@ Add multi-model consensus to any repo:
     input: ${{ steps.diff.outputs.content }}
     openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
 ```
-
-Full examples in [`.github/workflows/`](https://github.com/celesteimnskirakira/polyflow/tree/main/.github/workflows).

--- a/skills/polyflow/SKILL.md
+++ b/skills/polyflow/SKILL.md
@@ -28,21 +28,17 @@ polyflow run cross-validate -i "your design or problem statement"
 # Run headlessly in CI/CD
 polyflow run <workflow> --ci -i "..."
 
-# Browse 22 built-in workflows
+# Browse built-in workflows
 polyflow list
-polyflow list --tag security
 ```
 
-## Workflow selection
+## Built-in workflows
 
 | Task | Workflow |
 |---|---|
 | Code review | `code-review-multi-model` |
 | Security scan | `security-audit` |
 | Cross-validate a plan | `cross-validate` |
-| Bug triage | `bug-triage` |
-| Generate tests | `test-generation` |
-| PR description | `pr-description` |
 
 ## How consensus works
 

--- a/skills/polyflow/SKILL.md
+++ b/skills/polyflow/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: polyflow
+description: Use when running multi-model AI workflows where Claude, Gemini, and GPT-4 should analyze the same task in parallel — code review, security audit, cross-validation, or any task where consensus across models is more reliable than a single model's answer. Invoke when the user says "run polyflow", "multi-model review", "parallel AI analysis", "compare models", or wants multiple AI perspectives on the same input.
+---
+
+Run parallel multi-model AI workflows using the `polyflow` CLI. Three models check the same thing simultaneously — consensus findings are more reliable than any single model's output.
+
+## Setup
+
+```bash
+pip install polyflow-ai
+export OPENROUTER_API_KEY=sk-or-...   # one key covers Claude + Gemini + GPT-4
+polyflow doctor                        # verify setup
+```
+
+## Key commands
+
+```bash
+# Run a built-in workflow
+polyflow run code-review-multi-model -i "$(git diff HEAD~1)"
+polyflow run security-audit -i "$(cat src/auth.py)"
+polyflow run cross-validate -i "your design or problem statement"
+
+# Run headlessly — no prompts, auto-approve all checkpoints
+polyflow run <workflow> --ci -i "..."
+
+# Browse 22 built-in workflows
+polyflow list
+polyflow list --tag security
+
+# Validate a custom workflow file
+polyflow validate my-workflow.yaml
+```
+
+## Workflow selection guide
+
+| Task | Workflow |
+|---|---|
+| Review a code diff or PR | `code-review-multi-model` |
+| Security vulnerability scan | `security-audit` |
+| Cross-validate a plan or design | `cross-validate` |
+| Triage a bug report | `bug-triage` |
+| Generate unit tests | `test-generation` |
+| Write a PR description | `pr-description` |
+| Architecture decision record | `adr-generator` |
+
+## How multi-model consensus works
+
+Each `type: parallel` step sends the same prompt to multiple models at the same time. The `aggregate` block synthesizes results:
+
+- `mode: vote` — surfaces findings all models agree on (high confidence)
+- `mode: diff` — highlights where models disagree (needs human review)
+- `mode: summary` — one model synthesizes all outputs into a single report
+
+This is not about humans being smarter than AI. It's about models checking each other — the same principle behind ensemble methods in ML.
+
+## Write a custom consensus workflow
+
+```yaml
+name: my-consensus-review
+steps:
+  - id: validate
+    type: parallel
+    steps:
+      - id: claude_view
+        model: claude
+        prompt: "Review this and list issues: {{input}}"
+      - id: gemini_view
+        model: gemini
+        prompt: "Review this and list issues: {{input}}"
+      - id: gpt4_view
+        model: gpt-4
+        prompt: "Review this and list issues: {{input}}"
+    aggregate:
+      mode: vote            # high-confidence: all three agree
+      model: claude         # Claude synthesizes the final report
+      prompt: |
+        Three models independently reviewed this.
+        Synthesize findings. Mark items all three flagged as HIGH CONFIDENCE.
+        {{aggregated}}
+
+output:
+  format: markdown
+  save_to: review.md
+```
+
+Run it: `polyflow run ./my-consensus-review.yaml -i "your input"`
+
+## GitHub Actions integration
+
+Add three-model consensus to any repo:
+
+```yaml
+- uses: celesteimnskirakira/polyflow@main
+  with:
+    workflow: code-review-multi-model
+    input: ${{ steps.diff.outputs.content }}
+    openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+```
+
+Full examples in [`.github/workflows/`](https://github.com/celesteimnskirakira/polyflow/tree/main/.github/workflows).

--- a/skills/polyflow/SKILL.md
+++ b/skills/polyflow/SKILL.md
@@ -3,7 +3,7 @@ name: polyflow
 description: Use when running multi-model AI workflows where Claude, Gemini, and GPT-4 should analyze the same task in parallel — code review, security audit, cross-validation, or any task where consensus across models is more reliable than a single model's answer. Invoke when the user says "run polyflow", "multi-model review", "parallel AI analysis", "compare models", or wants multiple AI perspectives on the same input.
 ---
 
-Run parallel multi-model AI workflows using the `polyflow` CLI. Three models check the same thing simultaneously — consensus findings are more reliable than any single model's output.
+Run parallel multi-model AI workflows using the `polyflow` CLI. Three models check the same thing simultaneously — consensus findings are more reliable than any single model's output. Describe what you want in plain English, or use one of 22 built-in workflows.
 
 ## Setup
 
@@ -16,17 +16,17 @@ polyflow doctor                        # verify setup
 ## Key commands
 
 ```bash
-# Run a built-in workflow
+# Describe what you want — Polyflow generates the workflow
+polyflow new "three models audit my API for security issues, vote on findings" -o audit.yaml
+polyflow run ./audit.yaml -i "$(cat src/api.py)"
+
+# Or use a built-in workflow directly
 polyflow run code-review-multi-model -i "$(git diff HEAD~1)"
 polyflow run security-audit -i "$(cat src/auth.py)"
 polyflow run cross-validate -i "your design or problem statement"
 
 # Run headlessly — no prompts, auto-approve all checkpoints
 polyflow run <workflow> --ci -i "..."
-
-# Generate a custom workflow from natural language
-polyflow new "three models review my API design, vote on findings" -o api-review.yaml
-polyflow new "claude and gemini cross-validate my code, diff mode"
 
 # Browse 22 built-in workflows
 polyflow list
@@ -59,6 +59,14 @@ Each `type: parallel` step sends the same prompt to multiple models at the same 
 This is not about humans being smarter than AI. It's about models checking each other — the same principle behind ensemble methods in ML.
 
 ## Write a custom consensus workflow
+
+**From natural language (recommended):**
+
+```bash
+polyflow new "claude and gemini cross-validate my code logic, diff mode" -o review.yaml
+```
+
+**Or write YAML directly:**
 
 ```yaml
 name: my-consensus-review

--- a/skills/polyflow/SKILL.md
+++ b/skills/polyflow/SKILL.md
@@ -82,7 +82,7 @@ Any [OpenRouter model ID](https://openrouter.ai/models) works in the `model` fie
 ## GitHub Actions integration
 
 ```yaml
-- uses: celesteimnskirakira/polyflow@main
+- uses: celesteimnskirakira/polyflow@v1
   with:
     workflow: code-review-multi-model
     input: ${{ steps.diff.outputs.content }}

--- a/skills/polyflow/SKILL.md
+++ b/skills/polyflow/SKILL.md
@@ -3,7 +3,7 @@ name: polyflow
 description: Use when running parallel multi-model AI workflows — code review, security audit, cross-validation, or any task where consensus across models is more reliable than a single model's answer. Invoke when the user says "run polyflow", "multi-model review", "parallel AI analysis", "compare models", or wants multiple AI perspectives on the same input.
 ---
 
-Run parallel multi-model AI workflows using the `polyflow` CLI. Three models check the same thing simultaneously — consensus findings are more reliable than any single model's output. Describe what you want in plain English, or use one of 22 built-in workflows.
+Run parallel multi-model AI workflows using the `polyflow` CLI. Multiple models check the same thing simultaneously — consensus findings are more reliable than any single model's output. Describe what you want in plain English, or use one of 22 built-in workflows.
 
 ## Setup
 
@@ -17,7 +17,7 @@ polyflow doctor                        # verify setup
 
 ```bash
 # Describe what you want — Polyflow generates the workflow
-polyflow new "three models audit my API for security issues, vote on findings" -o audit.yaml
+polyflow new "multiple models audit my API for security issues, vote on findings" -o audit.yaml
 polyflow run ./audit.yaml -i "$(cat src/api.py)"
 
 # Or use a built-in workflow directly
@@ -84,11 +84,11 @@ steps:
         model: gpt-4
         prompt: "Review this and list issues: {{input}}"
     aggregate:
-      mode: vote            # high-confidence: all three agree
+      mode: vote            # high-confidence: all models agree
       model: claude         # Claude synthesizes the final report
       prompt: |
-        Three models independently reviewed this.
-        Synthesize findings. Mark items all three flagged as HIGH CONFIDENCE.
+        Multiple models independently reviewed this.
+        Synthesize findings. Mark items all models flagged as HIGH CONFIDENCE.
         {{aggregated}}
 
 output:
@@ -100,7 +100,7 @@ Run it: `polyflow run ./my-consensus-review.yaml -i "your input"`
 
 ## GitHub Actions integration
 
-Add three-model consensus to any repo:
+Add multi-model consensus to any repo:
 
 ```yaml
 - uses: celesteimnskirakira/polyflow@main


### PR DESCRIPTION
## What this adds

A skill for [polyflow-ai](https://github.com/celesteimnskirakira/polyflow) — a CLI tool that runs multiple AI models in parallel on the same task and synthesizes consensus results. Supports 290+ models via OpenRouter, one key.

## Why it's useful for Claude Code users

Instead of relying on a single model's answer, users get consensus across multiple models simultaneously:

```bash
# Natural language → workflow → run
polyflow new "multiple models audit my API for security issues, vote on findings" -o audit.yaml
polyflow run ./audit.yaml -i "$(cat src/api.py)"

# Or use a built-in workflow
polyflow run code-review-multi-model -i "$(git diff HEAD~1)"
polyflow run security-audit -i "$(cat src/auth.py)"
```

Works in terminal, CI/CD (`--ci`), and as a GitHub Action.

## Skill contents

- Setup (one OpenRouter key covers all models)
- `polyflow new` — generate workflows from natural language
- Workflow selection guide (22 built-in workflows)
- How `mode: vote / diff / summary` works
- Custom YAML example
- GitHub Actions snippet

## Verified working

Tested 10 rounds end-to-end: natural language → parallel YAML generation → validate → dry-run → full API run. All pass.