### PR TITLE
Fix: Use HTTPS instead of HTTP for agentskills.io link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> **Note:** This repository contains Anthropic's implementation of skills for Claude. For information about the Agent Skills standard, see [agentskills.io](http://agentskills.io).
+> **Note:** This repository contains Anthropic's implementation of skills for Claude. For information about the Agent Skills standard, see [agentskills.io](https://agentskills.io).
 
 # Skills
 Skills are folders of instructions, scripts, and resources that Claude loads dynamically to improve performance on specialized tasks. Skills teach Claude how to complete specific tasks in a repeatable way, whether that's creating documents with your company's brand guidelines, analyzing data using your organization's specific workflows, or automating personal tasks.


### PR DESCRIPTION
## Description

The agentskills.io link in the README used HTTP instead of HTTPS. This is a minor security improvement to ensure encrypted connections.

## Changes

- Changed `[agentskills.io](http://agentskills.io)` to `[agentskills.io](https://agentskills.io)` in README.md line 1

Good day,

Thank you for your contribution. I hope this helps. If there are any issues or suggestions for improvement, please let me know and I will address them.

Warmly,
Jah-yee