### PR TITLE
fix: properly kill process group on timeout to prevent zombie processes

### DIFF
--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -9,6 +9,7 @@ import argparse
 import json
 import os
 import select
+import signal
 import subprocess
 import sys
 import time
@@ -88,6 +89,8 @@ def run_single_query(
             stderr=subprocess.DEVNULL,
             cwd=project_root,
             env=env,
+            # Create new process group for proper cleanup on timeout
+            start_new_session=True,
         )
 
         triggered = False
@@ -172,7 +175,18 @@ def run_single_query(
         finally:
             # Clean up process on any exit path (return, exception, timeout)
             if process.poll() is None:
-                process.kill()
+                # Kill the entire process group to ensure child processes are terminated
+                try:
+                    os.killpg(os.getpgid(process.pid), signal.SIGTERM)
+                except ProcessLookupError:
+                    # Process already terminated
+                    pass
+                except PermissionError:
+                    # Fallback to regular kill if we don't have permission to kill group
+                    try:
+                        process.kill()
+                    except ProcessLookupError:
+                        pass
                 process.wait()
 
         return triggered


### PR DESCRIPTION
When a skill evaluation times out, only the parent process was being killed, leaving any child processes running as zombies. This fix:

1. Uses `start_new_session=True` to create a new process group
2. Uses `os.killpg()` to kill the entire process group on timeout
3. Adds proper error handling for PermissionError and ProcessLookupError

This ensures all child processes are properly cleaned up when a timeout occurs, preventing zombie processes and resource leaks.

Fixes #620