### PR TITLE
Add threat-hunter skill: multi-source IOC analysis (IP/domain/hash/email/CVE)

### DIFF
--- a/skills/threat-hunter/LICENSE.txt
+++ b/skills/threat-hunter/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/threat-hunter/SKILL.md
+++ b/skills/threat-hunter/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: threat-hunter
+description: Security intelligence aggregator. Analyzes IPs, domains, URLs, file hashes, and email addresses against multiple threat databases. Use when investigating security incidents, checking indicators of compromise (IOCs), analyzing suspicious IPs or domains, security research, checking if an IP is malicious, or threat intelligence gathering. Triggers on phrases like "is this IP malicious", "check this domain", "analyze this URL", "IOC analysis", "threat intelligence", "security check", "is this suspicious", "check for malware", "OSINT on IP", "investigate domain".
+license: Complete terms in LICENSE.txt
+allowed-tools: Bash(python:*) WebFetch
+metadata:
+  author: Maksim Soltan
+  version: 1.0.0
+  apis: ip-api.com, AbuseIPDB, VirusTotal, urlscan.io, Have I Been Pwned, NVD/NIST CVE
+  auth: partial-some-apis-need-keys
+---
+
+# Threat Hunter
+
+Multi-source security intelligence. Correlates signals across threat databases to generate IOC reports.
+
+## APIs Used
+
+**No auth required:**
+- **ip-api.com**: `http://ip-api.com/json/{IP}` — geolocation, ASN, ISP (free, no auth)
+- **NVD/NIST CVE**: `https://services.nvd.nist.gov/rest/json/cves/2.0` — vulnerability database
+- **Shodan InternetDB**: `https://internetdb.shodan.io/{IP}` — open ports, vulns (no auth, limited)
+
+**API key required (check if configured):**
+- **AbuseIPDB**: `https://api.abuseipdb.com/api/v2/check` — IP abuse reports
+- **VirusTotal**: `https://www.virustotal.com/api/v3/{resource_type}/{resource}` — multi-AV scan
+- **urlscan.io**: `https://urlscan.io/api/v1/search/` — URL analysis
+- **Have I Been Pwned**: `https://haveibeenpwned.com/api/v3/breachedaccount/{account}` — breach data
+
+## IOC Type Detection
+
+Parse user input to determine IOC type:
+```
+IPv4 regex: ^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$
+IPv6 regex: contains colons, hex chars
+Domain: contains dots, no slashes, not IP
+URL: starts with http:// or https://
+Hash MD5: 32 hex chars
+Hash SHA1: 40 hex chars
+Hash SHA256: 64 hex chars
+Email: contains @
+```
+
+## Workflows by IOC Type
+
+### IP Address Analysis
+
+```python
+scripts/threat_check.py --ioc 1.2.3.4 --type ip
+```
+
+**Step 1: Geolocation (no auth)**
+```
+GET http://ip-api.com/json/1.2.3.4?fields=status,message,country,regionName,city,isp,org,as,query,proxy,hosting
+```
+
+**Step 2: Shodan InternetDB (no auth)**
+```
+GET https://internetdb.shodan.io/1.2.3.4
+```
+Returns: open ports, known vulns, CPEs, tags (tor, vpn, etc.)
+
+**Step 3: AbuseIPDB (if key available)**
+```
+GET https://api.abuseipdb.com/api/v2/check?ipAddress=1.2.3.4&maxAgeInDays=90&verbose
+Header: Key: {ABUSEIPDB_API_KEY}
+```
+
+**Step 4: Score & classify**
+```
+Score 0-100:
+- Shodan tags (tor, vpn, scanner): +30 each
+- AbuseIPDB confidence > 50: +40
+- Hosting provider / datacenter (not residential): +10
+- Known malicious ASN: +20
+```
+
+### Domain Analysis
+
+**Step 1: DNS resolution** (via ip-api for the resolved IP)
+**Step 2: VirusTotal** (if key available)
+```
+GET https://www.virustotal.com/api/v3/domains/{DOMAIN}
+Header: x-apikey: {VT_API_KEY}
+```
+**Step 3: urlscan.io search** (limited free search)
+```
+GET https://urlscan.io/api/v1/search/?q=domain:{DOMAIN}&size=5
+```
+
+### URL Analysis
+
+**VirusTotal URL scan:**
+```
+POST https://www.virustotal.com/api/v3/urls
+Body: url={URL}
+```
+Then poll:
+```
+GET https://www.virustotal.com/api/v3/analyses/{ANALYSIS_ID}
+```
+
+### Hash Analysis (VirusTotal)
+
+```
+GET https://www.virustotal.com/api/v3/files/{HASH}
+Header: x-apikey: {VT_API_KEY}
+```
+
+### Email / Breach Check (HIBP)
+
+```
+GET https://haveibeenpwned.com/api/v3/breachedaccount/{EMAIL}
+Header: hibp-api-key: {HIBP_KEY}
+Header: User-Agent: threat-hunter
+```
+
+## Output Format
+
+```
+## Threat Intelligence Report
+IOC: {VALUE} | Type: {TYPE}
+Score: {N}/100 — {CLASSIFICATION}
+Date: {DATE}
+
+### Verdict
+[CLEAN / SUSPICIOUS / MALICIOUS / UNKNOWN] — [1-sentence reason]
+
+### Geolocation & Infrastructure
+- Country: [X]
+- ISP/ASN: [X]
+- Hosting: [datacenter/residential/cloud]
+- Tags: [tor, vpn, scanner, etc.]
+
+### Open Ports (Shodan)
+[port list if available]
+
+### Threat Database Results
+| Source | Result | Details |
+|--------|--------|---------|
+| AbuseIPDB | X reports | Confidence: X% |
+| VirusTotal | X/Y detections | [engines] |
+| Shodan | [tags] | [vulns] |
+
+### Associated Infrastructure
+[Related IPs/domains if found]
+
+### Recommended Actions
+- [Block/allow/investigate/monitor]
+```
+
+## API Key Configuration
+
+Check environment variables:
+```bash
+echo $ABUSEIPDB_API_KEY
+echo $VIRUSTOTAL_API_KEY
+echo $URLSCAN_API_KEY
+echo $HIBP_API_KEY
+```
+
+If not set, run no-auth checks only (Shodan InternetDB + ip-api + NVD) and note in output which sources were skipped.
+
+## Error Handling
+
+- API key missing: skip that source, note in output
+- Rate limited: note which source hit limit, continue with others
+- IOC not found in database: report as "not found" (not same as clean)
+- Network timeout: retry once, then skip
+
+## Examples
+
+User: "Is 185.220.101.45 malicious?"
+→ IP analysis: ip-api + Shodan + AbuseIPDB
+
+User: "Check this domain: evil-phishing-site.ru"
+→ Domain analysis: DNS + VirusTotal + urlscan.io
+
+User: "Analyze this URL for malware: http://suspicious.site/download"
+→ URL analysis: VirusTotal submission + urlscan.io
+
+User: "Was my email compromised: user@domain.com"
+→ HIBP breach lookup

--- a/skills/threat-hunter/scripts/threat_check.py
+++ b/skills/threat-hunter/scripts/threat_check.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Multi-source threat intelligence checker. Some features need API keys."""
+
+import sys
+import re
+import json
+import os
+import urllib.request
+import urllib.parse
+import argparse
+import threading
+from datetime import datetime
+
+# API keys from environment
+ABUSEIPDB_KEY = os.getenv("ABUSEIPDB_API_KEY", "")
+VT_KEY = os.getenv("VIRUSTOTAL_API_KEY", "")
+URLSCAN_KEY = os.getenv("URLSCAN_API_KEY", "")
+HIBP_KEY = os.getenv("HIBP_API_KEY", "")
+
+
+def fetch_json(url, headers=None, method="GET", data=None, timeout=12):
+    try:
+        req = urllib.request.Request(
+            url,
+            headers=headers or {"User-Agent": "threat-hunter/1.0", "Accept": "application/json"},
+            method=method,
+            data=data
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode('utf-8'))
+    except urllib.error.HTTPError as e:
+        return {"_error": f"HTTP {e.code}", "_status": e.code}
+    except Exception as e:
+        return {"_error": str(e)}
+
+
+def detect_ioc_type(value):
+    value = value.strip()
+    ipv4_re = re.compile(r'^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$')
+    md5_re = re.compile(r'^[a-fA-F0-9]{32}$')
+    sha1_re = re.compile(r'^[a-fA-F0-9]{40}$')
+    sha256_re = re.compile(r'^[a-fA-F0-9]{64}$')
+
+    if ipv4_re.match(value):
+        return "ip"
+    if md5_re.match(value) or sha1_re.match(value) or sha256_re.match(value):
+        return "hash"
+    if "@" in value:
+        return "email"
+    if value.startswith("http://") or value.startswith("https://"):
+        return "url"
+    if "." in value and not value.startswith("CVE"):
+        return "domain"
+    if value.upper().startswith("CVE"):
+        return "cve"
+    return "unknown"
+
+
+# --- IP Analysis ---
+def check_ip_geoasn(ip):
+    url = f"http://ip-api.com/json/{ip}?fields=status,country,countryCode,regionName,city,isp,org,as,asname,proxy,hosting,query"
+    return fetch_json(url)
+
+
+def check_ip_shodan(ip):
+    url = f"https://internetdb.shodan.io/{ip}"
+    return fetch_json(url, headers={"User-Agent": "threat-hunter/1.0"})
+
+
+def check_ip_abuseipdb(ip):
+    if not ABUSEIPDB_KEY:
+        return {"_skipped": "no ABUSEIPDB_API_KEY"}
+    url = f"https://api.abuseipdb.com/api/v2/check?ipAddress={ip}&maxAgeInDays=90&verbose=true"
+    return fetch_json(url, headers={
+        "Key": ABUSEIPDB_KEY,
+        "Accept": "application/json",
+        "User-Agent": "threat-hunter/1.0"
+    })
+
+
+def check_ip_virustotal(ip):
+    if not VT_KEY:
+        return {"_skipped": "no VIRUSTOTAL_API_KEY"}
+    url = f"https://www.virustotal.com/api/v3/ip_addresses/{ip}"
+    return fetch_json(url, headers={"x-apikey": VT_KEY, "User-Agent": "threat-hunter/1.0"})
+
+
+# --- Domain Analysis ---
+def check_domain_virustotal(domain):
+    if not VT_KEY:
+        return {"_skipped": "no VIRUSTOTAL_API_KEY"}
+    url = f"https://www.virustotal.com/api/v3/domains/{domain}"
+    return fetch_json(url, headers={"x-apikey": VT_KEY, "User-Agent": "threat-hunter/1.0"})
+
+
+def check_domain_urlscan(domain):
+    url = f"https://urlscan.io/api/v1/search/?q=domain:{domain}&size=5"
+    headers = {"User-Agent": "threat-hunter/1.0", "Accept": "application/json"}
+    if URLSCAN_KEY:
+        headers["API-Key"] = URLSCAN_KEY
+    return fetch_json(url, headers=headers)
+
+
+# --- Hash Analysis ---
+def check_hash_virustotal(hash_val):
+    if not VT_KEY:
+        return {"_skipped": "no VIRUSTOTAL_API_KEY"}
+    url = f"https://www.virustotal.com/api/v3/files/{hash_val}"
+    return fetch_json(url, headers={"x-apikey": VT_KEY, "User-Agent": "threat-hunter/1.0"})
+
+
+# --- Email / HIBP ---
+def check_email_hibp(email):
+    if not HIBP_KEY:
+        return {"_skipped": "no HIBP_API_KEY"}
+    encoded = urllib.parse.quote(email)
+    url = f"https://haveibeenpwned.com/api/v3/breachedaccount/{encoded}"
+    return fetch_json(url, headers={
+        "hibp-api-key": HIBP_KEY,
+        "User-Agent": "threat-hunter/1.0"
+    })
+
+
+# --- CVE Lookup ---
+def check_cve(cve_id):
+    encoded = urllib.parse.quote(cve_id)
+    url = f"https://services.nvd.nist.gov/rest/json/cves/2.0?cveId={encoded}"
+    return fetch_json(url, headers={"User-Agent": "threat-hunter/1.0"})
+
+
+# --- Scoring ---
+def score_ip(geo, shodan, abuseipdb, vt):
+    score = 0
+    reasons = []
+
+    # Shodan tags
+    tags = shodan.get("tags", []) if "_error" not in shodan else []
+    for tag in tags:
+        if tag in ["tor", "vpn", "scanner", "botnet"]:
+            score += 25
+            reasons.append(f"Shodan tag: {tag}")
+        elif tag in ["honeypot"]:
+            score += 10
+
+    # Open ports
+    ports = shodan.get("ports", []) if "_error" not in shodan else []
+    suspicious_ports = [p for p in ports if p in [4444, 1337, 6667, 31337, 9001, 9030]]
+    if suspicious_ports:
+        score += 15
+        reasons.append(f"Suspicious ports: {suspicious_ports}")
+
+    # Shodan vulns
+    vulns = shodan.get("vulns", []) if "_error" not in shodan else []
+    if vulns:
+        score += min(len(vulns) * 5, 20)
+        reasons.append(f"Known vulns: {', '.join(vulns[:3])}")
+
+    # AbuseIPDB
+    if "_skipped" not in abuseipdb and "_error" not in abuseipdb:
+        ab_data = abuseipdb.get("data", {})
+        confidence = ab_data.get("abuseConfidenceScore", 0)
+        reports = ab_data.get("totalReports", 0)
+        if confidence > 50:
+            score += 35
+            reasons.append(f"AbuseIPDB: {confidence}% confidence, {reports} reports")
+        elif confidence > 20:
+            score += 15
+            reasons.append(f"AbuseIPDB: {confidence}% confidence")
+
+    # VirusTotal
+    if "_skipped" not in vt and "_error" not in vt:
+        attrs = vt.get("data", {}).get("attributes", {})
+        stats = attrs.get("last_analysis_stats", {})
+        malicious = stats.get("malicious", 0)
+        if malicious > 5:
+            score += 30
+            reasons.append(f"VirusTotal: {malicious} malicious detections")
+        elif malicious > 0:
+            score += 10
+
+    # Hosting classification
+    if geo.get("hosting"):
+        score += 5
+        reasons.append("Datacenter/hosting IP")
+
+    return min(score, 100), reasons
+
+
+def classify_score(score):
+    if score >= 70:
+        return "MALICIOUS"
+    if score >= 40:
+        return "SUSPICIOUS"
+    if score >= 15:
+        return "LOW RISK"
+    return "CLEAN"
+
+
+def print_ip_report(ip, geo, shodan, abuseipdb, vt):
+    score, reasons = score_ip(geo, shodan, abuseipdb, vt)
+    classification = classify_score(score)
+    icons = {"MALICIOUS": "🔴", "SUSPICIOUS": "🟡", "LOW RISK": "🟡", "CLEAN": "🟢"}
+
+    print(f"# Threat Intelligence: {ip}")
+    print(f"*{datetime.utcnow().strftime('%Y-%m-%d %H:%M UTC')}*\n")
+    print(f"## Verdict: {icons.get(classification, '⚪')} **{classification}** (Score: {score}/100)\n")
+
+    if geo and "_error" not in geo:
+        print("## Geolocation & Infrastructure")
+        print(f"- **Location:** {geo.get('city', 'N/A')}, {geo.get('regionName', 'N/A')}, {geo.get('country', 'N/A')}")
+        print(f"- **ISP:** {geo.get('isp', 'N/A')}")
+        print(f"- **ASN:** {geo.get('as', 'N/A')}")
+        if geo.get("proxy"):
+            print(f"- **Proxy/VPN:** Yes ⚠️")
+        if geo.get("hosting"):
+            print(f"- **Hosting/Datacenter:** Yes")
+        print()
+
+    if shodan and "_error" not in shodan:
+        ports = shodan.get("ports", [])
+        tags = shodan.get("tags", [])
+        vulns = shodan.get("vulns", [])
+        if ports or tags or vulns:
+            print("## Shodan Intelligence")
+            if ports:
+                print(f"- **Open Ports:** {', '.join(map(str, ports))}")
+            if tags:
+                print(f"- **Tags:** {', '.join(tags)}")
+            if vulns:
+                print(f"- **Known Vulns:** {', '.join(vulns[:5])}")
+            print()
+
+    if "_skipped" not in abuseipdb and "_error" not in abuseipdb:
+        ab = abuseipdb.get("data", {})
+        print("## AbuseIPDB")
+        print(f"- **Confidence Score:** {ab.get('abuseConfidenceScore', 0)}%")
+        print(f"- **Total Reports:** {ab.get('totalReports', 0)}")
+        print(f"- **Last Reported:** {ab.get('lastReportedAt', 'N/A')}")
+        print()
+    elif "_skipped" in abuseipdb:
+        print(f"*AbuseIPDB: skipped (no API key)*\n")
+
+    if reasons:
+        print("## Risk Signals")
+        for r in reasons:
+            print(f"- ⚠️ {r}")
+        print()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Multi-source threat intelligence")
+    parser.add_argument("--ioc", required=True, help="IOC to check (IP, domain, URL, hash, email, CVE)")
+    parser.add_argument("--type", help="IOC type (auto-detected if not specified)")
+    parser.add_argument("--format", default="markdown", choices=["markdown", "json"])
+    args = parser.parse_args()
+
+    ioc = args.ioc.strip()
+    ioc_type = args.type or detect_ioc_type(ioc)
+
+    if ioc_type == "ip":
+        results = {}
+        threads = [
+            threading.Thread(target=lambda: results.update({"geo": check_ip_geoasn(ioc)})),
+            threading.Thread(target=lambda: results.update({"shodan": check_ip_shodan(ioc)})),
+            threading.Thread(target=lambda: results.update({"abuseipdb": check_ip_abuseipdb(ioc)})),
+            threading.Thread(target=lambda: results.update({"vt": check_ip_virustotal(ioc)})),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=15)
+
+        if args.format == "json":
+            print(json.dumps(results, indent=2))
+        else:
+            print_ip_report(ioc, results.get("geo", {}), results.get("shodan", {}),
+                          results.get("abuseipdb", {}), results.get("vt", {}))
+
+    elif ioc_type == "domain":
+        results = {}
+        threads = [
+            threading.Thread(target=lambda: results.update({"vt": check_domain_virustotal(ioc)})),
+            threading.Thread(target=lambda: results.update({"urlscan": check_domain_urlscan(ioc)})),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=15)
+
+        if args.format == "json":
+            print(json.dumps(results, indent=2))
+        else:
+            print(f"# Domain Analysis: {ioc}\n")
+            if "_skipped" not in results.get("vt", {}) and "_error" not in results.get("vt", {}):
+                attrs = results["vt"].get("data", {}).get("attributes", {})
+                stats = attrs.get("last_analysis_stats", {})
+                print(f"**VirusTotal:** {stats.get('malicious', 0)} malicious / {stats.get('harmless', 0)} clean")
+            if results.get("urlscan") and "_error" not in results["urlscan"]:
+                total = results["urlscan"].get("total", 0)
+                print(f"**urlscan.io:** {total} previous scans found")
+
+    elif ioc_type == "hash":
+        data = check_hash_virustotal(ioc)
+        if args.format == "json":
+            print(json.dumps(data, indent=2))
+        else:
+            print(f"# File Hash Analysis: {ioc[:16]}...\n")
+            if "_skipped" in data:
+                print("*VirusTotal: skipped (no API key)*")
+            elif "_error" not in data:
+                attrs = data.get("data", {}).get("attributes", {})
+                stats = attrs.get("last_analysis_stats", {})
+                print(f"**Detections:** {stats.get('malicious', 0)}/{sum(stats.values())} engines flagged")
+                print(f"**Name:** {attrs.get('meaningful_name', 'Unknown')}")
+
+    elif ioc_type == "email":
+        data = check_email_hibp(ioc)
+        if args.format == "json":
+            print(json.dumps(data, indent=2))
+        else:
+            print(f"# Email Breach Check: {ioc}\n")
+            if "_skipped" in data:
+                print("*HIBP: skipped (no API key)*")
+            elif "_error" not in data and data.get("_status") != 404:
+                print(f"⚠️ **Found in {len(data)} breach(es):**")
+                for breach in (data if isinstance(data, list) else []):
+                    print(f"- {breach.get('Name', 'Unknown')} ({breach.get('BreachDate', 'N/A')})")
+            else:
+                print("✅ No breaches found for this email")
+
+    elif ioc_type == "cve":
+        data = check_cve(ioc)
+        if args.format == "json":
+            print(json.dumps(data, indent=2))
+        else:
+            vulns = data.get("vulnerabilities", [])
+            if vulns:
+                cve_data = vulns[0].get("cve", {})
+                desc = cve_data.get("descriptions", [{}])[0].get("value", "N/A")
+                metrics = cve_data.get("metrics", {})
+                cvss = metrics.get("cvssMetricV31", [{}])[0].get("cvssData", {}) if metrics.get("cvssMetricV31") else {}
+                print(f"# {ioc}\n")
+                print(f"**Score:** {cvss.get('baseScore', 'N/A')} ({cvss.get('baseSeverity', 'N/A')})")
+                print(f"**Description:** {desc[:400]}")
+            else:
+                print(f"CVE {ioc} not found in NVD")
+
+    else:
+        print(f"Unknown IOC type for: {ioc}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds **threat-hunter** skill for security intelligence across multiple threat databases
- Auto-detects IOC type (IP, domain, URL, hash, email, CVE) from input
- Core features work with **zero API keys** (ip-api.com + Shodan InternetDB + NVD/NIST)
- Optional enrichment via AbuseIPDB, VirusTotal, urlscan.io, Have I Been Pwned (env vars)

## What's included

```
skills/threat-hunter/
├── SKILL.md          # IOC routing, scoring logic, output format, API key config
├── LICENSE.txt       # Apache 2.0
└── scripts/
    └── threat_check.py  # Multi-source IOC analyzer with threat scoring
```

## Workflows

1. **IP analysis** — geolocation + ASN + Shodan ports/tags/vulns + AbuseIPDB confidence
2. **Domain analysis** — VirusTotal detections + urlscan.io history
3. **File hash** — VirusTotal multi-AV scan results
4. **Email breach** — Have I Been Pwned breach lookup
5. **CVE lookup** — NVD/NIST vulnerability database (no auth)

## API Keys (all optional, graceful degradation without)

- `ABUSEIPDB_API_KEY` — IP abuse confidence scores
- `VIRUSTOTAL_API_KEY` — file/domain/URL/IP multi-AV scanning
- `URLSCAN_API_KEY` — URL/domain visual analysis
- `HIBP_API_KEY` — email breach lookups

## Prerequisites

- Python 3.8+ (stdlib only)

## Test plan

- [x] IOC type auto-detection covers IPv4, domain, URL, MD5/SHA1/SHA256, email, CVE
- [x] Shodan InternetDB returns open ports and vulnerability tags without auth
- [x] Threat scoring weighted across multiple signal sources
- [x] All sources fail gracefully when keys missing (noted in output, not crashed)
- [x] Parallel thread execution with 15s timeout per source

🤖 Generated with [Claude Code](https://claude.com/claude-code)