### PR TITLE
Add Figma skill: design tokens + code generation for 7 frameworks

### DIFF
--- a/skills/figma/LICENSE.txt
+++ b/skills/figma/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/figma/SKILL.md
+++ b/skills/figma/SKILL.md
@@ -2,7 +2,6 @@
 name: figma
 description: Figma design bridge for Claude Code. Browse files, extract components, download assets, extract design tokens, and generate code for Tailwind, React, Vue, Svelte, React Native, Flutter, and CSS. Use when user mentions Figma, design tokens, Figma-to-code, or wants to convert designs to components.
 argument-hint: "[figma-url-or-file-key]"
-license: Complete terms in LICENSE.txt
 allowed-tools:
   - Bash
   - Read
@@ -225,24 +224,157 @@ Combine all workflows for a complete Figma-to-code pipeline:
 
 ---
 
-## Workflow 6: Discover Figma Community Resources
+## Workflow 6: Smart Figma Community Discovery & Retrieval
 
-When the user needs design inspiration, templates, or UI kits from Figma Community:
+This workflow turns Claude into an expert design sourcer. Instead of just searching, Claude must deeply understand the user's project, run multiple targeted searches, evaluate results against specific criteria, and then retrieve the actual design data.
 
-1. **Search Figma Community** — Use web search to find relevant community files:
-   - Search for: `site:figma.com/community "<topic> UI kit"` or `site:figma.com/community "<topic> design system"`
-   - Look for files with high duplication counts and recent updates
-2. **Evaluate results** — Check that the community file matches the user's framework, style, and project needs
-3. **Extract the file key** — From the community file URL: `https://www.figma.com/community/file/<FILE_KEY>/...`
-4. **Note**: Community files must be duplicated to the user's Figma account before they can be accessed via the API. Instruct the user to click "Open in Figma" / "Duplicate" on the community page first.
-5. **Then proceed** with Workflow 1 to browse and extract from the duplicated file
+### Step 1: Build a Project Profile
 
-**Example searches by project type:**
-- Dashboard: `"dashboard UI kit" OR "admin panel" site:figma.com/community`
-- E-commerce: `"e-commerce" OR "shopping" UI kit site:figma.com/community`
-- Mobile app: `"mobile app" OR "iOS" OR "Android" UI kit site:figma.com/community`
-- Landing page: `"landing page" OR "marketing" template site:figma.com/community`
-- Design system: `"design system" OR "component library" site:figma.com/community`
+Before searching, gather or infer these details from the conversation context and the user's codebase:
+
+| Signal | How to Detect |
+|--------|--------------|
+| **Project type** | Read package.json, existing routes, folder structure, or ask: dashboard, e-commerce, SaaS, mobile app, landing page, blog, portfolio, social platform, admin panel, etc. |
+| **Framework** | Check package.json for react/vue/svelte/next/nuxt/flutter, or existing component files |
+| **Style direction** | Check existing CSS/Tailwind config for colors, fonts, border-radius patterns: minimal, bold, corporate, playful, glassmorphism, brutalist, dark mode, etc. |
+| **Components needed** | Infer from the task: navbar, hero, pricing table, dashboard charts, cards, forms, modals, sidebars, footers, onboarding flows, etc. |
+| **Color palette** | Extract from existing tailwind.config, CSS variables, or brand assets in the project |
+| **Typography** | Check existing font imports, Google Fonts links, or Tailwind font config |
+| **Responsive needs** | Mobile-first? Desktop dashboard? Both? Check existing breakpoints |
+| **Industry/domain** | Finance, health, food, travel, education, fitness, real estate, etc. — affects visual language |
+
+Summarize the profile internally before searching. Example:
+> "Building a SaaS dashboard in React + Tailwind. Dark theme, Inter font, blue/purple palette. Needs: sidebar nav, data tables, chart cards, user settings page. Finance domain."
+
+### Step 2: Multi-Strategy Search
+
+Run **at least 3 different searches** to cast a wide net. Tailor queries to the profile:
+
+**Search A — By project type + quality signals:**
+```
+site:figma.com/community/file "<project-type> UI kit" OR "<project-type> design system"
+```
+
+**Search B — By specific components needed:**
+```
+site:figma.com/community/file "<component-1>" "<component-2>" UI kit
+```
+
+**Search C — By style/aesthetic + industry:**
+```
+site:figma.com/community/file "<style>" "<industry>" dashboard OR app template
+```
+
+**Search D (optional) — By design system / framework match:**
+```
+site:figma.com/community/file "<framework>" components OR "design system" 2024 OR 2025 OR 2026
+```
+
+**Category-specific search patterns:**
+
+| Project Type | Search Queries |
+|-------------|---------------|
+| SaaS Dashboard | `"admin dashboard" UI kit`, `"analytics dashboard" components`, `"SaaS" "design system"` |
+| E-commerce | `"e-commerce" UI kit`, `"product page" "shopping cart" template`, `"online store" design system` |
+| Mobile App | `"mobile app" UI kit`, `"iOS" OR "Android" app template`, `"mobile" "design system"` |
+| Landing Page | `"landing page" template`, `"marketing" "hero section"`, `"startup" landing page` |
+| Blog/Content | `"blog" template`, `"content" "editorial" design`, `"magazine" layout` |
+| Social Platform | `"social media" app UI`, `"chat" "messaging" UI kit`, `"feed" "stories" template` |
+| Finance/Fintech | `"fintech" UI kit`, `"banking" "finance" dashboard`, `"crypto" "trading" UI` |
+| Health/Wellness | `"health" "medical" UI kit`, `"fitness" app template`, `"wellness" dashboard` |
+| Real Estate | `"real estate" "property" UI kit`, `"listing" template` |
+| Education | `"e-learning" "education" UI kit`, `"LMS" "course" template` |
+| Restaurant/Food | `"food delivery" UI kit`, `"restaurant" app template` |
+
+### Step 3: Deep Evaluation
+
+For each promising result, use `WebFetch` to load the Figma Community page and extract:
+
+1. **File description** — Does it mention the components/features the user needs?
+2. **Likes and duplicates count** — Higher = more trusted (prefer 1K+ duplicates for UI kits)
+3. **Last updated date** — Prefer files updated within the last 12 months
+4. **Preview screenshots** — Do they show the components the user needs?
+5. **Creator credibility** — Established design teams, agencies, or prolific creators
+6. **Completeness** — Full design system vs. single-page template
+7. **Responsiveness** — Does it include mobile + desktop variants?
+8. **Component coverage** — Score against the user's specific needs
+
+**Scoring criteria (rank each 1-5):**
+
+| Criteria | Weight | What to Check |
+|----------|--------|---------------|
+| Component match | High | Has the specific components the user needs |
+| Style match | High | Visual direction matches the project profile |
+| Completeness | Medium | Full system vs. partial template |
+| Recency | Medium | Updated recently, uses modern patterns |
+| Popularity | Low | Duplicate/like count (social proof) |
+| Responsiveness | Medium | Includes mobile + desktop variants |
+
+### Step 4: Present Top Recommendations
+
+Present the **top 3** options to the user with clear reasoning:
+
+For each recommendation, show:
+- **Name and link** to the Community page
+- **Why it's a good match** — specific components it has that the user needs
+- **What's included** — pages, components, design tokens
+- **Style assessment** — how well the visual direction matches
+- **Any gaps** — what's missing that would need to be built manually
+- **Duplicate count** — social proof
+
+Example format:
+> **1. [Dashboard UI Kit Pro](community-url)** — 12K duplicates
+> Best match for your dark-theme SaaS dashboard. Includes sidebar navigation, data tables, chart cards, and settings page — all in dark mode with a blue accent palette. Missing: finance-specific chart types. You'd need to adapt the generic charts.
+
+### Step 5: Duplicate & Retrieve
+
+Once the user picks a file:
+
+1. **Provide the direct Community link** and tell them:
+   > "Open this link, click **'Open in Figma'** (or **'Get a copy'**), and it will be duplicated to your drafts. Once it's in your account, give me the URL of the duplicated file."
+
+2. **Extract the file key** from the duplicated file URL:
+   ```
+   https://www.figma.com/design/<FILE_KEY>/...
+   ```
+
+3. **Browse the full file** to map its structure:
+   ```
+   mcp__figma__get_figma_data(fileKey: "<FILE_KEY>", depth: 2)
+   ```
+
+4. **Identify the most relevant frames** — Match pages/frames to the user's component needs. List them:
+   > "Found these relevant frames:
+   > - `Sidebar Navigation` (node 123:456)
+   > - `Data Table` (node 234:567)
+   > - `Chart Card` (node 345:678)"
+
+5. **Extract design tokens** from the full file:
+   ```bash
+   python3 ${CLAUDE_SKILL_DIR}/scripts/extract_tokens.py --input figma-data.json --format <user-format> --output tokens.<ext>
+   ```
+
+6. **Generate code** for each relevant component the user needs:
+   ```bash
+   python3 ${CLAUDE_SKILL_DIR}/scripts/figma_to_code.py --input <node>.json --framework <user-framework> --name <ComponentName>
+   ```
+
+7. **Download assets** (icons, images, illustrations) from the design:
+   ```
+   mcp__figma__download_figma_images(fileKey, nodes, localPath)
+   ```
+
+8. **Integrate into the user's project** — Place tokens in their config, components in their component directory, assets in their assets folder. Adapt the generated code to use the user's existing patterns and naming conventions.
+
+### Step 6: Adapt to Project Conventions
+
+After retrieving design data, do NOT just dump raw generated code. Adapt it:
+
+- **Match naming conventions** — If the user's project uses `kebab-case` filenames and `PascalCase` components, follow that
+- **Use existing tokens** — If the project already has a color system, map the Figma colors to existing tokens instead of adding new ones
+- **Follow project structure** — Put components where the project's other components live
+- **Merge design tokens** — Don't overwrite existing tokens; merge new ones in, flagging conflicts
+- **Preserve existing patterns** — If the project uses a specific state management, router, or styling approach, integrate with that
 
 ---
 
@@ -320,3 +452,5 @@ When the user needs design inspiration, templates, or UI kits from Figma Communi
 6. **Component names matter** — Use `--name` flag with the code generator for clean component names
 7. **Pipe for speed** — Both scripts accept stdin: `cat data.json | python3 ${CLAUDE_SKILL_DIR}/scripts/extract_tokens.py -f css`
 8. **Iterate** — Generated code is a starting point; refine layout, add interactivity, and connect to your state management
+9. **Community discovery is context-first** — Always build a project profile before searching Figma Community. A generic search yields generic results; a targeted search finds exactly what the user needs.
+10. **Adapt, don't dump** — When pulling from Community files, adapt code to the user's existing project conventions, token system, and file structure. Never blindly overwrite existing design tokens or patterns.

--- a/skills/figma/SKILL.md
+++ b/skills/figma/SKILL.md
@@ -1,0 +1,322 @@
+---
+name: figma
+description: Figma design bridge for Claude Code. Browse files, extract components, download assets, extract design tokens, and generate code for Tailwind, React, Vue, Svelte, React Native, Flutter, and CSS. Use when user mentions Figma, design tokens, Figma-to-code, or wants to convert designs to components.
+argument-hint: "[figma-url-or-file-key]"
+license: Complete terms in LICENSE.txt
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - WebSearch
+  - WebFetch
+  - mcp__figma__get_figma_data
+  - mcp__figma__download_figma_images
+---
+# figma
+
+Universal Figma-to-code skill for Claude Code. Uses the `figma-developer-mcp` server to browse designs, download assets, extract design tokens, and generate production-ready code for 7 frameworks.
+
+## Prerequisites
+
+### 1. Figma API Key
+
+Get a personal access token from [Figma Developer Settings](https://www.figma.com/developers/api#access-tokens).
+
+### 2. MCP Server Configuration
+
+Add this to your project's `.mcp.json` (or copy from `.mcp.json.example`):
+
+```json
+{
+  "mcpServers": {
+    "figma": {
+      "command": "npx",
+      "args": ["-y", "figma-developer-mcp", "--stdio"],
+      "env": {
+        "FIGMA_API_KEY": "<your-figma-api-key>"
+      }
+    }
+  }
+}
+```
+
+After adding the key, run **"Developer: Reload Window"** in VS Code (or restart Claude Code CLI).
+
+### 3. Python 3.8+
+
+Required for the token extraction and code generation scripts. No pip dependencies needed — stdlib only.
+
+```bash
+python3 --version
+```
+
+---
+
+## Workflow 1: Browse & Inspect Figma Files
+
+### Get the File Key
+
+Extract the file key from any Figma URL:
+
+```
+https://www.figma.com/design/<FILE_KEY>/...
+https://www.figma.com/file/<FILE_KEY>/...
+```
+
+### Browse the Full File
+
+```
+mcp__figma__get_figma_data(fileKey: "<FILE_KEY>")
+```
+
+Returns pages, frames, components, layout info, text content, fills, strokes, effects, and component instances.
+
+### Inspect a Specific Node
+
+```
+mcp__figma__get_figma_data(fileKey: "<FILE_KEY>", nodeId: "1234:5678")
+```
+
+Node IDs come from Figma URLs (`?node-id=1234:5678`) or from browsing the file tree. Formats: `1234:5678`, `1234-5678`, or `I5666:180910;1:10515` for nested instances.
+
+Use the optional `depth` parameter to limit tree traversal depth.
+
+---
+
+## Workflow 2: Download Assets
+
+Export PNG or SVG assets from specific nodes:
+
+```
+mcp__figma__download_figma_images(
+  fileKey: "<FILE_KEY>",
+  localPath: "/absolute/path/to/assets/",
+  nodes: [
+    { "nodeId": "1234:5678", "fileName": "hero-image.png" },
+    { "nodeId": "2345:6789", "fileName": "logo.svg" }
+  ]
+)
+```
+
+**Parameters:**
+
+| Parameter | Description |
+|-----------|-------------|
+| `localPath` | Absolute path to save directory (created if missing) |
+| `nodes[].nodeId` | Figma node ID to export |
+| `nodes[].fileName` | Local filename with `.png` or `.svg` extension |
+| `nodes[].imageRef` | Required for image fills (raster photos); leave blank for vectors |
+| `pngScale` | Export scale for PNGs (default: 2 for retina) |
+
+**Tips:**
+- Use `.svg` for icons and illustrations — crisp at any size
+- Use `.png` for photos and complex raster images
+- Set `pngScale: 3` for mobile @3x assets
+- Set `pngScale: 1` for web thumbnails
+
+---
+
+## Workflow 3: Extract Design Tokens
+
+Automatically extract colors, typography, spacing, shadows, gradients, and border-radius from Figma data into reusable token files.
+
+### Step 1: Save Figma Data to JSON
+
+After fetching data with `get_figma_data`, save the response to a file:
+
+```bash
+# Claude will save the Figma API response as JSON
+# Example: figma-data.json
+```
+
+### Step 2: Run the Token Extractor
+
+```bash
+# CSS custom properties (default)
+python3 ${CLAUDE_SKILL_DIR}/scripts/extract_tokens.py --input figma-data.json --format css --output tokens.css
+
+# Tailwind config
+python3 ${CLAUDE_SKILL_DIR}/scripts/extract_tokens.py --input figma-data.json --format tailwind --output tailwind-tokens.js
+
+# JSON tokens
+python3 ${CLAUDE_SKILL_DIR}/scripts/extract_tokens.py --input figma-data.json --format json --output tokens.json
+
+# SCSS variables
+python3 ${CLAUDE_SKILL_DIR}/scripts/extract_tokens.py --input figma-data.json --format scss --output _tokens.scss
+```
+
+**Supported formats:**
+
+| Format | Output | Use Case |
+|--------|--------|----------|
+| `css` | `:root { --color-*: ...; }` | Any web project |
+| `tailwind` | `theme.extend` config block | Tailwind CSS projects |
+| `json` | Raw token JSON | Design systems, Style Dictionary |
+| `scss` | `$color-*: ...;` | SCSS/Sass projects |
+
+**What gets extracted:**
+- **Colors** — all solid fills with layer name as token name
+- **Typography** — font family, size, weight, line-height, letter-spacing
+- **Spacing** — padding and gap from auto-layout frames
+- **Border Radius** — uniform and per-corner values
+- **Shadows** — drop shadows and inner shadows
+- **Gradients** — linear, radial, and angular gradients with stops
+
+---
+
+## Workflow 4: Convert Figma to Code
+
+Generate framework-specific code from Figma nodes.
+
+### Step 1: Save Node Data
+
+Fetch a specific frame/component and save the JSON response.
+
+### Step 2: Run the Code Generator
+
+```bash
+# Tailwind/HTML (default)
+python3 ${CLAUDE_SKILL_DIR}/scripts/figma_to_code.py --input node.json --framework tailwind
+
+# React (JSX + Tailwind)
+python3 ${CLAUDE_SKILL_DIR}/scripts/figma_to_code.py --input node.json --framework react --name HeroSection
+
+# Vue SFC
+python3 ${CLAUDE_SKILL_DIR}/scripts/figma_to_code.py --input node.json --framework vue --name HeroSection
+
+# Svelte
+python3 ${CLAUDE_SKILL_DIR}/scripts/figma_to_code.py --input node.json --framework svelte --name HeroSection
+
+# React Native
+python3 ${CLAUDE_SKILL_DIR}/scripts/figma_to_code.py --input node.json --framework react-native --name HeroSection
+
+# Flutter (Dart)
+python3 ${CLAUDE_SKILL_DIR}/scripts/figma_to_code.py --input node.json --framework flutter --name HeroSection
+
+# Plain CSS + HTML
+python3 ${CLAUDE_SKILL_DIR}/scripts/figma_to_code.py --input node.json --framework css
+```
+
+**Supported frameworks:**
+
+| Framework | Output | Layout Model |
+|-----------|--------|-------------|
+| `tailwind` | HTML + Tailwind classes | Flexbox via utilities |
+| `react` | JSX component + Tailwind | Flexbox via utilities |
+| `vue` | Vue SFC `<template>` + Tailwind | Flexbox via utilities |
+| `svelte` | Svelte component + Tailwind | Flexbox via utilities |
+| `react-native` | RN component + StyleSheet | Flexbox via StyleSheet |
+| `flutter` | Dart StatelessWidget | Row/Column/Container |
+| `css` | HTML + CSS classes | Flexbox via CSS |
+
+---
+
+## Workflow 5: Full Component Pipeline
+
+Combine all workflows for a complete Figma-to-code pipeline:
+
+1. **Browse** the file to find the target frame or component
+2. **Inspect** the specific node to understand structure
+3. **Extract tokens** for the design system (colors, fonts, spacing)
+4. **Generate code** for your framework
+5. **Download assets** (images, icons) referenced in the design
+6. **Integrate** — paste tokens into your config, code into your components, assets into your project
+
+---
+
+## Workflow 6: Discover Figma Community Resources
+
+When the user needs design inspiration, templates, or UI kits from Figma Community:
+
+1. **Search Figma Community** — Use web search to find relevant community files:
+   - Search for: `site:figma.com/community "<topic> UI kit"` or `site:figma.com/community "<topic> design system"`
+   - Look for files with high duplication counts and recent updates
+2. **Evaluate results** — Check that the community file matches the user's framework, style, and project needs
+3. **Extract the file key** — From the community file URL: `https://www.figma.com/community/file/<FILE_KEY>/...`
+4. **Note**: Community files must be duplicated to the user's Figma account before they can be accessed via the API. Instruct the user to click "Open in Figma" / "Duplicate" on the community page first.
+5. **Then proceed** with Workflow 1 to browse and extract from the duplicated file
+
+**Example searches by project type:**
+- Dashboard: `"dashboard UI kit" OR "admin panel" site:figma.com/community`
+- E-commerce: `"e-commerce" OR "shopping" UI kit site:figma.com/community`
+- Mobile app: `"mobile app" OR "iOS" OR "Android" UI kit site:figma.com/community`
+- Landing page: `"landing page" OR "marketing" template site:figma.com/community`
+- Design system: `"design system" OR "component library" site:figma.com/community`
+
+---
+
+## Figma-to-Code Conversion Reference
+
+### Layout (Auto-Layout)
+
+| Figma Property | Tailwind | React Native | Flutter | CSS |
+|---------------|----------|-------------|---------|-----|
+| Auto-layout: Horizontal | `flex flex-row` | `flexDirection: 'row'` | `Row()` | `display: flex; flex-direction: row;` |
+| Auto-layout: Vertical | `flex flex-col` | `flexDirection: 'column'` | `Column()` | `display: flex; flex-direction: column;` |
+| Gap: 16 | `gap-4` | `gap: 16` | `SizedBox(height: 16)` | `gap: 16px;` |
+| Padding: 24 | `p-6` | `padding: 24` | `EdgeInsets.all(24)` | `padding: 24px;` |
+| Align: Center/Center | `justify-center items-center` | `justifyContent: 'center', alignItems: 'center'` | `MainAxisAlignment.center, CrossAxisAlignment.center` | `justify-content: center; align-items: center;` |
+| Fill container | `w-full` | `flex: 1` | `Expanded()` | `width: 100%;` |
+| Hug contents | `w-fit` | `alignSelf: 'flex-start'` | `IntrinsicWidth()` | `width: fit-content;` |
+
+### Typography
+
+| Figma Property | Tailwind | React Native | Flutter | CSS |
+|---------------|----------|-------------|---------|-----|
+| Font: Inter 600 16px | `font-semibold text-base` | `fontWeight: '600', fontSize: 16` | `TextStyle(fontWeight: FontWeight.w600, fontSize: 16)` | `font-weight: 600; font-size: 16px;` |
+| Line height: 1.5 | `leading-normal` | `lineHeight: 24` | `height: 1.5` | `line-height: 1.5;` |
+| Letter spacing: 0.05em | `tracking-wider` | `letterSpacing: 0.8` | `letterSpacing: 0.8` | `letter-spacing: 0.05em;` |
+| Align: Center | `text-center` | `textAlign: 'center'` | `textAlign: TextAlign.center` | `text-align: center;` |
+
+### Colors & Fills
+
+| Figma Property | Tailwind | React Native | Flutter | CSS |
+|---------------|----------|-------------|---------|-----|
+| Solid fill #3B82F6 | `bg-[#3B82F6]` | `backgroundColor: '#3B82F6'` | `Color(0xFF3B82F6)` | `background-color: #3B82F6;` |
+| Text color #1F2937 | `text-[#1F2937]` | `color: '#1F2937'` | `Color(0xFF1F2937)` | `color: #1F2937;` |
+| Opacity: 50% | `opacity-50` | `opacity: 0.5` | `Opacity(opacity: 0.5)` | `opacity: 0.5;` |
+
+### Effects
+
+| Figma Property | Tailwind | React Native | Flutter | CSS |
+|---------------|----------|-------------|---------|-----|
+| Drop shadow (4px blur) | `shadow` | `shadowRadius: 4, elevation: 2` | `BoxShadow(blurRadius: 4)` | `box-shadow: 0 2px 4px rgba(0,0,0,0.1);` |
+| Drop shadow (10px blur) | `shadow-lg` | `shadowRadius: 10, elevation: 5` | `BoxShadow(blurRadius: 10)` | `box-shadow: 0 4px 10px rgba(0,0,0,0.15);` |
+
+### Borders & Corners
+
+| Figma Property | Tailwind | React Native | Flutter | CSS |
+|---------------|----------|-------------|---------|-----|
+| Border-radius: 8 | `rounded-lg` | `borderRadius: 8` | `BorderRadius.circular(8)` | `border-radius: 8px;` |
+| Border-radius: 9999 | `rounded-full` | `borderRadius: 9999` | `BorderRadius.circular(9999)` | `border-radius: 9999px;` |
+| Border: 1px solid | `border border-[color]` | `borderWidth: 1, borderColor: color` | `Border.all(width: 1)` | `border: 1px solid color;` |
+
+---
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Browse full file | `get_figma_data(fileKey)` |
+| Inspect a node | `get_figma_data(fileKey, nodeId)` |
+| Download PNG @2x | `download_figma_images(fileKey, nodes: [{nodeId, fileName: "x.png"}], localPath)` |
+| Download SVG | `download_figma_images(fileKey, nodes: [{nodeId, fileName: "x.svg"}], localPath)` |
+| Download @3x | `download_figma_images(fileKey, nodes, localPath, pngScale: 3)` |
+| Extract CSS tokens | `python3 ${CLAUDE_SKILL_DIR}/scripts/extract_tokens.py -i data.json -f css -o tokens.css` |
+| Extract TW tokens | `python3 ${CLAUDE_SKILL_DIR}/scripts/extract_tokens.py -i data.json -f tailwind -o tw.js` |
+| Generate React code | `python3 ${CLAUDE_SKILL_DIR}/scripts/figma_to_code.py -i node.json -f react -n MyComponent` |
+| Generate Flutter | `python3 ${CLAUDE_SKILL_DIR}/scripts/figma_to_code.py -i node.json -f flutter -n MyWidget` |
+
+---
+
+## Tips
+
+1. **Always browse first** — Fetch the full file before drilling into nodes to understand the structure
+2. **Use node IDs from URLs** — When a user shares a link with `?node-id=X:Y`, pass that directly as `nodeId`
+3. **SVG for icons, PNG for photos** — Use `.svg` for vector graphics, `.png` for raster images
+4. **Retina by default** — `pngScale: 2` is the default; use `3` for mobile @3x
+5. **Extract tokens early** — Run token extraction on the full file to build your design system before generating component code
+6. **Component names matter** — Use `--name` flag with the code generator for clean component names
+7. **Pipe for speed** — Both scripts accept stdin: `cat data.json | python3 ${CLAUDE_SKILL_DIR}/scripts/extract_tokens.py -f css`
+8. **Iterate** — Generated code is a starting point; refine layout, add interactivity, and connect to your state management

--- a/skills/figma/data/framework-mappings.json
+++ b/skills/figma/data/framework-mappings.json
@@ -1,0 +1,319 @@
+{
+  "frameworks": {
+    "tailwind": {
+      "layout": {
+        "HORIZONTAL": "flex flex-row",
+        "VERTICAL": "flex flex-col",
+        "WRAP": "flex flex-wrap",
+        "NONE": "relative"
+      },
+      "mainAxisAlign": {
+        "MIN": "justify-start",
+        "CENTER": "justify-center",
+        "MAX": "justify-end",
+        "SPACE_BETWEEN": "justify-between"
+      },
+      "crossAxisAlign": {
+        "MIN": "items-start",
+        "CENTER": "items-center",
+        "MAX": "items-end",
+        "STRETCH": "items-stretch",
+        "BASELINE": "items-baseline"
+      },
+      "sizing": {
+        "FIXED": "{dimension}",
+        "FILL": "w-full",
+        "HUG": "w-fit"
+      },
+      "overflow": {
+        "SCROLL": "overflow-auto",
+        "HIDDEN": "overflow-hidden"
+      },
+      "position": {
+        "ABSOLUTE": "absolute"
+      },
+      "textAlign": {
+        "LEFT": "text-left",
+        "CENTER": "text-center",
+        "RIGHT": "text-right",
+        "JUSTIFIED": "text-justify"
+      },
+      "textDecoration": {
+        "UNDERLINE": "underline",
+        "STRIKETHROUGH": "line-through"
+      },
+      "textTransform": {
+        "UPPER": "uppercase",
+        "LOWER": "lowercase",
+        "TITLE": "capitalize"
+      },
+      "blendMode": {
+        "MULTIPLY": "mix-blend-multiply",
+        "SCREEN": "mix-blend-screen",
+        "OVERLAY": "mix-blend-overlay",
+        "DARKEN": "mix-blend-darken",
+        "LIGHTEN": "mix-blend-lighten"
+      }
+    },
+    "react": {
+      "layout": {
+        "HORIZONTAL": "display: 'flex', flexDirection: 'row'",
+        "VERTICAL": "display: 'flex', flexDirection: 'column'",
+        "WRAP": "display: 'flex', flexWrap: 'wrap'",
+        "NONE": "position: 'relative'"
+      },
+      "mainAxisAlign": {
+        "MIN": "justifyContent: 'flex-start'",
+        "CENTER": "justifyContent: 'center'",
+        "MAX": "justifyContent: 'flex-end'",
+        "SPACE_BETWEEN": "justifyContent: 'space-between'"
+      },
+      "crossAxisAlign": {
+        "MIN": "alignItems: 'flex-start'",
+        "CENTER": "alignItems: 'center'",
+        "MAX": "alignItems: 'flex-end'",
+        "STRETCH": "alignItems: 'stretch'",
+        "BASELINE": "alignItems: 'baseline'"
+      },
+      "sizing": {
+        "FIXED": "{dimension}px",
+        "FILL": "width: '100%'",
+        "HUG": "width: 'auto'"
+      },
+      "componentTemplate": "jsx"
+    },
+    "vue": {
+      "layout": {
+        "HORIZONTAL": "display: flex; flex-direction: row",
+        "VERTICAL": "display: flex; flex-direction: column",
+        "WRAP": "display: flex; flex-wrap: wrap",
+        "NONE": "position: relative"
+      },
+      "mainAxisAlign": {
+        "MIN": "justify-content: flex-start",
+        "CENTER": "justify-content: center",
+        "MAX": "justify-content: flex-end",
+        "SPACE_BETWEEN": "justify-content: space-between"
+      },
+      "crossAxisAlign": {
+        "MIN": "align-items: flex-start",
+        "CENTER": "align-items: center",
+        "MAX": "align-items: flex-end",
+        "STRETCH": "align-items: stretch",
+        "BASELINE": "align-items: baseline"
+      },
+      "componentTemplate": "sfc"
+    },
+    "svelte": {
+      "layout": {
+        "HORIZONTAL": "display: flex; flex-direction: row",
+        "VERTICAL": "display: flex; flex-direction: column",
+        "WRAP": "display: flex; flex-wrap: wrap",
+        "NONE": "position: relative"
+      },
+      "componentTemplate": "svelte"
+    },
+    "react-native": {
+      "layout": {
+        "HORIZONTAL": "flexDirection: 'row'",
+        "VERTICAL": "flexDirection: 'column'",
+        "WRAP": "flexDirection: 'row', flexWrap: 'wrap'",
+        "NONE": "position: 'relative'"
+      },
+      "mainAxisAlign": {
+        "MIN": "justifyContent: 'flex-start'",
+        "CENTER": "justifyContent: 'center'",
+        "MAX": "justifyContent: 'flex-end'",
+        "SPACE_BETWEEN": "justifyContent: 'space-between'"
+      },
+      "crossAxisAlign": {
+        "MIN": "alignItems: 'flex-start'",
+        "CENTER": "alignItems: 'center'",
+        "MAX": "alignItems: 'flex-end'",
+        "STRETCH": "alignItems: 'stretch'"
+      },
+      "sizing": {
+        "FIXED": "{dimension}",
+        "FILL": "flex: 1",
+        "HUG": "alignSelf: 'flex-start'"
+      },
+      "componentTemplate": "rn"
+    },
+    "flutter": {
+      "layout": {
+        "HORIZONTAL": "Row",
+        "VERTICAL": "Column",
+        "WRAP": "Wrap",
+        "NONE": "Stack"
+      },
+      "mainAxisAlign": {
+        "MIN": "MainAxisAlignment.start",
+        "CENTER": "MainAxisAlignment.center",
+        "MAX": "MainAxisAlignment.end",
+        "SPACE_BETWEEN": "MainAxisAlignment.spaceBetween"
+      },
+      "crossAxisAlign": {
+        "MIN": "CrossAxisAlignment.start",
+        "CENTER": "CrossAxisAlignment.center",
+        "MAX": "CrossAxisAlignment.end",
+        "STRETCH": "CrossAxisAlignment.stretch"
+      },
+      "sizing": {
+        "FIXED": "SizedBox(width: {w}, height: {h})",
+        "FILL": "Expanded",
+        "HUG": "IntrinsicWidth / IntrinsicHeight"
+      },
+      "componentTemplate": "dart"
+    },
+    "css": {
+      "layout": {
+        "HORIZONTAL": "display: flex; flex-direction: row;",
+        "VERTICAL": "display: flex; flex-direction: column;",
+        "WRAP": "display: flex; flex-wrap: wrap;",
+        "NONE": "position: relative;"
+      },
+      "mainAxisAlign": {
+        "MIN": "justify-content: flex-start;",
+        "CENTER": "justify-content: center;",
+        "MAX": "justify-content: flex-end;",
+        "SPACE_BETWEEN": "justify-content: space-between;"
+      },
+      "crossAxisAlign": {
+        "MIN": "align-items: flex-start;",
+        "CENTER": "align-items: center;",
+        "MAX": "align-items: flex-end;",
+        "STRETCH": "align-items: stretch;",
+        "BASELINE": "align-items: baseline;"
+      },
+      "sizing": {
+        "FIXED": "{dimension}px",
+        "FILL": "width: 100%;",
+        "HUG": "width: fit-content;"
+      },
+      "componentTemplate": "html"
+    }
+  },
+  "figma_scales": {
+    "spacing": {
+      "0": "0",
+      "1": "px",
+      "2": "0.5",
+      "4": "1",
+      "6": "1.5",
+      "8": "2",
+      "10": "2.5",
+      "12": "3",
+      "14": "3.5",
+      "16": "4",
+      "20": "5",
+      "24": "6",
+      "28": "7",
+      "32": "8",
+      "36": "9",
+      "40": "10",
+      "44": "11",
+      "48": "12",
+      "56": "14",
+      "64": "16",
+      "80": "20",
+      "96": "24",
+      "112": "28",
+      "128": "32",
+      "144": "36",
+      "160": "40",
+      "176": "44",
+      "192": "48",
+      "208": "52",
+      "224": "56",
+      "240": "60",
+      "256": "64",
+      "288": "72",
+      "320": "80",
+      "384": "96"
+    },
+    "fontSize": {
+      "12": "xs",
+      "14": "sm",
+      "16": "base",
+      "18": "lg",
+      "20": "xl",
+      "24": "2xl",
+      "30": "3xl",
+      "36": "4xl",
+      "48": "5xl",
+      "60": "6xl",
+      "72": "7xl",
+      "96": "8xl",
+      "128": "9xl"
+    },
+    "fontWeight": {
+      "100": "thin",
+      "200": "extralight",
+      "300": "light",
+      "400": "normal",
+      "500": "medium",
+      "600": "semibold",
+      "700": "bold",
+      "800": "extrabold",
+      "900": "black"
+    },
+    "borderRadius": {
+      "0": "none",
+      "2": "sm",
+      "4": "DEFAULT",
+      "6": "md",
+      "8": "lg",
+      "12": "xl",
+      "16": "2xl",
+      "24": "3xl",
+      "9999": "full"
+    },
+    "opacity": {
+      "0": "0",
+      "0.05": "5",
+      "0.1": "10",
+      "0.15": "15",
+      "0.2": "20",
+      "0.25": "25",
+      "0.3": "30",
+      "0.35": "35",
+      "0.4": "40",
+      "0.45": "45",
+      "0.5": "50",
+      "0.55": "55",
+      "0.6": "60",
+      "0.65": "65",
+      "0.7": "70",
+      "0.75": "75",
+      "0.8": "80",
+      "0.85": "85",
+      "0.9": "90",
+      "0.95": "95",
+      "1": "100"
+    },
+    "shadow": {
+      "2": "sm",
+      "4": "DEFAULT",
+      "6": "md",
+      "10": "lg",
+      "15": "xl",
+      "25": "2xl"
+    },
+    "lineHeight": {
+      "1": "none",
+      "1.25": "tight",
+      "1.375": "snug",
+      "1.5": "normal",
+      "1.625": "relaxed",
+      "2": "loose"
+    },
+    "letterSpacing": {
+      "-0.05": "tighter",
+      "-0.025": "tight",
+      "0": "normal",
+      "0.025": "wide",
+      "0.05": "wider",
+      "0.1": "widest"
+    }
+  }
+}

--- a/skills/figma/scripts/extract_tokens.py
+++ b/skills/figma/scripts/extract_tokens.py
@@ -1,0 +1,572 @@
+#!/usr/bin/env python3
+"""
+Figma Design Token Extractor
+
+Extracts colors, typography, spacing, shadows, gradients, and border-radius
+from Figma API JSON data and outputs as CSS custom properties, Tailwind config,
+JSON tokens, or SCSS variables.
+
+Usage:
+    python3 extract_tokens.py --input figma-data.json --format css
+    python3 extract_tokens.py --input figma-data.json --format tailwind --output tailwind.config.js
+    cat figma-data.json | python3 extract_tokens.py --format json
+
+Part of the Figma Skill for Claude Code.
+Requires: Python 3.8+ (stdlib only, no pip dependencies)
+"""
+
+import json
+import sys
+import argparse
+import colorsys
+import re
+from pathlib import Path
+from collections import OrderedDict
+
+
+# ---------------------------------------------------------------------------
+# Color helpers
+# ---------------------------------------------------------------------------
+
+def figma_color_to_hex(color: dict) -> str:
+    """Convert Figma RGBA (0-1 floats) to #RRGGBB or #RRGGBBAA."""
+    r = round(color.get("r", 0) * 255)
+    g = round(color.get("g", 0) * 255)
+    b = round(color.get("b", 0) * 255)
+    a = color.get("a", 1)
+    if a < 1:
+        return f"#{r:02x}{g:02x}{b:02x}{round(a * 255):02x}"
+    return f"#{r:02x}{g:02x}{b:02x}"
+
+
+def figma_color_to_rgba(color: dict) -> str:
+    """Convert Figma RGBA to rgba() CSS string."""
+    r = round(color.get("r", 0) * 255)
+    g = round(color.get("g", 0) * 255)
+    b = round(color.get("b", 0) * 255)
+    a = round(color.get("a", 1), 3)
+    if a == 1:
+        return f"rgb({r}, {g}, {b})"
+    return f"rgba({r}, {g}, {b}, {a})"
+
+
+def figma_color_to_hsl(color: dict) -> str:
+    """Convert Figma RGBA to hsl() / hsla() CSS string."""
+    r = color.get("r", 0)
+    g = color.get("g", 0)
+    b = color.get("b", 0)
+    a = round(color.get("a", 1), 3)
+    h, l, s = colorsys.rgb_to_hls(r, g, b)
+    h = round(h * 360)
+    s = round(s * 100, 1)
+    l = round(l * 100, 1)
+    if a < 1:
+        return f"hsla({h}, {s}%, {l}%, {a})"
+    return f"hsl({h}, {s}%, {l}%)"
+
+
+def _slugify(name: str) -> str:
+    """Convert a Figma layer name to a valid CSS/token identifier."""
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", name.strip()).strip("-").lower()
+    return slug or "unnamed"
+
+
+# ---------------------------------------------------------------------------
+# Extraction functions — walk the Figma JSON tree
+# ---------------------------------------------------------------------------
+
+def extract_colors(node: dict, prefix: str = "", collected: dict = None) -> dict:
+    """Recursively extract solid fill colors from the node tree."""
+    if collected is None:
+        collected = OrderedDict()
+
+    name = node.get("name", "")
+    node_type = node.get("type", "")
+
+    # Color styles defined at document level
+    if node_type in ("RECTANGLE", "ELLIPSE", "FRAME", "COMPONENT", "INSTANCE", "VECTOR", "TEXT"):
+        fills = node.get("fills", [])
+        for fill in fills:
+            if fill.get("type") == "SOLID" and fill.get("visible", True):
+                color = fill.get("color", {})
+                opacity = fill.get("opacity", color.get("a", 1))
+                color_with_opacity = {**color, "a": opacity}
+                token_name = _slugify(f"{prefix}{name}") if prefix else _slugify(name)
+                if token_name and token_name not in collected:
+                    collected[token_name] = {
+                        "hex": figma_color_to_hex(color_with_opacity),
+                        "rgba": figma_color_to_rgba(color_with_opacity),
+                        "hsl": figma_color_to_hsl(color_with_opacity),
+                        "figma": color_with_opacity,
+                    }
+
+    # Recurse into children
+    for child in node.get("children", []):
+        child_prefix = f"{prefix}{name}/" if name and node_type in ("FRAME", "GROUP", "SECTION", "PAGE", "COMPONENT_SET") else prefix
+        extract_colors(child, child_prefix, collected)
+
+    return collected
+
+
+def extract_typography(node: dict, collected: dict = None) -> dict:
+    """Recursively extract text styles (font, size, weight, line-height, letter-spacing)."""
+    if collected is None:
+        collected = OrderedDict()
+
+    if node.get("type") == "TEXT":
+        style = node.get("style", {})
+        name = _slugify(node.get("name", "text"))
+        if style and name not in collected:
+            collected[name] = {
+                "fontFamily": style.get("fontFamily", "sans-serif"),
+                "fontSize": style.get("fontSize", 16),
+                "fontWeight": style.get("fontWeight", 400),
+                "lineHeight": _extract_line_height(style),
+                "letterSpacing": _extract_letter_spacing(style),
+                "textAlign": style.get("textAlignHorizontal", "LEFT").lower(),
+                "textTransform": style.get("textCase", "ORIGINAL").lower(),
+            }
+
+    for child in node.get("children", []):
+        extract_typography(child, collected)
+
+    return collected
+
+
+def _extract_line_height(style: dict):
+    """Extract line-height from Figma text style."""
+    lh = style.get("lineHeightPx")
+    fs = style.get("fontSize", 16)
+    if lh and fs:
+        ratio = round(lh / fs, 3)
+        return {"px": round(lh, 1), "ratio": ratio}
+    unit = style.get("lineHeightUnit", "AUTO")
+    if unit == "FONT_SIZE_%":
+        pct = style.get("lineHeightPercentFontSize", 100)
+        return {"px": round(fs * pct / 100, 1), "ratio": round(pct / 100, 3)}
+    return {"px": round(fs * 1.5, 1), "ratio": 1.5}
+
+
+def _extract_letter_spacing(style: dict):
+    """Extract letter-spacing from Figma text style."""
+    ls = style.get("letterSpacing", 0)
+    fs = style.get("fontSize", 16)
+    if ls and fs:
+        return {"px": round(ls, 2), "em": round(ls / fs, 4)}
+    return {"px": 0, "em": 0}
+
+
+def extract_spacing(node: dict, collected: dict = None) -> dict:
+    """Extract padding and gap values from auto-layout frames."""
+    if collected is None:
+        collected = OrderedDict()
+
+    if node.get("type") in ("FRAME", "COMPONENT", "INSTANCE"):
+        layout_mode = node.get("layoutMode")
+        if layout_mode:
+            name = _slugify(node.get("name", "frame"))
+            pt = node.get("paddingTop", 0)
+            pr = node.get("paddingRight", 0)
+            pb = node.get("paddingBottom", 0)
+            pl = node.get("paddingLeft", 0)
+            gap = node.get("itemSpacing", 0)
+
+            spacing_data = {}
+            if any([pt, pr, pb, pl]):
+                if pt == pr == pb == pl:
+                    spacing_data["padding"] = pt
+                else:
+                    spacing_data["paddingTop"] = pt
+                    spacing_data["paddingRight"] = pr
+                    spacing_data["paddingBottom"] = pb
+                    spacing_data["paddingLeft"] = pl
+            if gap:
+                spacing_data["gap"] = gap
+
+            if spacing_data and name not in collected:
+                collected[name] = spacing_data
+
+    for child in node.get("children", []):
+        extract_spacing(child, collected)
+
+    return collected
+
+
+def extract_border_radii(node: dict, collected: dict = None) -> dict:
+    """Extract border-radius values from nodes."""
+    if collected is None:
+        collected = OrderedDict()
+
+    cr = node.get("cornerRadius")
+    rectangleCornerRadii = node.get("rectangleCornerRadii")
+    if cr is not None or rectangleCornerRadii:
+        name = _slugify(node.get("name", "element"))
+        if name not in collected:
+            if rectangleCornerRadii:
+                collected[name] = {
+                    "topLeft": rectangleCornerRadii[0],
+                    "topRight": rectangleCornerRadii[1],
+                    "bottomRight": rectangleCornerRadii[2],
+                    "bottomLeft": rectangleCornerRadii[3],
+                }
+            elif cr is not None:
+                collected[name] = {"all": cr}
+
+    for child in node.get("children", []):
+        extract_border_radii(child, collected)
+
+    return collected
+
+
+def extract_shadows(node: dict, collected: dict = None) -> dict:
+    """Extract drop shadow and inner shadow effects."""
+    if collected is None:
+        collected = OrderedDict()
+
+    effects = node.get("effects", [])
+    for effect in effects:
+        if effect.get("type") in ("DROP_SHADOW", "INNER_SHADOW") and effect.get("visible", True):
+            name = _slugify(node.get("name", "shadow"))
+            if name not in collected:
+                color = effect.get("color", {})
+                collected[name] = {
+                    "type": "inset" if effect["type"] == "INNER_SHADOW" else "drop",
+                    "x": effect.get("offset", {}).get("x", 0),
+                    "y": effect.get("offset", {}).get("y", 0),
+                    "blur": effect.get("radius", 0),
+                    "spread": effect.get("spread", 0),
+                    "color": figma_color_to_rgba(color),
+                }
+
+    for child in node.get("children", []):
+        extract_shadows(child, collected)
+
+    return collected
+
+
+def extract_gradients(node: dict, collected: dict = None) -> dict:
+    """Extract gradient fills from nodes."""
+    if collected is None:
+        collected = OrderedDict()
+
+    fills = node.get("fills", [])
+    for fill in fills:
+        if fill.get("type") in ("GRADIENT_LINEAR", "GRADIENT_RADIAL", "GRADIENT_ANGULAR") and fill.get("visible", True):
+            name = _slugify(node.get("name", "gradient"))
+            if name not in collected:
+                stops = []
+                for stop in fill.get("gradientStops", []):
+                    stops.append({
+                        "color": figma_color_to_hex(stop.get("color", {})),
+                        "position": round(stop.get("position", 0) * 100, 1),
+                    })
+                gradient_type = fill["type"].replace("GRADIENT_", "").lower()
+                collected[name] = {
+                    "type": gradient_type,
+                    "stops": stops,
+                }
+
+    for child in node.get("children", []):
+        extract_gradients(child, collected)
+
+    return collected
+
+
+def extract_all_tokens(data: dict) -> dict:
+    """Extract all design tokens from Figma JSON data."""
+    # Handle both full file responses and single node responses
+    root = data.get("document", data)
+    if "nodes" in data:
+        # Response from get_figma_data with nodeId — merge all nodes
+        nodes = data["nodes"]
+        root = {"children": [v.get("document", v) for v in nodes.values()]}
+
+    return {
+        "colors": extract_colors(root),
+        "typography": extract_typography(root),
+        "spacing": extract_spacing(root),
+        "borderRadius": extract_border_radii(root),
+        "shadows": extract_shadows(root),
+        "gradients": extract_gradients(root),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Output formatters
+# ---------------------------------------------------------------------------
+
+def format_css(tokens: dict) -> str:
+    """Format tokens as CSS custom properties."""
+    lines = ["/* Design Tokens — extracted from Figma */", "/* Generated by Figma Skill for Claude Code */", "", ":root {"]
+
+    # Colors
+    if tokens.get("colors"):
+        lines.append("  /* Colors */")
+        for name, val in tokens["colors"].items():
+            lines.append(f"  --color-{name}: {val['hex']};")
+        lines.append("")
+
+    # Typography
+    if tokens.get("typography"):
+        lines.append("  /* Typography */")
+        for name, val in tokens["typography"].items():
+            lines.append(f"  --font-{name}-family: '{val['fontFamily']}', sans-serif;")
+            lines.append(f"  --font-{name}-size: {val['fontSize']}px;")
+            lines.append(f"  --font-{name}-weight: {val['fontWeight']};")
+            lines.append(f"  --font-{name}-line-height: {val['lineHeight']['ratio']};")
+            if val["letterSpacing"]["px"]:
+                lines.append(f"  --font-{name}-letter-spacing: {val['letterSpacing']['px']}px;")
+        lines.append("")
+
+    # Spacing
+    if tokens.get("spacing"):
+        lines.append("  /* Spacing */")
+        seen_values = set()
+        for name, val in tokens["spacing"].items():
+            for prop, px_val in val.items():
+                if px_val and px_val not in seen_values:
+                    lines.append(f"  --spacing-{px_val}: {px_val}px;")
+                    seen_values.add(px_val)
+        lines.append("")
+
+    # Border Radius
+    if tokens.get("borderRadius"):
+        lines.append("  /* Border Radius */")
+        seen_values = set()
+        for name, val in tokens["borderRadius"].items():
+            if "all" in val and val["all"] not in seen_values:
+                lines.append(f"  --radius-{name}: {val['all']}px;")
+                seen_values.add(val["all"])
+            else:
+                tl = val.get("topLeft", 0)
+                tr = val.get("topRight", 0)
+                br = val.get("bottomRight", 0)
+                bl = val.get("bottomLeft", 0)
+                lines.append(f"  --radius-{name}: {tl}px {tr}px {br}px {bl}px;")
+        lines.append("")
+
+    # Shadows
+    if tokens.get("shadows"):
+        lines.append("  /* Shadows */")
+        for name, val in tokens["shadows"].items():
+            inset = "inset " if val["type"] == "inset" else ""
+            lines.append(f"  --shadow-{name}: {inset}{val['x']}px {val['y']}px {val['blur']}px {val['spread']}px {val['color']};")
+        lines.append("")
+
+    # Gradients
+    if tokens.get("gradients"):
+        lines.append("  /* Gradients */")
+        for name, val in tokens["gradients"].items():
+            stops_str = ", ".join(f"{s['color']} {s['position']}%" for s in val["stops"])
+            if val["type"] == "linear":
+                lines.append(f"  --gradient-{name}: linear-gradient(to right, {stops_str});")
+            elif val["type"] == "radial":
+                lines.append(f"  --gradient-{name}: radial-gradient(circle, {stops_str});")
+            elif val["type"] == "angular":
+                lines.append(f"  --gradient-{name}: conic-gradient({stops_str});")
+        lines.append("")
+
+    lines.append("}")
+    return "\n".join(lines)
+
+
+def format_tailwind(tokens: dict) -> str:
+    """Format tokens as a Tailwind CSS config extend block."""
+    lines = [
+        "// Design Tokens — extracted from Figma",
+        "// Generated by Figma Skill for Claude Code",
+        "// Paste into tailwind.config.js > theme.extend",
+        "",
+        "module.exports = {",
+        "  theme: {",
+        "    extend: {",
+    ]
+
+    # Colors
+    if tokens.get("colors"):
+        lines.append("      colors: {")
+        for name, val in tokens["colors"].items():
+            lines.append(f"        '{name}': '{val['hex']}',")
+        lines.append("      },")
+
+    # Font families
+    families = set()
+    if tokens.get("typography"):
+        lines.append("      fontFamily: {")
+        for name, val in tokens["typography"].items():
+            family = val["fontFamily"]
+            if family not in families:
+                slug = _slugify(family)
+                lines.append(f"        '{slug}': ['{family}', 'sans-serif'],")
+                families.add(family)
+        lines.append("      },")
+
+        # Font sizes
+        lines.append("      fontSize: {")
+        seen_sizes = set()
+        for name, val in tokens["typography"].items():
+            fs = val["fontSize"]
+            if fs not in seen_sizes:
+                lh = val["lineHeight"]["ratio"]
+                lines.append(f"        '{name}': ['{fs}px', {{ lineHeight: '{lh}' }}],")
+                seen_sizes.add(fs)
+        lines.append("      },")
+
+    # Border radius
+    if tokens.get("borderRadius"):
+        lines.append("      borderRadius: {")
+        for name, val in tokens["borderRadius"].items():
+            if "all" in val:
+                lines.append(f"        '{name}': '{val['all']}px',")
+        lines.append("      },")
+
+    # Box shadow
+    if tokens.get("shadows"):
+        lines.append("      boxShadow: {")
+        for name, val in tokens["shadows"].items():
+            inset = "inset " if val["type"] == "inset" else ""
+            lines.append(f"        '{name}': '{inset}{val['x']}px {val['y']}px {val['blur']}px {val['spread']}px {val['color']}',")
+        lines.append("      },")
+
+    lines.extend([
+        "    },",
+        "  },",
+        "};",
+    ])
+    return "\n".join(lines)
+
+
+def format_json(tokens: dict) -> str:
+    """Format tokens as raw JSON."""
+    # Simplify for JSON output — flatten figma internals
+    output = {}
+    if tokens.get("colors"):
+        output["colors"] = {name: val["hex"] for name, val in tokens["colors"].items()}
+    if tokens.get("typography"):
+        output["typography"] = tokens["typography"]
+    if tokens.get("spacing"):
+        output["spacing"] = tokens["spacing"]
+    if tokens.get("borderRadius"):
+        output["borderRadius"] = tokens["borderRadius"]
+    if tokens.get("shadows"):
+        output["shadows"] = tokens["shadows"]
+    if tokens.get("gradients"):
+        output["gradients"] = tokens["gradients"]
+    return json.dumps(output, indent=2)
+
+
+def format_scss(tokens: dict) -> str:
+    """Format tokens as SCSS variables."""
+    lines = [
+        "// Design Tokens — extracted from Figma",
+        "// Generated by Figma Skill for Claude Code",
+        "",
+    ]
+
+    if tokens.get("colors"):
+        lines.append("// Colors")
+        for name, val in tokens["colors"].items():
+            lines.append(f"$color-{name}: {val['hex']};")
+        lines.append("")
+
+    if tokens.get("typography"):
+        lines.append("// Typography")
+        for name, val in tokens["typography"].items():
+            lines.append(f"$font-{name}-family: '{val['fontFamily']}', sans-serif;")
+            lines.append(f"$font-{name}-size: {val['fontSize']}px;")
+            lines.append(f"$font-{name}-weight: {val['fontWeight']};")
+            lines.append(f"$font-{name}-line-height: {val['lineHeight']['ratio']};")
+        lines.append("")
+
+    if tokens.get("shadows"):
+        lines.append("// Shadows")
+        for name, val in tokens["shadows"].items():
+            inset = "inset " if val["type"] == "inset" else ""
+            lines.append(f"$shadow-{name}: {inset}{val['x']}px {val['y']}px {val['blur']}px {val['spread']}px {val['color']};")
+        lines.append("")
+
+    if tokens.get("gradients"):
+        lines.append("// Gradients")
+        for name, val in tokens["gradients"].items():
+            stops_str = ", ".join(f"{s['color']} {s['position']}%" for s in val["stops"])
+            if val["type"] == "linear":
+                lines.append(f"$gradient-{name}: linear-gradient(to right, {stops_str});")
+            elif val["type"] == "radial":
+                lines.append(f"$gradient-{name}: radial-gradient(circle, {stops_str});")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+FORMATTERS = {
+    "css": format_css,
+    "tailwind": format_tailwind,
+    "json": format_json,
+    "scss": format_scss,
+}
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Extract design tokens from Figma JSON data.",
+        epilog="Part of the Figma Skill for Claude Code — https://github.com/figma-skill",
+    )
+    parser.add_argument(
+        "--input", "-i",
+        help="Path to Figma JSON file (or pipe via stdin)",
+    )
+    parser.add_argument(
+        "--format", "-f",
+        choices=list(FORMATTERS.keys()),
+        default="css",
+        help="Output format (default: css)",
+    )
+    parser.add_argument(
+        "--output", "-o",
+        help="Output file path (default: stdout)",
+    )
+    args = parser.parse_args()
+
+    # Read input
+    if args.input:
+        path = Path(args.input)
+        if not path.exists():
+            print(f"Error: File not found: {args.input}", file=sys.stderr)
+            sys.exit(1)
+        data = json.loads(path.read_text(encoding="utf-8"))
+    elif not sys.stdin.isatty():
+        data = json.load(sys.stdin)
+    else:
+        parser.print_help()
+        print("\nError: Provide --input file or pipe JSON via stdin.", file=sys.stderr)
+        sys.exit(1)
+
+    # Extract tokens
+    tokens = extract_all_tokens(data)
+
+    # Check if anything was extracted
+    total = sum(len(v) for v in tokens.values())
+    if total == 0:
+        print("Warning: No design tokens found in the input data.", file=sys.stderr)
+        print("Tip: Make sure the JSON contains Figma node data with fills, text styles, or effects.", file=sys.stderr)
+
+    # Format output
+    formatter = FORMATTERS[args.format]
+    result = formatter(tokens)
+
+    # Write output
+    if args.output:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(result, encoding="utf-8")
+        print(f"Tokens written to {args.output} ({total} tokens, {args.format} format)", file=sys.stderr)
+    else:
+        print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/figma/scripts/figma_to_code.py
+++ b/skills/figma/scripts/figma_to_code.py
@@ -1,0 +1,981 @@
+#!/usr/bin/env python3
+"""
+Figma-to-Code Generator
+
+Converts Figma node JSON into code for multiple frameworks:
+Tailwind/HTML, React (JSX), Vue (SFC), Svelte, React Native, Flutter, plain CSS.
+
+Usage:
+    python3 figma_to_code.py --framework tailwind --input node.json
+    python3 figma_to_code.py --framework react --input node.json --name MyComponent
+    cat node.json | python3 figma_to_code.py --framework flutter
+
+Part of the Figma Skill for Claude Code.
+Requires: Python 3.8+ (stdlib only, no pip dependencies)
+"""
+
+import json
+import sys
+import argparse
+import re
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Load framework mappings
+# ---------------------------------------------------------------------------
+
+DATA_DIR = Path(__file__).parent.parent / "data"
+
+def load_mappings() -> dict:
+    """Load framework-mappings.json from the data directory."""
+    mappings_file = DATA_DIR / "framework-mappings.json"
+    if not mappings_file.exists():
+        print(f"Error: {mappings_file} not found.", file=sys.stderr)
+        print("Make sure the data/ directory is alongside the scripts/ directory.", file=sys.stderr)
+        sys.exit(1)
+    return json.loads(mappings_file.read_text(encoding="utf-8"))
+
+
+MAPPINGS = None  # Lazy loaded
+
+
+def get_mappings() -> dict:
+    global MAPPINGS
+    if MAPPINGS is None:
+        MAPPINGS = load_mappings()
+    return MAPPINGS
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def slugify(name: str) -> str:
+    """Convert Figma layer name to a valid identifier."""
+    return re.sub(r"[^a-zA-Z0-9]+", "-", name.strip()).strip("-").lower()
+
+
+def pascal_case(name: str) -> str:
+    """Convert to PascalCase for component names."""
+    parts = re.sub(r"[^a-zA-Z0-9]+", " ", name.strip()).split()
+    return "".join(w.capitalize() for w in parts) or "Component"
+
+
+def camel_case(name: str) -> str:
+    """Convert to camelCase."""
+    pc = pascal_case(name)
+    return pc[0].lower() + pc[1:] if pc else "component"
+
+
+def figma_color_to_hex(color: dict) -> str:
+    """Convert Figma RGBA floats to hex."""
+    r = round(color.get("r", 0) * 255)
+    g = round(color.get("g", 0) * 255)
+    b = round(color.get("b", 0) * 255)
+    a = color.get("a", 1)
+    if a < 1:
+        return f"#{r:02x}{g:02x}{b:02x}{round(a * 255):02x}"
+    return f"#{r:02x}{g:02x}{b:02x}"
+
+
+def figma_color_to_rgba_str(color: dict) -> str:
+    """Convert Figma RGBA floats to rgba() string."""
+    r = round(color.get("r", 0) * 255)
+    g = round(color.get("g", 0) * 255)
+    b = round(color.get("b", 0) * 255)
+    a = round(color.get("a", 1), 3)
+    if a == 1:
+        return f"rgb({r}, {g}, {b})"
+    return f"rgba({r}, {g}, {b}, {a})"
+
+
+def closest_tw_spacing(px: float) -> str:
+    """Find the closest Tailwind spacing class value for a pixel amount."""
+    scales = get_mappings()["figma_scales"]["spacing"]
+    closest_key = min(scales.keys(), key=lambda k: abs(int(k) - px))
+    return scales[closest_key]
+
+
+def closest_tw_font_size(px: float) -> str:
+    """Find closest Tailwind text-* class for a font size."""
+    scales = get_mappings()["figma_scales"]["fontSize"]
+    closest_key = min(scales.keys(), key=lambda k: abs(int(k) - px))
+    return scales[closest_key]
+
+
+def closest_tw_font_weight(weight: int) -> str:
+    """Find closest Tailwind font weight name."""
+    scales = get_mappings()["figma_scales"]["fontWeight"]
+    closest_key = min(scales.keys(), key=lambda k: abs(int(k) - weight))
+    return scales[closest_key]
+
+
+def closest_tw_radius(px: float) -> str:
+    """Find closest Tailwind rounded-* class."""
+    scales = get_mappings()["figma_scales"]["borderRadius"]
+    closest_key = min(scales.keys(), key=lambda k: abs(int(k) - px))
+    val = scales[closest_key]
+    if val == "DEFAULT":
+        return "rounded"
+    if val == "none":
+        return "rounded-none"
+    return f"rounded-{val}"
+
+
+def closest_tw_shadow(blur: float) -> str:
+    """Find closest Tailwind shadow class."""
+    scales = get_mappings()["figma_scales"]["shadow"]
+    closest_key = min(scales.keys(), key=lambda k: abs(int(k) - blur))
+    val = scales[closest_key]
+    if val == "DEFAULT":
+        return "shadow"
+    return f"shadow-{val}"
+
+
+# ---------------------------------------------------------------------------
+# FigmaNode wrapper
+# ---------------------------------------------------------------------------
+
+class FigmaNode:
+    """Convenience wrapper around a Figma JSON node."""
+
+    def __init__(self, data: dict):
+        self._data = data
+
+    @property
+    def name(self) -> str:
+        return self._data.get("name", "Untitled")
+
+    @property
+    def type(self) -> str:
+        return self._data.get("type", "FRAME")
+
+    @property
+    def layout_mode(self):
+        return self._data.get("layoutMode")
+
+    @property
+    def primary_axis_align(self) -> str:
+        return self._data.get("primaryAxisAlignItems", "MIN")
+
+    @property
+    def counter_axis_align(self) -> str:
+        return self._data.get("counterAxisAlignItems", "MIN")
+
+    @property
+    def padding(self) -> dict:
+        return {
+            "top": self._data.get("paddingTop", 0),
+            "right": self._data.get("paddingRight", 0),
+            "bottom": self._data.get("paddingBottom", 0),
+            "left": self._data.get("paddingLeft", 0),
+        }
+
+    @property
+    def gap(self) -> float:
+        return self._data.get("itemSpacing", 0)
+
+    @property
+    def width(self) -> float:
+        bbox = self._data.get("absoluteBoundingBox", {})
+        return bbox.get("width", 0)
+
+    @property
+    def height(self) -> float:
+        bbox = self._data.get("absoluteBoundingBox", {})
+        return bbox.get("height", 0)
+
+    @property
+    def corner_radius(self):
+        return self._data.get("cornerRadius")
+
+    @property
+    def corner_radii(self):
+        return self._data.get("rectangleCornerRadii")
+
+    @property
+    def fills(self) -> list:
+        return [f for f in self._data.get("fills", []) if f.get("visible", True)]
+
+    @property
+    def strokes(self) -> list:
+        return [s for s in self._data.get("strokes", []) if s.get("visible", True)]
+
+    @property
+    def stroke_weight(self) -> float:
+        return self._data.get("strokeWeight", 0)
+
+    @property
+    def effects(self) -> list:
+        return [e for e in self._data.get("effects", []) if e.get("visible", True)]
+
+    @property
+    def opacity(self) -> float:
+        return self._data.get("opacity", 1)
+
+    @property
+    def text_style(self) -> dict:
+        return self._data.get("style", {})
+
+    @property
+    def characters(self) -> str:
+        return self._data.get("characters", "")
+
+    @property
+    def children(self) -> list:
+        return [FigmaNode(c) for c in self._data.get("children", [])]
+
+    @property
+    def sizing_horizontal(self) -> str:
+        return self._data.get("layoutSizingHorizontal", "FIXED")
+
+    @property
+    def sizing_vertical(self) -> str:
+        return self._data.get("layoutSizingVertical", "FIXED")
+
+    @property
+    def overflow(self) -> str:
+        return self._data.get("clipsContent", False)
+
+
+# ---------------------------------------------------------------------------
+# Code generators
+# ---------------------------------------------------------------------------
+
+class TailwindGenerator:
+    """Generate Tailwind/HTML code from Figma nodes."""
+
+    def __init__(self, jsx: bool = False):
+        self.attr = "className" if jsx else "class"
+
+    def generate(self, node: FigmaNode, indent: int = 0) -> str:
+        if node.type == "TEXT":
+            return self._text(node, indent)
+        return self._container(node, indent)
+
+    def _classes(self, node: FigmaNode) -> list:
+        cls = []
+        mappings = get_mappings()["frameworks"]["tailwind"]
+
+        # Layout
+        if node.layout_mode:
+            layout_cls = mappings["layout"].get(node.layout_mode, "")
+            cls.extend(layout_cls.split())
+            align_main = mappings["mainAxisAlign"].get(node.primary_axis_align, "")
+            align_cross = mappings["crossAxisAlign"].get(node.counter_axis_align, "")
+            if align_main:
+                cls.append(align_main)
+            if align_cross:
+                cls.append(align_cross)
+
+        # Gap
+        if node.gap:
+            cls.append(f"gap-{closest_tw_spacing(node.gap)}")
+
+        # Padding
+        p = node.padding
+        if p["top"] == p["right"] == p["bottom"] == p["left"] and p["top"] > 0:
+            cls.append(f"p-{closest_tw_spacing(p['top'])}")
+        else:
+            if p["top"]:
+                cls.append(f"pt-{closest_tw_spacing(p['top'])}")
+            if p["right"]:
+                cls.append(f"pr-{closest_tw_spacing(p['right'])}")
+            if p["bottom"]:
+                cls.append(f"pb-{closest_tw_spacing(p['bottom'])}")
+            if p["left"]:
+                cls.append(f"pl-{closest_tw_spacing(p['left'])}")
+
+        # Sizing
+        if node.sizing_horizontal == "FILL":
+            cls.append("w-full")
+        elif node.sizing_horizontal == "HUG":
+            cls.append("w-fit")
+
+        # Corner radius
+        if node.corner_radius is not None and node.corner_radius > 0:
+            cls.append(closest_tw_radius(node.corner_radius))
+
+        # Background
+        for fill in node.fills:
+            if fill.get("type") == "SOLID":
+                color = fill.get("color", {})
+                hex_color = figma_color_to_hex(color)
+                cls.append(f"bg-[{hex_color}]")
+                break
+
+        # Border
+        if node.strokes and node.stroke_weight:
+            cls.append(f"border-{max(1, round(node.stroke_weight))}" if node.stroke_weight > 1 else "border")
+            for stroke in node.strokes:
+                if stroke.get("type") == "SOLID":
+                    hex_color = figma_color_to_hex(stroke.get("color", {}))
+                    cls.append(f"border-[{hex_color}]")
+                    break
+
+        # Shadow
+        for effect in node.effects:
+            if effect.get("type") == "DROP_SHADOW":
+                cls.append(closest_tw_shadow(effect.get("radius", 4)))
+                break
+
+        # Opacity
+        if node.opacity < 1:
+            scales = get_mappings()["figma_scales"]["opacity"]
+            closest_key = min(scales.keys(), key=lambda k: abs(float(k) - node.opacity))
+            cls.append(f"opacity-{scales[closest_key]}")
+
+        # Overflow
+        if node.overflow:
+            cls.append("overflow-hidden")
+
+        return cls
+
+    def _text_classes(self, node: FigmaNode) -> list:
+        cls = []
+        style = node.text_style
+
+        # Font size
+        fs = style.get("fontSize", 16)
+        cls.append(f"text-{closest_tw_font_size(fs)}")
+
+        # Font weight
+        fw = style.get("fontWeight", 400)
+        cls.append(f"font-{closest_tw_font_weight(fw)}")
+
+        # Text color
+        for fill in node.fills:
+            if fill.get("type") == "SOLID":
+                hex_color = figma_color_to_hex(fill.get("color", {}))
+                cls.append(f"text-[{hex_color}]")
+                break
+
+        # Text align
+        mappings = get_mappings()["frameworks"]["tailwind"]
+        align = style.get("textAlignHorizontal", "LEFT")
+        if align in mappings.get("textAlign", {}):
+            cls.append(mappings["textAlign"][align])
+
+        # Line height
+        lh_px = style.get("lineHeightPx")
+        if lh_px and fs:
+            ratio = round(lh_px / fs, 3)
+            lh_scales = get_mappings()["figma_scales"]["lineHeight"]
+            closest_key = min(lh_scales.keys(), key=lambda k: abs(float(k) - ratio))
+            cls.append(f"leading-{lh_scales[closest_key]}")
+
+        # Letter spacing
+        ls = style.get("letterSpacing", 0)
+        if ls and fs:
+            em = round(ls / fs, 4)
+            ls_scales = get_mappings()["figma_scales"]["letterSpacing"]
+            closest_key = min(ls_scales.keys(), key=lambda k: abs(float(k) - em))
+            cls.append(f"tracking-{ls_scales[closest_key]}")
+
+        return cls
+
+    def _text(self, node: FigmaNode, indent: int) -> str:
+        cls = self._text_classes(node)
+        pad = "  " * indent
+        class_str = " ".join(cls)
+        text = node.characters or "Text"
+        return f'{pad}<p {self.attr}="{class_str}">{text}</p>'
+
+    def _container(self, node: FigmaNode, indent: int) -> str:
+        cls = self._classes(node)
+        pad = "  " * indent
+        class_str = " ".join(cls)
+        tag = "section" if node.type == "SECTION" else "div"
+
+        children_code = []
+        for child in node.children:
+            children_code.append(self.generate(child, indent + 1))
+
+        if children_code:
+            inner = "\n".join(children_code)
+            return f'{pad}<{tag} {self.attr}="{class_str}">\n{inner}\n{pad}</{tag}>'
+        return f'{pad}<{tag} {self.attr}="{class_str}"></{tag}>'
+
+
+class ReactGenerator:
+    """Generate React JSX + Tailwind component."""
+
+    def __init__(self):
+        self.tw = TailwindGenerator(jsx=True)
+
+    def generate(self, node: FigmaNode, component_name: str = None) -> str:
+        name = component_name or pascal_case(node.name)
+        body = self.tw.generate(node, indent=2)
+
+        return (
+            f"export default function {name}() {{\n"
+            f"  return (\n"
+            f"{body}\n"
+            f"  );\n"
+            f"}}\n"
+        )
+
+
+class VueGenerator:
+    """Generate Vue SFC component."""
+
+    def __init__(self):
+        self.tw = TailwindGenerator()
+
+    def generate(self, node: FigmaNode, component_name: str = None) -> str:
+        name = component_name or pascal_case(node.name)
+        template = self.tw.generate(node, indent=1)
+
+        return (
+            f"<script setup lang=\"ts\">\n"
+            f"// {name} — generated from Figma\n"
+            f"</script>\n"
+            f"\n"
+            f"<template>\n"
+            f"{template}\n"
+            f"</template>\n"
+        )
+
+
+class SvelteGenerator:
+    """Generate Svelte component."""
+
+    def __init__(self):
+        self.tw = TailwindGenerator()
+
+    def generate(self, node: FigmaNode, component_name: str = None) -> str:
+        name = component_name or pascal_case(node.name)
+        template = self.tw.generate(node, indent=0)
+
+        return (
+            f"<script lang=\"ts\">\n"
+            f"  // {name} — generated from Figma\n"
+            f"</script>\n"
+            f"\n"
+            f"{template}\n"
+        )
+
+
+class CSSGenerator:
+    """Generate plain HTML + CSS."""
+
+    def generate(self, node: FigmaNode, indent: int = 0) -> str:
+        css_rules = []
+        html = self._node_html(node, indent, css_rules)
+
+        css_block = "\n\n".join(css_rules)
+        return f"<style>\n{css_block}\n</style>\n\n{html}"
+
+    def _css_props(self, node: FigmaNode) -> dict:
+        props = {}
+
+        # Layout
+        if node.layout_mode:
+            props["display"] = "flex"
+            props["flex-direction"] = "row" if node.layout_mode == "HORIZONTAL" else "column"
+
+            align_map = {"MIN": "flex-start", "CENTER": "center", "MAX": "flex-end", "SPACE_BETWEEN": "space-between"}
+            cross_map = {"MIN": "flex-start", "CENTER": "center", "MAX": "flex-end", "STRETCH": "stretch", "BASELINE": "baseline"}
+            props["justify-content"] = align_map.get(node.primary_axis_align, "flex-start")
+            props["align-items"] = cross_map.get(node.counter_axis_align, "flex-start")
+
+        # Gap
+        if node.gap:
+            props["gap"] = f"{node.gap}px"
+
+        # Padding
+        p = node.padding
+        if p["top"] == p["right"] == p["bottom"] == p["left"] and p["top"] > 0:
+            props["padding"] = f"{p['top']}px"
+        elif any(v for v in p.values()):
+            props["padding"] = f"{p['top']}px {p['right']}px {p['bottom']}px {p['left']}px"
+
+        # Sizing
+        if node.sizing_horizontal == "FILL":
+            props["width"] = "100%"
+
+        # Border radius
+        if node.corner_radius is not None and node.corner_radius > 0:
+            props["border-radius"] = f"{node.corner_radius}px"
+
+        # Background
+        for fill in node.fills:
+            if fill.get("type") == "SOLID":
+                props["background-color"] = figma_color_to_hex(fill.get("color", {}))
+                break
+
+        # Border
+        if node.strokes and node.stroke_weight:
+            for stroke in node.strokes:
+                if stroke.get("type") == "SOLID":
+                    hex_c = figma_color_to_hex(stroke.get("color", {}))
+                    props["border"] = f"{node.stroke_weight}px solid {hex_c}"
+                    break
+
+        # Shadow
+        for effect in node.effects:
+            if effect.get("type") == "DROP_SHADOW":
+                color = figma_color_to_rgba_str(effect.get("color", {}))
+                x = effect.get("offset", {}).get("x", 0)
+                y = effect.get("offset", {}).get("y", 0)
+                blur = effect.get("radius", 0)
+                spread = effect.get("spread", 0)
+                props["box-shadow"] = f"{x}px {y}px {blur}px {spread}px {color}"
+                break
+
+        # Opacity
+        if node.opacity < 1:
+            props["opacity"] = str(round(node.opacity, 2))
+
+        # Overflow
+        if node.overflow:
+            props["overflow"] = "hidden"
+
+        return props
+
+    def _text_css_props(self, node: FigmaNode) -> dict:
+        props = {}
+        style = node.text_style
+
+        fs = style.get("fontSize", 16)
+        props["font-size"] = f"{fs}px"
+        props["font-weight"] = str(style.get("fontWeight", 400))
+        props["font-family"] = f"'{style.get('fontFamily', 'sans-serif')}', sans-serif"
+
+        lh = style.get("lineHeightPx")
+        if lh:
+            props["line-height"] = f"{round(lh, 1)}px"
+
+        ls = style.get("letterSpacing", 0)
+        if ls:
+            props["letter-spacing"] = f"{round(ls, 2)}px"
+
+        align_map = {"LEFT": "left", "CENTER": "center", "RIGHT": "right", "JUSTIFIED": "justify"}
+        align = style.get("textAlignHorizontal", "LEFT")
+        if align in align_map:
+            props["text-align"] = align_map[align]
+
+        # Text color
+        for fill in node.fills:
+            if fill.get("type") == "SOLID":
+                props["color"] = figma_color_to_hex(fill.get("color", {}))
+                break
+
+        return props
+
+    def _node_html(self, node: FigmaNode, indent: int, css_rules: list) -> str:
+        class_name = slugify(node.name) or "element"
+        pad = "  " * indent
+
+        if node.type == "TEXT":
+            props = self._text_css_props(node)
+            css = f".{class_name} {{\n" + "\n".join(f"  {k}: {v};" for k, v in props.items()) + "\n}"
+            css_rules.append(css)
+            text = node.characters or "Text"
+            return f'{pad}<p class="{class_name}">{text}</p>'
+
+        props = self._css_props(node)
+        if props:
+            css = f".{class_name} {{\n" + "\n".join(f"  {k}: {v};" for k, v in props.items()) + "\n}"
+            css_rules.append(css)
+
+        children_code = []
+        for child in node.children:
+            children_code.append(self._node_html(child, indent + 1, css_rules))
+
+        tag = "section" if node.type == "SECTION" else "div"
+        if children_code:
+            inner = "\n".join(children_code)
+            return f'{pad}<{tag} class="{class_name}">\n{inner}\n{pad}</{tag}>'
+        return f'{pad}<{tag} class="{class_name}"></{tag}>'
+
+
+class ReactNativeGenerator:
+    """Generate React Native component with StyleSheet."""
+
+    def generate(self, node: FigmaNode, component_name: str = None) -> str:
+        name = component_name or pascal_case(node.name)
+        styles = {}
+        jsx = self._node_jsx(node, 2, styles)
+
+        style_lines = []
+        for style_name, props in styles.items():
+            prop_str = ",\n    ".join(f"{k}: {v}" for k, v in props.items())
+            style_lines.append(f"  {style_name}: {{\n    {prop_str},\n  }}")
+
+        styles_block = ",\n".join(style_lines)
+
+        return (
+            f"import React from 'react';\n"
+            f"import {{ View, Text, StyleSheet }} from 'react-native';\n"
+            f"\n"
+            f"export default function {name}() {{\n"
+            f"  return (\n"
+            f"{jsx}\n"
+            f"  );\n"
+            f"}}\n"
+            f"\n"
+            f"const styles = StyleSheet.create({{\n"
+            f"{styles_block},\n"
+            f"}});\n"
+        )
+
+    def _style_props(self, node: FigmaNode) -> dict:
+        props = {}
+
+        if node.layout_mode:
+            props["flexDirection"] = "'row'" if node.layout_mode == "HORIZONTAL" else "'column'"
+            align_map = {"MIN": "'flex-start'", "CENTER": "'center'", "MAX": "'flex-end'", "SPACE_BETWEEN": "'space-between'"}
+            cross_map = {"MIN": "'flex-start'", "CENTER": "'center'", "MAX": "'flex-end'", "STRETCH": "'stretch'"}
+            props["justifyContent"] = align_map.get(node.primary_axis_align, "'flex-start'")
+            props["alignItems"] = cross_map.get(node.counter_axis_align, "'flex-start'")
+
+        if node.gap:
+            props["gap"] = str(round(node.gap))
+
+        p = node.padding
+        if p["top"] == p["right"] == p["bottom"] == p["left"] and p["top"] > 0:
+            props["padding"] = str(round(p["top"]))
+        elif any(v for v in p.values()):
+            if p["top"]: props["paddingTop"] = str(round(p["top"]))
+            if p["right"]: props["paddingRight"] = str(round(p["right"]))
+            if p["bottom"]: props["paddingBottom"] = str(round(p["bottom"]))
+            if p["left"]: props["paddingLeft"] = str(round(p["left"]))
+
+        if node.sizing_horizontal == "FILL":
+            props["flex"] = "1"
+
+        if node.corner_radius is not None and node.corner_radius > 0:
+            props["borderRadius"] = str(round(node.corner_radius))
+
+        for fill in node.fills:
+            if fill.get("type") == "SOLID":
+                props["backgroundColor"] = f"'{figma_color_to_hex(fill.get('color', {}))}'"
+                break
+
+        if node.strokes and node.stroke_weight:
+            props["borderWidth"] = str(round(node.stroke_weight))
+            for stroke in node.strokes:
+                if stroke.get("type") == "SOLID":
+                    props["borderColor"] = f"'{figma_color_to_hex(stroke.get('color', {}))}'"
+                    break
+
+        for effect in node.effects:
+            if effect.get("type") == "DROP_SHADOW":
+                props["shadowOffset"] = f"{{ width: {effect.get('offset', {}).get('x', 0)}, height: {effect.get('offset', {}).get('y', 0)} }}"
+                props["shadowRadius"] = str(effect.get("radius", 0))
+                props["shadowOpacity"] = str(round(effect.get("color", {}).get("a", 0.25), 2))
+                props["elevation"] = str(max(1, round(effect.get("radius", 0) / 2)))
+                break
+
+        if node.opacity < 1:
+            props["opacity"] = str(round(node.opacity, 2))
+
+        return props
+
+    def _text_style_props(self, node: FigmaNode) -> dict:
+        props = {}
+        style = node.text_style
+
+        props["fontSize"] = str(style.get("fontSize", 16))
+        fw = style.get("fontWeight", 400)
+        props["fontWeight"] = f"'{fw}'"
+
+        for fill in node.fills:
+            if fill.get("type") == "SOLID":
+                props["color"] = f"'{figma_color_to_hex(fill.get('color', {}))}'"
+                break
+
+        lh = style.get("lineHeightPx")
+        if lh:
+            props["lineHeight"] = str(round(lh))
+
+        ls = style.get("letterSpacing", 0)
+        if ls:
+            props["letterSpacing"] = str(round(ls, 1))
+
+        align_map = {"LEFT": "'left'", "CENTER": "'center'", "RIGHT": "'right'"}
+        align = style.get("textAlignHorizontal", "LEFT")
+        if align in align_map:
+            props["textAlign"] = align_map[align]
+
+        return props
+
+    def _node_jsx(self, node: FigmaNode, indent: int, styles: dict) -> str:
+        pad = "  " * indent
+        style_name = camel_case(node.name) or "container"
+
+        # Ensure unique style names
+        base_name = style_name
+        counter = 1
+        while style_name in styles:
+            style_name = f"{base_name}{counter}"
+            counter += 1
+
+        if node.type == "TEXT":
+            props = self._text_style_props(node)
+            styles[style_name] = props
+            text = node.characters or "Text"
+            return f'{pad}<Text style={{styles.{style_name}}}>{text}</Text>'
+
+        props = self._style_props(node)
+        styles[style_name] = props
+
+        children_code = []
+        for child in node.children:
+            children_code.append(self._node_jsx(child, indent + 1, styles))
+
+        if children_code:
+            inner = "\n".join(children_code)
+            return f'{pad}<View style={{styles.{style_name}}}>\n{inner}\n{pad}</View>'
+        return f'{pad}<View style={{styles.{style_name}}} />'
+
+
+class FlutterGenerator:
+    """Generate Flutter/Dart widget code."""
+
+    def generate(self, node: FigmaNode, component_name: str = None) -> str:
+        name = component_name or pascal_case(node.name)
+        body = self._node_dart(node, 2)
+
+        return (
+            f"import 'package:flutter/material.dart';\n"
+            f"\n"
+            f"class {name} extends StatelessWidget {{\n"
+            f"  const {name}({{super.key}});\n"
+            f"\n"
+            f"  @override\n"
+            f"  Widget build(BuildContext context) {{\n"
+            f"    return {body.strip()};\n"
+            f"  }}\n"
+            f"}}\n"
+        )
+
+    def _node_dart(self, node: FigmaNode, indent: int) -> str:
+        pad = "  " * indent
+
+        if node.type == "TEXT":
+            return self._text_dart(node, indent)
+
+        # Build decoration
+        decoration_parts = []
+        for fill in node.fills:
+            if fill.get("type") == "SOLID":
+                hex_c = figma_color_to_hex(fill.get("color", {}))
+                decoration_parts.append(f"color: Color(0xFF{hex_c[1:7].upper()})")
+                break
+
+        if node.corner_radius is not None and node.corner_radius > 0:
+            decoration_parts.append(f"borderRadius: BorderRadius.circular({node.corner_radius})")
+
+        for effect in node.effects:
+            if effect.get("type") == "DROP_SHADOW":
+                x = effect.get("offset", {}).get("x", 0)
+                y = effect.get("offset", {}).get("y", 0)
+                blur = effect.get("radius", 0)
+                color = effect.get("color", {})
+                a = round(color.get("a", 0.25), 2)
+                decoration_parts.append(
+                    f"boxShadow: [BoxShadow(offset: Offset({x}, {y}), blurRadius: {blur}, color: Colors.black.withValues(alpha: {a}))]"
+                )
+                break
+
+        if node.strokes and node.stroke_weight:
+            for stroke in node.strokes:
+                if stroke.get("type") == "SOLID":
+                    hex_c = figma_color_to_hex(stroke.get("color", {}))
+                    decoration_parts.append(
+                        f"border: Border.all(color: Color(0xFF{hex_c[1:7].upper()}), width: {node.stroke_weight})"
+                    )
+                    break
+
+        # Build padding
+        p = node.padding
+        padding_str = ""
+        if p["top"] == p["right"] == p["bottom"] == p["left"] and p["top"] > 0:
+            padding_str = f"EdgeInsets.all({p['top']})"
+        elif any(v for v in p.values()):
+            padding_str = f"EdgeInsets.fromLTRB({p['left']}, {p['top']}, {p['right']}, {p['bottom']})"
+
+        # Build children
+        children_dart = []
+        for child in node.children:
+            children_dart.append(self._node_dart(child, indent + 2))
+
+        # Choose widget
+        mappings = get_mappings()["frameworks"]["flutter"]
+        layout_widget = mappings["layout"].get(node.layout_mode, "Container") if node.layout_mode else "Container"
+
+        if layout_widget in ("Row", "Column"):
+            main_align = mappings["mainAxisAlign"].get(node.primary_axis_align, "MainAxisAlignment.start")
+            cross_align = mappings["crossAxisAlign"].get(node.counter_axis_align, "CrossAxisAlignment.start")
+
+            inner_children = (",\n").join(c.strip() for c in children_dart)
+
+            # Wrap in Container for decoration/padding
+            layout_code = f"{pad}{layout_widget}(\n"
+            layout_code += f"{pad}  mainAxisAlignment: {main_align},\n"
+            layout_code += f"{pad}  crossAxisAlignment: {cross_align},\n"
+            if node.gap:
+                # Use SizedBox spacing
+                spaced = []
+                for i, c in enumerate(children_dart):
+                    spaced.append(c.strip())
+                    if i < len(children_dart) - 1:
+                        dim = "height" if layout_widget == "Column" else "width"
+                        spaced.append(f"SizedBox({dim}: {node.gap})")
+                inner_children = (",\n" + pad + "    ").join(spaced)
+            layout_code += f"{pad}  children: [\n{pad}    {inner_children},\n{pad}  ],\n"
+            layout_code += f"{pad})"
+
+            if decoration_parts or padding_str:
+                wrap = f"{pad}Container(\n"
+                if padding_str:
+                    wrap += f"{pad}  padding: {padding_str},\n"
+                if decoration_parts:
+                    dec_str = ", ".join(decoration_parts)
+                    wrap += f"{pad}  decoration: BoxDecoration({dec_str}),\n"
+                wrap += f"{pad}  child: {layout_code.strip()},\n"
+                wrap += f"{pad})"
+                return wrap
+            return layout_code
+
+        # Container (no auto-layout)
+        code = f"{pad}Container(\n"
+        if padding_str:
+            code += f"{pad}  padding: {padding_str},\n"
+        if decoration_parts:
+            dec_str = ", ".join(decoration_parts)
+            code += f"{pad}  decoration: BoxDecoration({dec_str}),\n"
+        if node.width:
+            code += f"{pad}  width: {node.width},\n"
+        if node.height:
+            code += f"{pad}  height: {node.height},\n"
+        if children_dart:
+            code += f"{pad}  child: {children_dart[0].strip()},\n"
+        code += f"{pad})"
+        return code
+
+    def _text_dart(self, node: FigmaNode, indent: int) -> str:
+        pad = "  " * indent
+        style = node.text_style
+        text = node.characters or "Text"
+
+        parts = []
+        fs = style.get("fontSize", 16)
+        parts.append(f"fontSize: {fs}")
+        fw = style.get("fontWeight", 400)
+        fw_map = {100: "w100", 200: "w200", 300: "w300", 400: "w400", 500: "w500", 600: "w600", 700: "w700", 800: "w800", 900: "w900"}
+        closest_fw = min(fw_map.keys(), key=lambda k: abs(k - fw))
+        parts.append(f"fontWeight: FontWeight.{fw_map[closest_fw]}")
+
+        for fill in node.fills:
+            if fill.get("type") == "SOLID":
+                hex_c = figma_color_to_hex(fill.get("color", {}))
+                parts.append(f"color: Color(0xFF{hex_c[1:7].upper()})")
+                break
+
+        lh = style.get("lineHeightPx")
+        if lh and fs:
+            parts.append(f"height: {round(lh / fs, 2)}")
+
+        ls = style.get("letterSpacing", 0)
+        if ls:
+            parts.append(f"letterSpacing: {round(ls, 1)}")
+
+        style_str = ", ".join(parts)
+        return f"{pad}Text(\n{pad}  '{text}',\n{pad}  style: TextStyle({style_str}),\n{pad})"
+
+
+# ---------------------------------------------------------------------------
+# Generator registry
+# ---------------------------------------------------------------------------
+
+GENERATORS = {
+    "tailwind": TailwindGenerator,
+    "react": ReactGenerator,
+    "vue": VueGenerator,
+    "svelte": SvelteGenerator,
+    "react-native": ReactNativeGenerator,
+    "flutter": FlutterGenerator,
+    "css": CSSGenerator,
+}
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert Figma node JSON to code for multiple frameworks.",
+        epilog="Part of the Figma Skill for Claude Code — https://github.com/figma-skill",
+    )
+    parser.add_argument(
+        "--framework", "-f",
+        choices=list(GENERATORS.keys()),
+        default="tailwind",
+        help="Target framework (default: tailwind)",
+    )
+    parser.add_argument(
+        "--input", "-i",
+        help="Path to Figma node JSON file (or pipe via stdin)",
+    )
+    parser.add_argument(
+        "--name", "-n",
+        help="Component name (default: derived from Figma layer name)",
+    )
+    parser.add_argument(
+        "--output", "-o",
+        help="Output file path (default: stdout)",
+    )
+    args = parser.parse_args()
+
+    # Read input
+    if args.input:
+        path = Path(args.input)
+        if not path.exists():
+            print(f"Error: File not found: {args.input}", file=sys.stderr)
+            sys.exit(1)
+        data = json.loads(path.read_text(encoding="utf-8"))
+    elif not sys.stdin.isatty():
+        data = json.load(sys.stdin)
+    else:
+        parser.print_help()
+        print("\nError: Provide --input file or pipe JSON via stdin.", file=sys.stderr)
+        sys.exit(1)
+
+    # Handle Figma API response formats
+    if "document" in data:
+        node_data = data["document"]
+    elif "nodes" in data:
+        nodes = data["nodes"]
+        first_key = next(iter(nodes))
+        node_data = nodes[first_key].get("document", nodes[first_key])
+    else:
+        node_data = data
+
+    node = FigmaNode(node_data)
+
+    # Generate code
+    generator_cls = GENERATORS[args.framework]
+    generator = generator_cls()
+
+    if args.framework in ("react", "vue", "svelte", "react-native", "flutter"):
+        result = generator.generate(node, component_name=args.name)
+    else:
+        result = generator.generate(node)
+
+    # Write output
+    if args.output:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(result, encoding="utf-8")
+        print(f"Code written to {args.output} ({args.framework})", file=sys.stderr)
+    else:
+        print(result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds a **Figma skill** that bridges Figma designs with Claude Code via `figma-developer-mcp`
- Supports **browsing files**, **downloading assets** (PNG/SVG), **extracting design tokens** (CSS, Tailwind, JSON, SCSS), and **generating code** for 7 frameworks (Tailwind, React, Vue, Svelte, React Native, Flutter, CSS)
- Zero pip dependencies — Python scripts use only the standard library

## What's included

```
skills/figma/
├── SKILL.md                        # Skill entry point (6 workflows, conversion reference tables)
├── LICENSE.txt                     # Apache 2.0
├── scripts/
│   ├── extract_tokens.py           # Design token extractor (colors, typography, spacing, shadows, gradients)
│   └── figma_to_code.py            # Code generator (7 frameworks from Figma node JSON)
└── data/
    └── framework-mappings.json     # Figma property → framework class/style lookup tables
```

## Prerequisites

- `figma-developer-mcp` MCP server configured in `.mcp.json` (provides `get_figma_data` and `download_figma_images` tools)
- Python 3.8+ (for the extraction/generation scripts — stdlib only, no pip install)

## Workflows

1. **Browse & Inspect** — Navigate Figma file trees, inspect any frame or component
2. **Download Assets** — Export PNG/SVG at any scale (1x, 2x, 3x)
3. **Extract Design Tokens** — Auto-extract colors, typography, spacing, shadows, gradients into 4 formats
4. **Generate Code** — Convert Figma auto-layout nodes to Tailwind, React, Vue, Svelte, RN, Flutter, or CSS
5. **Full Pipeline** — Combine all workflows end-to-end
6. **Discover Community Resources** — Search Figma Community for templates and UI kits

## Test plan

- [x] All 7 framework code generators produce clean, properly indented output
- [x] All 4 token format outputs (CSS, Tailwind, JSON, SCSS) generate correctly
- [x] Edge cases: empty Figma files show warning, semi-transparent colors generate proper hex+alpha
- [x] `${CLAUDE_SKILL_DIR}` paths resolve correctly (no hardcoded paths)
- [x] `allowed-tools` frontmatter enables seamless execution without permission prompts

## Standalone repo

Full source with README, install instructions, and `.mcp.json.example`:
https://github.com/nafiurrahmanniloy/figma-skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)