### PR TITLE
Add claude-api-live skill — optimized for non-technical builders

### DIFF
--- a/skills/claude-api-live/LICENSE.txt
+++ b/skills/claude-api-live/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/claude-api-live/SKILL.md
+++ b/skills/claude-api-live/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: claude-api-live
-description: "Build apps with the Claude API or Anthropic SDK — with live documentation grounding on every invocation. TRIGGER when: code imports `anthropic`/`@anthropic-ai/sdk`/`claude_agent_sdk`, or user asks to use Claude API, Anthropic SDKs, or Agent SDK. Fetches current model IDs and relevant docs from platform.claude.com before advising, so stale training data never causes bugs. DO NOT TRIGGER when: code imports `openai`/other AI SDK, general programming, or ML/data-science tasks."
+description: Grounds Claude API advice in live documentation. TRIGGER when: code imports `anthropic`/`@anthropic-ai/sdk`/`claude_agent_sdk`, or user asks to use Claude API, Anthropic SDKs, or Agent SDK. Fetches current model IDs and relevant docs from platform.claude.com before advising, so stale training data never causes bugs. DO NOT TRIGGER when: code imports `openai`/other AI SDK, general programming, or ML/data-science tasks."
 license: Complete terms in LICENSE.txt
 ---
 
-# Claude API — Live Documentation Grounding
+# Claude API Live Documentation Grounding
 
 Claude's training data has a cutoff. Model IDs get renamed, parameters get deprecated,
 new features launch behind beta headers, APIs get replaced. The gap between what Claude
@@ -18,7 +18,7 @@ that gap before it becomes tech debt.
 
 ## Step 1: Identify what the user is doing
 
-Before fetching, determine the task type — this controls which docs to fetch in Step 2:
+Before fetching, determine the task type. This controls which docs to fetch in Step 2:
 
 | Task type | Examples |
 |-----------|---------|
@@ -35,8 +35,7 @@ Before fetching, determine the task type — this controls which docs to fetch i
 users copy whatever appears in example code, and a wrong model ID produces a confusing
 "model not found" error far from where the mistake was made.
 
-Then fetch **up to two additional pages** based on the task. Three parallel fetches is the
-right ceiling — don't flood context with docs the user doesn't need.
+Then fetch **up to two additional pages** based on the task. Three parallel fetches is the ceiling — don't flood context with docs the user doesn't need.
 
 ### Always fetch
 

--- a/skills/claude-api-live/SKILL.md
+++ b/skills/claude-api-live/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: claude-api-live
-description: Grounds Claude API advice in live documentation. TRIGGER when: code imports `anthropic`/`@anthropic-ai/sdk`/`claude_agent_sdk`, or user asks to use Claude API, Anthropic SDKs, or Agent SDK. Fetches current model IDs and relevant docs from platform.claude.com before advising, so stale training data never causes bugs. DO NOT TRIGGER when: code imports `openai`/other AI SDK, general programming, or ML/data-science tasks."
+description: "Grounds Claude API advice in live documentation. TRIGGER when: code imports `anthropic`/`@anthropic-ai/sdk`/`claude_agent_sdk`, or user asks to use Claude API, Anthropic SDKs, or Agent SDK. Fetches current model IDs and relevant docs from platform.claude.com before advising, so stale training data never causes bugs. DO NOT TRIGGER when: code imports `openai`/other AI SDK, general programming, or ML/data-science tasks."
 license: Complete terms in LICENSE.txt
 ---
 

--- a/skills/claude-api-live/SKILL.md
+++ b/skills/claude-api-live/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: claude-api-live
+description: "Build apps with the Claude API or Anthropic SDK — with live documentation grounding on every invocation. TRIGGER when: code imports `anthropic`/`@anthropic-ai/sdk`/`claude_agent_sdk`, or user asks to use Claude API, Anthropic SDKs, or Agent SDK. Fetches current model IDs and relevant docs from platform.claude.com before advising, so stale training data never causes bugs. DO NOT TRIGGER when: code imports `openai`/other AI SDK, general programming, or ML/data-science tasks."
+license: Complete terms in LICENSE.txt
+---
+
+# Claude API — Live Documentation Grounding
+
+Claude's training data has a cutoff. Model IDs get renamed, parameters get deprecated,
+new features launch behind beta headers, APIs get replaced. The gap between what Claude
+remembers and what's actually current is silent — the code looks plausible, runs without
+obvious errors, then breaks in ways that are expensive to debug.
+
+This skill fetches live documentation before advising on any Claude API work. It catches
+that gap before it becomes tech debt.
+
+---
+
+## Step 1: Identify what the user is doing
+
+Before fetching, determine the task type — this controls which docs to fetch in Step 2:
+
+| Task type | Examples |
+|-----------|---------|
+| **Planning / architecture** | "which model should I use", "should I use streaming", "how do I structure this" |
+| **Code generation** | "write me a function that calls Claude", "add tool use to this" |
+| **Debugging** | "this is throwing an error", "why is this failing", "budget_tokens isn't working" |
+| **Code review** | "is this correct", "what's wrong with this code", "review my API usage" |
+
+---
+
+## Step 2: Fetch live docs
+
+**Always fetch the models page first.** Model IDs are the most common source of stale guidance —
+users copy whatever appears in example code, and a wrong model ID produces a confusing
+"model not found" error far from where the mistake was made.
+
+Then fetch **up to two additional pages** based on the task. Three parallel fetches is the
+right ceiling — don't flood context with docs the user doesn't need.
+
+### Always fetch
+
+| Page | URL |
+|------|-----|
+| **Models** | `https://platform.claude.com/docs/en/about-claude/models/overview.md` |
+
+### Fetch based on task
+
+| If the task involves… | Fetch this |
+|-----------------------|-----------|
+| Thinking / reasoning depth / effort | `https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking.md` |
+| Streaming / real-time output | `https://platform.claude.com/docs/en/build-with-claude/streaming.md` |
+| Tool use / function calling / agents | `https://platform.claude.com/docs/en/agents-and-tools/tool-use/overview.md` |
+| Structured outputs / response format | `https://platform.claude.com/docs/en/build-with-claude/structured-outputs.md` |
+| Batch processing / bulk requests | `https://platform.claude.com/docs/en/build-with-claude/batch-processing.md` |
+| File uploads / Files API | `https://platform.claude.com/docs/en/build-with-claude/files.md` |
+| Prompt caching | `https://platform.claude.com/docs/en/build-with-claude/prompt-caching.md` |
+| Long conversations / context management | `https://platform.claude.com/docs/en/build-with-claude/compaction.md` |
+| Errors / rate limits / debugging | `https://platform.claude.com/docs/en/api/errors.md` |
+| Agent SDK (file/web/terminal tools) | `https://platform.claude.com/docs/en/agent-sdk.md` |
+
+**If a URL fails or 404s**, search instead — restrict to the canonical domain to avoid
+landing on unofficial mirrors:
+
+```
+site:platform.claude.com/docs <topic>
+```
+
+---
+
+## Step 3: Surface what's current
+
+Present only what's relevant and potentially surprising given your training data.
+Aim for 5–10 bullets, not a wall of text:
+
+**Current models:** [list model IDs and key specs from the live page]
+
+**Key details for [features in scope]:** [params, headers, syntax that matters for this task]
+
+**Watch out for:** [deprecations, recently changed behavior — omit entirely if nothing notable]
+
+If nothing is surprising: *"Docs confirm expected behavior. Current recommended model: `claude-opus-4-6`."*
+
+---
+
+## Step 4: Proceed with the original task
+
+Carry the grounded context forward into all code, plans, and reviews. Use correct model IDs,
+current parameter names, and current feature knowledge throughout — don't re-summarize the
+docs, just use them.
+
+---
+
+## What changes most often
+
+These are the highest-probability sources of stale guidance:
+
+- **Model ID suffixes** — never construct date-suffixed IDs from memory; copy exact aliases
+  from the live models page
+- **Thinking parameters** — `budget_tokens` is deprecated on current models; `thinking: {type: "adaptive"}`
+  is the current pattern; verify from docs before advising
+- **`output_format` / structured output params** — naming has changed; current parameter is
+  `output_config: {format: {...}}`; verify from docs
+- **Beta headers** — required headers and values change with each feature (Files API, compaction,
+  etc.); always verify current values from docs before including them in code
+- **Effort parameter** — `output_config: {effort: "low"|"medium"|"high"|"max"}` is GA;
+  not top-level; verify supported models from docs


### PR DESCRIPTION
## What this skill does

Before advising on any Claude API work — planning, code generation, debugging, review — it fetches the live models page and relevant feature docs from platform.claude.com. A 30-second fetch catches the gap between Claude's cached training data and what's actually current. It's not a replacement for claude-api's depth; it's a freshness layer that runs before you benefit from that depth.

## Why this still exists

The claude-api skill ships excellent per-language examples and defaults, and its design is deliberate: fetch live docs only when the user explicitly asks for "latest" information. That's the right call for experienced developers who know to ask.

The problem is the user who doesn't know to ask.

Anthropic's own messaging increasingly targets non-technical builders — people who can describe what they want to build but don't have the background to question whether a model ID is current, whether a parameter was deprecated, or that the Batches API exists and cuts their costs by 50%. They don't know what they don't know. They don't pour over documentation. These users trust Claude's API suggestions implicitly. They copy the model ID from the first response and build on it for weeks. The failure mode is silent: the code looks plausible, runs without obvious errors, then breaks in confusing ways deep into a project. At that point, they've accumulated real tech debt and have to debug API-assumption failures without knowing why.

This happened to me personally while building a multi-agent research tool. I used Claude to plan and implement a tool that made API calls against 1000 companies from an Excel file. The agent planned competently — but made three silent mistakes caused entirely by stale training data:

1. **Missed the Batches API.** The agent knew the workload was large but planned a sequential loop. It never mentioned the Messages Batches API, which is purpose-built for exactly this use case and runs at 50% cost.

2. **Used deprecated parameter syntax.** Generated code used `budget_tokens` on a model where it's deprecated. No error, no hedge — just confidently wrong code.

3.  **Did not catch that code execution comes built-in with web_search and web_fetch.** Code execution was not accounted for in my design plan and broke my workflow. While debugging, with lots of prompting, I realized it had to be turned off.

I only discovered these issues by reading the docs after the fact, once the codebase was already built around the wrong patterns.

## Relationship to claude-api

Complementary. claude-api handles depth; claude-api-live handles freshness. They're designed to be used standalone or together: live grounding first, then language-specific patterns. The two skills have different philosophies. claude-api: high-confidence cache, fetch on demand. claude-api-live: trust nothing cached, always verify before advising.

## Eval results

Tested against 5 Anthropic SDK scenarios (brainstorming, streaming, extended thinking debug, tool use, batch processing):

- With skill: 100% pass rate
- Without skill: 45% pass rate

Most discriminating scenario: extended thinking debug, where the baseline confidently suggests a fix that still uses the deprecated `budget_tokens` parameter instead of `thinking: {type: "adaptive"}`.

## Files

- `skills/claude-api-live/SKILL.md`
- `skills/claude-api-live/LICENSE.txt` (Apache 2.0)