### PR TITLE
Add windows-screenshot-paste skill

### DIFF
--- a/skills/windows-screenshot-paste/SKILL.md
+++ b/skills/windows-screenshot-paste/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: windows-screenshot-paste
+description: Use when a Windows user wants to paste screenshots directly into Claude Code terminal with Ctrl+V. Installs an AutoHotkey v2 script that intercepts clipboard images, saves them as PNG files, and types the file path into the terminal so Claude can read them.
+---
+
+# Windows Screenshot Paste for Claude Code
+
+> **Author:** [sharooncs](https://github.com/sharooncs)
+
+Enables `Ctrl+V` screenshot pasting in Claude Code on Windows. When you copy a screenshot to your clipboard and press `Ctrl+V` in the terminal, the image is saved automatically and the file path is typed in — so Claude can read it directly.
+
+## Requirements
+
+- Windows 10 or 11
+- [AutoHotkey v2](https://www.autohotkey.com/) (installed automatically by the script)
+- Windows Terminal, PowerShell, or CMD
+
+## Installation
+
+Run this one-time setup in your terminal:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File "${CLAUDE_SKILL_DIR}\scripts\install.ps1"
+```
+
+This will:
+1. Install AutoHotkey v2 via `winget` if not already present
+2. Copy `ClaudeScreenshot.ahk` to your home folder
+3. Register it in Windows Startup so it runs on every login
+4. Launch it immediately for the current session
+
+> See [`scripts/install.ps1`](scripts/install.ps1) for the full installation script.
+> See [`scripts/ClaudeScreenshot.ahk`](scripts/ClaudeScreenshot.ahk) for the AutoHotkey script.
+
+## Usage
+
+1. Press `Win+Shift+S` and snip any region of your screen
+2. Click back into your terminal
+3. Press `Ctrl+V`
+
+The file path is typed automatically, e.g.:
+```
+C:\Users\you\Pictures\Claude_Screenshots\Screenshot_20260314_163045.png
+```
+
+Claude reads the image from that path. Screenshots are saved to `%USERPROFILE%\Pictures\Claude_Screenshots\`.
+
+## How It Works
+
+- Only activates inside Windows Terminal, PowerShell, and CMD — no effect on other apps
+- Uses Win32 `IsClipboardFormatAvailable` to detect bitmap data on the clipboard (CF_BITMAP=2, CF_DIB=8)
+- Saves the image via PowerShell's `System.Windows.Forms.Clipboard.GetImage()` using a temp `.ps1` file to avoid shell quoting issues
+- Types the saved file path into the terminal with `SendInput`
+
+## Troubleshooting
+
+| Problem | Fix |
+|---------|-----|
+| Nothing happens on Ctrl+V | Check system tray for green AutoHotkey icon — if missing, re-run `install.ps1` |
+| "Failed to save image" popup | Make sure you copied an image (not text) before pressing Ctrl+V |
+| Script not running after reboot | Check `shell:startup` folder contains `ClaudeScreenshot.ahk` |

--- a/skills/windows-screenshot-paste/scripts/ClaudeScreenshot.ahk
+++ b/skills/windows-screenshot-paste/scripts/ClaudeScreenshot.ahk
@@ -1,0 +1,40 @@
+#Requires AutoHotkey v2.0
+#SingleInstance Force
+
+SaveDir := EnvGet("USERPROFILE") "\Pictures\Claude_Screenshots"
+
+#HotIf WinActive("ahk_exe WindowsTerminal.exe") or WinActive("ahk_exe powershell.exe") or WinActive("ahk_exe cmd.exe")
+
+~^v::
+{
+    ; Check if clipboard contains a bitmap image (CF_BITMAP=2 or CF_DIB=8)
+    if DllCall("IsClipboardFormatAvailable", "uint", 2) || DllCall("IsClipboardFormatAvailable", "uint", 8)
+    {
+        Timestamp := FormatTime(, "yyyyMMdd_HHmmss")
+        FilePath := SaveDir "\Screenshot_" Timestamp ".png"
+
+        If (!FileExist(SaveDir))
+            DirCreate(SaveDir)
+
+        ; Write a temp PS1 script to avoid quoting issues with file paths
+        ps1 := EnvGet("TEMP") "\claude_save_img.ps1"
+        if FileExist(ps1)
+            FileDelete(ps1)
+        FileAppend(
+            "Add-Type -AssemblyName System.Windows.Forms`n"
+            . '$img = [System.Windows.Forms.Clipboard]::GetImage()`n'
+            . 'if ($img) { $img.Save("' FilePath '") }',
+            ps1
+        )
+
+        RunWait('powershell.exe -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File "' ps1 '"',, "Hide")
+
+        if FileExist(FilePath)
+            SendInput(FilePath)
+        else
+            MsgBox("Failed to save image.")
+
+        return
+    }
+}
+#HotIf

--- a/skills/windows-screenshot-paste/scripts/install.ps1
+++ b/skills/windows-screenshot-paste/scripts/install.ps1
@@ -1,0 +1,29 @@
+# install.ps1 — Installs ClaudeScreenshot.ahk and registers it for auto-start
+# Usage: powershell -ExecutionPolicy Bypass -File install.ps1
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ahkSource = Join-Path $scriptDir "ClaudeScreenshot.ahk"
+$ahkDest   = Join-Path $env:USERPROFILE "ClaudeScreenshot.ahk"
+$startup   = [Environment]::GetFolderPath('Startup')
+$startupLink = Join-Path $startup "ClaudeScreenshot.ahk"
+
+# 1. Check for AutoHotkey v2
+$ahkExe = Get-Command "AutoHotkey64.exe" -ErrorAction SilentlyContinue
+if (-not $ahkExe) {
+    Write-Host "AutoHotkey v2 not found. Installing via winget..."
+    winget install AutoHotkey.AutoHotkey --accept-source-agreements --accept-package-agreements
+}
+
+# 2. Copy script to user home
+Copy-Item $ahkSource $ahkDest -Force
+Write-Host "Copied script to: $ahkDest"
+
+# 3. Add to Windows startup
+Copy-Item $ahkDest $startupLink -Force
+Write-Host "Added to startup: $startupLink"
+
+# 4. Kill any existing instance and launch
+Stop-Process -Name "AutoHotkey64" -Force -ErrorAction SilentlyContinue
+Start-Sleep -Milliseconds 500
+Start-Process $ahkDest
+Write-Host "Script is now running. Screenshots save to: $env:USERPROFILE\Pictures\Claude_Screenshots"


### PR DESCRIPTION
## Summary

Adds a new skill that enables `Ctrl+V` screenshot pasting in Claude Code on Windows.

Windows Terminal cannot natively paste images from the clipboard. This skill installs an AutoHotkey v2 script that:
- Detects when an image is on the clipboard (using Win32 `IsClipboardFormatAvailable`)
- Saves it as a timestamped PNG to `%USERPROFILE%\Pictures\Claude_Screenshots\`
- Types the file path into the terminal so Claude can read it directly

## Files

```
skills/windows-screenshot-paste/
  SKILL.md                  ← instructions + documentation
  scripts/
    ClaudeScreenshot.ahk    ← AutoHotkey v2 script
    install.ps1             ← one-command installer (handles winget, startup registration)
```

## Usage

After installation, the workflow is:
1. `Win+Shift+S` → snip a region
2. `Ctrl+V` in terminal → file path is typed automatically
3. Claude reads the image from the path

## Requirements

- Windows 10 or 11
- AutoHotkey v2 (installed automatically by `install.ps1`)
- Windows Terminal, PowerShell, or CMD

## Author

Created by [@sharooncs](https://github.com/sharooncs)