### PR TITLE
Add google-maps skill: 17 geospatial tools for AI agents

### DIFF
--- a/skills/google-maps/LICENSE.txt
+++ b/skills/google-maps/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 CabLate
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/google-maps/SKILL.md
+++ b/skills/google-maps/SKILL.md
@@ -1,74 +1,94 @@
 ---
 name: google-maps
-description: Geospatial query capabilities — geocoding, nearby search, routing, place details, elevation. Trigger when the user mentions locations, addresses, coordinates, navigation, "what's nearby", "how to get there", distance/duration, or any question involving geographic information.
+description: Geospatial query capabilities — geocoding, nearby search, routing, place details, elevation, weather, air quality, and map visualization. Trigger when the user mentions locations, addresses, coordinates, navigation, "what's nearby", "how to get there", distance/duration, or any question that inherently involves geographic information — even if they don't explicitly say "map".
 license: Complete terms in LICENSE.txt
 ---
 
 # Google Maps - Geospatial Query Capabilities
 
+## Overview
+
 Gives an AI Agent the ability to reason about physical space — understand locations, distances, routes, and elevation, and naturally weave that information into conversation.
 
-## Prerequisites
+Without this Skill, the agent can only guess or refuse when asked "how do I get from Taipei 101 to the National Palace Museum?". With it, the agent returns exact coordinates, step-by-step routes, and travel times.
 
-```bash
-npm install -g @cablate/mcp-google-map
-```
+---
 
-Set `GOOGLE_MAPS_API_KEY` environment variable (get one at https://console.cloud.google.com).
+## Core Principles
+
+| Principle | Explanation |
+|-----------|-------------|
+| Chain over single-shot | Most geo questions require 2-5 tool calls chained together. See Scenario Recipes in references/tools-api.md for the full patterns. |
+| Match recipe to intent | Map the user's question to a recipe (Trip Planning, Local Discovery, Route Comparison, Neighborhood Analysis, Multi-Stop, Place Comparison, Along the Route) before calling any tool. |
+| Precise input saves trouble | Use coordinates over address strings when available. Use place_id over name search. More precise input = more reliable output. |
+| Output is structured | Every tool returns JSON. Use it directly for downstream computation or comparison — no extra parsing needed. |
+| Present as tables | Users prefer comparison tables and scorecards over raw JSON. Format results for readability. |
+
+---
 
 ## Tool Map
 
-8 tools in three categories — pick by scenario:
+17 tools in five categories — pick by scenario:
 
 ### Place Discovery
 | Tool | When to use | Example |
 |------|-------------|---------|
-| `geocode` | Have an address/landmark, need coordinates | "Coordinates of Tokyo Tower?" |
+| `geocode` | Have an address/landmark, need coordinates | "What are the coordinates of Tokyo Tower?" |
 | `reverse-geocode` | Have coordinates, need an address | "What's at 35.65, 139.74?" |
 | `search-nearby` | Know a location, find nearby places by type | "Coffee shops near my hotel" |
 | `search-places` | Natural language place search | "Best ramen in Tokyo" |
-| `place-details` | Have a place_id, need full info | "Opening hours for this restaurant?" |
+| `place-details` | Have a place_id, need full info | "Opening hours and reviews for this restaurant?" |
+| `batch-geocode` | Geocode multiple addresses at once (max 50) | "Get coordinates for all these offices" |
 
 ### Routing & Distance
 | Tool | When to use | Example |
 |------|-------------|---------|
 | `directions` | How to get from A to B | "Route from Taipei Main Station to the airport" |
-| `distance-matrix` | Compare distances across multiple points | "Which hotel is closest to the airport?" |
+| `distance-matrix` | Compare distances across multiple points | "Which of these 3 hotels is closest to the airport?" |
+| `search-along-route` | Find places along a route (meals, stops) ranked by detour time | "Restaurants between Fushimi Inari and Kiyomizu-dera" |
 
-### Terrain
+### Environment
 | Tool | When to use | Example |
 |------|-------------|---------|
-| `elevation` | Query altitude | "Elevation along this hiking trail" |
+| `elevation` | Query altitude | "Elevation profile along this hiking trail" |
+| `timezone` | Need local time at a destination | "What time is it in Tokyo?" |
+| `weather` | Weather at a location (current or forecast) | "What's the weather in Paris?" |
+| `air-quality` | AQI, pollutants, health recommendations | "Is the air safe for jogging?" |
+
+### Visualization
+| Tool | When to use | Example |
+|------|-------------|---------|
+| `static-map` | Show locations/routes on a map image | "Show me these places on a map" |
+
+### Composite (one-call shortcuts)
+| Tool | When to use | Example |
+|------|-------------|---------|
+| `explore-area` | Overview of a neighborhood | "What's around Tokyo Tower?" |
+| `plan-route` | Multi-stop optimized itinerary | "Visit these 5 places efficiently" |
+| `compare-places` | Side-by-side comparison | "Which ramen shop near Shibuya?" |
+
+---
 
 ## Invocation
 
 ```bash
-# As MCP server (stdio)
-npx @cablate/mcp-google-map --stdio
-
-# Standalone CLI
-npx @cablate/mcp-google-map exec geocode '{"address":"Tokyo Tower"}'
-npx @cablate/mcp-google-map exec search-places '{"query":"ramen in Tokyo"}'
+npx @cablate/mcp-google-map exec <tool> '<json_params>' [-k API_KEY]
 ```
 
-## Common Chaining Patterns
+- **API Key**: `-k` flag or `GOOGLE_MAPS_API_KEY` environment variable
+- **Output**: JSON to stdout, errors to stderr
+- **Stateless**: each call is independent
 
-Most geo questions need 2-5 tool calls chained together:
+---
 
-**Search then Details** — find places, then get full info:
-```
-search-places → place-details (use place_id from results)
-```
+## Reference
 
-**Geocode then Explore** — turn address into coordinates, then search nearby:
-```
-geocode → search-nearby (use coordinates from geocode)
-```
+| File | Content | When to read |
+|------|---------|--------------|
+| `references/tools-api.md` | Full parameter specs, response formats, 7 scenario recipes, and decision guide | When you need exact parameters, response shapes, or multi-tool workflow patterns |
+| `references/travel-planning.md` | Travel planning methodology — 6-layer model, Search Along Route, anti-patterns | When planning multi-day trips — **read before Recipe 1** |
 
-**Multi-point Comparison** — compare travel options:
-```
-geocode (all points) → distance-matrix → directions (for best route)
-```
+---
 
 ## Source
 

--- a/skills/google-maps/SKILL.md
+++ b/skills/google-maps/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: google-maps
+description: Geospatial query capabilities — geocoding, nearby search, routing, place details, elevation. Trigger when the user mentions locations, addresses, coordinates, navigation, "what's nearby", "how to get there", distance/duration, or any question involving geographic information.
+license: Complete terms in LICENSE.txt
+---
+
+# Google Maps - Geospatial Query Capabilities
+
+Gives an AI Agent the ability to reason about physical space — understand locations, distances, routes, and elevation, and naturally weave that information into conversation.
+
+## Prerequisites
+
+```bash
+npm install -g @cablate/mcp-google-map
+```
+
+Set `GOOGLE_MAPS_API_KEY` environment variable (get one at https://console.cloud.google.com).
+
+## Tool Map
+
+8 tools in three categories — pick by scenario:
+
+### Place Discovery
+| Tool | When to use | Example |
+|------|-------------|---------|
+| `geocode` | Have an address/landmark, need coordinates | "Coordinates of Tokyo Tower?" |
+| `reverse-geocode` | Have coordinates, need an address | "What's at 35.65, 139.74?" |
+| `search-nearby` | Know a location, find nearby places by type | "Coffee shops near my hotel" |
+| `search-places` | Natural language place search | "Best ramen in Tokyo" |
+| `place-details` | Have a place_id, need full info | "Opening hours for this restaurant?" |
+
+### Routing & Distance
+| Tool | When to use | Example |
+|------|-------------|---------|
+| `directions` | How to get from A to B | "Route from Taipei Main Station to the airport" |
+| `distance-matrix` | Compare distances across multiple points | "Which hotel is closest to the airport?" |
+
+### Terrain
+| Tool | When to use | Example |
+|------|-------------|---------|
+| `elevation` | Query altitude | "Elevation along this hiking trail" |
+
+## Invocation
+
+```bash
+# As MCP server (stdio)
+npx @cablate/mcp-google-map --stdio
+
+# Standalone CLI
+npx @cablate/mcp-google-map exec geocode '{"address":"Tokyo Tower"}'
+npx @cablate/mcp-google-map exec search-places '{"query":"ramen in Tokyo"}'
+```
+
+## Common Chaining Patterns
+
+Most geo questions need 2-5 tool calls chained together:
+
+**Search then Details** — find places, then get full info:
+```
+search-places → place-details (use place_id from results)
+```
+
+**Geocode then Explore** — turn address into coordinates, then search nearby:
+```
+geocode → search-nearby (use coordinates from geocode)
+```
+
+**Multi-point Comparison** — compare travel options:
+```
+geocode (all points) → distance-matrix → directions (for best route)
+```
+
+## Source
+
+- GitHub: https://github.com/cablate/mcp-google-map
+- npm: https://www.npmjs.com/package/@cablate/mcp-google-map

--- a/skills/google-maps/SKILL.md
+++ b/skills/google-maps/SKILL.md
@@ -33,39 +33,49 @@ Without this Skill, the agent can only guess or refuse when asked "how do I get 
 ### Place Discovery
 | Tool | When to use | Example |
 |------|-------------|---------|
-| `geocode` | Have an address/landmark, need coordinates | "What are the coordinates of Tokyo Tower?" |
-| `reverse-geocode` | Have coordinates, need an address | "What's at 35.65, 139.74?" |
-| `search-nearby` | Know a location, find nearby places by type | "Coffee shops near my hotel" |
-| `search-places` | Natural language place search | "Best ramen in Tokyo" |
-| `place-details` | Have a place_id, need full info | "Opening hours and reviews for this restaurant?" |
-| `batch-geocode` | Geocode multiple addresses at once (max 50) | "Get coordinates for all these offices" |
+| `maps_geocode` | Have an address/landmark, need coordinates | "What are the coordinates of Tokyo Tower?" |
+| `maps_reverse_geocode` | Have coordinates, need an address | "What's at 35.65, 139.74?" |
+| `maps_search_nearby` | Know a location, find nearby places by type | "Coffee shops near my hotel" |
+| `maps_search_places` | Natural language place search | "Best ramen in Tokyo" |
+| `maps_place_details` | Have a place_id, need full info | "Opening hours and reviews for this restaurant?" |
+| `maps_batch_geocode` | Geocode multiple addresses at once (max 50) | "Get coordinates for all these offices" |
 
 ### Routing & Distance
 | Tool | When to use | Example |
 |------|-------------|---------|
-| `directions` | How to get from A to B | "Route from Taipei Main Station to the airport" |
-| `distance-matrix` | Compare distances across multiple points | "Which of these 3 hotels is closest to the airport?" |
-| `search-along-route` | Find places along a route (meals, stops) ranked by detour time | "Restaurants between Fushimi Inari and Kiyomizu-dera" |
+| `maps_directions` | How to get from A to B | "Route from Taipei Main Station to the airport" |
+| `maps_distance_matrix` | Compare distances across multiple points | "Which of these 3 hotels is closest to the airport?" |
+| `maps_search_along_route` | Find places along a route (meals, stops) ranked by detour time | "Restaurants between Fushimi Inari and Kiyomizu-dera" |
 
 ### Environment
 | Tool | When to use | Example |
 |------|-------------|---------|
-| `elevation` | Query altitude | "Elevation profile along this hiking trail" |
-| `timezone` | Need local time at a destination | "What time is it in Tokyo?" |
-| `weather` | Weather at a location (current or forecast) | "What's the weather in Paris?" |
-| `air-quality` | AQI, pollutants, health recommendations | "Is the air safe for jogging?" |
+| `maps_elevation` | Query altitude | "Elevation profile along this hiking trail" |
+| `maps_timezone` | Need local time at a destination | "What time is it in Tokyo?" |
+| `maps_weather` | Weather at a location (current or forecast) | "What's the weather in Paris?" |
+| `maps_air_quality` | AQI, pollutants, health recommendations | "Is the air safe for jogging?" |
 
 ### Visualization
 | Tool | When to use | Example |
 |------|-------------|---------|
-| `static-map` | Show locations/routes on a map image | "Show me these places on a map" |
+| `maps_static_map` | Show locations/routes on a map image | "Show me these places on a map" |
 
 ### Composite (one-call shortcuts)
 | Tool | When to use | Example |
 |------|-------------|---------|
-| `explore-area` | Overview of a neighborhood | "What's around Tokyo Tower?" |
-| `plan-route` | Multi-stop optimized itinerary | "Visit these 5 places efficiently" |
-| `compare-places` | Side-by-side comparison | "Which ramen shop near Shibuya?" |
+| `maps_explore_area` | Overview of a neighborhood | "What's around Tokyo Tower?" |
+| `maps_plan_route` | Multi-stop optimized itinerary | "Visit these 5 places efficiently" |
+| `maps_compare_places` | Side-by-side comparison | "Which ramen shop near Shibuya?" |
+
+---
+
+## Known API Limitations
+
+| Tool | Limitation | Workaround |
+|------|-----------|------------|
+| `maps_weather` | Unsupported regions: Japan, China, South Korea, Cuba, Iran, North Korea, Syria | Use web search for weather in these regions |
+| `maps_distance_matrix` | Transit mode returns null in some regions (notably Japan) | Fall back to `driving` or `walking` mode |
+| `maps_air_quality` | Works globally including Japan (unlike weather) | — |
 
 ---
 
@@ -78,6 +88,7 @@ npx @cablate/mcp-google-map exec <tool> '<json_params>' [-k API_KEY]
 - **API Key**: `-k` flag or `GOOGLE_MAPS_API_KEY` environment variable
 - **Output**: JSON to stdout, errors to stderr
 - **Stateless**: each call is independent
+- **Tool names**: CLI accepts both `maps_geocode` and `geocode` short forms
 
 ---
 

--- a/skills/google-maps/references/tools-api.md
+++ b/skills/google-maps/references/tools-api.md
@@ -1,0 +1,604 @@
+# Google Maps Tools - Parameter & Response Reference
+
+## geocode
+
+Convert an address or landmark name to GPS coordinates.
+
+```bash
+exec geocode '{"address": "Tokyo Tower"}'
+```
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| address | string | yes | Address or landmark name |
+
+Response:
+```json
+{
+  "success": true,
+  "data": {
+    "location": { "lat": 35.6585805, "lng": 139.7454329 },
+    "formatted_address": "4-chome-2-8 Shibakoen, Minato City, Tokyo 105-0011, Japan",
+    "place_id": "ChIJCewJkL2LGGAR3Qmk0vCTGkg"
+  }
+}
+```
+
+---
+
+## batch-geocode
+
+Geocode multiple addresses in one call (max 50).
+
+```bash
+exec batch-geocode-tool '{"addresses": ["Tokyo Tower", "Eiffel Tower", "Statue of Liberty"]}'
+```
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| addresses | string[] | yes | List of addresses or landmarks (max 50) |
+
+Response:
+```json
+{
+  "total": 3,
+  "succeeded": 3,
+  "failed": 0,
+  "results": [
+    { "address": "Tokyo Tower", "success": true, "data": { "location": { "lat": 35.658, "lng": 139.745 }, "formatted_address": "..." } },
+    ...
+  ]
+}
+```
+
+---
+
+## reverse-geocode
+
+Convert GPS coordinates to a street address.
+
+```bash
+exec reverse-geocode '{"latitude": 35.6586, "longitude": 139.7454}'
+```
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| latitude | number | yes | Latitude |
+| longitude | number | yes | Longitude |
+
+Response:
+```json
+{
+  "success": true,
+  "data": {
+    "formatted_address": "...",
+    "place_id": "ChIJ...",
+    "address_components": [...]
+  }
+}
+```
+
+---
+
+## search-nearby
+
+Find places near a location by type.
+
+```bash
+exec search-nearby '{"center": {"value": "35.6586,139.7454", "isCoordinates": true}, "keyword": "restaurant", "radius": 500}'
+```
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| center | object | yes | `{ value: string, isCoordinates: boolean }` — address or `lat,lng` |
+| keyword | string | no | Place type (restaurant, cafe, hotel, gas_station, hospital, etc.) |
+| radius | number | no | Search radius in meters (default: 1000) |
+| openNow | boolean | no | Only show currently open places |
+| minRating | number | no | Minimum rating (0-5) |
+
+Response: `{ success, location, data: [{ name, place_id, formatted_address, geometry, rating, user_ratings_total, opening_hours }] }`
+
+---
+
+## search-places
+
+Free-text place search. More flexible than search-nearby.
+
+```bash
+exec search-places '{"query": "ramen in Tokyo"}'
+```
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| query | string | yes | Natural language search query |
+| locationBias | object | no | `{ latitude, longitude, radius? }` to bias results toward |
+| openNow | boolean | no | Only show currently open places |
+| minRating | number | no | Minimum rating (1.0-5.0) |
+| includedType | string | no | Place type filter |
+
+Response: `{ success, data: [{ name, place_id, address, location, rating, total_ratings, open_now }] }`
+
+---
+
+## place-details
+
+Get full details for a place by its place_id (from search results). Returns reviews, phone, website, hours, photos.
+
+```bash
+exec place-details '{"placeId": "ChIJCewJkL2LGGAR3Qmk0vCTGkg"}'
+```
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| placeId | string | yes | Google Maps place ID (from search results) |
+
+---
+
+## directions
+
+Get step-by-step navigation between two points.
+
+```bash
+exec directions '{"origin": "Tokyo Tower", "destination": "Shibuya Station", "mode": "transit"}'
+```
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| origin | string | yes | Starting point (address or landmark) |
+| destination | string | yes | End point (address or landmark) |
+| mode | string | no | Travel mode: driving, walking, bicycling, transit |
+| departure_time | string | no | Departure time (ISO 8601 or "now") |
+| arrival_time | string | no | Desired arrival time (transit only) |
+
+---
+
+## distance-matrix
+
+Calculate travel distances and times between multiple origins and destinations.
+
+```bash
+exec distance-matrix '{"origins": ["Tokyo Tower"], "destinations": ["Shibuya Station", "Shinjuku Station"], "mode": "driving"}'
+```
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| origins | string[] | yes | List of origin addresses |
+| destinations | string[] | yes | List of destination addresses |
+| mode | string | no | Travel mode: driving, walking, bicycling, transit |
+
+---
+
+## elevation
+
+Get elevation data for geographic coordinates.
+
+```bash
+exec elevation '{"locations": [{"latitude": 35.6586, "longitude": 139.7454}]}'
+```
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| locations | object[] | yes | Array of `{ latitude, longitude }` |
+
+Response:
+```json
+[{ "elevation": 17.23, "location": { "lat": 35.6586, "lng": 139.7454 }, "resolution": 610.81 }]
+```
+
+---
+
+## timezone
+
+Get timezone and local time for coordinates.
+
+```bash
+exec timezone '{"latitude": 35.6586, "longitude": 139.7454}'
+```
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| latitude | number | yes | Latitude |
+| longitude | number | yes | Longitude |
+| timestamp | number | no | Unix timestamp in ms (defaults to now) |
+
+Response:
+```json
+{ "timeZoneId": "Asia/Tokyo", "timeZoneName": "Japan Standard Time", "utcOffset": 32400, "dstOffset": 0, "localTime": "2026-03-14T16:19:16.000" }
+```
+
+---
+
+## weather
+
+Get current weather or forecast. Coverage: most regions, but China, Japan, South Korea, Cuba, Iran, North Korea, Syria are unsupported.
+
+```bash
+exec weather '{"latitude": 37.4220, "longitude": -122.0841}'
+exec weather '{"latitude": 37.4220, "longitude": -122.0841, "type": "forecast_daily", "forecastDays": 3}'
+```
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| latitude | number | yes | Latitude |
+| longitude | number | yes | Longitude |
+| type | string | no | `current` (default), `forecast_daily`, `forecast_hourly` |
+| forecastDays | number | no | 1-10, for forecast_daily (default: 5) |
+| forecastHours | number | no | 1-240, for forecast_hourly (default: 24) |
+
+---
+
+## air-quality
+
+Get air quality index, pollutant concentrations, and health recommendations for a location.
+
+```bash
+exec air-quality '{"latitude": 35.6762, "longitude": 139.6503}'
+exec air-quality '{"latitude": 35.6762, "longitude": 139.6503, "includePollutants": true}'
+```
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| latitude | number | yes | Latitude |
+| longitude | number | yes | Longitude |
+| includeHealthRecommendations | boolean | no | Health advice per demographic group (default: true) |
+| includePollutants | boolean | no | Individual pollutant concentrations (default: false) |
+
+Response:
+```json
+{
+  "aqi": 76,
+  "category": "Good",
+  "dominantPollutant": "pm25",
+  "healthRecommendations": {
+    "generalPopulation": "...",
+    "elderly": "...",
+    "lungDiseasePopulation": "...",
+    "heartDiseasePopulation": "...",
+    "athletes": "...",
+    "pregnantWomen": "...",
+    "children": "..."
+  }
+}
+```
+
+Chaining: `geocode` → `air-quality` when the user gives an address instead of coordinates.
+
+---
+
+## static-map
+
+Generate a map image with markers, paths, or routes. Returns an inline PNG image.
+
+```bash
+exec static-map '{"center": "Tokyo Tower", "zoom": 14}'
+exec static-map '{"markers": ["color:red|label:A|35.6586,139.7454", "color:blue|label:B|35.6595,139.7006"]}'
+exec static-map '{"markers": ["color:red|35.6586,139.7454"], "maptype": "satellite", "zoom": 16}'
+```
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| center | string | no | "lat,lng" or address. Optional if markers/path provided. |
+| zoom | number | no | 0-21 (auto-fit if omitted) |
+| size | string | no | "WxH" pixels. Default: "600x400". Max: "640x640" |
+| maptype | string | no | roadmap, satellite, terrain, hybrid. Default: roadmap |
+| markers | string[] | no | Marker descriptors: "color:red\|label:A\|lat,lng" |
+| path | string[] | no | Path descriptors: "color:0x0000ff\|weight:3\|lat1,lng1\|lat2,lng2" |
+
+Response: MCP image content (inline PNG) + size metadata.
+
+Chaining patterns:
+- `search-nearby` → `static-map` (mark found places on map)
+- `plan-route` / `directions` → `static-map` (draw the route with path + markers)
+- `explore-area` → `static-map` (visualize neighborhood search results)
+- `compare-places` → `static-map` (show compared places side by side)
+
+---
+
+## search-along-route
+
+Search for places along a route between two points. Results ranked by minimal detour time — perfect for finding meals, cafes, or attractions "on the way" between landmarks.
+
+```bash
+exec search-along-route '{"textQuery": "restaurant", "origin": "Fushimi Inari, Kyoto", "destination": "Kiyomizu-dera, Kyoto", "mode": "walking"}'
+```
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| textQuery | string | yes | What to search for ("restaurant", "cafe", "temple") |
+| origin | string | yes | Route start point |
+| destination | string | yes | Route end point |
+| mode | string | no | walking, driving, bicycling, transit (default: walking) |
+| maxResults | number | no | Max results (default: 5, max: 20) |
+
+Response:
+```json
+{
+  "places": [
+    { "name": "SUSHI MATSUHIRO", "rating": 5.0, "location": { "lat": 34.968, "lng": 135.771 } }
+  ],
+  "route": { "distance": "4.0 km", "duration": "58 mins", "polyline": "..." }
+}
+```
+
+Key for trip planning: use this between consecutive anchors to find **along-the-way** stops instead of searching at endpoints.
+
+---
+
+## explore-area (composite)
+
+Explore a neighborhood in one call. Internally chains geocode → search-nearby (per type) → place-details (top N).
+
+```bash
+exec explore-area '{"location": "Tokyo Tower", "types": ["restaurant", "cafe"], "topN": 2}'
+```
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| location | string | yes | Address or landmark |
+| types | string[] | no | Place types to search (default: restaurant, cafe, attraction) |
+| radius | number | no | Search radius in meters (default: 1000) |
+| topN | number | no | Top results per type to get details for (default: 3) |
+
+---
+
+## plan-route (composite)
+
+Plan an optimized multi-stop route. Internally chains geocode → distance-matrix → nearest-neighbor → directions.
+
+```bash
+exec plan-route '{"stops": ["Tokyo Tower", "Shibuya Station", "Shinjuku Station", "Ueno Park"], "mode": "driving"}'
+```
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| stops | string[] | yes | Addresses or landmarks (min 2) |
+| mode | string | no | driving, walking, bicycling, transit (default: driving) |
+| optimize | boolean | no | Auto-optimize visit order (default: true) |
+
+---
+
+## compare-places (composite)
+
+Compare places side-by-side. Internally chains search-places → place-details → distance-matrix.
+
+```bash
+exec compare-places '{"query": "ramen near Shibuya", "limit": 3}'
+```
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| query | string | yes | Search query |
+| userLocation | object | no | `{ latitude, longitude }` — adds distance/drive time |
+| limit | number | no | Max places to compare (default: 5) |
+
+---
+
+## Chaining Patterns
+
+### Basic Patterns
+
+**Search → Details** — Find places, then get full info on the best ones.
+```
+search-places {"query":"Michelin restaurants in Taipei"}
+place-details {"placeId":"ChIJ..."}  ← use place_id from results
+```
+
+**Geocode → Nearby** — Turn a landmark into coordinates, then explore the area.
+```
+geocode {"address":"Taipei 101"}
+search-nearby {"center":{"value":"25.033,121.564","isCoordinates":true},"keyword":"cafe","radius":500}
+```
+
+**Multi-point Comparison** — Compare distances across multiple origins and destinations in one call.
+```
+distance-matrix {"origins":["Taipei Main Station","Banqiao Station"],"destinations":["Taoyuan Airport","Songshan Airport"],"mode":"driving"}
+```
+
+**Geocode → Air Quality** — Check air quality at a named location.
+```
+geocode {"address":"Tokyo"}
+air-quality {"latitude":35.6762,"longitude":139.6503}
+```
+
+**Search → Map** — Find places, then show them on a map.
+```
+search-nearby {"center":{"value":"35.6586,139.7454","isCoordinates":true},"keyword":"cafe","radius":500}
+static-map {"markers":["color:red|label:1|lat1,lng1","color:red|label:2|lat2,lng2"]}
+```
+
+**Directions → Map** — Get a route, then visualize it.
+```
+directions {"origin":"Tokyo Tower","destination":"Shibuya Station","mode":"walking"}
+static-map {"path":["color:0x4285F4|weight:4|lat1,lng1|lat2,lng2|..."],"markers":["color:green|label:A|origin","color:red|label:B|dest"]}
+```
+
+---
+
+## Scenario Recipes
+
+Use these recipes when the user's question maps to a multi-step workflow. Think of each recipe as a **decision tree**, not a script — adapt based on what the user actually needs.
+
+### Recipe 1: Trip Planning ("Plan a day in Tokyo")
+
+This is the most common complex scenario. The goal is a time-ordered itinerary with routes between stops.
+
+> **Read `references/travel-planning.md` first** — it contains the full methodology, anti-patterns, and time budget guidelines.
+
+**Steps:**
+1. `search-places` — Search "top attractions in {city}" → geographically diverse **anchor points**
+2. **Design arcs** — Group nearby anchors into same-day arcs. One direction per day (south→north).
+3. `search-along-route` — Between each pair of anchors, find restaurants/cafes **along the walking route** (ranked by minimal detour)
+4. `place-details` — Get ratings, hours for top candidates
+5. `plan-route` — Validate each day's route. Use `optimize: false` (you already know the geographic order).
+6. `weather` + `air-quality` — Adjust for conditions
+7. `static-map` — **Always** visualize each day with numbered markers + path
+
+**Key decisions:**
+- **Use `search-along-route` for meals and breaks** — not explore_area or search_nearby. Along-route results are on the path, not random nearby points.
+- **Never backtrack**: stops progress in one direction per day.
+- Alternate activity types: temple → food → walk → shrine → cafe.
+- Budget 5-7 stops per day max. Major temples = 90-120 min.
+- Edge landmarks (geographically isolated) go at start or end of a day.
+- **Always generate a map** for each day.
+
+**Example flow (Kyoto 2-day):**
+```
+search_places("top attractions in Kyoto")
+→ Fushimi Inari(south), Kiyomizu(east), Kinkaku-ji(north), Arashiyama(west)
+
+Day 1 arc: south→center — Fushimi → Kiyomizu → Gion → Pontocho
+Day 2 arc: center→west — Nishiki → Nijo Castle → Arashiyama
+
+search_along_route("restaurant", "Fushimi Inari", "Kiyomizu-dera", "walking")
+→ finds lunch options ALONG the 4km route (not at endpoints)
+
+search_along_route("kaiseki restaurant", "Gion, Kyoto", "Arashiyama, Kyoto")
+→ finds dinner along the afternoon route
+
+plan_route(Day 1 stops, optimize:false) → static_map(Day 1)
+plan_route(Day 2 stops, optimize:false) → static_map(Day 2)
+```
+
+**Example output:**
+```
+Day 1: South → Center arc
+  08:30 Fushimi Inari (90 min) → 25 min transit
+  10:30 Kiyomizu-dera (90 min) → walk down Sannen-zaka
+  12:30 [along-route find] Gion lunch ★4.7 (75 min)
+  14:00 Yasaka Shrine (30 min) → 15 min walk
+  14:45 Pontocho stroll + cafe (45 min)
+  17:30 Dinner near Kawaramachi
+[map with markers 1-6 and walking path]
+```
+
+---
+
+### Recipe 2: "What's nearby?" / Local Discovery
+
+User asks about places around a location. May or may not specify what type.
+
+**Steps:**
+1. `geocode` — Resolve the location (skip if user gave coordinates)
+2. `search-nearby` — Search with keyword + radius. Use `openNow: true` if the user implies "right now"
+3. `place-details` — Get details for the top 3-5 results (ratings, reviews, hours)
+
+**Key decisions:**
+- If no keyword specified, search multiple types: restaurant, cafe, attraction
+- Use `minRating: 4.0` by default unless the user wants comprehensive results
+- Sort results by rating × review count, not just rating alone
+
+---
+
+### Recipe 3: Route Comparison ("Best way to get from A to B")
+
+User wants to compare travel options between two points.
+
+**Steps:**
+1. `directions` with `mode: "driving"` — Get driving route
+2. `directions` with `mode: "transit"` — Get transit route
+3. `directions` with `mode: "walking"` — Get walking route (if distance < 5 km)
+
+**Present as comparison table:**
+```
+| Mode    | Duration | Distance | Notes            |
+|---------|----------|----------|------------------|
+| Driving | 25 min   | 12.3 km  | Via Highway 1    |
+| Transit | 35 min   | —        | Metro Line 2     |
+| Walking | 2h 10min | 10.1 km  | Not recommended  |
+```
+
+---
+
+### Recipe 4: Neighborhood Analysis ("Is this a good area?")
+
+User wants to evaluate a location for living, working, or investing.
+
+**Steps:**
+1. `geocode` — Resolve the address
+2. `search-nearby` — Run multiple searches from the same center:
+   - `keyword: "school"` radius 2000
+   - `keyword: "hospital"` radius 3000
+   - `keyword: "supermarket"` radius 1000
+   - `keyword: "restaurant"` radius 500
+   - `keyword: "park"` radius 1000
+3. `distance-matrix` — Calculate commute time to important locations (office, airport, city center)
+4. `elevation` — Check if the area is in a low-elevation flood zone
+
+**Present as scorecard:**
+```
+📍 742 Evergreen Terrace
+Schools within 2km: 4 (avg ★4.2)
+Hospitals within 3km: 2
+Supermarkets within 1km: 3
+Commute to downtown: 22 min driving, 35 min transit
+Elevation: 45m (not a flood risk)
+```
+
+---
+
+### Recipe 5: Multi-Stop Route ("Visit these 5 places efficiently")
+
+User has a list of places and wants the optimal visit order.
+
+**Steps:**
+1. `geocode` — Resolve all addresses to coordinates
+2. `distance-matrix` — Calculate NxN matrix (all origins × all destinations)
+3. Use the matrix to determine the nearest-neighbor route order
+4. `directions` — Generate route for the final order (chain waypoints)
+
+**Key decisions:**
+- For ≤ 5 stops, nearest-neighbor heuristic is good enough
+- For the `directions` call, set origin = first stop, destination = last stop, and mention intermediate stops in conversation
+- If the user says "return to start", plan a round trip
+
+---
+
+### Recipe 6: Place Comparison ("Which restaurant should I pick?")
+
+User is choosing between specific places.
+
+**Steps:**
+1. `search-places` — Find each place (or use place_id if already known)
+2. `place-details` — Get full details for each candidate
+3. `distance-matrix` — Calculate distance from user's location to each candidate
+
+**Present as comparison:**
+```
+| Restaurant | Rating | Reviews | Distance | Price | Open Now |
+|-----------|--------|---------|----------|-------|----------|
+| Sushi Dai  | ★4.6   | 2,340   | 1.2 km   | $$   | Yes      |
+| Tsukiji    | ★4.3   | 890     | 0.8 km   | $    | Yes      |
+| Omakase    | ★4.8   | 156     | 3.1 km   | $$$$ | No       |
+```
+
+---
+
+### Recipe 7: "Along the Route" Search
+
+User wants to find things along a route (gas stations, rest stops, food).
+
+**Steps:**
+1. `directions` — Get the route first, extract key waypoints from the steps
+2. `search-nearby` — Search near 2-3 midpoints along the route
+3. `place-details` — Get details for top results at each midpoint
+
+**Key decisions:**
+- Extract waypoints at roughly equal intervals along the route
+- Use the `start_location` of route steps at ~1/3 and ~2/3 of the total distance
+- Set `radius` based on road type: 1000m for highways, 500m for city streets
+
+---
+
+## Decision Guide: Which Recipe to Use
+
+| User says... | Recipe | First tool |
+|-------------|--------|------------|
+| "Plan a trip / itinerary / day in X" | Trip Planning | `geocode` |
+| "What's near X / around X" | Local Discovery | `geocode` → `search-nearby` |
+| "How do I get to X" / "route from A to B" | Route Comparison | `directions` |
+| "Is X a good neighborhood" / "analyze this area" | Neighborhood Analysis | `geocode` |
+| "Visit A, B, C, D efficiently" | Multi-Stop Route | `geocode` → `distance-matrix` |
+| "Which X should I pick" / "compare these" | Place Comparison | `search-places` |
+| "Find gas stations on the way to X" | Along the Route | `directions` → `search-nearby` |
+
+---

--- a/skills/google-maps/references/tools-api.md
+++ b/skills/google-maps/references/tools-api.md
@@ -1,11 +1,11 @@
 # Google Maps Tools - Parameter & Response Reference
 
-## geocode
+## maps_geocode
 
 Convert an address or landmark name to GPS coordinates.
 
 ```bash
-exec geocode '{"address": "Tokyo Tower"}'
+exec maps_geocode '{"address": "Tokyo Tower"}'
 ```
 
 | Param | Type | Required | Description |
@@ -26,12 +26,12 @@ Response:
 
 ---
 
-## batch-geocode
+## maps_batch_geocode
 
 Geocode multiple addresses in one call (max 50).
 
 ```bash
-exec batch-geocode-tool '{"addresses": ["Tokyo Tower", "Eiffel Tower", "Statue of Liberty"]}'
+exec maps_batch_geocode '{"addresses": ["Tokyo Tower", "Eiffel Tower", "Statue of Liberty"]}'
 ```
 
 | Param | Type | Required | Description |
@@ -53,12 +53,12 @@ Response:
 
 ---
 
-## reverse-geocode
+## maps_reverse_geocode
 
 Convert GPS coordinates to a street address.
 
 ```bash
-exec reverse-geocode '{"latitude": 35.6586, "longitude": 139.7454}'
+exec maps_reverse_geocode '{"latitude": 35.6586, "longitude": 139.7454}'
 ```
 
 | Param | Type | Required | Description |
@@ -80,12 +80,12 @@ Response:
 
 ---
 
-## search-nearby
+## maps_search_nearby
 
 Find places near a location by type.
 
 ```bash
-exec search-nearby '{"center": {"value": "35.6586,139.7454", "isCoordinates": true}, "keyword": "restaurant", "radius": 500}'
+exec maps_search_nearby '{"center": {"value": "35.6586,139.7454", "isCoordinates": true}, "keyword": "restaurant", "radius": 500}'
 ```
 
 | Param | Type | Required | Description |
@@ -100,12 +100,12 @@ Response: `{ success, location, data: [{ name, place_id, formatted_address, geom
 
 ---
 
-## search-places
+## maps_search_places
 
-Free-text place search. More flexible than search-nearby.
+Free-text place search. More flexible than maps_search_nearby.
 
 ```bash
-exec search-places '{"query": "ramen in Tokyo"}'
+exec maps_search_places '{"query": "ramen in Tokyo"}'
 ```
 
 | Param | Type | Required | Description |
@@ -120,12 +120,12 @@ Response: `{ success, data: [{ name, place_id, address, location, rating, total_
 
 ---
 
-## place-details
+## maps_place_details
 
 Get full details for a place by its place_id (from search results). Returns reviews, phone, website, hours, photos.
 
 ```bash
-exec place-details '{"placeId": "ChIJCewJkL2LGGAR3Qmk0vCTGkg"}'
+exec maps_place_details '{"placeId": "ChIJCewJkL2LGGAR3Qmk0vCTGkg"}'
 ```
 
 | Param | Type | Required | Description |
@@ -134,12 +134,12 @@ exec place-details '{"placeId": "ChIJCewJkL2LGGAR3Qmk0vCTGkg"}'
 
 ---
 
-## directions
+## maps_directions
 
 Get step-by-step navigation between two points.
 
 ```bash
-exec directions '{"origin": "Tokyo Tower", "destination": "Shibuya Station", "mode": "transit"}'
+exec maps_directions '{"origin": "Tokyo Tower", "destination": "Shibuya Station", "mode": "transit"}'
 ```
 
 | Param | Type | Required | Description |
@@ -152,12 +152,14 @@ exec directions '{"origin": "Tokyo Tower", "destination": "Shibuya Station", "mo
 
 ---
 
-## distance-matrix
+## maps_distance_matrix
 
 Calculate travel distances and times between multiple origins and destinations.
 
+> **Known limitation:** Transit mode returns null in some regions (notably Japan). Fall back to `driving` or `walking` mode if transit returns no results.
+
 ```bash
-exec distance-matrix '{"origins": ["Tokyo Tower"], "destinations": ["Shibuya Station", "Shinjuku Station"], "mode": "driving"}'
+exec maps_distance_matrix '{"origins": ["Tokyo Tower"], "destinations": ["Shibuya Station", "Shinjuku Station"], "mode": "driving"}'
 ```
 
 | Param | Type | Required | Description |
@@ -168,12 +170,12 @@ exec distance-matrix '{"origins": ["Tokyo Tower"], "destinations": ["Shibuya Sta
 
 ---
 
-## elevation
+## maps_elevation
 
 Get elevation data for geographic coordinates.
 
 ```bash
-exec elevation '{"locations": [{"latitude": 35.6586, "longitude": 139.7454}]}'
+exec maps_elevation '{"locations": [{"latitude": 35.6586, "longitude": 139.7454}]}'
 ```
 
 | Param | Type | Required | Description |
@@ -187,12 +189,12 @@ Response:
 
 ---
 
-## timezone
+## maps_timezone
 
 Get timezone and local time for coordinates.
 
 ```bash
-exec timezone '{"latitude": 35.6586, "longitude": 139.7454}'
+exec maps_timezone '{"latitude": 35.6586, "longitude": 139.7454}'
 ```
 
 | Param | Type | Required | Description |
@@ -208,13 +210,15 @@ Response:
 
 ---
 
-## weather
+## maps_weather
 
-Get current weather or forecast. Coverage: most regions, but China, Japan, South Korea, Cuba, Iran, North Korea, Syria are unsupported.
+Get current weather or forecast.
+
+> **Known limitation:** Unsupported regions: China, Japan, South Korea, Cuba, Iran, North Korea, Syria. For these regions, use web search as fallback. `maps_air_quality` works in these regions (different API).
 
 ```bash
-exec weather '{"latitude": 37.4220, "longitude": -122.0841}'
-exec weather '{"latitude": 37.4220, "longitude": -122.0841, "type": "forecast_daily", "forecastDays": 3}'
+exec maps_weather '{"latitude": 37.4220, "longitude": -122.0841}'
+exec maps_weather '{"latitude": 37.4220, "longitude": -122.0841, "type": "forecast_daily", "forecastDays": 3}'
 ```
 
 | Param | Type | Required | Description |
@@ -227,13 +231,13 @@ exec weather '{"latitude": 37.4220, "longitude": -122.0841, "type": "forecast_da
 
 ---
 
-## air-quality
+## maps_air_quality
 
 Get air quality index, pollutant concentrations, and health recommendations for a location.
 
 ```bash
-exec air-quality '{"latitude": 35.6762, "longitude": 139.6503}'
-exec air-quality '{"latitude": 35.6762, "longitude": 139.6503, "includePollutants": true}'
+exec maps_air_quality '{"latitude": 35.6762, "longitude": 139.6503}'
+exec maps_air_quality '{"latitude": 35.6762, "longitude": 139.6503, "includePollutants": true}'
 ```
 
 | Param | Type | Required | Description |
@@ -261,18 +265,18 @@ Response:
 }
 ```
 
-Chaining: `geocode` → `air-quality` when the user gives an address instead of coordinates.
+Chaining: `maps_geocode` → `maps_air_quality` when the user gives an address instead of coordinates.
 
 ---
 
-## static-map
+## maps_static_map
 
 Generate a map image with markers, paths, or routes. Returns an inline PNG image.
 
 ```bash
-exec static-map '{"center": "Tokyo Tower", "zoom": 14}'
-exec static-map '{"markers": ["color:red|label:A|35.6586,139.7454", "color:blue|label:B|35.6595,139.7006"]}'
-exec static-map '{"markers": ["color:red|35.6586,139.7454"], "maptype": "satellite", "zoom": 16}'
+exec maps_static_map '{"center": "Tokyo Tower", "zoom": 14}'
+exec maps_static_map '{"markers": ["color:red|label:A|35.6586,139.7454", "color:blue|label:B|35.6595,139.7006"]}'
+exec maps_static_map '{"markers": ["color:red|35.6586,139.7454"], "maptype": "satellite", "zoom": 16}'
 ```
 
 | Param | Type | Required | Description |
@@ -287,19 +291,19 @@ exec static-map '{"markers": ["color:red|35.6586,139.7454"], "maptype": "satelli
 Response: MCP image content (inline PNG) + size metadata.
 
 Chaining patterns:
-- `search-nearby` → `static-map` (mark found places on map)
-- `plan-route` / `directions` → `static-map` (draw the route with path + markers)
-- `explore-area` → `static-map` (visualize neighborhood search results)
-- `compare-places` → `static-map` (show compared places side by side)
+- `maps_search_nearby` → `maps_static_map` (mark found places on map)
+- `maps_plan_route` / `maps_directions` → `maps_static_map` (draw the route with path + markers)
+- `maps_explore_area` → `maps_static_map` (visualize neighborhood search results)
+- `maps_compare_places` → `maps_static_map` (show compared places side by side)
 
 ---
 
-## search-along-route
+## maps_search_along_route
 
 Search for places along a route between two points. Results ranked by minimal detour time — perfect for finding meals, cafes, or attractions "on the way" between landmarks.
 
 ```bash
-exec search-along-route '{"textQuery": "restaurant", "origin": "Fushimi Inari, Kyoto", "destination": "Kiyomizu-dera, Kyoto", "mode": "walking"}'
+exec maps_search_along_route '{"textQuery": "restaurant", "origin": "Fushimi Inari, Kyoto", "destination": "Kiyomizu-dera, Kyoto", "mode": "walking"}'
 ```
 
 | Param | Type | Required | Description |
@@ -324,12 +328,12 @@ Key for trip planning: use this between consecutive anchors to find **along-the-
 
 ---
 
-## explore-area (composite)
+## maps_explore_area (composite)
 
 Explore a neighborhood in one call. Internally chains geocode → search-nearby (per type) → place-details (top N).
 
 ```bash
-exec explore-area '{"location": "Tokyo Tower", "types": ["restaurant", "cafe"], "topN": 2}'
+exec maps_explore_area '{"location": "Tokyo Tower", "types": ["restaurant", "cafe"], "topN": 2}'
 ```
 
 | Param | Type | Required | Description |
@@ -341,12 +345,12 @@ exec explore-area '{"location": "Tokyo Tower", "types": ["restaurant", "cafe"], 
 
 ---
 
-## plan-route (composite)
+## maps_plan_route (composite)
 
 Plan an optimized multi-stop route. Internally chains geocode → distance-matrix → nearest-neighbor → directions.
 
 ```bash
-exec plan-route '{"stops": ["Tokyo Tower", "Shibuya Station", "Shinjuku Station", "Ueno Park"], "mode": "driving"}'
+exec maps_plan_route '{"stops": ["Tokyo Tower", "Shibuya Station", "Shinjuku Station", "Ueno Park"], "mode": "driving"}'
 ```
 
 | Param | Type | Required | Description |
@@ -357,12 +361,12 @@ exec plan-route '{"stops": ["Tokyo Tower", "Shibuya Station", "Shinjuku Station"
 
 ---
 
-## compare-places (composite)
+## maps_compare_places (composite)
 
 Compare places side-by-side. Internally chains search-places → place-details → distance-matrix.
 
 ```bash
-exec compare-places '{"query": "ramen near Shibuya", "limit": 3}'
+exec maps_compare_places '{"query": "ramen near Shibuya", "limit": 3}'
 ```
 
 | Param | Type | Required | Description |
@@ -379,37 +383,37 @@ exec compare-places '{"query": "ramen near Shibuya", "limit": 3}'
 
 **Search → Details** — Find places, then get full info on the best ones.
 ```
-search-places {"query":"Michelin restaurants in Taipei"}
-place-details {"placeId":"ChIJ..."}  ← use place_id from results
+maps_search_places {"query":"Michelin restaurants in Taipei"}
+maps_place_details {"placeId":"ChIJ..."}  ← use place_id from results
 ```
 
 **Geocode → Nearby** — Turn a landmark into coordinates, then explore the area.
 ```
-geocode {"address":"Taipei 101"}
-search-nearby {"center":{"value":"25.033,121.564","isCoordinates":true},"keyword":"cafe","radius":500}
+maps_geocode {"address":"Taipei 101"}
+maps_search_nearby {"center":{"value":"25.033,121.564","isCoordinates":true},"keyword":"cafe","radius":500}
 ```
 
 **Multi-point Comparison** — Compare distances across multiple origins and destinations in one call.
 ```
-distance-matrix {"origins":["Taipei Main Station","Banqiao Station"],"destinations":["Taoyuan Airport","Songshan Airport"],"mode":"driving"}
+maps_distance_matrix {"origins":["Taipei Main Station","Banqiao Station"],"destinations":["Taoyuan Airport","Songshan Airport"],"mode":"driving"}
 ```
 
 **Geocode → Air Quality** — Check air quality at a named location.
 ```
-geocode {"address":"Tokyo"}
-air-quality {"latitude":35.6762,"longitude":139.6503}
+maps_geocode {"address":"Tokyo"}
+maps_air_quality {"latitude":35.6762,"longitude":139.6503}
 ```
 
 **Search → Map** — Find places, then show them on a map.
 ```
-search-nearby {"center":{"value":"35.6586,139.7454","isCoordinates":true},"keyword":"cafe","radius":500}
-static-map {"markers":["color:red|label:1|lat1,lng1","color:red|label:2|lat2,lng2"]}
+maps_search_nearby {"center":{"value":"35.6586,139.7454","isCoordinates":true},"keyword":"cafe","radius":500}
+maps_static_map {"markers":["color:red|label:1|lat1,lng1","color:red|label:2|lat2,lng2"]}
 ```
 
 **Directions → Map** — Get a route, then visualize it.
 ```
-directions {"origin":"Tokyo Tower","destination":"Shibuya Station","mode":"walking"}
-static-map {"path":["color:0x4285F4|weight:4|lat1,lng1|lat2,lng2|..."],"markers":["color:green|label:A|origin","color:red|label:B|dest"]}
+maps_directions {"origin":"Tokyo Tower","destination":"Shibuya Station","mode":"walking"}
+maps_static_map {"path":["color:0x4285F4|weight:4|lat1,lng1|lat2,lng2|..."],"markers":["color:green|label:A|origin","color:red|label:B|dest"]}
 ```
 
 ---
@@ -425,16 +429,16 @@ This is the most common complex scenario. The goal is a time-ordered itinerary w
 > **Read `references/travel-planning.md` first** — it contains the full methodology, anti-patterns, and time budget guidelines.
 
 **Steps:**
-1. `search-places` — Search "top attractions in {city}" → geographically diverse **anchor points**
+1. `maps_search_places` — Search "top attractions in {city}" → geographically diverse **anchor points**
 2. **Design arcs** — Group nearby anchors into same-day arcs. One direction per day (south→north).
-3. `search-along-route` — Between each pair of anchors, find restaurants/cafes **along the walking route** (ranked by minimal detour)
-4. `place-details` — Get ratings, hours for top candidates
-5. `plan-route` — Validate each day's route. Use `optimize: false` (you already know the geographic order).
-6. `weather` + `air-quality` — Adjust for conditions
-7. `static-map` — **Always** visualize each day with numbered markers + path
+3. `maps_search_along_route` — Between each pair of anchors, find restaurants/cafes **along the walking route** (ranked by minimal detour)
+4. `maps_place_details` — Get ratings, hours for top candidates
+5. `maps_plan_route` — Validate each day's route. Use `optimize: false` (you already know the geographic order).
+6. `maps_weather` + `maps_air_quality` — Adjust for conditions. **Note:** `maps_weather` is unavailable in Japan/China/Korea — use web search fallback.
+7. `maps_static_map` — **Always** visualize each day with numbered markers + path
 
 **Key decisions:**
-- **Use `search-along-route` for meals and breaks** — not explore_area or search_nearby. Along-route results are on the path, not random nearby points.
+- **Use `maps_search_along_route` for meals and breaks** — not maps_explore_area or maps_search_nearby. Along-route results are on the path, not random nearby points.
 - **Never backtrack**: stops progress in one direction per day.
 - Alternate activity types: temple → food → walk → shrine → cafe.
 - Budget 5-7 stops per day max. Major temples = 90-120 min.
@@ -443,20 +447,20 @@ This is the most common complex scenario. The goal is a time-ordered itinerary w
 
 **Example flow (Kyoto 2-day):**
 ```
-search_places("top attractions in Kyoto")
+maps_search_places("top attractions in Kyoto")
 → Fushimi Inari(south), Kiyomizu(east), Kinkaku-ji(north), Arashiyama(west)
 
 Day 1 arc: south→center — Fushimi → Kiyomizu → Gion → Pontocho
 Day 2 arc: center→west — Nishiki → Nijo Castle → Arashiyama
 
-search_along_route("restaurant", "Fushimi Inari", "Kiyomizu-dera", "walking")
+maps_search_along_route("restaurant", "Fushimi Inari", "Kiyomizu-dera", "walking")
 → finds lunch options ALONG the 4km route (not at endpoints)
 
-search_along_route("kaiseki restaurant", "Gion, Kyoto", "Arashiyama, Kyoto")
+maps_search_along_route("kaiseki restaurant", "Gion, Kyoto", "Arashiyama, Kyoto")
 → finds dinner along the afternoon route
 
-plan_route(Day 1 stops, optimize:false) → static_map(Day 1)
-plan_route(Day 2 stops, optimize:false) → static_map(Day 2)
+maps_plan_route(Day 1 stops, optimize:false) → maps_static_map(Day 1)
+maps_plan_route(Day 2 stops, optimize:false) → maps_static_map(Day 2)
 ```
 
 **Example output:**
@@ -478,9 +482,9 @@ Day 1: South → Center arc
 User asks about places around a location. May or may not specify what type.
 
 **Steps:**
-1. `geocode` — Resolve the location (skip if user gave coordinates)
-2. `search-nearby` — Search with keyword + radius. Use `openNow: true` if the user implies "right now"
-3. `place-details` — Get details for the top 3-5 results (ratings, reviews, hours)
+1. `maps_geocode` — Resolve the location (skip if user gave coordinates)
+2. `maps_search_nearby` — Search with keyword + radius. Use `openNow: true` if the user implies "right now"
+3. `maps_place_details` — Get details for the top 3-5 results (ratings, reviews, hours)
 
 **Key decisions:**
 - If no keyword specified, search multiple types: restaurant, cafe, attraction
@@ -494,9 +498,9 @@ User asks about places around a location. May or may not specify what type.
 User wants to compare travel options between two points.
 
 **Steps:**
-1. `directions` with `mode: "driving"` — Get driving route
-2. `directions` with `mode: "transit"` — Get transit route
-3. `directions` with `mode: "walking"` — Get walking route (if distance < 5 km)
+1. `maps_directions` with `mode: "driving"` — Get driving route
+2. `maps_directions` with `mode: "transit"` — Get transit route
+3. `maps_directions` with `mode: "walking"` — Get walking route (if distance < 5 km)
 
 **Present as comparison table:**
 ```
@@ -514,15 +518,15 @@ User wants to compare travel options between two points.
 User wants to evaluate a location for living, working, or investing.
 
 **Steps:**
-1. `geocode` — Resolve the address
-2. `search-nearby` — Run multiple searches from the same center:
+1. `maps_geocode` — Resolve the address
+2. `maps_search_nearby` — Run multiple searches from the same center:
    - `keyword: "school"` radius 2000
    - `keyword: "hospital"` radius 3000
    - `keyword: "supermarket"` radius 1000
    - `keyword: "restaurant"` radius 500
    - `keyword: "park"` radius 1000
-3. `distance-matrix` — Calculate commute time to important locations (office, airport, city center)
-4. `elevation` — Check if the area is in a low-elevation flood zone
+3. `maps_distance_matrix` — Calculate commute time to important locations (office, airport, city center)
+4. `maps_elevation` — Check if the area is in a low-elevation flood zone
 
 **Present as scorecard:**
 ```
@@ -541,14 +545,14 @@ Elevation: 45m (not a flood risk)
 User has a list of places and wants the optimal visit order.
 
 **Steps:**
-1. `geocode` — Resolve all addresses to coordinates
-2. `distance-matrix` — Calculate NxN matrix (all origins × all destinations)
+1. `maps_geocode` — Resolve all addresses to coordinates
+2. `maps_distance_matrix` — Calculate NxN matrix (all origins × all destinations)
 3. Use the matrix to determine the nearest-neighbor route order
-4. `directions` — Generate route for the final order (chain waypoints)
+4. `maps_directions` — Generate route for the final order (chain waypoints)
 
 **Key decisions:**
 - For ≤ 5 stops, nearest-neighbor heuristic is good enough
-- For the `directions` call, set origin = first stop, destination = last stop, and mention intermediate stops in conversation
+- For the `maps_directions` call, set origin = first stop, destination = last stop, and mention intermediate stops in conversation
 - If the user says "return to start", plan a round trip
 
 ---
@@ -558,9 +562,9 @@ User has a list of places and wants the optimal visit order.
 User is choosing between specific places.
 
 **Steps:**
-1. `search-places` — Find each place (or use place_id if already known)
-2. `place-details` — Get full details for each candidate
-3. `distance-matrix` — Calculate distance from user's location to each candidate
+1. `maps_search_places` — Find each place (or use place_id if already known)
+2. `maps_place_details` — Get full details for each candidate
+3. `maps_distance_matrix` — Calculate distance from user's location to each candidate
 
 **Present as comparison:**
 ```
@@ -578,13 +582,17 @@ User is choosing between specific places.
 User wants to find things along a route (gas stations, rest stops, food).
 
 **Steps:**
-1. `directions` — Get the route first, extract key waypoints from the steps
-2. `search-nearby` — Search near 2-3 midpoints along the route
-3. `place-details` — Get details for top results at each midpoint
+1. `maps_search_along_route` — Search directly along the route (preferred — results ranked by minimal detour time)
+2. `maps_place_details` — Get details for top results
+
+**Fallback** (if maps_search_along_route is unavailable):
+1. `maps_directions` — Get the route first, extract key waypoints from the steps
+2. `maps_search_nearby` — Search near 2-3 midpoints along the route
+3. `maps_place_details` — Get details for top results at each midpoint
 
 **Key decisions:**
-- Extract waypoints at roughly equal intervals along the route
-- Use the `start_location` of route steps at ~1/3 and ~2/3 of the total distance
+- Prefer `maps_search_along_route` — it uses Google's Routes API to rank results by actual detour time, not just proximity
+- If using the fallback, extract waypoints at roughly equal intervals along the route
 - Set `radius` based on road type: 1000m for highways, 500m for city streets
 
 ---
@@ -593,12 +601,10 @@ User wants to find things along a route (gas stations, rest stops, food).
 
 | User says... | Recipe | First tool |
 |-------------|--------|------------|
-| "Plan a trip / itinerary / day in X" | Trip Planning | `geocode` |
-| "What's near X / around X" | Local Discovery | `geocode` → `search-nearby` |
-| "How do I get to X" / "route from A to B" | Route Comparison | `directions` |
-| "Is X a good neighborhood" / "analyze this area" | Neighborhood Analysis | `geocode` |
-| "Visit A, B, C, D efficiently" | Multi-Stop Route | `geocode` → `distance-matrix` |
-| "Which X should I pick" / "compare these" | Place Comparison | `search-places` |
-| "Find gas stations on the way to X" | Along the Route | `directions` → `search-nearby` |
-
----
+| "Plan a trip / itinerary / day in X" | Trip Planning | `maps_search_places` |
+| "What's near X / around X" | Local Discovery | `maps_geocode` → `maps_search_nearby` |
+| "How do I get to X" / "route from A to B" | Route Comparison | `maps_directions` |
+| "Is X a good neighborhood" / "analyze this area" | Neighborhood Analysis | `maps_geocode` |
+| "Visit A, B, C, D efficiently" | Multi-Stop Route | `maps_geocode` → `maps_distance_matrix` |
+| "Which X should I pick" / "compare these" | Place Comparison | `maps_search_places` |
+| "Find gas stations on the way to X" | Along the Route | `maps_search_along_route` |

--- a/skills/google-maps/references/travel-planning.md
+++ b/skills/google-maps/references/travel-planning.md
@@ -18,13 +18,15 @@ Human travel planners think in layers. Each layer constrains the next.
 
 ### Layer 1: Anchor Discovery
 **What:** Find 4-6 must-visit landmarks spread across the city.
-**Tool:** `search_places("top attractions in {city}")`
+**Tool:** `maps_search_places("top attractions in {city}")`
 **Why it works:** Google's algorithm returns geographically diverse results. Kyoto → Fushimi(south), Kiyomizu(east), Kinkaku-ji(north), Arashiyama(west) — natural 8km×10km spread.
 
 ### Layer 2: Arc Design
 **What:** Connect anchors into one-directional arcs per day. Edge landmarks go at start/end of a day.
-**Tool:** `distance_matrix` between anchors to understand spatial relationships.
+**Tool:** `maps_distance_matrix` between anchors to understand spatial relationships.
 **Rule:** Never backtrack. Each day sweeps one direction (south→north, east→west).
+
+> **Known limitation:** `maps_distance_matrix` with transit mode returns null in some regions (notably Japan). Use `driving` or `walking` mode instead, or reason from coordinates directly.
 
 Example:
 ```
@@ -44,11 +46,11 @@ Day 2: Nishiki(center) → Nijo Castle → train → Arashiyama(west)     [cente
 
 ### Layer 4: Along-Route Filling
 **What:** Between two anchors, find what's **on the way** — not at the destination.
-**Tool:** `search_along_route(textQuery, origin, destination)`
+**Tool:** `maps_search_along_route(textQuery, origin, destination)`
 **This is the key differentiator.** Results are ranked by minimal detour time, not proximity to a point.
 
 ```
-search_along_route("restaurant", "Fushimi Inari, Kyoto", "Kiyomizu-dera, Kyoto", "walking")
+maps_search_along_route("restaurant", "Fushimi Inari, Kyoto", "Kiyomizu-dera, Kyoto", "walking")
 → Finds restaurants ALONG the 4km walking route, not clustered at either end
 ```
 
@@ -56,22 +58,24 @@ search_along_route("restaurant", "Fushimi Inari, Kyoto", "Kiyomizu-dera, Kyoto",
 **What:** Meals appear where the traveler **will be** at mealtime, not where the "best restaurant" is.
 **Logic:**
 1. Estimate what time the traveler reaches each arc segment
-2. Lunch (~12:00) → search_along_route("lunch restaurant", previous_stop, next_stop)
-3. Dinner (~18:00) → search_nearby at the day's final area (no rush)
+2. Lunch (~12:00) → `maps_search_along_route("lunch restaurant", previous_stop, next_stop)`
+3. Dinner (~18:00) → `maps_search_nearby` at the day's final area (no rush)
 
 **Anti-pattern:** "I searched for the best restaurant in the whole city" → it's 3km off the route.
 **Correct:** "You'll be near Gion around noon — here are options along the way."
 
 ### Layer 6: Rhythm Validation
 **What:** Check the itinerary feels human, not robotic.
-**Tool:** `plan_route(stops, optimize: false)` to get actual times, `weather` for conditions.
+**Tool:** `maps_plan_route(stops, optimize: false)` to get actual times, `maps_weather` for conditions.
 **Checklist:**
 - [ ] Not 5 temples in a row (alternate: temple → food → walk → shrine → cafe)
 - [ ] Major temples get 90-120 min, not 30 min
 - [ ] Walking per day < 10km (suggest transit for >2km gaps)
 - [ ] Lunch 11:30-13:00, dinner 17:30-19:30
 - [ ] 5-7 stops per day max (including meals)
-- [ ] Final stop: call `static_map` with markers + path to visualize
+- [ ] Final stop: call `maps_static_map` with markers + path to visualize
+
+> **Known limitation:** `maps_weather` is unsupported in Japan, China, South Korea, and several other regions. Use web search as fallback for weather in these areas. `maps_air_quality` works globally including Japan.
 
 ---
 
@@ -79,20 +83,20 @@ search_along_route("restaurant", "Fushimi Inari, Kyoto", "Kiyomizu-dera, Kyoto",
 
 ```
 Phase 1 — Skeleton (2-3 calls)
-  search_places("top attractions in {city}")        → anchors
-  distance_matrix(all anchors)                       → spatial relationships
+  maps_search_places("top attractions in {city}")        → anchors
+  maps_distance_matrix(all anchors)                       → spatial relationships
 
 Phase 2 — Arc + Fill (2-4 calls per day)
-  search_along_route("restaurant", stop_A, stop_B)  → along-route meals
-  search_along_route("cafe", stop_B, stop_C)         → along-route breaks
+  maps_search_along_route("restaurant", stop_A, stop_B)  → along-route meals
+  maps_search_along_route("cafe", stop_B, stop_C)         → along-route breaks
 
 Phase 3 — Environment (2 calls)
-  weather(city coords)                               → rain → move indoor activities
-  air_quality(city coords)                           → bad AQI → reduce outdoor time
+  maps_weather(city coords)                               → rain → move indoor activities
+  maps_air_quality(city coords)                           → bad AQI → reduce outdoor time
 
 Phase 4 — Validate + Visualize (2 calls per day)
-  plan_route(day_stops, optimize: false)             → verify times/distances
-  static_map(markers + path)                         → map for each day
+  maps_plan_route(day_stops, optimize: false)             → verify times/distances
+  maps_static_map(markers + path)                         → map for each day
 
 Total: ~12-16 calls for a 2-day trip
 ```
@@ -103,11 +107,11 @@ Total: ~12-16 calls for a 2-day trip
 
 | Anti-Pattern | Symptom | Fix |
 |-------------|---------|-----|
-| Single-point explosion | `explore_area("Kyoto")` → all within 1km | search_places for anchors first |
+| Single-point explosion | `maps_explore_area("Kyoto")` → all within 1km | `maps_search_places` for anchors first |
 | Backtracking | east→west→east→west | One direction per day |
-| No along-route search | Meals at endpoints only | `search_along_route` between stops |
+| No along-route search | Meals at endpoints only | `maps_search_along_route` between stops |
 | Distance-optimal ordering | Ignores time-of-day quality | AI assigns time slots before routing |
-| No map output | Text/JSON only | Always `static_map` after each day's route |
+| No map output | Text/JSON only | Always `maps_static_map` after each day's route |
 | Over-scheduling | 12 stops in one day | Max 5-7 stops including meals |
 | Same-type clustering | 5 temples consecutively | Alternate activity types |
 

--- a/skills/google-maps/references/travel-planning.md
+++ b/skills/google-maps/references/travel-planning.md
@@ -1,0 +1,136 @@
+# Travel Planning Best Practices
+
+## Core Principle
+
+Real travel planning is **directional exploration**, not point collection.
+
+A human plans: "Start south at Fushimi Inari, walk up to Kiyomizu-dera, eat lunch somewhere along the way in Gion, then head west to Arashiyama for evening."
+
+An algorithm plans: "Here are the top 10 rated places. Optimizing shortest path..."
+
+The difference is **arc thinking** — one direction per day, discovering things along the way.
+
+---
+
+## The 6-Layer Decision Model
+
+Human travel planners think in layers. Each layer constrains the next.
+
+### Layer 1: Anchor Discovery
+**What:** Find 4-6 must-visit landmarks spread across the city.
+**Tool:** `search_places("top attractions in {city}")`
+**Why it works:** Google's algorithm returns geographically diverse results. Kyoto → Fushimi(south), Kiyomizu(east), Kinkaku-ji(north), Arashiyama(west) — natural 8km×10km spread.
+
+### Layer 2: Arc Design
+**What:** Connect anchors into one-directional arcs per day. Edge landmarks go at start/end of a day.
+**Tool:** `distance_matrix` between anchors to understand spatial relationships.
+**Rule:** Never backtrack. Each day sweeps one direction (south→north, east→west).
+
+Example:
+```
+Day 1: Fushimi(south) → Kiyomizu(east) → Gion → Pontocho(center)   [south→center arc]
+Day 2: Nishiki(center) → Nijo Castle → train → Arashiyama(west)     [center→west arc]
+```
+
+### Layer 3: Time-Slot Matching
+**What:** Assign anchors to times based on **experience quality**, not distance.
+**Tool:** None — this is AI knowledge.
+**Examples:**
+- Fushimi Inari = **early morning** (fewer crowds, best light for photos, hiking needs fresh legs)
+- Outdoor temples = **morning to afternoon** (natural light)
+- Shopping districts = **afternoon** (all stores open)
+- Scenic areas = **late afternoon** (golden hour light)
+- Fine dining = **evening at the final stop** (no rush to next destination)
+
+### Layer 4: Along-Route Filling
+**What:** Between two anchors, find what's **on the way** — not at the destination.
+**Tool:** `search_along_route(textQuery, origin, destination)`
+**This is the key differentiator.** Results are ranked by minimal detour time, not proximity to a point.
+
+```
+search_along_route("restaurant", "Fushimi Inari, Kyoto", "Kiyomizu-dera, Kyoto", "walking")
+→ Finds restaurants ALONG the 4km walking route, not clustered at either end
+```
+
+### Layer 5: Meal Embedding
+**What:** Meals appear where the traveler **will be** at mealtime, not where the "best restaurant" is.
+**Logic:**
+1. Estimate what time the traveler reaches each arc segment
+2. Lunch (~12:00) → search_along_route("lunch restaurant", previous_stop, next_stop)
+3. Dinner (~18:00) → search_nearby at the day's final area (no rush)
+
+**Anti-pattern:** "I searched for the best restaurant in the whole city" → it's 3km off the route.
+**Correct:** "You'll be near Gion around noon — here are options along the way."
+
+### Layer 6: Rhythm Validation
+**What:** Check the itinerary feels human, not robotic.
+**Tool:** `plan_route(stops, optimize: false)` to get actual times, `weather` for conditions.
+**Checklist:**
+- [ ] Not 5 temples in a row (alternate: temple → food → walk → shrine → cafe)
+- [ ] Major temples get 90-120 min, not 30 min
+- [ ] Walking per day < 10km (suggest transit for >2km gaps)
+- [ ] Lunch 11:30-13:00, dinner 17:30-19:30
+- [ ] 5-7 stops per day max (including meals)
+- [ ] Final stop: call `static_map` with markers + path to visualize
+
+---
+
+## Tool Call Sequence
+
+```
+Phase 1 — Skeleton (2-3 calls)
+  search_places("top attractions in {city}")        → anchors
+  distance_matrix(all anchors)                       → spatial relationships
+
+Phase 2 — Arc + Fill (2-4 calls per day)
+  search_along_route("restaurant", stop_A, stop_B)  → along-route meals
+  search_along_route("cafe", stop_B, stop_C)         → along-route breaks
+
+Phase 3 — Environment (2 calls)
+  weather(city coords)                               → rain → move indoor activities
+  air_quality(city coords)                           → bad AQI → reduce outdoor time
+
+Phase 4 — Validate + Visualize (2 calls per day)
+  plan_route(day_stops, optimize: false)             → verify times/distances
+  static_map(markers + path)                         → map for each day
+
+Total: ~12-16 calls for a 2-day trip
+```
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Symptom | Fix |
+|-------------|---------|-----|
+| Single-point explosion | `explore_area("Kyoto")` → all within 1km | search_places for anchors first |
+| Backtracking | east→west→east→west | One direction per day |
+| No along-route search | Meals at endpoints only | `search_along_route` between stops |
+| Distance-optimal ordering | Ignores time-of-day quality | AI assigns time slots before routing |
+| No map output | Text/JSON only | Always `static_map` after each day's route |
+| Over-scheduling | 12 stops in one day | Max 5-7 stops including meals |
+| Same-type clustering | 5 temples consecutively | Alternate activity types |
+
+---
+
+## Time Budget
+
+| Activity | Duration |
+|----------|----------|
+| Major temple/shrine | 60-120 min |
+| Small shrine / photo spot | 15-30 min |
+| Museum | 90-180 min |
+| Market / shopping street | 60-90 min |
+| Sit-down meal | 60-120 min |
+| Quick meal / street food | 20-40 min |
+| Cafe break | 30-45 min |
+| Walking <1km | 10-15 min |
+| Transit between areas | 20-40 min |
+
+---
+
+## When to Read This
+
+- User says "plan a trip", "create an itinerary", "plan X days in Y"
+- Trip plan clusters all stops in one area
+- Building multi-day travel content


### PR DESCRIPTION
## Summary

Add a **google-maps** skill — the first geospatial/location skill in this repository.

Gives AI agents the ability to geocode, search places, get directions, calculate distances, query elevation, check weather/air quality, and visualize results on static maps via Google Maps APIs. Powered by [@cablate/mcp-google-map](https://github.com/cablate/mcp-google-map) (MIT licensed).

## What's included

| File | Content |
|------|---------|
| `SKILL.md` | Core principles, 17-tool map, invocation patterns |
| `references/tools-api.md` | Full parameter specs, response formats, 7 scenario recipes, decision guide |
| `references/travel-planning.md` | 6-layer trip planning methodology, anti-patterns, time budgets |
| `LICENSE.txt` | MIT license |

## 17 Tools across 5 categories

| Category | Tools |
|----------|-------|
| **Place Discovery** | geocode, reverse-geocode, search-nearby, search-places, place-details, batch-geocode |
| **Routing & Distance** | directions, distance-matrix, search-along-route |
| **Environment** | elevation, timezone, weather, air-quality |
| **Visualization** | static-map |
| **Composite** | explore-area, plan-route, compare-places |

## Why this skill

- **No geo/maps/location skill exists yet** in this repository
- Google Maps is the most widely used mapping API
- Geospatial reasoning is a common gap for AI agents
- 7 scenario recipes (trip planning, local discovery, route comparison, neighborhood analysis, multi-stop, place comparison, along-the-route) teach Claude multi-tool chaining patterns

## How it works

The skill teaches Claude when and how to use geo tools:
- **Tool Map** — which tool for which scenario
- **Chaining Patterns** — most geo questions need 2-5 tools chained (geocode → search-nearby → place-details)
- **Travel Planning** — 6-layer methodology for multi-day itinerary planning with arc-based exploration
- **Invocation** — via MCP stdio or standalone CLI (`npx @cablate/mcp-google-map exec ...`)