### PR TITLE
Add TDD skill (Test-Driven Development)

### DIFF
--- a/skills/tdd/LICENSE.txt
+++ b/skills/tdd/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: tdd
+description: >
+  Use TDD for all code-writing tasks. TRIGGER when the user asks to implement, build,
+  create, fix, refactor, or write any code — features, bug fixes, refactors, APIs,
+  utilities, etc. DO NOT TRIGGER when the user is only debugging (reading logs, inspecting
+  state, tracing execution), asking questions about code without wanting changes, doing
+  exploratory/spike work, or writing tests for already-existing code.
+license: Complete terms in LICENSE.txt
+---
+
+# Test Driven Development (TDD)
+
+Strict TDD mode. Every line of production code must be justified by a failing test — this
+constraint is what makes TDD valuable, because it guarantees that tests actually verify
+behaviour rather than just existing alongside code.
+
+## Core Cycle: Red -> Green -> Refactor
+
+Follow this cycle for every behaviour. Never skip a phase.
+
+### RED: Write a Failing Test
+
+1. Choose the next behaviour from the test list.
+2. Write ONE test asserting ONE new behaviour. Name it as a behaviour specification
+   (e.g., `test_returns_empty_list_when_no_items_match`).
+3. **The test must compile, link, and run.** If the test references functions or methods
+   that don't exist yet (common in compiled languages like C/C++/Rust/Go/Java), add
+   minimal stubs first — declare the function in the header and provide an empty body
+   (or return a default value) in the source file. These stubs are scaffolding to make
+   the test runnable, not production code. Do NOT write any real logic in stubs.
+4. Run the test. It must fail.
+5. Verify it fails for the RIGHT reason — a wrong return value, an incorrect state, or
+   missing behaviour. The test output must show a **test assertion failure**, not a
+   compile error, linker error, or crash. If it fails for the wrong reason, fix the test
+   or stubs until it fails on an assertion.
+6. If the test already passes, it is not testing new behaviour — discard it and write a
+   different one.
+
+**Run the test and confirm the assertion failure before moving to Green.** Skipping this
+step defeats the purpose of TDD — an unverified red phase means there's no proof the test
+can catch a regression. A compile or link error is NOT a valid red — it proves nothing
+about behaviour.
+
+### GREEN: Write the Minimum Code to Pass
+
+1. Write the simplest, smallest amount of production code that makes the failing test pass.
+2. Prefer simpler transformations (Transformation Priority Premise):
+   - Return a constant before introducing a variable
+   - Use a variable before adding a conditional
+   - Use a conditional before introducing a loop
+   - Use a loop before introducing recursion
+   This ordering matters because jumping to complex transformations often introduces
+   speculative code that no test demanded.
+3. Do NOT write code that is not demanded by a failing test. Premature error handling,
+   optimisation, or extra features undermine TDD's feedback loop — they introduce untested
+   behaviour.
+4. Run ALL tests. They must all pass.
+5. If getting to green takes more than 1-2 attempts, the test covers too much ground.
+   Delete it, write a simpler test, and try again.
+
+**Run all tests and confirm they pass before moving to Refactor.**
+
+### REFACTOR: Improve Structure While Green
+
+1. Look at both production code AND test code for improvements:
+   - Remove duplication (in code AND tests)
+   - Improve naming
+   - Extract methods, functions, or classes
+   - Simplify conditionals
+   - Restructure test helpers, fixtures, or setup
+2. Test code deserves the same quality standards as production code. Hard-to-read tests
+   become a maintenance burden that slows down future TDD cycles.
+3. Make ONE refactoring change at a time. Run all tests after each change.
+4. If a refactoring breaks a test, undo it immediately and take a smaller step.
+5. Refactoring is optional in any given cycle — skip it if the code is already clean.
+
+**Run tests after every refactoring change to confirm they still pass.**
+
+## Rules
+
+1. **No production code without a failing test.** This is TDD's core discipline. If
+   there's an urge to write implementation code, channel it into writing a test first.
+
+2. **Run real tests every time.** Use the project's actual test runner. Never simulate
+   or assume test output — the whole point is to let real test results drive decisions.
+
+3. **Minimise mocking.** Mocks lie about how the system actually works. Only mock at
+   hard architectural boundaries (external HTTP APIs, databases without in-memory
+   alternatives, filesystem when truly necessary, system clock/randomness). If it can
+   be tested with real code, test it with real code.
+
+4. **Keep steps small.** Each cycle should touch a small, focused behaviour. Needing
+   more than ~10 lines of production code to pass a test usually means the test covers
+   too much.
+
+5. **Maintain a test list.** Before starting, brainstorm the behaviours to test and
+   write them as a checklist ordered from simplest to most complex. Update the list as
+   new cases are discovered or existing ones are completed. Share the list with the user.
+
+6. **Refactor tests too.** When test setup becomes repetitive or helper functions could
+   be clearer, refactor them with the same rigour as production code.
+
+7. **Announce the phase.** Before each action, state the current phase:
+   - `RED: Writing a test for [behaviour]`
+   - `GREEN: Writing minimum code to pass`
+   - `REFACTOR: [what is being improved]`
+
+## Getting Started
+
+When beginning a TDD task:
+
+1. **Understand the goal.** Read existing code, understand the requirement. Ask
+   clarifying questions if the desired behaviour is ambiguous.
+
+2. **Detect the test framework.** Check existing test files, `package.json`,
+   `pyproject.toml`, `Cargo.toml`, `go.mod`, `Gemfile`, `build.gradle`, or equivalent.
+   Use whatever framework and conventions the project already uses. If no tests exist,
+   ask the user which framework to use.
+
+3. **Brainstorm the test list.** List behaviours from simplest to most complex. Start
+   with degenerate cases (empty input, zero, null) and build toward core logic. Share
+   the list with the user.
+
+4. **Start the first Red-Green-Refactor cycle** with the simplest test from the list.
+
+## Completion
+
+The task is done when:
+- All behaviours on the test list are covered and passing
+- The user confirms the feature is complete
+- The code is in a clean, refactored state with all tests green
+
+Run the full test suite one final time to confirm everything passes.
+
+## Common Pitfalls
+
+- **Writing the whole implementation then backfilling tests** is not TDD. It loses the
+  design feedback that emerges from writing tests first.
+- **Skipping Red** means a passing test proves nothing — it might pass for the wrong
+  reason entirely.
+- **Over-mocking** (mocking three things to test one function) suggests testing through
+  a higher-level interface with fewer mocks would be more effective.
+- **Refactoring and adding behaviour simultaneously** conflates two concerns. Refactor
+  only when green; add behaviour only through a new failing test.
+- **Skipping test runs** removes the evidence that TDD is working. Every phase
+  transition requires actually running tests.
+- **Treating compile/link errors as Red** (compiled languages). A test that doesn't
+  compile or link never ran — it proves nothing about behaviour. Add stubs to make the
+  test runnable, then confirm it fails on an assertion. Only then is it genuinely Red.


### PR DESCRIPTION
## Add TDD skill: strict Red-Green-Refactor enforcement

### Summary

Adds a new `tdd` skill that puts Claude into strict Test Driven Development mode. When triggered, Claude follows the Red-Green-Refactor cycle for every behaviour — maintaining a test list, running real tests at every phase transition, and writing only the minimum production code demanded by failing tests.

### What it does

- **Red:** Write one failing test, run it, and verify it fails on an assertion (not a compile/link error)
- **Green:** Write the smallest amount of code to make the test pass, following the Transformation Priority Premise
- **Refactor:** Improve both production and test code while staying green
- **Test list:** Brainstorms behaviours upfront, ordered simplest-to-complex, and shares with the user
- **Phase announcements:** States the current phase before each action for transparency

### Trigger behaviour

**Activates** when the user asks to implement, build, create, fix, refactor, or write code.

**Does not activate** for debugging, asking questions about code, exploratory/spike work, or writing tests for already-existing code.

### Design notes

- Written in imperative voice per the skill-creator best practices
- Explains *why* rules matter rather than using ALWAYS/NEVER commands — Claude adheres better when it understands reasoning
- 150 lines / ~1,000 words — well under the 500-line recommendation
- No `scripts/`, `references/`, or `assets/` needed — the skill is self-contained instructions
- Handles compiled languages explicitly (stub guidance to avoid treating compile errors as a valid Red phase)
- Minimises mocking — only at hard architectural boundaries

### Files

```
skills/tdd/
├── SKILL.md       # Skill definition with YAML frontmatter
└── LICENSE.txt    # Apache 2.0
```
