### PR TITLE
Add session-memory skill: preserve technical facts across compaction

### DIFF
--- a/skills/session-memory/LICENSE.txt
+++ b/skills/session-memory/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Lordanakun
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/session-memory/README.md
+++ b/skills/session-memory/README.md
@@ -1,0 +1,68 @@
+# session-memory
+
+A Claude Code skill that preserves critical technical facts across context compaction and session restarts — with zero dependencies.
+
+## The problem
+
+When Claude Code's context window fills up, compaction silently discards all tool outputs: file contents you read, test results, applied patches, command output. After compaction, only a vague LLM summary remains. The model may forget which file was modified, what the test result was, or which paths were already ruled out.
+
+Empirically: in a typical coding session, **tool results account for ~79% of tokens but 0% survive compaction**. After two compactions, all critical technical facts are gone.
+
+## How this skill helps
+
+Session Memory teaches Claude to write a structured checkpoint file (`.claude/session-memory.md`) **proactively** — after each patch, test run, and key decision — so facts survive compaction and can be restored.
+
+No MCP server. No embeddings. No installation beyond adding the skill.
+
+## Install
+
+```bash
+claude skills add https://github.com/anthropics/skills/tree/main/skills/session-memory
+```
+
+Or add to your project's `.claude/settings.json`:
+
+```json
+{
+  "skills": ["session-memory"]
+}
+```
+
+## What gets saved
+
+| Entry type | Example |
+|---|---|
+| `[PATCH]` | Exact diff hunks applied to files |
+| `[TEST]` | Test suite results before and after |
+| `[FILE]` | Key function signatures, line numbers |
+| `[DECISION]` | Scoping decisions, paths ruled out |
+| `[CMD]` | Command output that informed a decision |
+
+## What it looks like
+
+After a coding session, `.claude/session-memory.md` might contain:
+
+```markdown
+# Session Memory
+_Updated: 2026-03-13 · task: fix auth token refresh race_
+
+## [PATCH] src/auth.rs:47
+```diff
++    cache::invalidate(&decoded.sub);
+```
+
+## [TEST] cargo test auth:: — 14 tests
+BEFORE: test_concurrent_refresh FAILED
+AFTER:  all 14 passed ✅
+
+## [DECISION] src/api/mobile.rs — no change needed
+Calls auth::refresh_token() directly, picks up fix automatically.
+```
+
+## Background
+
+This skill was developed alongside a quantitative analysis of compaction information loss ([openai/codex#14589](https://github.com/openai/codex/issues/14589)). The same problem exists in all LLM coding agents that use in-context compression.
+
+## License
+
+MIT

--- a/skills/session-memory/SKILL.md
+++ b/skills/session-memory/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: session-memory
+description: Preserve critical technical facts across context compaction and session restarts. Use when working on multi-step coding tasks, debugging sessions, or any long-running work where file edits, test results, and decisions need to survive context resets. Activates automatically when context is filling up or when resuming interrupted work.
+---
+
+# Session Memory
+
+Compaction silently discards all tool outputs — file contents, test results, applied patches, command output. After compaction, you retain only a vague LLM summary plus recent user messages. This skill gives you a structured way to save what matters *before* it disappears, and recall it *after* compaction replaces your context.
+
+---
+
+## The problem this solves
+
+In a typical coding session, 79% of tokens are tool results (file reads, test output, patches). Compaction drops all of them. After compaction you may:
+
+- Forget which file was modified and what the change was
+- Lose the test result that confirmed a fix worked
+- Miss that a downstream path (e.g. `mobile.rs`) was already checked
+
+This skill teaches you to write a checkpoint file **proactively**, so the facts survive compaction and can be restored.
+
+---
+
+## Checkpoint file
+
+All session memory lives in one file: **`.claude/session-memory.md`**
+
+Create the `.claude/` directory if it doesn't exist. The file is human-readable and git-committable, so teammates see the same context you do.
+
+---
+
+## When to write
+
+Write to `.claude/session-memory.md` after any of these events:
+
+| Trigger | Why |
+|---|---|
+| Applied a patch / wrote a file | Exact diffs are the first thing compaction drops |
+| Test run completed | Pass/fail state is high-value, easy to lose |
+| Made a scoping decision | "X doesn't need changes" is invisible to compaction |
+| Read a file at a specific line | The content and location both disappear |
+| Approaching context limit | Write *before* compaction triggers, not after |
+| Resuming a session | Read the file first, then confirm what's still accurate |
+
+**Do not wait for compaction to happen.** Write incrementally after each meaningful action.
+
+---
+
+## Entry format
+
+Each entry has a type tag, a location/label, and verbatim content. Keep entries concise — prefer exact snippets over prose summaries.
+
+```markdown
+# Session Memory
+_Updated: 2026-03-13 · task: fix auth token refresh race_
+
+## [PATCH] src/auth.rs:47
+```diff
+ if decoded.exp < Utc::now().timestamp() + 300 {
++    cache::invalidate(&decoded.sub);
+     let new_token = generate_token(&decoded.sub)?;
+```
+
+## [TEST] cargo test auth:: — 14 tests
+BEFORE: test_concurrent_refresh FAILED (assertion: old_token_invalid)
+AFTER:  all 14 passed ✅
+
+## [FILE] src/auth.rs — refresh_token() signature
+pub fn refresh_token(token: &str) -> Result<Token>
+Bug was at line 47: cache::set() called before cache::invalidate().
+
+## [DECISION] src/api/mobile.rs — no change needed
+mobile.rs:89 calls auth::refresh_token() directly → picks up fix automatically.
+Checked: web.rs:67 also confirmed in scope, same conclusion.
+
+## [DECISION] regression test added
+src/auth_test.rs: test_token_invalidated_on_concurrent_refresh
+Uses user_42, asserts cache::get("user_42") != original token after concurrent refresh.
+```
+
+### Entry types
+
+| Tag | Use for |
+|---|---|
+| `[PATCH]` | Exact diff hunks — the most critical to preserve |
+| `[TEST]` | Test suite results, before/after state |
+| `[FILE]` | Key function signatures, line numbers, relevant snippets |
+| `[DECISION]` | Scoping decisions, things explicitly ruled out |
+| `[CMD]` | Command output that informed a decision |
+| `[STATE]` | Current status of a multi-step task |
+
+---
+
+## When to read
+
+Read `.claude/session-memory.md` at the start of **every** turn after these events:
+
+- **Session start** — always read first before touching any files
+- **After compaction** — your history was replaced; this file is your ground truth
+- **When uncertain** — if you're about to re-run a test or re-read a file, check whether the result is already saved
+
+If the file doesn't exist, note that no checkpoint has been written yet and proceed normally.
+
+---
+
+## Maintenance
+
+Keep the file lean to avoid inflating your own context:
+
+- **Token budget**: aim for < 2,000 tokens total
+- **Prune on write**: when adding a new entry, remove entries that are no longer relevant (completed subtasks, superseded decisions)
+- **One file per task**: when starting a new unrelated task, archive or clear the file
+- **Verbatim over verbose**: a 3-line diff is more useful than a 3-paragraph description of what the diff does
+
+---
+
+## Compaction warning
+
+When you see the system message:
+
+> *"Heads up: Long threads and multiple compactions can cause the model to be less accurate."*
+
+This means compaction just happened. **Immediately read `.claude/session-memory.md`** and confirm your understanding of the current task state before continuing.
+
+---
+
+## Example workflow
+
+```
+User: fix the auth token refresh bug
+You:  [read .claude/session-memory.md — file doesn't exist yet, start fresh]
+      [read src/auth.rs]
+      → write [FILE] entry with the function signature and bug location
+
+      [run cargo test auth::]
+      → write [TEST] entry with BEFORE result
+
+      [apply patch]
+      → write [PATCH] entry with exact diff
+
+      [run cargo test auth:: again]
+      → update [TEST] entry with AFTER result
+
+      [grep mobile.rs]
+      → write [DECISION] entry: no change needed
+
+      <<< compaction happens here — tool outputs are gone >>>
+
+      [read .claude/session-memory.md — checkpoint restored]
+      You now know: what was fixed, at what line, that tests pass, that mobile.rs is clear
+      Continue task without re-reading files you already processed.
+```


### PR DESCRIPTION
## Summary

Adds **session-memory** — a skill that preserves critical technical facts across context compaction and session restarts, with zero dependencies.

## The problem

Context compaction silently discards all tool outputs. In a typical coding session, tool results (file reads, test output, patches) account for **~79% of session tokens but 0% survive compaction**. After compaction, the model may forget which file was modified, what the test result was, or which paths were already checked.

This was quantified empirically ([openai/codex#14589](https://github.com/openai/codex/issues/14589)):

- Original session: 1,670 tokens (100%)
- After 1st compaction: 229 tokens (**13.7% retained**)
- After 2nd compaction: 115 tokens (**6.9% retained**)

5 critical technical facts tracked: 2/5 survived first compaction, **0/5 survived second**.

## How this skill helps

Teaches Claude to proactively write a structured checkpoint to `.claude/session-memory.md` **before** compaction occurs — then read it back immediately after. No external tools required.

## Differentiators from existing PRs

- **vs shodh-memory (#154)**: zero dependencies vs external MCP server + npm package
- **vs record-knowledge (#521)**: adds compaction-aware timing + structured recall protocol, not just write-only
- **Unique**: explicitly teaches Claude *when* to write (approaching context limit, after each patch/test) and *when* to read (after compaction system message)

## Files

- `SKILL.md` — behavioral instructions for Claude (6 entry types, compaction triggers, recall protocol, token budget)
- `README.md` — user installation guide with background
- `LICENSE.txt` — MIT

## Checklist

- [x] SKILL.md with proper YAML frontmatter
- [x] README.md with installation instructions
- [x] MIT license
- [x] Zero external dependencies
- [x] Compaction-aware trigger and recall logic
