### PR TITLE
Add audio-transcriber skill

### DIFF
--- a/skills/audio-transcriber/LICENSE.txt
+++ b/skills/audio-transcriber/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/audio-transcriber/SKILL.md
+++ b/skills/audio-transcriber/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: audio-transcriber
 description: "Transcribes audio/video/YouTube to professional Markdown with speaker diarization. Accepts local files (MP3, MP4, WAV, M4A, etc.) or YouTube links. For YouTube, uses MCP youtube-transcript for instant captions; if unavailable, downloads audio with yt-dlp. For local files, uses MLX Whisper (Apple Silicon GPU) + SpeechBrain for lightweight diarization. Supports model selection (tiny/base/small/medium). Automatically generates meeting minutes."
+license: Complete terms in LICENSE.txt
 ---
 
 ## Purpose

--- a/skills/audio-transcriber/SKILL.md
+++ b/skills/audio-transcriber/SKILL.md
@@ -1,18 +1,19 @@
 ---
 name: audio-transcriber
-description: "Transcribes audio/video/YouTube to professional Markdown with speaker diarization. Accepts local files (MP3, MP4, WAV, M4A, etc.) or YouTube links. For YouTube, uses MCP youtube-transcript for instant captions; if unavailable, downloads audio with yt-dlp. For local files, uses MLX Whisper (Apple Silicon GPU) + SpeechBrain for lightweight diarization. Supports model selection (tiny/base/small/medium). Automatically generates meeting minutes."
+description: "Transcribes audio/video/YouTube to professional Markdown with speaker diarization and visual context detection. Accepts local files (MP3, MP4, WAV, M4A, etc.) or YouTube links. For YouTube, uses MCP youtube-transcript for instant captions; if unavailable, downloads audio with yt-dlp. For local files, uses MLX Whisper (Apple Silicon GPU) + SpeechBrain for lightweight diarization. Automatically detects moments where speakers reference visual elements (demos, screens, slides) and allows on-demand frame extraction via FFmpeg for analysis with Claude. Supports model selection (tiny/base/small/medium). Generates meeting minutes automatically."
 license: Complete terms in LICENSE.txt
 ---
 
 ## Purpose
 
-Transcribes audio, video, and YouTube videos to professional Markdown text with:
-- **YouTube** — extracts transcription/captions instantly via MCP `youtube-transcript` (no video download needed)
-- **Local transcription optimized for Apple Silicon** via MLX Whisper (GPU/Neural Engine)
-- **Lightweight diarization** via SpeechBrain ECAPA-TDNN (speaker identification without HuggingFace token)
-- **Interactive speaker identification** — after diarization, asks the user to name each SPEAKER
-- Rich metadata (duration, language, speakers, timestamps)
-- Automatic meeting minutes/summary generation via LLM
+Transcreve áudios, vídeos e vídeos do YouTube para texto em Markdown profissional com:
+- **YouTube** — extrai transcrição/legendas instantaneamente via MCP `youtube-transcript` (sem baixar vídeo)
+- **Transcrição local otimizada para Apple Silicon** via MLX Whisper (GPU/Neural Engine do Mac)
+- **Diarização leve** via SpeechBrain ECAPA-TDNN (identificação de locutores sem HuggingFace token)
+- **Identificação interativa de locutores** — após diarizar, pergunta ao usuário quem é cada SPEAKER
+- Metadados ricos (duração, idioma, locutores, timestamps)
+- **Detecção de contexto visual** — identifica momentos onde locutores referenciam elementos visuais (telas, cliques, slides, demos) e marca timestamps para extração de frames sob demanda
+- Geração de ata/resumo via LLM
 
 ## When to Use
 
@@ -23,222 +24,217 @@ Invoke this skill when:
 - User wants meeting minutes automatically generated from recordings
 - User requires speaker identification (diarization) in conversations
 - User wants executive summaries of long audio content
-- User asks variations of "transcribe this audio", "convert audio to text", "generate meeting notes from recording", "transcribe this YouTube video", "get the transcript from this link"
+- User asks variations of "transcribe this audio", "convert audio to text", "generate meeting notes from recording", "transcrever vídeo", "tirar texto do áudio", "gerar ata", "quem fala no áudio", "transcrever esse vídeo do YouTube", "pega a transcrição desse link"
 - User has audio files in common formats (MP3, MP4, WAV, M4A, OGG, FLAC, WEBM)
 - User has YouTube URLs (youtube.com, youtu.be)
+- User wants to understand what was being shown/demonstrated during a video call or screen share
+- User asks to "extract frames", "show what they were looking at", "visual context" from a video transcription
 
-## Input Sources
+## Fontes de Entrada
 
-| Source | Method | Speed | Requirements |
-|--------|--------|-------|-------------|
-| **YouTube URL** | MCP `youtube-transcript` (captions) | **Instant** | MCP installed |
-| **YouTube URL (no captions)** | `yt-dlp` + MLX Whisper | Moderate | `yt-dlp` installed |
-| **Local file** | MLX Whisper + SpeechBrain | Fast | Python dependencies |
+| Fonte | Método | Velocidade | Requisitos |
+|-------|--------|-----------|------------|
+| **YouTube URL** | MCP `youtube-transcript` (legendas) | **Instantâneo** | MCP instalado |
+| **YouTube URL (sem legenda)** | `yt-dlp` + MLX Whisper | Moderado | `yt-dlp` instalado |
+| **Arquivo local (áudio)** | MLX Whisper + SpeechBrain | Rápido | Dependências Python |
+| **Arquivo local (vídeo)** | MLX Whisper + SpeechBrain + Visual Cues | Rápido | Dependências Python + FFmpeg |
 
 ## Engines (Priority Order)
 
-| Engine | Platform | Diarization | Speed | Installation |
-|--------|----------|-------------|-------|-------------|
-| **MCP youtube-transcript** | Any | Not native | Instant | `claude mcp add youtube-transcript -- npx -y @sinco-lab/mcp-youtube-transcript` |
-| **MLX Whisper** (default) | Apple Silicon | Via SpeechBrain | Very fast | `pip install mlx-whisper` |
-| WhisperX | Any (CPU/GPU) | Via pyannote | Moderate | `pip install whisperx` |
-| Faster-Whisper | Any | Not native | Fast | `pip install faster-whisper` |
-| Whisper | Any | Not native | Baseline | `pip install openai-whisper` |
+| Engine | Plataforma | Diarização | Velocidade | Instalação |
+|--------|-----------|-----------|------------|------------|
+| **MCP youtube-transcript** | Qualquer | Não nativa | Instantâneo | `claude mcp add youtube-transcript -- npx -y @sinco-lab/mcp-youtube-transcript` |
+| **MLX Whisper** (padrão) | Apple Silicon | Via SpeechBrain | Muito rápido | `pip install mlx-whisper` |
+| WhisperX | Qualquer (CPU/GPU) | Via pyannote | Moderado | `pip install whisperx` |
+| Faster-Whisper | Qualquer | Não nativa | Rápido | `pip install faster-whisper` |
+| Whisper | Qualquer | Não nativa | Baseline | `pip install openai-whisper` |
 
-## Available Models (MLX Whisper)
+## Modelos Disponíveis (MLX Whisper)
 
-| Model | Size | RAM needed | Quality | HuggingFace Repo |
-|-------|------|-----------|---------|-------------------|
-| `tiny` | ~75 MB | ~500 MB | Basic | `mlx-community/whisper-tiny-mlx` |
-| `base` | ~140 MB | ~800 MB | Good | `mlx-community/whisper-base-mlx` |
-| **`small`** (default) | **~460 MB** | **~1.5 GB** | **Very good** | **`mlx-community/whisper-small-mlx`** |
-| `medium` | ~1.5 GB | ~3 GB | Excellent | `mlx-community/whisper-medium-mlx` |
+| Modelo | Tamanho | RAM necessária | Qualidade | Repo HuggingFace |
+|--------|---------|---------------|-----------|-------------------|
+| `tiny` | ~75 MB | ~500 MB | Básica | `mlx-community/whisper-tiny-mlx` |
+| `base` | ~140 MB | ~800 MB | Boa | `mlx-community/whisper-base-mlx` |
+| **`small`** (padrão) | **~460 MB** | **~1.5 GB** | **Muito boa** | **`mlx-community/whisper-small-mlx`** |
+| `medium` | ~1.5 GB | ~3 GB | Excelente | `mlx-community/whisper-medium-mlx` |
 | `large-v3-turbo` | ~1.5 GB | ~4 GB | Superior | `mlx-community/whisper-large-v3-turbo` |
 
-**Note:** `medium` and `large-v3-turbo` models require Macs with 16GB+ RAM.
+**Nota:** modelos `medium` e `large-v3-turbo` requerem Macs com 16GB+ de RAM.
 
-## Diarization (Speaker Identification)
+## Diarização (Identificação de Locutores)
 
-Uses **SpeechBrain ECAPA-TDNN** (~80 MB) with agglomerative clustering:
-- No HuggingFace token required
-- ~3 min for 85 min of audio (CPU)
-- Generates SPEAKER_00, SPEAKER_01, etc. labels
-- After diarization, the skill **interactively asks** the user to name each speaker
+Usa **SpeechBrain ECAPA-TDNN** (~80 MB) com clustering aglomerativo:
+- Não requer token do HuggingFace
+- ~3 min para 85 min de áudio (CPU)
+- Gera etiquetas SPEAKER_00, SPEAKER_01, etc.
+- Após diarização, o skill **pergunta interativamente** ao usuário o nome de cada locutor
 
-Dependencies: `pip install speechbrain scikit-learn soundfile`
+Dependências: `pip install speechbrain scikit-learn soundfile`
 
 ## Workflow
 
-### Step 0: Greeting and Model Selection
+### Step 0: Saudação e Escolha do Modelo
 
-**Goal:** Inform the user about available models and confirm the choice.
+**Objetivo:** Permitir que o usuário escolha o modelo de transcrição via menu interativo.
 
-**Actions:**
+**Ações:**
 
-1. When starting, ALWAYS inform the user:
-
-```
-Audio Transcriber — MLX Whisper (Apple Silicon)
-
-Available models:
-  tiny   (~75 MB)  — Fast, basic quality
-  base   (~140 MB) — Fast, good quality
-  small  (~460 MB) — Recommended default, very good quality
-  medium (~1.5 GB) — Excellent quality (requires 16GB+ RAM)
-  large  (~1.5 GB) — Superior (requires 16GB+ RAM)
-
-Current model: small (default)
-```
-
-2. If the user passed `--model <name>` in arguments, use that model
-3. If not specified, use `small` as default without asking
-4. If the user asked for "simplest model" or similar, use `tiny` or `base`
-
-### Step Y: YouTube — Transcription via MCP (if input is a URL)
-
-**Goal:** Extract transcription from YouTube videos without downloading the video.
-
-**When to use:** If the user's input is a YouTube link (youtube.com, youtu.be).
-
-**Decision flow:**
+1. Se o usuário passou `--model <nome>` nos argumentos, usar esse modelo diretamente (pular menu)
+2. Se não especificou modelo, usar `AskUserQuestion` para apresentar as opções:
 
 ```
-Is input a YouTube URL?
-  |-- YES -> Try MCP youtube-transcript (get_transcript)
-  |     |-- Success -> Format markdown (skip Steps 1-4)
-  |     |     \-- If multiple speakers -> Manual diarization or ask user
-  |     \-- Fail (no captions) -> Download audio with yt-dlp -> Follow Steps 1-6
-  \-- NO -> Follow Steps 1-6 (local file)
+Usar AskUserQuestion com:
+  question: "Qual modelo de transcrição usar?"
+  header: "Modelo"
+  options:
+    - label: "small (Recomendado)"
+      description: "~460 MB, ~1.5 GB RAM — Muito boa qualidade, melhor custo-benefício"
+    - label: "base"
+      description: "~140 MB, ~800 MB RAM — Boa qualidade, mais rápido"
+    - label: "medium"
+      description: "~1.5 GB, ~3 GB RAM — Excelente qualidade (requer 16GB+ RAM)"
+    - label: "tiny"
+      description: "~75 MB, ~500 MB RAM — Qualidade básica, o mais rápido"
 ```
 
-**Actions (MCP path):**
+3. O `small` deve ser a primeira opção (aparece como padrão no menu)
+4. Se o usuário pediu "modelo mais simples" ou similar na mensagem original, usar `tiny` ou `base` sem perguntar
 
-1. Detect that the input is a YouTube URL
-2. Use the MCP tool `get_transcript` with the URL and desired language:
-   - Try first with the detected/requested language
-   - If it fails, try without specifying language (gets default caption)
-3. If the transcription comes with timestamps, preserve them in markdown
-4. If the video has multiple speakers and the user requested identification:
-   - Ask the user if they want diarization
-   - If yes: download audio with yt-dlp, convert to WAV 16kHz, run SpeechBrain (Step 4)
-5. Generate final markdown (Step 6)
+### Step Y: YouTube — Transcrição via MCP (se input for URL)
 
-**Actions (yt-dlp fallback — when MCP fails or no captions available):**
+**Objetivo:** Extrair transcrição de vídeos do YouTube sem baixar o vídeo.
+
+**Quando usar:** Se o input do usuário for um link do YouTube (youtube.com, youtu.be).
+
+**Fluxo de decisão:**
+
+```
+Input é URL do YouTube?
+  ├── SIM → Tentar MCP youtube-transcript (get_transcript)
+  │     ├── Sucesso → Formatar markdown (pular Steps 1-4)
+  │     │     └── Se múltiplos locutores → Diarização manual ou pedir ao usuário
+  │     └── Falha (sem legendas) → Baixar áudio com yt-dlp → Seguir Steps 1-6
+  └── NÃO → Seguir Steps 1-6 (arquivo local)
+```
+
+**Ações (caminho MCP):**
+
+1. Detectar que o input é uma URL do YouTube
+2. Usar a tool MCP `get_transcript` com o URL e idioma desejado:
+   - Tentar primeiro com `lang: "pt"` (português)
+   - Se falhar, tentar sem especificar idioma (pega a legenda padrão)
+3. Se a transcrição vier com timestamps, preservá-los no markdown
+4. Se o vídeo tiver múltiplos locutores e o usuário pediu identificação:
+   - Perguntar ao usuário se quer diarização
+   - Se sim: baixar áudio com yt-dlp, converter para WAV 16kHz, rodar SpeechBrain (Step 4)
+5. Gerar markdown final (Step 6)
+
+**Ações (fallback yt-dlp — quando MCP falhar ou não houver legendas):**
 
 ```bash
-# Check if yt-dlp is installed
-which yt-dlp || python3 -m yt_dlp --version
+# Verificar se yt-dlp está instalado
+which yt-dlp || python3 -m yt_dlp --version  # binário pode estar fora do PATH
 
-# Try to download existing captions first (to /tmp/)
+# Tentar baixar legendas existentes primeiro (em /tmp/)
 yt-dlp --write-auto-subs --sub-lang pt --skip-download --convert-subs srt -o "/tmp/youtube-sub" "URL"
 
-# If no captions, download audio only (to /tmp/)
+# Se não houver legendas, baixar apenas o áudio (em /tmp/)
 yt-dlp -x --audio-format wav --audio-quality 0 -o "/tmp/youtube-audio.%(ext)s" "URL"
 
-# Convert to 16kHz mono (for diarization, to /tmp/)
+# Converter para 16kHz mono (para diarização, em /tmp/)
 ffmpeg -i "/tmp/youtube-audio.wav" -ar 16000 -ac 1 -f wav "/tmp/youtube-audio-16k.wav" -y
 ```
 
-After downloading audio, follow the normal flow (Steps 3-6).
+Após baixar o áudio, seguir o fluxo normal (Steps 3-6).
 
-**YouTube output template:**
+**Template de saída YouTube:**
 
 ```markdown
-# Video Transcription (YouTube)
+# Transcrição de Vídeo (YouTube)
 
-## Metadata
+## Metadados
 
-| Field | Value |
+| Campo | Valor |
 |-------|-------|
-| **Title** | {video_title} |
+| **Título** | {titulo_do_video} |
 | **URL** | {youtube_url} |
-| **Duration** | {duration} |
-| **Language** | {language} |
-| **Date** | {date} |
-| **Source** | YouTube (automatic/manual captions) |
+| **Duração** | {duration} |
+| **Idioma** | {language} |
+| **Data** | {date} |
+| **Fonte** | YouTube (legendas automáticas/manuais) |
 
 ---
 
-## Transcription
+## Transcrição
 
-{transcription_content}
+{conteudo_da_transcricao}
 ```
 
-### Step 1: Discovery (Auto-detect Tools)
+### Step 1: Discovery e Instalação Automática
 
-**Goal:** Detect installed tools.
+**Objetivo:** Detectar ferramentas instaladas e instalar automaticamente as que faltam. O usuário NÃO precisa instalar nada manualmente.
 
-**Actions:**
+**Ações:**
+
+1. Verificar cada dependência e instalar automaticamente se faltar:
+
+```bash
+# Verificar e instalar MLX Whisper (engine principal)
+python3 -c "import mlx_whisper" 2>/dev/null || pip install mlx-whisper
+
+# Verificar e instalar SpeechBrain + dependências de diarização
+python3 -c "from speechbrain.inference.speaker import EncoderClassifier" 2>/dev/null || pip install speechbrain scikit-learn soundfile
+
+# Verificar e instalar FFmpeg (necessário para vídeo, conversão e frames)
+which ffmpeg >/dev/null 2>&1 || brew install ffmpeg
+
+# Para YouTube (se input for URL):
+# yt-dlp só é necessário como fallback quando não houver legendas
+which yt-dlp >/dev/null 2>&1 || pip install yt-dlp
+```
+
+2. **IMPORTANTE:** Executar as instalações silenciosamente sem perguntar ao usuário. Se alguma instalação falhar, informar o erro e sugerir correção.
+
+3. Após instalar, verificar novamente:
 
 ```python
-# Priority: MLX Whisper > WhisperX > Faster-Whisper > Whisper
-engines = []
-try:
-    import mlx_whisper
-    engines.append("mlx-whisper")
-except: pass
-try:
-    import whisperx
-    engines.append("whisperx")
-except: pass
-try:
-    import faster_whisper
-    engines.append("faster-whisper")
-except: pass
-try:
-    import whisper
-    engines.append("whisper")
-except: pass
-
-# Check diarization
-try:
-    from speechbrain.inference.speaker import EncoderClassifier
-    diarization_available = True
-except:
-    diarization_available = False
-
-# Check ffmpeg
+import mlx_whisper  # Engine de transcrição
+from speechbrain.inference.speaker import EncoderClassifier  # Diarização
 import shutil
 ffmpeg_available = shutil.which("ffmpeg") is not None
 ```
 
-**If MLX Whisper is not installed:**
+### Step 2: Validar Arquivo e Extrair Metadados
 
-```
-pip install mlx-whisper speechbrain scikit-learn soundfile
-```
+**Objetivo:** Verificar arquivo, formato e duração.
 
-### Step 2: Validate File and Extract Metadata
+**IMPORTANTE — Arquivos intermediários:**
+- Todos os arquivos temporários (WAV convertido, JSONs de transcrição/diarização) devem ser gravados em `/tmp/`, NUNCA no diretório do arquivo original.
+- O único arquivo que deve ser salvo no diretório do arquivo original é o **markdown final** (transcript + ata).
+- Ao final do processo, **limpar todos os arquivos temporários** de `/tmp/`.
 
-**Goal:** Verify file, format and duration.
+**Ações:**
 
-**IMPORTANT — Intermediate files:**
-- All temporary files (converted WAV, transcription/diarization JSONs) must be saved to `/tmp/`, NEVER in the original file's directory.
-- The only files saved in the original file's directory are the **final markdown** (transcript + minutes).
-- At the end of the process, **clean up all temporary files** from `/tmp/`.
-
-**Actions:**
-
-1. Verify the file exists
-2. Extract metadata via ffprobe (duration, format, size)
-3. If format is not WAV and diarization is enabled, convert to WAV 16kHz mono **in /tmp/**:
+1. Verificar se o arquivo existe
+2. Extrair metadados via ffprobe (duração, formato, tamanho)
+3. Se formato não é WAV e diarização está ativada, converter para WAV 16kHz mono **em /tmp/**:
 
 ```bash
 ffmpeg -i "input.mp4" -ar 16000 -ac 1 -f wav "/tmp/input-16k.wav" -y
 ```
 
-4. Intermediate JSONs also in `/tmp/`:
+4. JSONs intermediários também em `/tmp/`:
    - `/tmp/transcription.json`
    - `/tmp/diarization.json`
 
-### Step 3: Transcription with MLX Whisper
+### Step 3: Transcrição com MLX Whisper
 
-**Goal:** Transcribe audio using Apple Silicon GPU.
+**Objetivo:** Transcrever áudio usando Apple Silicon GPU.
 
 ```python
 import mlx_whisper
 
-# Model map
+# Mapa de modelos
 MODELS = {
     "tiny": "mlx-community/whisper-tiny-mlx",
     "base": "mlx-community/whisper-base-mlx",
@@ -250,21 +246,21 @@ MODELS = {
 result = mlx_whisper.transcribe(
     audio_file,
     path_or_hf_repo=MODELS[model_name],
-    language="pt",  # or None for auto-detect
+    language="pt",  # ou None para auto-detect
     word_timestamps=True
 )
 ```
 
-### Step 4: Diarization with SpeechBrain
+### Step 4: Diarização com SpeechBrain
 
-**Goal:** Identify speakers using embeddings + clustering.
+**Objetivo:** Identificar locutores usando embeddings + clustering.
 
-**Method:**
-1. Load WAV audio 16kHz mono
-2. Extract embeddings in 3-second windows (1.5s hop) using SpeechBrain ECAPA-TDNN
-3. Normalize embeddings
-4. Cluster with AgglomerativeClustering (n_clusters=5 by default, or distance_threshold if unknown)
-5. Map each transcription segment to the nearest speaker by timestamp
+**Método:**
+1. Carregar áudio WAV 16kHz mono
+2. Extrair embeddings em janelas de 3 segundos (hop de 1.5s) usando SpeechBrain ECAPA-TDNN
+3. Normalizar embeddings
+4. Agrupar com AgglomerativeClustering (n_clusters=5 por padrão, ou distance_threshold se desconhecido)
+5. Mapear cada segmento da transcrição ao speaker mais próximo por timestamp
 
 ```python
 from speechbrain.inference.speaker import EncoderClassifier
@@ -274,17 +270,17 @@ import soundfile as sf
 import torch
 import numpy as np
 
-# Load model (~80 MB)
+# Carregar modelo (~80 MB)
 classifier = EncoderClassifier.from_hparams(
     source="speechbrain/spkrec-ecapa-voxceleb",
     savedir="/tmp/speechbrain_spkrec"
 )
 
-# Load WAV audio
+# Carregar áudio WAV
 signal_np, sr = sf.read("input-16k.wav")
 signal = torch.tensor(signal_np, dtype=torch.float32).unsqueeze(0)
 
-# Extract embeddings in 3s windows
+# Extrair embeddings em janelas de 3s
 window_size = 3 * sr
 hop_size = int(1.5 * sr)
 embeddings, window_times = [], []
@@ -303,7 +299,7 @@ emb_matrix = normalize(np.array(embeddings))
 clustering = AgglomerativeClustering(n_clusters=5, metric="cosine", linkage="average")
 labels = clustering.fit_predict(emb_matrix)
 
-# Map speaker to each transcription segment
+# Mapear speaker para cada segmento da transcrição
 speaker_map = {t: f"SPEAKER_{labels[i]:02d}" for i, t in enumerate(window_times)}
 for seg in segments:
     seg_mid = (seg["start"] + seg["end"]) / 2
@@ -311,146 +307,424 @@ for seg in segments:
     seg["speaker"] = speaker_map[best_t]
 ```
 
-### Step 5: Interactive Speaker Identification
+### Step 5: Identificação Interativa de Locutores
 
-**Goal:** Ask the user the real name of each speaker.
+**Objetivo:** Perguntar ao usuário o nome real de cada locutor.
 
-**IMPORTANT: This step is MANDATORY when diarization is enabled.**
+**IMPORTANTE: Este passo é OBRIGATÓRIO quando diarização está ativada.**
 
-**Actions:**
+**Ações:**
 
-1. Count segments per speaker and show a representative excerpt from each
-2. Ask the user, listing each SPEAKER with segment count
-3. The user responds with real names (e.g., "SPEAKER_00 is John, SPEAKER_01 is Mary")
-4. Find/replace all SPEAKER_XX labels with real names in the final markdown
+1. Contar segmentos por speaker e mostrar um trecho representativo de cada um
+2. Perguntar ao usuário usando AskUserQuestion, listando cada SPEAKER com quantidade de segmentos
+3. O usuário responde com os nomes reais (ex: "SPEAKER_00 é o João, SPEAKER_01 é o Felipe")
+4. Fazer find/replace de todas as etiquetas SPEAKER_XX pelos nomes reais no markdown final
 
-**Example interaction:**
+**Exemplo de interação:**
 
 ```
-Identified speakers:
+👥 Locutores identificados:
 
-  SPEAKER_00 (1320 segments) — Main speaker
-    Excerpt: "...I'm a software architect, requirements engineer..."
+  SPEAKER_00 (1320 segmentos) — Locutor principal
+    Trecho: "...eu sou arquiteto de software, engenheiro de requisitos..."
 
-  SPEAKER_01 (61 segments) — Second most active
-    Excerpt: "...I don't know, I'm not sure if Prisma is part of Adonis..."
+  SPEAKER_01 (61 segmentos) — Segundo mais ativo
+    Trecho: "...eu não conheço, não sei se o Prisma faz parte do Adonis..."
 
-  SPEAKER_02 (27 segments)
-    Excerpt: "...it's going up..."
+  SPEAKER_02 (27 segmentos)
+    Trecho: "...está subindo..."
 
-Who is each speaker? (e.g., "SPEAKER_00 is John, SPEAKER_01 is Mary")
+Quem é cada locutor? (ex: "SPEAKER_00 é João, SPEAKER_01 é Felipe")
 ```
 
-5. After receiving names, replace in markdown:
-   - `### SPEAKER_00` -> `### John (Architect)`
-   - In metadata, list participants with real names
+5. Após receber os nomes, substituir no markdown:
+   - `### SPEAKER_00` → `### João (Arquiteto)`
+   - Nos metadados, listar participantes com nomes reais
 
-### Step 6: Generate Final Markdown
+### Step 6: Gerar Markdown Final
 
-**Goal:** Create formatted markdown file with transcription, speakers and metadata.
+**Objetivo:** Criar arquivo markdown formatado com transcrição, speakers e metadados.
 
 **Template:**
 
 ```markdown
-# Audio Transcription
+# Transcrição de Áudio
 
-## Metadata
+## Metadados
 
-| Field | Value |
+| Campo | Valor |
 |-------|-------|
-| **File** | {filename} |
-| **Duration** | {duration} |
-| **Language** | {language} |
-| **Date** | {date} |
-| **Engine** | MLX Whisper (model: {model}) |
-| **Diarization** | SpeechBrain ECAPA-TDNN |
-| **Speakers** | {n_speakers} |
+| **Arquivo** | {filename} |
+| **Duração** | {duration} |
+| **Idioma** | {language} |
+| **Data** | {date} |
+| **Engine** | MLX Whisper (modelo: {model}) |
+| **Diarização** | SpeechBrain ECAPA-TDNN |
+| **Locutores** | {n_speakers} |
 
-## Participants
+## Participantes
 
-- **{real_name_1}** ({n} segments) — role/description
-- **{real_name_2}** ({n} segments)
+- **{nome_real_1}** ({n} segmentos) — papel/descrição
+- **{nome_real_2}** ({n} segmentos)
 
 ---
 
-## Transcription
+## Transcrição
 
-### {real_name_1}
+### {nome_real_1}
 
-**[00:02 -> 00:14]** segment text...
+**[00:02 → 00:14]** texto do segmento...
 
-### {real_name_2}
+### {nome_real_2}
 
-**[13:01 -> 13:07]** segment text...
+**[13:01 → 13:07]** texto do segmento...
 ```
 
 **Naming:** `transcript-YYYYMMDD-HHMMSS.md`
 
-### Step 7: Generate Meeting Minutes/Summary
+### Step 6.5: Detecção de Contexto Visual (apenas para vídeos)
 
-**ALWAYS generate meeting minutes automatically** after transcription (no need to ask the user).
+**Objetivo:** Identificar momentos na transcrição onde locutores referenciam elementos visuais — telas, cliques, demos, slides, reações a algo visível — e marcar esses timestamps para possível extração de frames sob demanda.
 
-1. Read the generated transcription
-2. Use the LLM (Claude) to generate:
-   - Meeting context and objective
-   - Participants and roles
-   - Topics discussed
-   - Decisions made
-   - Action items defined
-3. Save as `minutes-YYYYMMDD-HHMMSS.md` **in the same directory as the original file**
+**Quando executar:** SEMPRE que o arquivo de entrada for um **vídeo** (MP4, MOV, WEBM, MKV, AVI). NÃO executar para arquivos apenas de áudio (MP3, WAV, M4A, OGG, FLAC).
 
-### Step 8: Clean Up Temporary Files
+**Custo:** Zero adicional — é apenas análise de texto nos segmentos já transcritos.
 
-**MANDATORY:** At the end of the entire process, remove all intermediate files:
+**Padrões de detecção (Visual Cues):**
+
+Os seguintes padrões indicam que o locutor está referenciando algo visual. Classificados por categoria:
+
+| Categoria | Exemplos de padrões | Regex sugerido |
+|-----------|-------------------|----------------|
+| **Referência dêitica** (apontar) | "aqui", "ali", "isso aqui", "essa parte", "nessa tela", "esse botão", "esse campo" | `\b(aqui|ali|isso aqui|essa? parte|nessa? tela|essa? (botão\|campo\|menu\|aba\|página\|seção))\b` |
+| **Ação de demonstração** | "cliquei aqui", "vou clicar", "tô clicando", "arrasta pra cá", "abre isso", "fecha isso", "rola pra baixo", "scrolla" | `\b(clic(ar\|ou\|a\|ando\|quei)\|arrastar?\|abr(e\|ir\|iu)\|fech(a\|ar\|ou)\|rol(a\|ar)\|scrolla)\b` |
+| **Convite a observar** | "olha", "olha só", "viu?", "tá vendo?", "percebe?", "repara", "nota que", "presta atenção" | `\b(olha( só)?\|viu\?\|t[aá] vendo\|percebe\|repara\|nota que\|presta atenção)\b` |
+| **Reação visual/espanto** | "vixe", "nossa", "eita", "opa", "uai", "caramba", "poxa", "puts", "ué", "ih" | `\b(vixe\|nossa\|eita\|opa\|uai\|caramba\|poxa\|puts\|u[ée]\|ih)\b` |
+| **Referência a slides/apresentação** | "próximo slide", "slide anterior", "nesse slide", "na apresentação", "nesse gráfico", "nessa tabela" | `\b(pr[oó]ximo slide\|slide (anterior\|seguinte)\|nessa? (slide\|gráfico\|tabela\|imagem\|figura\|apresentação))\b` |
+| **Resultado/mudança na tela** | "apareceu", "sumiu", "mudou", "carregou", "atualizou", "travou", "bugou", "quebrou", "deu erro", "funcionou" | `\b(apareceu\|sumiu\|mudou\|carregou\|atualizou\|travou\|bugou\|quebrou\|deu erro\|funcionou)\b` |
+| **Navegação** | "entra em", "vai em", "acessa", "volta pra", "navega até" | `\b(entra em\|vai em\|acessa\|volta (pra\|para)\|navega)\b` |
+| **Digitação/input** | "digita", "escreve", "preenche", "seleciona", "marca", "desmarca" | `\b(digit[ao]\|escreve\|preenche\|seleciona\|marca\|desmarca)\b` |
+
+**Também detectar em inglês** (comum em reuniões técnicas):
+
+| Categoria | Exemplos | Regex sugerido |
+|-----------|----------|----------------|
+| **Dêitico** | "right here", "this one", "over here", "this part" | `\b(right here\|this one\|over here\|this (part\|button\|field\|screen))\b` |
+| **Demonstração** | "let me click", "I'll click", "click here", "scroll down" | `\b(click(ed\|ing)?\s*(here\|on\|this)\|scroll\s*(down\|up)\|drag)\b` |
+| **Observação** | "see?", "you see", "look at", "notice", "watch this" | `\b(see\?\|you see\|look at\|notice\|watch this)\b` |
+| **Reação** | "whoa", "oh", "wow", "oops", "huh" | `\b(whoa\|oh\b\|wow\|oops\|huh)\b` |
+
+**Algoritmo:**
+
+```python
+import re
+
+VISUAL_CUE_PATTERNS = {
+    "deictic": r'\b(aqui|ali|isso aqui|essa? parte|nessa? tela|essa? (?:botão|campo|menu|aba|página|seção)|right here|this one|over here|this (?:part|button|field|screen))\b',
+    "demonstration": r'\b(clic(?:ar|ou|a|ando|quei)|arrastar?|abr[eiu]r?|fech[aou]r?|rol[ao]r?|scrolla|click(?:ed|ing)?\s*(?:here|on|this)|scroll\s*(?:down|up)|drag)\b',
+    "observation": r'\b(olha(?: só)?|viu\?|t[aá] vendo|percebe|repara|nota que|presta atenção|see\?|you see|look at|notice|watch this)\b',
+    "reaction": r'\b(vixe|nossa|eita|opa|uai|caramba|poxa|puts|u[ée]|ih|whoa|oh\b|wow|oops|huh)\b',
+    "slides": r'\b(pr[oó]ximo slide|slide (?:anterior|seguinte)|nessa? (?:slide|gráfico|tabela|imagem|figura|apresentação))\b',
+    "screen_change": r'\b(apareceu|sumiu|mudou|carregou|atualizou|travou|bugou|quebrou|deu erro|funcionou)\b',
+    "navigation": r'\b(entra em|vai em|acessa|volta (?:pra|para)|navega)\b',
+    "input": r'\b(digit[ao]|escreve|preenche|seleciona|marca|desmarca)\b',
+}
+
+def detect_visual_cues(segments):
+    """Detecta segmentos com referências visuais e retorna lista de visual cues."""
+    visual_cues = []
+    for seg in segments:
+        text_lower = seg["text"].lower()
+        matched_categories = []
+        matched_words = []
+        for category, pattern in VISUAL_CUE_PATTERNS.items():
+            matches = re.findall(pattern, text_lower, re.IGNORECASE)
+            if matches:
+                matched_categories.append(category)
+                matched_words.extend(matches if isinstance(matches[0], str) else [m[0] for m in matches])
+        if matched_categories:
+            visual_cues.append({
+                "start": seg["start"],
+                "end": seg["end"],
+                "timestamp": format_timestamp(seg["start"]),
+                "speaker": seg.get("speaker", "unknown"),
+                "text": seg["text"],
+                "categories": matched_categories,
+                "matched_words": matched_words,
+            })
+    return visual_cues
+```
+
+**Saída:**
+
+1. Adicionar marcadores inline no markdown da transcrição:
+
+```markdown
+**[00:05:23] João** 👁️
+Cliquei aqui no botão de configurações e olha o que apareceu
+```
+
+O emoji 👁️ indica que esse segmento tem referência visual. É sutil e não polui a leitura.
+
+2. Salvar metadados de visual cues em JSON separado: `visual-cues-YYYYMMDD-HHMMSS.json`
+
+```json
+{
+  "source_video": "reuniao.mp4",
+  "total_cues": 15,
+  "cues": [
+    {
+      "start": 323.5,
+      "end": 328.1,
+      "timestamp": "00:05:23",
+      "speaker": "João",
+      "text": "Cliquei aqui no botão de configurações e olha o que apareceu",
+      "categories": ["demonstration", "observation", "screen_change"],
+      "matched_words": ["cliquei", "aqui", "olha", "apareceu"],
+      "frame_extracted": false
+    }
+  ]
+}
+```
+
+3. Ao final da transcrição, a LLM **sugere proativamente** a extração de frames ao usuário, mostrando o que detectou. Usar `AskUserQuestion` com o seguinte formato:
+
+```
+👁️ Detectei 15 momentos no vídeo onde os locutores parecem estar referenciando
+algo visual na tela (demos, cliques, reações). Extrair frames nesses pontos
+pode me ajudar a entender melhor o contexto da conversa.
+
+Resumo do que encontrei:
+   6x demonstração — "cliquei aqui", "vou abrir", "arrasta pra cá"
+   4x referência a tela — "essa parte aqui", "nesse botão"
+   3x reação/espanto — "nossa!", "vixe", "opa"
+   2x mudança na tela — "apareceu", "deu erro"
+
+Exemplos dos momentos mais relevantes:
+  [00:05:23] João: "Cliquei aqui no botão de configurações e olha o que apareceu"
+  [00:12:45] Maria: "Vixe, bugou! Tá vendo isso?"
+  [00:18:02] João: "Entra em Plugins e seleciona esse aqui"
+
+Quer que eu extraia frames desses momentos para entender melhor o que
+estava sendo mostrado na tela?
+
+Opções:
+  1. Sim, todos os 15 momentos
+  2. Só os mais importantes (demonstrações e mudanças na tela)
+  3. Não, a transcrição já está boa assim
+```
+
+**Regras da sugestão:**
+- Sempre mostrar a **contagem por categoria** para o usuário ter noção do volume
+- Sempre mostrar **2-4 exemplos concretos** (os mais representativos, priorizando demonstration > screen_change > deictic)
+- Se houver **poucos cues (≤ 3)**, sugerir extrair todos diretamente
+- Se houver **muitos cues (> 20)**, sugerir o modo seletivo como padrão
+- Se o arquivo for **apenas áudio** (sem vídeo), NÃO sugerir extração — apenas manter os marcadores 👁️ no markdown como informação
+
+### Step 9: Extração e Análise de Frames Visuais (após confirmação do usuário)
+
+**Objetivo:** Após o usuário confirmar no Step 6.5, extrair frames do vídeo nos timestamps marcados como visual cues e analisá-los com Claude para enriquecer a transcrição com contexto visual.
+
+**Quando executar:** Quando o usuário confirmar a sugestão do Step 6.5 (opção 1 ou 2). Se o usuário escolher opção 3, pular este step.
+
+**Pré-requisitos:**
+- Arquivo de vídeo original ainda acessível
+- Lista de visual cues detectados no Step 6.5
+- FFmpeg instalado
+
+**Modos de operação (baseado na resposta do usuário):**
+
+| Resposta | Modo | Descrição |
+|----------|------|-----------|
+| **Opção 1 / "todos"** | Completo | Extrair frames de todos os visual cues |
+| **Opção 2 / "importantes"** | Seletivo | Priorizar: demonstration > screen_change > deictic > observation. Ignorar reaction isoladas |
+| **Resposta específica** | Específico | Se o usuário mencionar momentos específicos ("só o do minuto 5 e 12"), extrair apenas esses |
+
+**Extração de frames com FFmpeg:**
+
+Os frames devem ser salvos **SEMPRE numa pasta local** no mesmo diretório do vídeo original, para que o usuário possa conferir as imagens. A pasta segue o padrão `frames-{nome_do_video}/`.
+
+```bash
+# Criar pasta local para frames (no diretório do vídeo)
+mkdir -p "/caminho/do/video/frames-reuniao/"
+
+# Frame único — para cues simples (observation, reaction, deictic)
+ffmpeg -ss 00:05:23 -i "reuniao.mp4" -frames:v 1 -q:v 2 "/caminho/do/video/frames-reuniao/frame-00-05-23.jpg" -y
+
+# Sequência de 3 frames — para cues de ação (demonstration, screen_change, navigation, input)
+# Captura antes/durante/depois para mostrar a transição
+ffmpeg -ss 00:05:22 -i "reuniao.mp4" -frames:v 1 -q:v 2 "/caminho/do/video/frames-reuniao/frame-00-05-22-before.jpg" -y
+ffmpeg -ss 00:05:23 -i "reuniao.mp4" -frames:v 1 -q:v 2 "/caminho/do/video/frames-reuniao/frame-00-05-23-action.jpg" -y
+ffmpeg -ss 00:05:24 -i "reuniao.mp4" -frames:v 1 -q:v 2 "/caminho/do/video/frames-reuniao/frame-00-05-24-after.jpg" -y
+```
+
+**Naming da pasta:** `frames-{nome_base_do_video}/` — onde `nome_base_do_video` é o nome do arquivo sem extensão, em slug (lowercase, hífens no lugar de espaços). Exemplo: vídeo `Alinhamento Octos - 2026_03_10.mp4` → pasta `frames-alinhamento-octos/`.
+
+**Regras de extração:**
+- Categorias de **ação** (demonstration, screen_change, navigation, input) → 3 frames (antes, durante, depois — 1s de intervalo)
+- Categorias **estáticas** (observation, deictic, slides, reaction) → 1 frame no timestamp exato
+- **Deduplicar:** se dois cues estão a menos de 3 segundos de distância, extrair frames apenas do primeiro (evita imagens duplicadas)
+
+**Análise com Claude:**
+
+Após extrair os frames, usar a ferramenta Read do Claude Code para ler cada imagem (Claude é multimodal) e gerar descrição do contexto visual:
+
+```
+Para cada frame extraído:
+1. Ler a imagem com Read tool
+2. Analisar o que está visível na tela (UI, elementos, texto, ações)
+3. Correlacionar com o texto da transcrição naquele timestamp
+4. Gerar descrição contextualizada
+```
+
+**Saída — Atualização do JSON de visual cues:**
+
+Após análise, salvar `visual-cues-YYYYMMDD-HHMMSS.json` com os resultados:
+
+```json
+{
+  "source_video": "reuniao.mp4",
+  "total_cues": 15,
+  "extracted": 10,
+  "cues": [
+    {
+      "start": 323.5,
+      "end": 328.1,
+      "timestamp": "00:05:23",
+      "speaker": "João",
+      "text": "Cliquei aqui no botão de configurações e olha o que apareceu",
+      "categories": ["demonstration", "observation", "screen_change"],
+      "matched_words": ["cliquei", "aqui", "olha", "apareceu"],
+      "frame_extracted": true,
+      "visual_description": "O speaker está no painel de Configurações do Figma. Na tela, é visível o menu lateral com opções de 'Geral', 'Plugins' e 'Notificações'. O cursor está sobre o botão 'Plugins'. No frame seguinte, um modal de gerenciamento de plugins aparece."
+    }
+  ]
+}
+```
+
+**Saída — Enriquecimento do Markdown (com links de imagem para VS Code):**
+
+SEMPRE inserir as descrições visuais inline no markdown da transcrição quando frames forem extraídos. O formato usa **links relativos** para que o VS Code (e qualquer visualizador de Markdown) renderize as imagens inline e permita clicar para abrir.
+
+**Formato para segmentos COM frame extraído:**
+
+```markdown
+**[00:05:23]** [👁️](frames-video/frame-00-05-23-action.jpg) Cliquei aqui no botão de configurações e olha o que apareceu
+
+> 📸 **Contexto visual:** O speaker está no painel de Configurações do Figma.
+>
+> ![frame-00:05:23](frames-video/frame-00-05-23-action.jpg)
+> [antes](frames-video/frame-00-05-23-before.jpg) | [depois](frames-video/frame-00-05-23-after.jpg)
+```
+
+**Regras do formato:**
+
+1. O `👁️` vira um **link clicável**: `[👁️](caminho/para/frame.jpg)` — ao clicar no VS Code, abre a imagem
+2. A imagem é renderizada **inline** com `![frame-TIMESTAMP](caminho/para/frame.jpg)` dentro do blockquote
+3. Para frames de ação (3 frames: before/action/after), mostrar o `action` como imagem principal e links textuais `[antes]` e `[depois]`
+4. Para frames estáticos (1 frame), mostrar apenas a imagem principal sem links extras
+5. **Paths relativos**: usar caminhos relativos ao diretório do markdown (ex: `frames-video/frame.jpg`), NÃO absolutos — assim funciona em qualquer máquina
+6. Segmentos com `👁️` que **NÃO tiveram frame extraído** mantêm o emoji sem link: `**[00:10:00]** 👁️ texto...`
+
+**Formato para segmentos SEM frame (apenas marcador):**
+
+```markdown
+**[00:10:00]** 👁️ Aí aqui a gente coloca as etapas.
+```
+
+**Frames ficam localmente:** Os frames são salvos SEMPRE na pasta local `frames-{video}/` no diretório do vídeo. Isso permite que o usuário confira visualmente o que a IA interpretou. Os frames NÃO são salvos em `/tmp/` — vão direto para a pasta local.
+
+**Estrutura final de saída:**
+
+```
+/diretorio/do/video/
+├── video-original.mp4
+├── transcript-20260312-143000.md          (transcrição com 👁️ e 📸 inline)
+├── ata-20260312-143000.md                 (ata/resumo)
+├── visual-cues-20260312-143000.json       (metadados dos visual cues)
+└── frames-video-original/                 (pasta com frames extraídos)
+    ├── frame-00-05-22-before.jpg
+    ├── frame-00-05-23-action.jpg
+    ├── frame-00-05-24-after.jpg
+    ├── frame-00-07-12-action.jpg
+    └── ...
+```
+
+Ao final, informar ao usuário quantos frames foram salvos e onde:
+```
+📁 18 frames salvos em: /diretorio/do/video/frames-video-original/
+   Você pode abrir a pasta para conferir as imagens que a IA analisou.
+```
+
+### Step 7: Gerar Ata/Resumo
+
+**SEMPRE gerar a ata automaticamente** após a transcrição (não precisa perguntar ao usuário).
+
+1. Ler a transcrição gerada
+2. Usar a própria LLM (Claude) para gerar:
+   - Contexto e objetivo da reunião
+   - Participantes e papéis
+   - Tópicos discutidos
+   - Decisões tomadas
+   - Ações definidas (action items)
+3. Salvar como `ata-YYYYMMDD-HHMMSS.md` **no mesmo diretório do arquivo original**
+
+### Step 8: Limpeza de Arquivos Temporários
+
+**OBRIGATÓRIO:** Ao final de todo o processo, remover todos os arquivos intermediários:
 
 ```bash
 rm -f /tmp/transcription.json /tmp/diarization.json /tmp/*-16k.wav /tmp/youtube-audio.*
 ```
 
-**General output rules:**
-- In the original file's directory, ONLY keep:
-  - `transcript-YYYYMMDD-HHMMSS.md` (transcription with speakers)
-  - `minutes-YYYYMMDD-HHMMSS.md` (summary/minutes)
-- Everything else (WAV, JSON, SRT) goes to `/tmp/` and is deleted at the end
+**Regra geral de saída:**
+- No diretório do arquivo original, ficam:
+  - `transcript-YYYYMMDD-HHMMSS.md` (transcrição com locutores, 👁️ e 📸 inline)
+  - `ata-YYYYMMDD-HHMMSS.md` (resumo/ata)
+  - `visual-cues-YYYYMMDD-HHMMSS.json` (metadados de contexto visual, apenas para vídeos)
+  - `frames-{video}/` (pasta com frames extraídos, quando o usuário confirmar extração)
+- Tudo mais (WAV convertido, JSONs intermediários, SRT) vai para `/tmp/` e é apagado no final
+- **Frames NÃO vão para `/tmp/`** — são salvos direto na pasta local para conferência do usuário
 
 ## Benchmarks (Apple M2, 8GB RAM)
 
-Test audio: ~85 min meeting recording
+Áudio de teste: ~85 min de reunião
 
-| Engine + Model | Transcription | Diarization | Total | Quality |
-|----------------|--------------|-------------|-------|---------|
-| WhisperX tiny (CPU) | ~7 min | ~84 min (pyannote) | **~91 min** | Poor |
-| MLX Whisper base (GPU) | ~5.7 min | ~3 min (SpeechBrain) | **~9 min** | Good |
-| **MLX Whisper small (GPU)** | **~6.5 min** | **~3 min (SpeechBrain)** | **~9.5 min** | **Very good** |
+| Engine + Modelo | Transcrição | Diarização | Total | Qualidade |
+|----------------|------------|-----------|-------|-----------|
+| WhisperX tiny (CPU) | ~7 min | ~84 min (pyannote) | **~91 min** | Ruim |
+| MLX Whisper base (GPU) | ~5.7 min | ~3 min (SpeechBrain) | **~9 min** | Boa |
+| **MLX Whisper small (GPU)** | **~6.5 min** | **~3 min (SpeechBrain)** | **~9.5 min** | **Muito boa** |
 
-## Requirements
+## Requisitos
 
 ```bash
-# Main engine (Apple Silicon)
+# Engine principal (Apple Silicon)
 pip install mlx-whisper
 
-# Lightweight diarization
+# Diarização leve
 pip install speechbrain scikit-learn soundfile
 
-# Format conversion (recommended)
+# Conversão de formatos + extração de frames visuais (obrigatório)
 brew install ffmpeg
 
-# YouTube (transcription via captions)
-claude mcp add youtube-transcript -- npx -y @sinco-lab/mcp-youtube-transcript
+# YouTube (transcrição via legendas)
+# MCP já configurado: claude mcp add youtube-transcript -- npx -y @sinco-lab/mcp-youtube-transcript
 
-# YouTube (fallback — download audio when no captions available)
+# YouTube (fallback — baixar áudio quando não houver legendas)
 pip install yt-dlp
+# ou: brew install yt-dlp
 ```
 
-## Fallback (non-Apple Silicon)
+## Fallback (não-Apple Silicon)
 
-If not on Apple Silicon, the skill automatically uses:
-1. WhisperX (if installed) — with pyannote for diarization
+Se não estiver em Apple Silicon, o skill usa automaticamente:
+1. WhisperX (se instalado) — com pyannote para diarização
 2. Faster-Whisper
 3. OpenAI Whisper
 
-For WhisperX with diarization, a HuggingFace token is needed:
-1. Create account at https://huggingface.co
-2. Generate token at https://huggingface.co/settings/tokens
-3. Accept terms at https://huggingface.co/pyannote/speaker-diarization-community-1
-4. Save token: `echo "hf_xxx" > ~/.hftoken`
+Para WhisperX com diarização, é necessário token HuggingFace:
+1. Criar conta em https://huggingface.co
+2. Gerar token em https://huggingface.co/settings/tokens
+3. Aceitar termos em https://huggingface.co/pyannote/speaker-diarization-community-1
+4. Salvar token: `echo "hf_xxx" > ~/.hftoken`

--- a/skills/audio-transcriber/SKILL.md
+++ b/skills/audio-transcriber/SKILL.md
@@ -1,0 +1,455 @@
+---
+name: audio-transcriber
+description: "Transcribes audio/video/YouTube to professional Markdown with speaker diarization. Accepts local files (MP3, MP4, WAV, M4A, etc.) or YouTube links. For YouTube, uses MCP youtube-transcript for instant captions; if unavailable, downloads audio with yt-dlp. For local files, uses MLX Whisper (Apple Silicon GPU) + SpeechBrain for lightweight diarization. Supports model selection (tiny/base/small/medium). Automatically generates meeting minutes."
+---
+
+## Purpose
+
+Transcribes audio, video, and YouTube videos to professional Markdown text with:
+- **YouTube** — extracts transcription/captions instantly via MCP `youtube-transcript` (no video download needed)
+- **Local transcription optimized for Apple Silicon** via MLX Whisper (GPU/Neural Engine)
+- **Lightweight diarization** via SpeechBrain ECAPA-TDNN (speaker identification without HuggingFace token)
+- **Interactive speaker identification** — after diarization, asks the user to name each SPEAKER
+- Rich metadata (duration, language, speakers, timestamps)
+- Automatic meeting minutes/summary generation via LLM
+
+## When to Use
+
+Invoke this skill when:
+
+- User needs to transcribe audio/video files to text
+- User shares a **YouTube link** and wants the transcript/transcription
+- User wants meeting minutes automatically generated from recordings
+- User requires speaker identification (diarization) in conversations
+- User wants executive summaries of long audio content
+- User asks variations of "transcribe this audio", "convert audio to text", "generate meeting notes from recording", "transcribe this YouTube video", "get the transcript from this link"
+- User has audio files in common formats (MP3, MP4, WAV, M4A, OGG, FLAC, WEBM)
+- User has YouTube URLs (youtube.com, youtu.be)
+
+## Input Sources
+
+| Source | Method | Speed | Requirements |
+|--------|--------|-------|-------------|
+| **YouTube URL** | MCP `youtube-transcript` (captions) | **Instant** | MCP installed |
+| **YouTube URL (no captions)** | `yt-dlp` + MLX Whisper | Moderate | `yt-dlp` installed |
+| **Local file** | MLX Whisper + SpeechBrain | Fast | Python dependencies |
+
+## Engines (Priority Order)
+
+| Engine | Platform | Diarization | Speed | Installation |
+|--------|----------|-------------|-------|-------------|
+| **MCP youtube-transcript** | Any | Not native | Instant | `claude mcp add youtube-transcript -- npx -y @sinco-lab/mcp-youtube-transcript` |
+| **MLX Whisper** (default) | Apple Silicon | Via SpeechBrain | Very fast | `pip install mlx-whisper` |
+| WhisperX | Any (CPU/GPU) | Via pyannote | Moderate | `pip install whisperx` |
+| Faster-Whisper | Any | Not native | Fast | `pip install faster-whisper` |
+| Whisper | Any | Not native | Baseline | `pip install openai-whisper` |
+
+## Available Models (MLX Whisper)
+
+| Model | Size | RAM needed | Quality | HuggingFace Repo |
+|-------|------|-----------|---------|-------------------|
+| `tiny` | ~75 MB | ~500 MB | Basic | `mlx-community/whisper-tiny-mlx` |
+| `base` | ~140 MB | ~800 MB | Good | `mlx-community/whisper-base-mlx` |
+| **`small`** (default) | **~460 MB** | **~1.5 GB** | **Very good** | **`mlx-community/whisper-small-mlx`** |
+| `medium` | ~1.5 GB | ~3 GB | Excellent | `mlx-community/whisper-medium-mlx` |
+| `large-v3-turbo` | ~1.5 GB | ~4 GB | Superior | `mlx-community/whisper-large-v3-turbo` |
+
+**Note:** `medium` and `large-v3-turbo` models require Macs with 16GB+ RAM.
+
+## Diarization (Speaker Identification)
+
+Uses **SpeechBrain ECAPA-TDNN** (~80 MB) with agglomerative clustering:
+- No HuggingFace token required
+- ~3 min for 85 min of audio (CPU)
+- Generates SPEAKER_00, SPEAKER_01, etc. labels
+- After diarization, the skill **interactively asks** the user to name each speaker
+
+Dependencies: `pip install speechbrain scikit-learn soundfile`
+
+## Workflow
+
+### Step 0: Greeting and Model Selection
+
+**Goal:** Inform the user about available models and confirm the choice.
+
+**Actions:**
+
+1. When starting, ALWAYS inform the user:
+
+```
+Audio Transcriber — MLX Whisper (Apple Silicon)
+
+Available models:
+  tiny   (~75 MB)  — Fast, basic quality
+  base   (~140 MB) — Fast, good quality
+  small  (~460 MB) — Recommended default, very good quality
+  medium (~1.5 GB) — Excellent quality (requires 16GB+ RAM)
+  large  (~1.5 GB) — Superior (requires 16GB+ RAM)
+
+Current model: small (default)
+```
+
+2. If the user passed `--model <name>` in arguments, use that model
+3. If not specified, use `small` as default without asking
+4. If the user asked for "simplest model" or similar, use `tiny` or `base`
+
+### Step Y: YouTube — Transcription via MCP (if input is a URL)
+
+**Goal:** Extract transcription from YouTube videos without downloading the video.
+
+**When to use:** If the user's input is a YouTube link (youtube.com, youtu.be).
+
+**Decision flow:**
+
+```
+Is input a YouTube URL?
+  |-- YES -> Try MCP youtube-transcript (get_transcript)
+  |     |-- Success -> Format markdown (skip Steps 1-4)
+  |     |     \-- If multiple speakers -> Manual diarization or ask user
+  |     \-- Fail (no captions) -> Download audio with yt-dlp -> Follow Steps 1-6
+  \-- NO -> Follow Steps 1-6 (local file)
+```
+
+**Actions (MCP path):**
+
+1. Detect that the input is a YouTube URL
+2. Use the MCP tool `get_transcript` with the URL and desired language:
+   - Try first with the detected/requested language
+   - If it fails, try without specifying language (gets default caption)
+3. If the transcription comes with timestamps, preserve them in markdown
+4. If the video has multiple speakers and the user requested identification:
+   - Ask the user if they want diarization
+   - If yes: download audio with yt-dlp, convert to WAV 16kHz, run SpeechBrain (Step 4)
+5. Generate final markdown (Step 6)
+
+**Actions (yt-dlp fallback — when MCP fails or no captions available):**
+
+```bash
+# Check if yt-dlp is installed
+which yt-dlp || python3 -m yt_dlp --version
+
+# Try to download existing captions first (to /tmp/)
+yt-dlp --write-auto-subs --sub-lang pt --skip-download --convert-subs srt -o "/tmp/youtube-sub" "URL"
+
+# If no captions, download audio only (to /tmp/)
+yt-dlp -x --audio-format wav --audio-quality 0 -o "/tmp/youtube-audio.%(ext)s" "URL"
+
+# Convert to 16kHz mono (for diarization, to /tmp/)
+ffmpeg -i "/tmp/youtube-audio.wav" -ar 16000 -ac 1 -f wav "/tmp/youtube-audio-16k.wav" -y
+```
+
+After downloading audio, follow the normal flow (Steps 3-6).
+
+**YouTube output template:**
+
+```markdown
+# Video Transcription (YouTube)
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **Title** | {video_title} |
+| **URL** | {youtube_url} |
+| **Duration** | {duration} |
+| **Language** | {language} |
+| **Date** | {date} |
+| **Source** | YouTube (automatic/manual captions) |
+
+---
+
+## Transcription
+
+{transcription_content}
+```
+
+### Step 1: Discovery (Auto-detect Tools)
+
+**Goal:** Detect installed tools.
+
+**Actions:**
+
+```python
+# Priority: MLX Whisper > WhisperX > Faster-Whisper > Whisper
+engines = []
+try:
+    import mlx_whisper
+    engines.append("mlx-whisper")
+except: pass
+try:
+    import whisperx
+    engines.append("whisperx")
+except: pass
+try:
+    import faster_whisper
+    engines.append("faster-whisper")
+except: pass
+try:
+    import whisper
+    engines.append("whisper")
+except: pass
+
+# Check diarization
+try:
+    from speechbrain.inference.speaker import EncoderClassifier
+    diarization_available = True
+except:
+    diarization_available = False
+
+# Check ffmpeg
+import shutil
+ffmpeg_available = shutil.which("ffmpeg") is not None
+```
+
+**If MLX Whisper is not installed:**
+
+```
+pip install mlx-whisper speechbrain scikit-learn soundfile
+```
+
+### Step 2: Validate File and Extract Metadata
+
+**Goal:** Verify file, format and duration.
+
+**IMPORTANT — Intermediate files:**
+- All temporary files (converted WAV, transcription/diarization JSONs) must be saved to `/tmp/`, NEVER in the original file's directory.
+- The only files saved in the original file's directory are the **final markdown** (transcript + minutes).
+- At the end of the process, **clean up all temporary files** from `/tmp/`.
+
+**Actions:**
+
+1. Verify the file exists
+2. Extract metadata via ffprobe (duration, format, size)
+3. If format is not WAV and diarization is enabled, convert to WAV 16kHz mono **in /tmp/**:
+
+```bash
+ffmpeg -i "input.mp4" -ar 16000 -ac 1 -f wav "/tmp/input-16k.wav" -y
+```
+
+4. Intermediate JSONs also in `/tmp/`:
+   - `/tmp/transcription.json`
+   - `/tmp/diarization.json`
+
+### Step 3: Transcription with MLX Whisper
+
+**Goal:** Transcribe audio using Apple Silicon GPU.
+
+```python
+import mlx_whisper
+
+# Model map
+MODELS = {
+    "tiny": "mlx-community/whisper-tiny-mlx",
+    "base": "mlx-community/whisper-base-mlx",
+    "small": "mlx-community/whisper-small-mlx",
+    "medium": "mlx-community/whisper-medium-mlx",
+    "large": "mlx-community/whisper-large-v3-turbo",
+}
+
+result = mlx_whisper.transcribe(
+    audio_file,
+    path_or_hf_repo=MODELS[model_name],
+    language="pt",  # or None for auto-detect
+    word_timestamps=True
+)
+```
+
+### Step 4: Diarization with SpeechBrain
+
+**Goal:** Identify speakers using embeddings + clustering.
+
+**Method:**
+1. Load WAV audio 16kHz mono
+2. Extract embeddings in 3-second windows (1.5s hop) using SpeechBrain ECAPA-TDNN
+3. Normalize embeddings
+4. Cluster with AgglomerativeClustering (n_clusters=5 by default, or distance_threshold if unknown)
+5. Map each transcription segment to the nearest speaker by timestamp
+
+```python
+from speechbrain.inference.speaker import EncoderClassifier
+from sklearn.cluster import AgglomerativeClustering
+from sklearn.preprocessing import normalize
+import soundfile as sf
+import torch
+import numpy as np
+
+# Load model (~80 MB)
+classifier = EncoderClassifier.from_hparams(
+    source="speechbrain/spkrec-ecapa-voxceleb",
+    savedir="/tmp/speechbrain_spkrec"
+)
+
+# Load WAV audio
+signal_np, sr = sf.read("input-16k.wav")
+signal = torch.tensor(signal_np, dtype=torch.float32).unsqueeze(0)
+
+# Extract embeddings in 3s windows
+window_size = 3 * sr
+hop_size = int(1.5 * sr)
+embeddings, window_times = [], []
+
+pos = 0
+while pos + window_size < signal.shape[1]:
+    chunk = signal[:, pos:pos+window_size]
+    with torch.no_grad():
+        emb = classifier.encode_batch(chunk)
+        embeddings.append(emb.squeeze().numpy())
+        window_times.append(pos / sr)
+    pos += hop_size
+
+# Clustering
+emb_matrix = normalize(np.array(embeddings))
+clustering = AgglomerativeClustering(n_clusters=5, metric="cosine", linkage="average")
+labels = clustering.fit_predict(emb_matrix)
+
+# Map speaker to each transcription segment
+speaker_map = {t: f"SPEAKER_{labels[i]:02d}" for i, t in enumerate(window_times)}
+for seg in segments:
+    seg_mid = (seg["start"] + seg["end"]) / 2
+    best_t = min(window_times, key=lambda t: abs(t - seg_mid))
+    seg["speaker"] = speaker_map[best_t]
+```
+
+### Step 5: Interactive Speaker Identification
+
+**Goal:** Ask the user the real name of each speaker.
+
+**IMPORTANT: This step is MANDATORY when diarization is enabled.**
+
+**Actions:**
+
+1. Count segments per speaker and show a representative excerpt from each
+2. Ask the user, listing each SPEAKER with segment count
+3. The user responds with real names (e.g., "SPEAKER_00 is John, SPEAKER_01 is Mary")
+4. Find/replace all SPEAKER_XX labels with real names in the final markdown
+
+**Example interaction:**
+
+```
+Identified speakers:
+
+  SPEAKER_00 (1320 segments) — Main speaker
+    Excerpt: "...I'm a software architect, requirements engineer..."
+
+  SPEAKER_01 (61 segments) — Second most active
+    Excerpt: "...I don't know, I'm not sure if Prisma is part of Adonis..."
+
+  SPEAKER_02 (27 segments)
+    Excerpt: "...it's going up..."
+
+Who is each speaker? (e.g., "SPEAKER_00 is John, SPEAKER_01 is Mary")
+```
+
+5. After receiving names, replace in markdown:
+   - `### SPEAKER_00` -> `### John (Architect)`
+   - In metadata, list participants with real names
+
+### Step 6: Generate Final Markdown
+
+**Goal:** Create formatted markdown file with transcription, speakers and metadata.
+
+**Template:**
+
+```markdown
+# Audio Transcription
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **File** | {filename} |
+| **Duration** | {duration} |
+| **Language** | {language} |
+| **Date** | {date} |
+| **Engine** | MLX Whisper (model: {model}) |
+| **Diarization** | SpeechBrain ECAPA-TDNN |
+| **Speakers** | {n_speakers} |
+
+## Participants
+
+- **{real_name_1}** ({n} segments) — role/description
+- **{real_name_2}** ({n} segments)
+
+---
+
+## Transcription
+
+### {real_name_1}
+
+**[00:02 -> 00:14]** segment text...
+
+### {real_name_2}
+
+**[13:01 -> 13:07]** segment text...
+```
+
+**Naming:** `transcript-YYYYMMDD-HHMMSS.md`
+
+### Step 7: Generate Meeting Minutes/Summary
+
+**ALWAYS generate meeting minutes automatically** after transcription (no need to ask the user).
+
+1. Read the generated transcription
+2. Use the LLM (Claude) to generate:
+   - Meeting context and objective
+   - Participants and roles
+   - Topics discussed
+   - Decisions made
+   - Action items defined
+3. Save as `minutes-YYYYMMDD-HHMMSS.md` **in the same directory as the original file**
+
+### Step 8: Clean Up Temporary Files
+
+**MANDATORY:** At the end of the entire process, remove all intermediate files:
+
+```bash
+rm -f /tmp/transcription.json /tmp/diarization.json /tmp/*-16k.wav /tmp/youtube-audio.*
+```
+
+**General output rules:**
+- In the original file's directory, ONLY keep:
+  - `transcript-YYYYMMDD-HHMMSS.md` (transcription with speakers)
+  - `minutes-YYYYMMDD-HHMMSS.md` (summary/minutes)
+- Everything else (WAV, JSON, SRT) goes to `/tmp/` and is deleted at the end
+
+## Benchmarks (Apple M2, 8GB RAM)
+
+Test audio: ~85 min meeting recording
+
+| Engine + Model | Transcription | Diarization | Total | Quality |
+|----------------|--------------|-------------|-------|---------|
+| WhisperX tiny (CPU) | ~7 min | ~84 min (pyannote) | **~91 min** | Poor |
+| MLX Whisper base (GPU) | ~5.7 min | ~3 min (SpeechBrain) | **~9 min** | Good |
+| **MLX Whisper small (GPU)** | **~6.5 min** | **~3 min (SpeechBrain)** | **~9.5 min** | **Very good** |
+
+## Requirements
+
+```bash
+# Main engine (Apple Silicon)
+pip install mlx-whisper
+
+# Lightweight diarization
+pip install speechbrain scikit-learn soundfile
+
+# Format conversion (recommended)
+brew install ffmpeg
+
+# YouTube (transcription via captions)
+claude mcp add youtube-transcript -- npx -y @sinco-lab/mcp-youtube-transcript
+
+# YouTube (fallback — download audio when no captions available)
+pip install yt-dlp
+```
+
+## Fallback (non-Apple Silicon)
+
+If not on Apple Silicon, the skill automatically uses:
+1. WhisperX (if installed) — with pyannote for diarization
+2. Faster-Whisper
+3. OpenAI Whisper
+
+For WhisperX with diarization, a HuggingFace token is needed:
+1. Create account at https://huggingface.co
+2. Generate token at https://huggingface.co/settings/tokens
+3. Accept terms at https://huggingface.co/pyannote/speaker-diarization-community-1
+4. Save token: `echo "hf_xxx" > ~/.hftoken`


### PR DESCRIPTION
## Summary

Adds a new **audio-transcriber** skill (v2.0.0) that transcribes audio, video, and YouTube content to professional Markdown with automatic speaker diarization, visual context detection, and meeting minutes generation.

### Key Features

- **Apple Silicon optimized** — MLX Whisper uses GPU/Neural Engine for ~10x real-time transcription speed
- **Lightweight speaker diarization** — SpeechBrain ECAPA-TDNN (~80 MB) identifies speakers without any API keys or HuggingFace tokens
- **YouTube support** — instant transcription via MCP `youtube-transcript` captions, with yt-dlp audio download fallback
- **Interactive speaker naming** — after diarization, prompts the user to name each identified speaker
- **Visual context detection** (v2.0.0) — automatically detects moments where speakers reference visual elements (demos, screens, slides, clicks) using regex-based pattern matching across 8 categories (PT + EN)
- **On-demand frame extraction** — uses FFmpeg to extract video frames at visual cue timestamps for analysis with Claude's multimodal capabilities
- **Automatic meeting minutes** — generates summaries with topics, decisions, and action items
- **Interactive model selection** — presents model options via `AskUserQuestion` menu
- **Auto-install dependencies** — installs missing tools silently without user intervention
- **Multiple engines** — MLX Whisper (default), WhisperX, Faster-Whisper, OpenAI Whisper
- **Model selection** — tiny/base/small/medium/large with RAM-based recommendations
- **Clean output** — temp files go to `/tmp/`, only `.md` and visual assets remain in the user's directory

### Visual Context Detection (v2.0.0)

Detects 8 categories of visual references in transcription segments:
- **Deictic references** — "aqui", "right here", "this button"
- **Demonstrations** — "cliquei aqui", "let me click", "scroll down"
- **Observation invites** — "olha só", "see?", "watch this"
- **Visual reactions** — "vixe", "nossa", "whoa"
- **Slide references** — "próximo slide", "nesse gráfico"
- **Screen changes** — "apareceu", "bugou", "deu erro"
- **Navigation** — "entra em", "vai em", "acessa"
- **Input actions** — "digita", "seleciona", "preenche"

After detection, suggests frame extraction with category breakdown and concrete examples.

### Benchmarks (Apple M2, 8GB RAM)

Test: ~85 min meeting recording

| Pipeline | Total Time | Speed | Quality |
|----------|-----------|-------|---------| 
| WhisperX tiny + pyannote | ~91 min | 0.9x | Poor |
| MLX Whisper base + SpeechBrain | ~9 min | 9.4x | Good |
| **MLX Whisper small + SpeechBrain** | **~9.5 min** | **8.9x** | **Very good** |

### Stack

- [MLX Whisper](https://github.com/ml-explore/mlx-examples/tree/main/whisper) — Speech-to-text on Apple Silicon
- [SpeechBrain ECAPA-TDNN](https://huggingface.co/speechbrain/spkrec-ecapa-voxceleb) — Speaker embeddings
- [yt-dlp](https://github.com/yt-dlp/yt-dlp) — YouTube audio/subtitle download
- [MCP youtube-transcript](https://github.com/sinco-lab/mcp-youtube-transcript) — YouTube captions via MCP
- [FFmpeg](https://ffmpeg.org/) — Video frame extraction for visual context analysis