### PR TITLE
Add claude-md-creator skill: 5-phase CLAUDE.md evaluator

### DIFF
--- a/skills/claude-md-creator/SKILL.md
+++ b/skills/claude-md-creator/SKILL.md
@@ -1,0 +1,367 @@
+---
+name: claude-md-creator
+description: |
+  Create, evaluate, and improve CLAUDE.md files for Claude Code projects. Use this skill whenever
+  the user mentions CLAUDE.md, project instructions, Claude Code memory, project rules, .claude/rules/,
+  or wants to set up persistent instructions for Claude Code. Also trigger when users say "init my project
+  for Claude", "set up Claude Code", "evaluate my CLAUDE.md", "improve my CLAUDE.md", "create project rules",
+  "audit my CLAUDE.md", or ask about best practices for Claude Code memory. This skill handles both creating
+  new CLAUDE.md files from scratch and evaluating/improving existing ones.
+---
+
+# CLAUDE.md Creator & Evaluator
+
+Create well-structured CLAUDE.md files and evaluate existing ones with a 5-phase pipeline that tests codebase coherence and blind effectiveness.
+
+## Overview
+
+CLAUDE.md files give Claude persistent instructions for a project. They're loaded into every session's context window and directly affect how reliably Claude follows your team's standards. This skill provides:
+
+1. **Create** — Generate a CLAUDE.md from scratch by interviewing the user and analyzing the codebase
+2. **Quick Eval** — Verify that every claim in your CLAUDE.md matches the actual codebase (~1 min)
+3. **Full Eval** — Quick Eval + blind A/B test proving your CLAUDE.md actually changes Claude's behavior (~5-10 min)
+4. **Improve** — Apply evaluation findings to fix stale, vague, or ineffective instructions
+
+## Mode Detection
+
+- **"Create CLAUDE.md"** / **"Init for Claude"** → Create mode
+- **"Evaluate CLAUDE.md"** / **"Audit"** / **"Quick eval"** → Quick Eval
+- **"Full eval"** / **"Blind test"** / **"Test effectiveness"** → Full Eval
+- **"Improve CLAUDE.md"** / **"Fix my CLAUDE.md"** → Quick Eval → Improve
+- Ambiguous → Ask the user
+
+---
+
+## Create Mode
+
+### Step 1: Analyze the Codebase
+
+Scan the project to gather context:
+
+1. **Package manager & scripts**: Read `package.json`, `pyproject.toml`, `Cargo.toml`, `Makefile`, etc.
+2. **Framework detection**: Check for Next.js, React, Vue, Django, Rails, etc.
+3. **Test framework**: Look for jest, pytest, vitest, etc. and how to run tests
+4. **Linting/formatting**: Check for eslint, prettier, ruff, black, etc.
+5. **Directory structure**: `ls` the top-level and key directories (`src/`, `app/`, `lib/`, `tests/`)
+6. **Existing configuration**: Check for `.claude/`, `.claude/rules/`, existing CLAUDE.md
+7. **Git conventions**: Read recent commit messages for style patterns
+8. **CI/CD**: Check for `.github/workflows/`, `Jenkinsfile`, etc.
+
+### Step 2: Interview the User
+
+Fill gaps that can't be determined from code alone:
+
+1. **Build & deploy**: Any non-obvious build steps? Environment-specific commands?
+2. **Architecture decisions**: Patterns the team follows that aren't obvious from code?
+3. **Coding standards**: Naming conventions, import ordering, error handling patterns?
+4. **Common workflows**: Feature branch strategy? PR process?
+5. **Gotchas**: Known pitfalls or anti-patterns specific to this project?
+6. **Team context**: Monorepo? Multiple teams with different conventions?
+
+Don't ask about things already found from the codebase scan.
+
+### Step 3: Generate the CLAUDE.md
+
+#### Size: Target under 200 lines
+
+The entire CLAUDE.md is loaded into every session's context window. Longer files consume more tokens and reduce adherence. Split using `.claude/rules/` files.
+
+#### Structure: Markdown headers and bullets
+
+Claude scans structure the way readers do. Organized sections are easier to follow.
+
+#### Specificity: Concrete and verifiable
+
+- "Use 2-space indentation" instead of "Format code properly"
+- "Run `npm test` before committing" instead of "Test your changes"
+- "API handlers live in `src/api/handlers/`" instead of "Keep files organized"
+
+#### Recommended Structure
+
+```markdown
+# Project Name
+
+Brief one-line description.
+
+## Build & Run
+
+- `command` — what it does
+
+## Test
+
+- `command` — run all tests
+
+## Code Style
+
+- Concrete rule 1
+
+## Architecture
+
+- Directory conventions
+
+## Conventions
+
+- Naming, imports, error handling
+
+## Common Pitfalls
+
+- Gotcha — why and how to avoid
+```
+
+#### What to include
+
+- Build, lint, and test commands (exact commands)
+- Code style preferences (indentation, naming, imports)
+- Architecture patterns and directory conventions
+- Common pitfalls specific to this project
+- Workflow instructions (branch naming, PR process)
+
+#### What NOT to include
+
+- Things derivable from reading code
+- Git history or recent changes
+- Long reference documentation (use `.claude/rules/` or `references/`)
+- Ephemeral task details
+- Generic programming advice Claude already knows
+
+### Step 4: Generate .claude/rules/ Files (if needed)
+
+If instructions exceed 200 lines, or if the project has distinct domains, split:
+
+```
+.claude/
+├── CLAUDE.md              # Main instructions (under 200 lines)
+└── rules/
+    ├── code-style.md      # Code style guidelines
+    ├── testing.md         # Testing conventions
+    └── api-design.md      # API development rules
+```
+
+Path-specific rules use YAML frontmatter:
+
+```markdown
+---
+paths:
+  - "src/api/**/*.ts"
+---
+
+# API Development Rules
+
+- All endpoints must include input validation
+```
+
+### Step 5: Present and Iterate
+
+Show the generated files. Ask for feedback. Adjust.
+
+---
+
+## Quick Eval (Phase 1-2)
+
+Fast codebase coherence check. Verifies every instruction matches the real project.
+
+### Phase 1: Claim Extraction
+
+Extract every testable instruction from the CLAUDE.md into structured claims.
+
+```bash
+python <skill-path>/scripts/extract_claims.py <claude-md-path> --rules-dir <rules-dir> --pretty --output <workspace>/claims.json
+```
+
+Then launch the `claim_extractor` agent to enrich claims the script missed (natural language conventions, implicit architecture decisions, compound rules):
+
+```
+Agent(claim_extractor): Enrich claims.json with semantic claims missed by the script.
+  Inputs: claude_md_path, rules_dir, script output at <workspace>/claims.json
+  Output: Enriched <workspace>/claims.json
+```
+
+### Phase 2: Codebase Coherence Verification
+
+Verify each claim against the actual project.
+
+```bash
+python <skill-path>/scripts/verify_coherence.py <workspace>/claims.json <project-root> --pretty --output <workspace>/coherence_raw.json
+```
+
+Then launch the `coherence_checker` agent to handle claims the script marked `unverifiable` (conventions, naming patterns, import rules — these require code sampling):
+
+```
+Agent(coherence_checker): Enrich coherence_raw.json by sampling actual code files.
+  Inputs: claims.json, coherence_raw.json, project_root
+  Output: Enriched <workspace>/coherence_report.json
+```
+
+### Generate Quick Eval Report
+
+Aggregate and generate HTML report:
+
+```bash
+python <skill-path>/scripts/aggregate_results.py <workspace>/coherence_report.json --claims <workspace>/claims.json --pretty --output <workspace>/evaluation_summary.json
+python <skill-path>/scripts/generate_report.py <workspace>/evaluation_summary.json --output /tmp/claude-md-eval.html
+```
+
+Open the report and present the summary to the user:
+- Overall score (0-100) with grade (A-F)
+- Coherence breakdown (verified / stale / partial / unverifiable)
+- Top issues ranked by severity
+- Fix suggestions with specific corrections
+
+---
+
+## Full Eval (Phase 1-5)
+
+Everything in Quick Eval plus a blind A/B test proving the CLAUDE.md actually changes Claude's behavior.
+
+### Phase 1-2: Same as Quick Eval
+
+Run the same claim extraction and coherence verification.
+
+### Phase 3: Dynamic Eval Task Generation
+
+Generate coding tasks that test whether Claude follows the CLAUDE.md conventions.
+
+```bash
+python <skill-path>/scripts/generate_eval_tasks.py <workspace>/claims.json <workspace>/coherence_report.json <project-root> --pretty --output <workspace>/eval_tasks_skeleton.json
+```
+
+Then launch the `eval_generator` agent to fill in natural task prompts:
+
+```
+Agent(eval_generator): Create 3-7 realistic coding tasks from verified claims.
+  Inputs: claims.json, coherence_report.json, project_root, eval_tasks_skeleton.json
+  Output: <workspace>/eval_tasks.json with natural task_prompt for each task
+```
+
+**Important**: Task prompts must NOT mention CLAUDE.md conventions. The whole point is to test whether Claude follows them from context, not from explicit instructions.
+
+### Phase 4: Blind Effectiveness Test
+
+For each eval task, run two coding sessions:
+
+#### Step 4a: Run WITH CLAUDE.md
+
+```
+Agent(blind_coder): Complete coding task with CLAUDE.md context.
+  Inputs: task_prompt, project_root, output_dir=<workspace>/with_claude_md/<task-id>/, claude_md_content=<full CLAUDE.md content>
+```
+
+#### Step 4b: Run WITHOUT CLAUDE.md
+
+```
+Agent(blind_coder): Complete coding task without CLAUDE.md context.
+  Inputs: task_prompt, project_root, output_dir=<workspace>/without_claude_md/<task-id>/
+```
+
+Run both in parallel per task for efficiency.
+
+#### Step 4c: Programmatic Checks
+
+For each task's expected_behaviors, run the programmatic checks:
+- `code_pattern`: regex match in generated code
+- `file_location`: file created in expected directory
+- `file_naming`: filename matches regex pattern
+- `import_style`: import follows convention
+- `code_absence`: pattern does NOT appear
+
+#### Step 4d: Blind Judgment
+
+Randomly assign outputs as "A" and "B" (so the judge doesn't know which had CLAUDE.md):
+
+```
+Agent(blind_judge): Compare Output A vs Output B.
+  Inputs: task_prompt, output_a_dir, output_b_dir, project_root, expected_behaviors
+  Output: JSON with winner, reasoning, scores (naming/structure/style/patterns/overall 1-5)
+```
+
+Collect all results into `<workspace>/blind_results.json`.
+
+### Phase 5: Final Report
+
+Aggregate everything:
+
+```bash
+python <skill-path>/scripts/aggregate_results.py <workspace>/coherence_report.json --blind <workspace>/blind_results.json --claims <workspace>/claims.json --pretty --output <workspace>/evaluation_summary.json
+python <skill-path>/scripts/generate_report.py <workspace>/evaluation_summary.json --output /tmp/claude-md-eval.html
+```
+
+Present the full report with all three tabs:
+1. **Coherence** — codebase alignment details
+2. **Effectiveness** — blind test wins/ties/losses + score delta
+3. **Recommendations** — remove, fix, add, strengthen
+
+---
+
+## Improve Mode
+
+After evaluation, apply improvements:
+
+1. Read the evaluation report (run Quick Eval if not already done)
+2. Fix issues in priority order:
+   - **Remove** vague/generic instructions
+   - **Fix** stale paths and outdated references
+   - **Add** missing key sections (build, test commands)
+   - **Strengthen** partially-followed conventions
+3. Show the user a diff of changes
+4. If the file needs splitting, create `.claude/rules/` files
+5. Re-run Quick Eval to confirm improvement
+
+---
+
+## Scoring & Grades
+
+### Coherence Score (Quick Eval)
+
+Percentage of verifiable claims that match the codebase:
+
+```
+coherence_score = verified_claims / (verified + stale + partial) × 100
+```
+
+### Effectiveness Score (Full Eval)
+
+Weighted blind test results:
+
+```
+effectiveness_score = (wins + ties × 0.5) / total_tasks × 100
+```
+
+### Overall Score
+
+| Eval Type | Formula |
+|-----------|---------|
+| Quick Eval | `coherence_score` |
+| Full Eval | `coherence × 0.5 + effectiveness × 0.5` |
+
+### Grades
+
+| Score | Grade | Meaning |
+|-------|-------|---------|
+| 90-100 | A | Excellent — all claims match, high effectiveness |
+| 80-89 | B | Good — minor issues |
+| 70-79 | C | Adequate — several fixes needed |
+| 60-69 | D | Needs work — significant gaps |
+| 0-59 | F | Major rewrite recommended |
+
+---
+
+## File Reference
+
+### Scripts
+- `scripts/extract_claims.py` — Phase 1: parse CLAUDE.md into structured claims
+- `scripts/verify_coherence.py` — Phase 2: verify claims against codebase
+- `scripts/generate_eval_tasks.py` — Phase 3: generate eval task skeletons
+- `scripts/aggregate_results.py` — Phase 5: aggregate all results
+- `scripts/generate_report.py` — Phase 5: generate HTML report
+
+### Agents
+- `agents/claim_extractor.md` — Enriches script-extracted claims with semantic analysis
+- `agents/coherence_checker.md` — Verifies conventions by sampling actual code
+- `agents/eval_generator.md` — Creates natural coding tasks from claims
+- `agents/blind_coder.md` — Executes coding tasks (with or without CLAUDE.md)
+- `agents/blind_judge.md` — Blind comparison of two code outputs
+
+### References
+- `references/schemas.md` — JSON schemas for all data structures
+- `references/claim-taxonomy.md` — Claim type definitions and patterns
+- `references/best-practices.md` — CLAUDE.md best practices from official docs

--- a/skills/claude-md-creator/agents/blind_coder.md
+++ b/skills/claude-md-creator/agents/blind_coder.md
@@ -1,0 +1,29 @@
+# Blind Coder Agent
+
+Execute a coding task in a project workspace. This agent is deliberately minimal to avoid biasing behavior.
+
+## Role
+
+You are a developer completing a coding task. Follow the task prompt and produce working code. Save all output files to the specified output directory.
+
+## Inputs
+
+- **task_prompt**: The coding task to complete
+- **project_root**: The project to work in
+- **output_dir**: Where to save output files
+- **claude_md_content** (optional): Project instructions to follow. If provided, treat these as the project's coding standards and conventions. If not provided, use your best judgment based on the existing codebase.
+
+## Process
+
+1. If claude_md_content is provided, read it carefully and follow its conventions
+2. Read the existing project structure to understand patterns
+3. Complete the task as described
+4. Save all created/modified files to output_dir
+5. Write a brief `transcript.md` in output_dir summarizing what you did
+
+## Important
+
+- Focus on completing the task naturally
+- Do not explain your reasoning about conventions — just follow them (or don't, if no instructions were given)
+- Do not mention CLAUDE.md or evaluation in your output
+- Write production-quality code

--- a/skills/claude-md-creator/agents/blind_judge.md
+++ b/skills/claude-md-creator/agents/blind_judge.md
@@ -1,0 +1,90 @@
+# Blind Judge Agent
+
+Compare two coding outputs and determine which better follows the project's conventions — without knowing which one had CLAUDE.md instructions.
+
+## Role
+
+You receive two code outputs labeled "Output A" and "Output B" from the same coding task. You do NOT know which output was produced with CLAUDE.md and which without. Your job is to evaluate which output better fits the project's conventions based solely on the existing codebase.
+
+## Inputs
+
+- **task_prompt**: The coding task that was given
+- **output_a_dir**: Directory containing Output A's files
+- **output_b_dir**: Directory containing Output B's files
+- **project_root**: The project root (for comparing against existing patterns)
+- **expected_behaviors**: List of specific checks to evaluate (from eval_tasks.json)
+
+## Process
+
+### Step 1: Understand the project context
+
+Read existing code in the project to understand its conventions:
+- File naming patterns
+- Export styles (named vs default)
+- Import ordering
+- Indentation and formatting
+- Directory structure patterns
+- Error handling approaches
+
+### Step 2: Examine both outputs
+
+Read all files from both output directories. For each output, note:
+- File placement and naming
+- Code structure and patterns
+- Import style
+- Export style
+- Naming conventions for variables, functions, types
+- How well it fits with existing project code
+
+### Step 3: Evaluate expected behaviors
+
+For each expected_behavior, check both outputs:
+- Does Output A satisfy the check?
+- Does Output B satisfy the check?
+- Record pass/fail with evidence
+
+### Step 4: Holistic comparison
+
+Beyond the specific checks, evaluate overall project fit:
+- Which output "feels" more like it belongs in this codebase?
+- Which follows more of the project's implicit conventions?
+- Which would require fewer style corrections in code review?
+
+### Step 5: Score and declare winner
+
+Score each output on these dimensions (1-5 scale):
+
+| Dimension | What to evaluate |
+|-----------|-----------------|
+| **naming** | Do identifiers match the project's style? |
+| **structure** | Are files placed in contextually appropriate locations? |
+| **style** | Does the code style match existing code? (indentation, formatting) |
+| **patterns** | Does it use the same patterns as the rest of the codebase? (error handling, imports, exports) |
+| **overall** | Overall fit with the project |
+
+## Output
+
+Write your judgment as JSON:
+
+```json
+{
+  "winner": "A" | "B" | "tie",
+  "reasoning": "2-3 sentence explanation of why the winner is better",
+  "expected_behavior_results": {
+    "A": [{"claim_id": "...", "passed": true, "evidence": "..."}],
+    "B": [{"claim_id": "...", "passed": false, "evidence": "..."}]
+  },
+  "scores": {
+    "A": {"naming": 3, "structure": 4, "style": 3, "patterns": 3, "overall": 3.3},
+    "B": {"naming": 5, "structure": 5, "style": 4, "patterns": 4, "overall": 4.5}
+  }
+}
+```
+
+## Critical rules
+
+- You do NOT know which output had CLAUDE.md. Do not guess or assume.
+- Judge purely on how well each output fits the existing project.
+- If both outputs are equally good, declare a "tie".
+- Base your judgment on evidence, not assumptions.
+- Be specific in your reasoning — cite actual code patterns you observed.

--- a/skills/claude-md-creator/agents/claim_extractor.md
+++ b/skills/claude-md-creator/agents/claim_extractor.md
@@ -1,0 +1,57 @@
+# Claim Extractor Agent
+
+Parse a CLAUDE.md file into a comprehensive list of testable claims, enriching the mechanical extraction done by `scripts/extract_claims.py`.
+
+## Role
+
+You take the raw output of `extract_claims.py` and enrich it with claims the script missed — especially natural language conventions, implicit architecture decisions, and semantic rules that require understanding context rather than regex matching.
+
+## Inputs
+
+- **claude_md_path**: Path to the CLAUDE.md file
+- **rules_dir**: Path to `.claude/rules/` (optional)
+- **script_path**: Path to the extract_claims.py script
+
+## Process
+
+### Step 1: Run the extraction script
+
+```bash
+python -m scripts.extract_claims <claude_md_path> --rules-dir <rules_dir> --pretty --output <workspace>/claims_raw.json
+```
+
+### Step 2: Read the CLAUDE.md yourself
+
+Read the CLAUDE.md (and any rules files) line by line. Look for claims the script missed:
+
+1. **Natural language conventions** without directive keywords — e.g., "Server Components are the default" (no "use" or "always" keyword, but clearly a convention)
+2. **Implicit architecture decisions** — e.g., "The auth middleware wraps all API routes" (architecture claim, not just a path)
+3. **Compound rules** — e.g., "named exports only (no default exports except pages)" contains both a positive and negative rule
+4. **Contextual framework usage** — e.g., "queries through Prisma" implies both a framework reference AND a convention about how to access the database
+5. **Negation rules that the script missed** — Korean or non-English negations, or complex sentence structures
+
+### Step 3: Classify and flag
+
+For each claim (both from the script and your additions):
+
+1. **Confirm the type** — Is `extract_claims.py`'s classification correct?
+2. **Flag vague claims** — If the script didn't catch a vague instruction, re-classify it
+3. **Flag generic claims** — Same for generic advice
+4. **Split compound claims** — If one line contains multiple independent rules, create separate claims
+5. **Add check hints** — For convention claims, suggest what to look for when verifying (regex patterns, file types to sample, etc.)
+
+### Step 4: Deduplicate
+
+If the script extracted overlapping claims (e.g., a framework reference AND a convention from the same line), keep both only if they test different things.
+
+### Step 5: Output enriched claims.json
+
+Write the final `claims.json` to the workspace. It should follow the schema in `references/schemas.md`.
+
+## Output
+
+Save the enriched `claims.json` to the path specified in your prompt. Report a summary:
+- Total claims extracted
+- Breakdown by type
+- Number of claims added beyond what the script found
+- Number of untestable claims (vague + generic)

--- a/skills/claude-md-creator/agents/coherence_checker.md
+++ b/skills/claude-md-creator/agents/coherence_checker.md
@@ -1,0 +1,75 @@
+# Coherence Checker Agent
+
+Verify extracted claims against the actual codebase, enriching the automated checks done by `scripts/verify_coherence.py`.
+
+## Role
+
+You take the output of `verify_coherence.py` and handle cases the script cannot resolve: convention adherence checks, naming pattern verification, fuzzy path matching, and generating fix suggestions for stale claims.
+
+## Inputs
+
+- **claims_json**: Path to claims.json (from Phase 1)
+- **coherence_json**: Path to the script's coherence_report.json
+- **project_root**: Path to the project root
+- **script_path**: Path to verify_coherence.py
+
+## Process
+
+### Step 1: Run the verification script
+
+```bash
+python -m scripts.verify_coherence <claims_json> <project_root> --pretty --output <workspace>/coherence_raw.json
+```
+
+### Step 2: Enrich unverifiable results
+
+Read the raw coherence report. Focus on claims with status `unverifiable` — these are the ones the script could not check programmatically.
+
+For **convention** claims:
+1. Identify which file types the convention applies to (e.g., `.ts`, `.tsx`, `.py`)
+2. Sample 10-20 files of that type from the project
+3. Check whether the convention is followed
+4. Calculate an adherence ratio
+5. Update status to `verified` (ratio >= 0.7), `partial` (0.3-0.7), or `stale` (< 0.3)
+
+For **naming_pattern** claims:
+1. List files in the relevant directories
+2. Check filenames against the claimed pattern
+3. Check exported identifiers if the claim is about code naming
+
+For **import_rule** claims:
+1. Read import blocks from sampled files
+2. Check ordering and style against the claim
+
+### Step 3: Handle stale paths with fuzzy matching
+
+For path claims marked `stale`:
+1. Check if the directory was renamed (look for similar names in the parent)
+2. Check if the path moved (search for the leaf directory name elsewhere)
+3. Generate a concrete fix suggestion with the correct path
+
+### Step 4: Verify workflow claims
+
+For workflow claims:
+1. Check `.github/workflows/` for CI configuration
+2. Check `.husky/` or `.git/hooks/` for git hooks
+3. Check for branch naming conventions in recent git history
+
+### Step 5: Generate fix suggestions
+
+For every stale or partially-verified claim, generate a specific fix:
+- **Stale path**: "Update `src/api/handlers/` to `src/app/api/`"
+- **Missing framework**: "Remove Prisma reference or install: `pnpm add prisma @prisma/client`"
+- **Low convention adherence**: "Convention followed in 3/20 files. Consider removing this rule or enforcing it with a linter"
+
+### Step 6: Output enriched coherence report
+
+Write the final `coherence_report.json`. Update the coherence score based on your enrichments.
+
+## Output
+
+Save the enriched `coherence_report.json` to the workspace. Report:
+- Overall coherence score
+- Number of claims verified/stale/partial
+- Top 3 issues found
+- Suggested fixes

--- a/skills/claude-md-creator/agents/eval_generator.md
+++ b/skills/claude-md-creator/agents/eval_generator.md
@@ -1,0 +1,109 @@
+# Eval Task Generator Agent
+
+Generate realistic coding tasks that test whether Claude follows CLAUDE.md conventions when writing code.
+
+## Role
+
+You design small, focused coding tasks where each task tests 1-3 specific claims from the CLAUDE.md. The tasks must produce checkable artifacts (files, not explanations) so that both programmatic checks and blind judges can evaluate the results.
+
+## Inputs
+
+- **claims_json**: Path to claims.json (from Phase 1)
+- **coherence_json**: Path to coherence_report.json (from Phase 2)
+- **project_root**: Path to the project
+
+## Process
+
+### Step 1: Select testable claims
+
+From claims.json, filter to claims that:
+1. Are `testable: true`
+2. Were `verified` or `partial` in the coherence report (don't test stale claims)
+3. Are of types: `convention`, `naming_pattern`, `import_rule`, `architecture`, `path_reference`
+
+Command and framework claims are already verified by the coherence check — they don't need blind testing.
+
+### Step 2: Group related claims
+
+Group claims that can be tested together:
+- Same section (e.g., "Code Style" claims can share one task)
+- Same domain (e.g., all API-related claims)
+- Complementary checks (e.g., "named exports" + "import ordering")
+
+Target: 3-7 tasks total. More than 7 dilutes signal; fewer than 3 is insufficient.
+
+### Step 3: Design tasks
+
+For each group, write a realistic coding task:
+
+**Good task characteristics:**
+- Small scope (completable in 1-2 minutes by a subagent)
+- Produces files (not just explanations)
+- Natural — the kind of thing a developer would actually ask Claude to do
+- Tests claims implicitly (doesn't say "use named exports" — just asks to create a function)
+
+**Bad task characteristics:**
+- Too large or vague
+- Tells Claude what conventions to follow (that defeats the test)
+- Tests things that can't be checked programmatically
+- Tests trivially (any reasonable code would pass)
+
+### Step 4: Define checks
+
+For each expected behavior, define a programmatic check:
+
+| check_type | When to use | Fields |
+|------------|-------------|--------|
+| `code_pattern` | Check that code contains a regex | `pattern`, optional `anti_pattern` |
+| `file_location` | Check file was created in right directory | `expected_dir` |
+| `file_naming` | Check filename follows convention | `pattern` (regex) |
+| `import_style` | Check import ordering/style | `pattern` |
+| `code_absence` | Check that a pattern does NOT appear | `pattern` |
+
+### Step 5: Output eval_tasks.json
+
+Write the tasks following the schema in `references/schemas.md`.
+
+## Example task
+
+If CLAUDE.md says:
+- "Named exports only (no default exports except pages)"
+- "Components in `src/components/`"
+- "2-space indentation"
+
+Generate:
+
+```json
+{
+  "id": "task-1",
+  "tests_claims": ["conv-7", "arch-2"],
+  "description": "Tests named export convention and component placement",
+  "task_prompt": "Create a new React component called UserAvatar that displays a user's profile picture with a fallback to their initials. It should accept props for imageUrl, name, and size (small/medium/large).",
+  "expected_behaviors": [
+    {
+      "claim_id": "conv-7",
+      "description": "Uses named export",
+      "check_type": "code_pattern",
+      "pattern": "export (function|const) UserAvatar"
+    },
+    {
+      "claim_id": "conv-7",
+      "description": "No default export",
+      "check_type": "code_absence",
+      "pattern": "export default"
+    },
+    {
+      "claim_id": "arch-2",
+      "description": "Component placed in src/components/",
+      "check_type": "file_location",
+      "expected_dir": "src/components/"
+    }
+  ]
+}
+```
+
+## Important
+
+- Do NOT include CLAUDE.md instructions in the task prompt. The whole point is to test whether Claude follows conventions from CLAUDE.md context, not from explicit instructions.
+- Make tasks project-appropriate. If the project is a Python backend, don't generate React component tasks.
+- Read the project structure to understand what kind of tasks make sense.

--- a/skills/claude-md-creator/docs/SPEC-auto-refinement.md
+++ b/skills/claude-md-creator/docs/SPEC-auto-refinement.md
@@ -1,0 +1,326 @@
+# claude-md-creator Auto-Refinement SPEC
+
+## 1. 개요
+
+autoresearch의 "자동 반복 실험 → 메트릭 비교 → 개선 유지/폐기" 패턴을 차용하여, claude-md-creator 스킬의 Python 스크립트 로직(claim 추출, 코드베이스 검증 등)을 실제 GitHub 레포들에 대해 대규모로 테스트하고, 실패 모드를 자동 감지/수정하는 완전 자동화 파이프라인.
+
+### 목적
+
+**스킬 로직 개선**에 집중. CLAUDE.md 생성 품질이 아닌, `extract_claims.py`의 precision/recall과 `verify_coherence.py`의 정확도를 다양한 레포에서 테스트하여 패턴 매칭/검증 로직을 정교하게 다듬는 것이 핵심.
+
+### 핵심 아이디어: autoresearch 매핑
+
+| autoresearch | claude-md-creator Auto-Refinement |
+|---|---|
+| `train.py` (수정 대상) | `scripts/*.py` — extract_claims.py, verify_coherence.py 등 |
+| `prepare.py` (고정) | 테스트 하네스 + golden set (고정) |
+| `val_bpb` (메트릭) | 실패 모드 점수 (6가지 실패 감지 메트릭) |
+| `program.md` (가이드) | 수정 가이드 문서 (실패 모드 + 코드 구조 + 금지 사항) |
+| 5분 고정 예산 | N회 고정 반복 |
+| git baseline 비교 | golden set 회귀 테스트 |
+
+## 2. 배경
+
+- **문제**: claude-md-creator의 claim 추출/검증 로직이 특정 프로젝트 유형(주로 Node/Next.js)에 편향되어 있을 수 있음. 다른 생태계(Rust, Go, Ruby 등)에서 추출 실패, 과적합, 검증 에러 등이 발생할 가능성이 높음.
+- **접근**: 실제 내용의 적합성 검증(Ground Truth)은 평가하기 너무 어려우므로, **실패 모드 감지**에 집중 — 0점/과소 추출/과다 추출/스크립트 에러/과적합 등 명확한 이상 징후만 탐지.
+- **영감**: karpathy/autoresearch — 고정 예산 실험 + 단일 메트릭(val_bpb) + keep/discard 반복으로 자율적 개선.
+
+## 3. 요구사항
+
+### 기능적 요구사항
+
+#### FR1: 테스트 레포 자동 수집
+- GitHub Search API로 `filename:CLAUDE.md` 검색
+- 필터링 기준: 스타 수, 언어 분포, 레포 크기
+- 20-30개 레포 풀 구성 (다양한 생태계 커버)
+- shallow clone (depth=1)으로 디스크 최소화
+- 레포 목록을 JSON으로 캐싱하여 재사용
+
+#### FR2: 실패 모드 자동 감지 (6가지)
+
+| # | 실패 모드 | 감지 조건 | 심각도 |
+|---|-----------|----------|--------|
+| 1 | **추출 실패** | `len(claims) == 0` | CRITICAL |
+| 2 | **과소 추출** | `claim_count / non_empty_lines < threshold` | HIGH |
+| 3 | **과다 추출 (과적합)** | `(vague + generic) / total > 0.5` | HIGH |
+| 4 | **스크립트 런타임 에러** | Python exception / non-zero exit code | CRITICAL |
+| 5 | **Coherence 0점** | `coherence_score == 0` (모든 claim stale) | HIGH |
+| 6 | **Coherence 100점 과신** | `coherence_score == 100` AND `unverifiable > 50%` | MEDIUM |
+
+#### FR3: 자동 수정 루프
+- Claude가 `scripts/*.py`만 수정 (에이전트 지시문, SKILL.md 등은 고정)
+- 실패 리포트를 분석하여 패턴/정규식/검증 로직 수정
+- 수정 후 golden set 회귀 테스트 통과 확인
+- 통과 시 keep, 실패 시 git revert (discard)
+
+#### FR4: 회귀 방지 (Golden Set)
+- 5-10개 레포를 golden set으로 지정
+- 매 반복마다 golden set 전체 통과 필수
+- 새 레포에서 실패를 고치고 golden set도 통과하면 → keep + 해당 레포를 golden set에 추가 검토
+- golden set이 점진적으로 확장되어 기준선이 올라감
+
+#### FR5: 결과 출력
+- 반복별 JSON 로그: `iterations/<N>/result.json`
+- 최종 HTML 리포트: 반복 진행 경과 + 개선 사항 시각화
+- 터미널 실시간 요약 (진행률, 현재 점수, keep/discard 상태)
+
+#### FR6: Claude Code 스킬로 구현
+- `/auto-refine` 또는 유사한 스킬 커맨드로 실행
+- Claude Code 세션에서 인터랙티브하게 동작
+- 기존 claude-md-creator 스킬 디렉토리 내에 서브 모듈로 구성
+
+### 비기능적 요구사항
+
+- **NFR1**: 한 반복(iteration)당 실행 시간 < 5분 (스크립트 실행만, clone 제외)
+- **NFR2**: 로컬 디스크 사용량 < 2GB (shallow clone + 완료 후 cleanup)
+- **NFR3**: GitHub API rate limit 준수 (인증된 요청 5000/h)
+- **NFR4**: 수정된 스크립트가 기존 인터페이스(입출력 형식)를 유지해야 함
+
+## 4. 기술 설계
+
+### 아키텍처
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    Auto-Refinement Loop                   │
+│                                                           │
+│  ┌──────────┐   ┌──────────┐   ┌──────────┐   ┌───────┐ │
+│  │ 1. Collect│──→│ 2. Test  │──→│ 3. Analyze│──→│4. Fix │ │
+│  │   Repos   │   │  Scripts │   │ Failures  │   │Scripts│ │
+│  └──────────┘   └──────────┘   └──────────┘   └───┬───┘ │
+│       ↑                                            │     │
+│       │         ┌──────────┐   ┌──────────┐        │     │
+│       │         │6. Decide │←──│5. Regress │←───────┘     │
+│       └─────────│keep/disc.│   │   Test    │              │
+│                 └──────────┘   └──────────┘              │
+└─────────────────────────────────────────────────────────┘
+```
+
+#### 컴포넌트 구성
+
+```
+skills/claude-md-creator/
+├── auto-refine/
+│   ├── SKILL.md                    # /auto-refine 스킬 정의
+│   ├── program.md                  # Claude 수정 가이드 (실패 모드 + 코드 구조 + 금지 사항)
+│   ├── harness/
+│   │   ├── collect_repos.py        # GitHub API로 CLAUDE.md 있는 레포 수집
+│   │   ├── run_test.py             # 단일 레포에 대해 scripts 실행 + 실패 감지
+│   │   ├── run_suite.py            # 전체 레포 셋 테스트 + 결과 집계
+│   │   └── regression_check.py     # golden set 회귀 테스트
+│   ├── config/
+│   │   ├── golden_set.json         # golden set 레포 목록 + 기대 결과
+│   │   ├── repo_pool.json          # 전체 테스트 레포 풀 (캐싱)
+│   │   └── thresholds.json         # 실패 모드 임계값 설정
+│   ├── results/
+│   │   ├── iterations/             # 반복별 결과 JSON
+│   │   └── report.html             # 최종 HTML 리포트
+│   └── agents/
+│       └── script_modifier.md      # Claude에게 수정 방향을 지시하는 에이전트 정의
+```
+
+### 데이터 흐름
+
+#### 1단계: 레포 수집 (`collect_repos.py`)
+```
+GitHub Search API ("filename:CLAUDE.md")
+  → 필터 (stars > 10, 최근 6개월 활동, 다양한 언어)
+  → repo_pool.json (owner, name, language, stars, clone_url)
+  → 매 반복에서 10개 랜덤 선택 + golden set(5개) = 15개 테스트
+```
+
+#### 2단계: 테스트 실행 (`run_test.py`)
+```
+각 레포에 대해:
+  1. shallow clone → /tmp/auto-refine/<repo>/
+  2. CLAUDE.md + .claude/rules/ 파일 위치 확인
+  3. extract_claims.py 실행 → claims.json
+  4. verify_coherence.py 실행 → coherence_report.json
+  5. 실패 모드 6가지 체크 → test_result.json
+  6. cleanup (clone 삭제)
+```
+
+#### 3단계: 실패 분석 (`run_suite.py`)
+```
+전체 레포 결과 집계:
+  - 레포별 실패 모드 발생 여부
+  - 생태계별 성공률 (Node: 90%, Python: 70%, Rust: 40% ...)
+  - claim type 분포 균형도
+  - 전체 점수 = (성공 레포 수 / 전체 레포 수) × 100
+```
+
+#### 4단계: 스크립트 수정 (Claude + `program.md`)
+```
+실패 리포트 + program.md → Claude가 scripts/*.py 수정
+  - 실패한 레포의 CLAUDE.md 패턴 분석
+  - 누락된 정규식/키워드 추가
+  - 과적합 필터 강화
+  - 새 생태계 지원 추가
+```
+
+#### 5단계: 회귀 테스트 (`regression_check.py`)
+```
+수정된 scripts로 golden set 전체 재실행
+  - 모든 golden set 레포가 이전과 동일하거나 더 나은 결과
+  - 어떤 golden set 레포든 악화 → FAIL → git revert
+```
+
+#### 6단계: Keep/Discard 결정
+```
+회귀 테스트 통과:
+  - git commit "auto-refine: iteration N - fix {failure_type} for {ecosystem}"
+  - 새로 성공한 레포를 golden set 추가 후보에 기록
+  - 다음 반복 진행
+
+회귀 테스트 실패:
+  - git revert
+  - 실패 원인 로그 기록
+  - 다음 반복에서 다른 접근 시도
+```
+
+### 테스트 레포 선정 기준
+
+#### GitHub Search 쿼리
+```
+filename:CLAUDE.md path:/
+```
+
+#### 필터링 조건
+- stars >= 10 (최소 활용 검증)
+- 최근 6개월 내 커밋 활동 (활성 프로젝트)
+- CLAUDE.md 크기 >= 500 bytes (최소 내용 보장)
+- 레포 크기 < 500MB (clone 시간/디스크 절약)
+
+#### 생태계 다양성 보장 (목표 분포)
+| 언어/생태계 | 목표 비율 | 최소 레포 수 |
+|------------|----------|-------------|
+| JavaScript/TypeScript (Node) | 30% | 6개 |
+| Python | 25% | 5개 |
+| Rust | 15% | 3개 |
+| Go | 15% | 3개 |
+| 기타 (Ruby, Java, PHP 등) | 15% | 3개 |
+
+## 5. 엣지 케이스
+
+### EC1: CLAUDE.md 구조가 극단적인 경우
+- **빈 CLAUDE.md** (파일은 존재하지만 내용 없음): 추출 실패로 감지되지만, 스크립트가 graceful하게 처리해야 함
+- **초대형 CLAUDE.md** (1000줄+): 추출 시간이 길어지거나 메모리 문제 가능. 타임아웃 설정 필요
+- **비표준 Markdown**: HTML 혼용, 탭 기반 들여쓰기, 비ASCII 문자 등
+
+### EC2: 레포 접근 문제
+- **private 레포**: Search API에 나타나지 않으므로 자동 필터링됨
+- **clone 실패**: 네트워크 에러, 인증 문제 → skip + 로그 기록
+- **CLAUDE.md 경로 변형**: `.claude/CLAUDE.md`, `docs/CLAUDE.md` 등 비표준 경로
+
+### EC3: 수정 루프 관련
+- **Claude 수정이 항상 discard되는 교착 상태**: N회 연속 discard 시 경고 + 실패 패턴을 program.md에 추가하여 다른 접근 유도
+- **수정이 한 레포만 고치고 다른 레포를 망가뜨리는 반복**: golden set이 방지하지만, golden set 외 레포 간 충돌은 감지 못함
+- **스크립트 인터페이스 변경**: 입출력 JSON 스키마가 바뀌면 다운스트림(aggregate, report) 스크립트도 깨짐 → program.md에서 인터페이스 변경 금지 명시
+
+### EC4: GitHub API 제약
+- **Rate limit**: 인증 5000/h, 비인증 60/h → 인증 토큰 필수
+- **Search 결과 편향**: 인기 레포 위주로 검색됨 → stars 범위를 구간별로 분리 수집
+- **일시적 API 오류**: 재시도 로직 (exponential backoff)
+
+## 6. 트레이드오프 기록
+
+### TD1: 실패 모드 감지 vs Ground Truth 평가
+- **선택**: 실패 모드 감지 (정답 없이 이상 징후만 탐지)
+- **대안**: 수동 라벨링으로 precision/recall 측정
+- **배제 이유**: 수동 라벨링 비용이 너무 높고, 실제 내용 적합성을 사람이 판단하기도 주관적
+- **향후 개선**: 실패 모드 기반으로 충분히 안정화되면, 소규모 golden claim set으로 precision/recall 측정 추가 검토
+
+### TD2: Python 스크립트만 수정 vs 에이전트 지시문도 수정
+- **선택**: Python 스크립트만 수정
+- **대안**: agents/*.md도 함께 수정 허용
+- **배제 이유**: 에이전트 지시문 변경의 영향을 정량화하기 어려움 (스크립트는 deterministic, 에이전트는 non-deterministic)
+- **향후 개선**: 스크립트 안정화 후 에이전트 지시문 A/B 테스트 별도 파이프라인 구축 가능
+
+### TD3: Golden Set 회귀 vs 전체 점수 합산
+- **선택**: Golden Set 회귀 테스트 (어떤 golden set 레포도 악화 불가)
+- **대안**: 전체 레포 점수 합산이 이전보다 높으면 keep
+- **배제 이유**: 전체 합산은 개별 레포 회귀를 허용하여, 특정 생태계가 점점 악화될 위험
+- **향후 개선**: golden set 크기가 충분히 커지면 (15개+) 전체 합산 방식으로 전환 검토
+
+### TD4: 완전 자동 vs 반자동 수정
+- **선택**: 완전 자동 (Claude가 수정 + 테스트 + keep/discard)
+- **대안**: Claude 제안 → 사람 승인 → 적용
+- **배제 이유**: 자동화 속도가 핵심 가치. git revert 안전장치가 있으므로 리스크 관리 가능
+- **향후 개선**: 큰 구조 변경이 필요할 때만 사람 개입 (코드 줄 수 변경 > threshold 시 pause)
+
+### TD5: 로컬 실행 vs CI/CD
+- **선택**: 로컬 머신
+- **대안**: GitHub Actions, Docker
+- **배제 이유**: 초기 개발/디버깅이 로컬에서 훨씬 빠름. Python 스크립트만 실행하므로 환경 격리 불필요
+- **향후 개선**: 안정화 후 GitHub Actions로 이관하여 야간 자동 실행 가능
+
+## 7. 구현 체크리스트
+
+### Phase 0: 기반 구축
+- [ ] `auto-refine/` 디렉토리 구조 생성
+- [ ] `program.md` 작성 (실패 모드 정의 + 코드 구조 설명 + 금지 사항)
+- [ ] `thresholds.json` 초기값 설정 (과소/과다 추출 임계값 등)
+
+### Phase 1: 레포 수집기
+- [ ] `collect_repos.py` 구현 (GitHub Search API + 필터링)
+- [ ] 생태계별 다양성 보장 로직
+- [ ] `repo_pool.json` 캐싱/갱신 메커니즘
+- [ ] 초기 golden set 수동 선정 (5개: Node, Python, Rust, Go, 기타 각 1개)
+
+### Phase 2: 테스트 하네스
+- [ ] `run_test.py` 구현 (단일 레포 테스트 + 6가지 실패 모드 감지)
+- [ ] `run_suite.py` 구현 (전체 레포 셋 테스트 + 결과 집계)
+- [ ] `regression_check.py` 구현 (golden set 회귀 테스트)
+- [ ] JSON 결과 스키마 정의
+
+### Phase 3: 자동 수정 루프
+- [ ] `/auto-refine` 스킬 SKILL.md 작성
+- [ ] `script_modifier.md` 에이전트 정의 (수정 전략 + 제약 사항)
+- [ ] 반복 루프 구현 (테스트 → 분석 → 수정 → 회귀 → keep/discard)
+- [ ] git commit/revert 자동화
+- [ ] 종료 조건 구현 (N회 고정 반복)
+
+### Phase 4: 결과 리포팅
+- [ ] 반복별 JSON 로그 저장 (`iterations/<N>/result.json`)
+- [ ] HTML 리포트 생성 (반복 진행 경과 + 개선 시각화)
+- [ ] 터미널 실시간 요약 출력
+
+### Phase 5: 통합 테스트
+- [ ] 전체 파이프라인 end-to-end 테스트 (3회 반복)
+- [ ] 교착 상태 감지/복구 테스트
+- [ ] golden set 확장 프로세스 검증
+
+## 8. 실행 예시
+
+```bash
+# Claude Code 세션에서:
+/auto-refine --iterations 10 --golden-set config/golden_set.json
+
+# 또는 기본값으로:
+/auto-refine
+```
+
+### 예상 출력 (터미널)
+```
+🔄 Auto-Refinement Loop - claude-md-creator
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+📦 Repo pool: 25 repos (6 Node, 5 Python, 3 Rust, 3 Go, 3 Ruby, 5 other)
+🏅 Golden set: 5 repos (all passing)
+
+Iteration 1/10
+├── Testing 15 repos (10 random + 5 golden)...
+├── Failures: 3 repos (2 CRITICAL, 1 HIGH)
+│   ├── rust-analyzer: CRITICAL - extract_claims runtime error (TOML parsing)
+│   ├── servo: HIGH - coherence 0% (Rust ecosystem unsupported)
+│   └── django-ninja: HIGH - under-extraction (4 claims from 120-line CLAUDE.md)
+├── Fixing scripts...
+│   └── verify_coherence.py: Added Cargo.toml dependency parser
+├── Regression test: ✅ PASS (5/5 golden repos OK)
+├── Decision: ✅ KEEP
+└── Score: 80% → 87% (+7%)
+
+Iteration 2/10
+├── Testing 15 repos (10 random + 5 golden)...
+...
+```

--- a/skills/claude-md-creator/evals/evals.json
+++ b/skills/claude-md-creator/evals/evals.json
@@ -1,0 +1,61 @@
+{
+  "skill_name": "claude-md-creator",
+  "evals": [
+    {
+      "id": 1,
+      "category": "create",
+      "prompt": "I just cloned a Next.js project and want to set up CLAUDE.md for the team. Can you create one?",
+      "expected_output": "Analyzes the codebase (package.json, directory structure, frameworks), interviews the user for missing context, then generates a well-structured CLAUDE.md under 200 lines with build/test commands, code style rules, and Next.js-specific architecture conventions. May also suggest .claude/rules/ files if needed.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "category": "create",
+      "prompt": "We have a Python FastAPI monorepo with separate services. How should I organize CLAUDE.md and rules?",
+      "expected_output": "Creates a concise main CLAUDE.md with shared conventions, plus .claude/rules/ files scoped with paths: frontmatter for each service. Detects FastAPI, pytest, and relevant dependencies from pyproject.toml.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "category": "quick-eval",
+      "prompt": "Can you evaluate my CLAUDE.md and tell me if everything is still accurate?",
+      "expected_output": "Runs Phase 1 (claim extraction) and Phase 2 (coherence verification). Produces a coherence score showing how many claims match the codebase. Identifies stale paths, missing dependencies, and vague instructions. Generates an HTML report at /tmp/claude-md-eval.html.",
+      "files": []
+    },
+    {
+      "id": 4,
+      "category": "quick-eval",
+      "prompt": "Audit my CLAUDE.md — I think some paths are outdated after our recent refactor.",
+      "expected_output": "Extracts path_reference claims and verifies each against the filesystem. Reports stale paths with fuzzy-match suggestions for correct replacements. Shows coherence score and a prioritized list of fixes.",
+      "files": []
+    },
+    {
+      "id": 5,
+      "category": "full-eval",
+      "prompt": "Run a full evaluation with blind testing to see if my CLAUDE.md actually helps Claude write better code.",
+      "expected_output": "Runs all 5 phases: claim extraction, coherence check, eval task generation (3-7 tasks from verified claims), blind A/B coding test (with vs without CLAUDE.md), and final report. Shows effectiveness score with win/tie/loss counts, programmatic check delta, and blind judge scores.",
+      "files": []
+    },
+    {
+      "id": 6,
+      "category": "full-eval",
+      "prompt": "I want to test whether my CLAUDE.md conventions actually change Claude's output. Run the blind test.",
+      "expected_output": "Generates dynamic eval tasks from the CLAUDE.md's own conventions. Runs blind_coder with and without CLAUDE.md context. Runs blind_judge comparison without revealing which output had CLAUDE.md. Reports effectiveness score and identifies conventions that don't change behavior (candidates for removal).",
+      "files": []
+    },
+    {
+      "id": 7,
+      "category": "improve",
+      "prompt": "My CLAUDE.md got a C grade. Can you fix it?",
+      "expected_output": "Runs Quick Eval to identify issues, then applies fixes in priority order: removes vague/generic instructions, updates stale paths, adds missing sections (build/test commands), and strengthens partially-followed conventions. Shows diff and re-runs eval to confirm improvement.",
+      "files": []
+    },
+    {
+      "id": 8,
+      "category": "improve",
+      "prompt": "My CLAUDE.md is over 400 lines and Claude keeps ignoring some instructions. Help me fix it.",
+      "expected_output": "Diagnoses the size issue, identifies which instructions are vague/generic/redundant, suggests splitting into .claude/rules/ files with path-specific scoping, and produces a trimmed main CLAUDE.md under 200 lines.",
+      "files": []
+    }
+  ]
+}

--- a/skills/claude-md-creator/references/best-practices.md
+++ b/skills/claude-md-creator/references/best-practices.md
@@ -1,0 +1,230 @@
+# CLAUDE.md Best Practices Reference
+
+Comprehensive reference from the official Claude Code documentation (https://code.claude.com/docs/en/memory).
+
+## Table of Contents
+
+1. [File Locations and Scope](#file-locations-and-scope)
+2. [Writing Effective Instructions](#writing-effective-instructions)
+3. [Import System](#import-system)
+4. [Rules Organization](#rules-organization)
+5. [Auto Memory vs CLAUDE.md](#auto-memory-vs-claudemd)
+6. [Anti-Patterns](#anti-patterns)
+7. [Examples of Good Instructions](#examples-of-good-instructions)
+8. [Examples of Bad Instructions](#examples-of-bad-instructions)
+
+---
+
+## File Locations and Scope
+
+| Scope | Location | Purpose | Shared with |
+|-------|----------|---------|-------------|
+| **Managed policy** | OS-specific system path | Org-wide instructions by IT/DevOps | All users in org |
+| **Project** | `./CLAUDE.md` or `./.claude/CLAUDE.md` | Team-shared project instructions | Team via source control |
+| **User** | `~/.claude/CLAUDE.md` | Personal preferences for all projects | Just you |
+
+Resolution order (most specific wins):
+1. Managed policy CLAUDE.md (cannot be excluded)
+2. CLAUDE.md files from current directory up to root
+3. `.claude/rules/` files (unconditional ones at launch, path-scoped on demand)
+4. User `~/.claude/CLAUDE.md`
+5. Subdirectory CLAUDE.md files (loaded when Claude reads files in those dirs)
+
+## Writing Effective Instructions
+
+### Size Guidelines
+
+- **Target**: Under 200 lines per CLAUDE.md file
+- **Why**: Loaded into every session's context window; longer files consume tokens and reduce adherence
+- **If too long**: Split using `@` imports or `.claude/rules/` files
+- **Auto memory**: Only first 200 lines of MEMORY.md loaded; this doesn't apply to CLAUDE.md (loaded in full)
+
+### Structure
+
+- Use markdown headers (`##`, `###`) to group related instructions
+- Use bullet lists for scannable items
+- Avoid dense paragraphs
+- Logical flow: build commands → test commands → code style → architecture → conventions → pitfalls
+
+### Specificity
+
+Concrete and verifiable instructions work best:
+
+| Bad | Good |
+|-----|------|
+| Format code properly | Use 2-space indentation |
+| Test your changes | Run `npm test` before committing |
+| Keep files organized | API handlers live in `src/api/handlers/` |
+| Use good naming | Components: PascalCase, hooks: use- prefix, utils: camelCase |
+| Handle errors well | Wrap API calls in try/catch, log to Sentry, return user-friendly message |
+
+### Consistency
+
+- Review all CLAUDE.md files and `.claude/rules/` for contradictions
+- If two rules conflict, Claude picks one arbitrarily
+- In monorepos, use `claudeMdExcludes` to skip irrelevant CLAUDE.md files
+
+## Import System
+
+Use `@path/to/file` syntax to import additional files:
+
+```markdown
+See @README for project overview.
+See @package.json for available npm commands.
+
+# Additional Instructions
+- git workflow @docs/git-instructions.md
+```
+
+Rules:
+- Both relative and absolute paths allowed
+- Relative paths resolve relative to the file containing the import
+- Maximum 5 hops of recursive imports
+- First encounter shows approval dialog to user
+- Personal imports: `@~/.claude/my-project-instructions.md` (not checked in)
+
+## Rules Organization
+
+### Basic Setup
+
+```
+.claude/
+├── CLAUDE.md           # Main project instructions
+└── rules/
+    ├── code-style.md   # Code style guidelines
+    ├── testing.md      # Testing conventions
+    └── security.md     # Security requirements
+```
+
+### Path-Specific Rules
+
+```markdown
+---
+paths:
+  - "src/api/**/*.ts"
+---
+
+# API Development Rules
+- All endpoints must include input validation
+```
+
+### Glob Patterns
+
+| Pattern | Matches |
+|---------|---------|
+| `**/*.ts` | All TypeScript files in any directory |
+| `src/**/*` | All files under `src/` |
+| `*.md` | Markdown files in project root |
+| `src/components/*.tsx` | React components in a specific directory |
+| `src/**/*.{ts,tsx}` | Multiple extensions with brace expansion |
+
+### User-Level Rules
+
+Personal rules in `~/.claude/rules/` apply to every project. Loaded before project rules (project rules take higher priority).
+
+### Symlinks
+
+`.claude/rules/` supports symlinks for sharing rules across projects:
+```bash
+ln -s ~/shared-claude-rules .claude/rules/shared
+ln -s ~/company-standards/security.md .claude/rules/security.md
+```
+
+## Auto Memory vs CLAUDE.md
+
+| Aspect | CLAUDE.md | Auto Memory |
+|--------|-----------|-------------|
+| **Who writes** | You | Claude |
+| **Content** | Instructions and rules | Learnings and patterns |
+| **Scope** | Project, user, or org | Per working tree |
+| **Loaded** | Every session (full) | Every session (first 200 lines) |
+| **Best for** | Coding standards, workflows, architecture | Build commands, debugging insights, preferences |
+| **Location** | Project root or `.claude/` | `~/.claude/projects/<project>/memory/` |
+
+Use CLAUDE.md when you want to guide Claude's behavior explicitly.
+Use auto memory to let Claude learn from corrections without manual effort.
+
+## Anti-Patterns
+
+### Things to Avoid in CLAUDE.md
+
+1. **Code patterns derivable from reading code** — Claude can read the codebase
+2. **Git history** — `git log` / `git blame` are authoritative
+3. **Debugging solutions** — The fix is in the code; commit message has context
+4. **Generic programming advice** — Claude already knows this
+5. **Ephemeral task details** — Temporary state doesn't belong in persistent instructions
+6. **Long reference documentation** — Put in `.claude/rules/` or external files with `@` import
+7. **Contradicting instructions** — Claude picks arbitrarily between conflicts
+8. **ALL CAPS EMPHASIS** — Explain the "why" instead of shouting
+9. **Overly rigid MUSTs/NEVERs without explanation** — Claude follows reasoned instructions better
+
+### Size Anti-Patterns
+
+- Putting everything in one giant CLAUDE.md (split into rules)
+- Including full API documentation (use `@` imports)
+- Duplicating information from README or package.json (reference them instead)
+
+## Examples of Good Instructions
+
+```markdown
+## Build & Run
+
+- `pnpm dev` — start dev server on localhost:3000
+- `pnpm build` — production build (runs type check first)
+- `pnpm lint` — eslint + prettier check
+
+## Test
+
+- `pnpm test` — run all tests with vitest
+- `pnpm test src/utils/date.test.ts` — run single test file
+- Tests use MSW for API mocking; handlers are in `src/mocks/handlers.ts`
+
+## Code Style
+
+- 2-space indentation, no tabs
+- Named exports only (no default exports except pages)
+- Import order: react → external libs → @/ internal → relative → types
+- `import type` on separate line from value imports
+
+## Architecture
+
+- App Router (Next.js 14): pages in `app/`, components in `src/components/`
+- Server Components by default; 'use client' only when needed
+- API routes in `app/api/` — all use the `withAuth` middleware wrapper
+- Database queries through Prisma; schema at `prisma/schema.prisma`
+
+## Gotchas
+
+- `NEXT_PUBLIC_*` env vars are in client bundle — never put secrets there
+- The `users` table has a soft-delete (`deleted_at`) — always filter in queries
+- Auth tokens expire in 15min; refresh logic is in `src/lib/auth.ts`
+```
+
+## Examples of Bad Instructions
+
+```markdown
+# Bad: Too vague
+- Write clean code
+- Follow best practices
+- Make sure tests pass
+
+# Bad: Derivable from code
+- The User model has fields: id, name, email, created_at
+- The fetchUsers function takes a page parameter
+
+# Bad: Too long / reference doc
+- [500 lines of API documentation that should be a separate file]
+
+# Bad: Generic advice
+- Use meaningful variable names
+- Don't repeat yourself
+- Keep functions small
+
+# Bad: Contradicting
+- Always use semicolons (in one section)
+- No semicolons (in another section)
+
+# Bad: Ephemeral
+- We're currently working on the auth migration (ticket #1234)
+- The staging server is down today
+```

--- a/skills/claude-md-creator/references/claim-taxonomy.md
+++ b/skills/claude-md-creator/references/claim-taxonomy.md
@@ -1,0 +1,196 @@
+# Claim Taxonomy
+
+Every instruction in a CLAUDE.md is a **claim** about how the project works or how code should be written. This document defines the types of claims, how to extract them, and how to verify each type.
+
+## Table of Contents
+
+1. [Claim Types](#claim-types)
+2. [Extraction Patterns](#extraction-patterns)
+3. [Verification Strategies](#verification-strategies)
+
+---
+
+## Claim Types
+
+| Type | Description | Example | Testable |
+|------|-------------|---------|----------|
+| `command` | A CLI command for building, testing, linting, etc. | `` `pnpm dev` — start dev server `` | Yes |
+| `path_reference` | A file or directory path | "API handlers live in `src/api/handlers/`" | Yes |
+| `framework_reference` | A framework, library, or tool name | "Database queries through Prisma" | Yes |
+| `convention` | A coding rule or pattern to follow | "Named exports only (no default exports)" | Yes |
+| `naming_pattern` | A naming convention for files or identifiers | "Components: PascalCase, hooks: use- prefix" | Yes |
+| `import_rule` | Import ordering or style requirement | "Import order: react → external → @/ → relative → types" | Yes |
+| `architecture` | A structural description of the project | "App Router: pages in `app/`, components in `src/components/`" | Yes |
+| `env_reference` | An environment variable reference | "`NEXT_PUBLIC_*` vars are in client bundle" | Yes |
+| `workflow` | A git, CI/CD, or process instruction | "Run `npm test` before committing" | Partially |
+| `vague` | An instruction too vague to verify | "Write clean code" | No |
+| `generic` | Generic advice Claude already knows | "Use meaningful variable names" | No |
+
+---
+
+## Extraction Patterns
+
+### command
+
+Look for backtick-enclosed strings that start with a known command prefix or appear in a "commands" section.
+
+**Regex patterns:**
+```
+`(npm|pnpm|yarn|npx|pip|python|cargo|make|go|ruby|bundle|docker|kubectl|terraform|gradle|mvn|dotnet|mix)\s+[^`]+`
+```
+
+Also match: bullets starting with `` ` `` followed by ` — ` or ` - ` description.
+
+**Section hints:** "Build", "Run", "Test", "Lint", "Deploy", "Scripts"
+
+### path_reference
+
+Look for backtick-enclosed strings that look like filesystem paths.
+
+**Regex patterns:**
+```
+`\.?/?[\w@-]+(/[\w@.*{}-]+)+/?`
+```
+
+Also match: directory descriptions like "X lives in `path`" or "X at `path`".
+
+**Exclusions:** URLs (http/https), import paths without `/` context.
+
+### framework_reference
+
+Look for known framework/library names in natural language context.
+
+**Known frameworks (detect case-insensitively):**
+- JS/TS: React, Next.js, Vue, Angular, Svelte, Express, Fastify, Nest, Nuxt, Remix, Vite, Webpack, esbuild, Tailwind, Prisma, Drizzle, TypeORM, Sequelize, Mongoose, Jest, Vitest, Playwright, Cypress, ESLint, Prettier, Storybook, MSW, Zod
+- Python: Django, Flask, FastAPI, SQLAlchemy, Alembic, pytest, Pydantic, Celery, Redis, Ruff, Black, mypy
+- Rust: Tokio, Actix, Axum, Diesel, SeaORM, Serde, Clap
+- Go: Gin, Echo, Fiber, GORM, sqlx
+- Ruby: Rails, Sinatra, RSpec, Sidekiq
+- General: Docker, Kubernetes, Terraform, PostgreSQL, MySQL, MongoDB, Redis, Elasticsearch, GraphQL, gRPC, Kafka, RabbitMQ
+
+**Disambiguation:** "React" in "React component" = framework. "react" in "react to events" = not a framework.
+
+### convention
+
+Look for directive language patterns:
+
+**Patterns:**
+- "Use X" / "Always use X"
+- "X only" / "X, not Y"
+- "No X" / "Never X" / "Avoid X"
+- "Prefer X over Y"
+- "X should be Y"
+- "X must be Y"
+- Negation with reason: "Don't X because Y"
+
+**Section hints:** "Style", "Conventions", "Rules", "Standards", "Guidelines"
+
+### naming_pattern
+
+Look for naming convention descriptions:
+
+**Patterns:**
+- "PascalCase" / "camelCase" / "snake_case" / "kebab-case" / "UPPER_SNAKE_CASE"
+- "X: YCase" (e.g., "Components: PascalCase")
+- "prefix X with Y" (e.g., "hooks: use- prefix")
+- File naming patterns: "*.test.ts", "*.spec.ts"
+
+### import_rule
+
+Look for import ordering or style descriptions:
+
+**Patterns:**
+- "Import order: A → B → C"
+- "`import type` on separate line"
+- "No barrel imports"
+- "@/ absolute path"
+- "relative imports only within same directory"
+
+### architecture
+
+Look for directory structure descriptions:
+
+**Patterns:**
+- "X in `path/`" or "X lives in `path/`"
+- Directory tree diagrams (indented with ├── or └──)
+- "App Router" / "Pages Router" patterns
+- Layer descriptions: "controllers", "services", "repositories"
+
+### env_reference
+
+Look for environment variable patterns:
+
+**Patterns:**
+- `UPPER_SNAKE_CASE` strings (especially with `NEXT_PUBLIC_`, `VITE_`, `REACT_APP_` prefixes)
+- ".env" file references
+- "environment variable" in text
+
+### workflow
+
+Look for process instructions:
+
+**Patterns:**
+- "before committing" / "before pushing"
+- "branch naming" / "PR process"
+- "CI/CD" / "pipeline"
+- Git-related commands and conventions
+
+### vague
+
+Flag instructions that are too vague to verify:
+
+**Indicators:**
+- No specific tool, pattern, or measurable outcome
+- Subjective quality terms without definition: "clean", "readable", "maintainable", "good", "proper"
+- "Write X code" without specifying what X means
+
+### generic
+
+Flag advice Claude already knows:
+
+**Known generic patterns:**
+- "DRY principle" / "Don't repeat yourself"
+- "KISS principle"
+- "SOLID principles"
+- "Keep functions small"
+- "Use meaningful variable names"
+- "Single responsibility"
+- "Separation of concerns"
+
+---
+
+## Verification Strategies
+
+### By claim type
+
+| Type | Automated verification | Confidence |
+|------|----------------------|------------|
+| `command` | Parse package.json/Makefile scripts, check executable existence | High (1.0) |
+| `path_reference` | `os.path.exists()` relative to project root | High (1.0) |
+| `framework_reference` | Check dependency files (package.json, requirements.txt, etc.) | High (1.0) |
+| `convention` | Sample 10-20 relevant files, regex check adherence ratio | Medium (0.7-0.9) |
+| `naming_pattern` | List files in relevant dirs, match naming pattern | Medium (0.7-0.9) |
+| `import_rule` | Parse import blocks from sampled files | Medium (0.7-0.9) |
+| `architecture` | Directory existence + file type matching | High (0.9-1.0) |
+| `env_reference` | Check .env.example or grep code for usage | Medium (0.8) |
+| `workflow` | Check CI config files, git hooks | Medium (0.7-0.8) |
+| `vague` | Not verified — flagged for improvement | N/A |
+| `generic` | Not verified — flagged for removal | N/A |
+
+### Dependency file detection
+
+The verification engine auto-detects the project ecosystem by checking for:
+
+| File | Ecosystem | What to check |
+|------|-----------|---------------|
+| `package.json` | Node.js/JS/TS | `scripts`, `dependencies`, `devDependencies` |
+| `pyproject.toml` | Python | `[project.dependencies]`, `[tool.poetry.dependencies]`, `[project.scripts]` |
+| `requirements.txt` | Python | Package list |
+| `Cargo.toml` | Rust | `[dependencies]`, `[dev-dependencies]` |
+| `go.mod` | Go | `require` block |
+| `Gemfile` | Ruby | `gem` declarations |
+| `pom.xml` | Java (Maven) | `<dependencies>` |
+| `build.gradle` | Java/Kotlin (Gradle) | `dependencies` block |
+| `composer.json` | PHP | `require`, `require-dev` |
+| `mix.exs` | Elixir | `deps` function |
+| `Makefile` | Any | Target names |

--- a/skills/claude-md-creator/references/schemas.md
+++ b/skills/claude-md-creator/references/schemas.md
@@ -1,0 +1,320 @@
+# JSON Schemas
+
+Data structures used across all phases of the CLAUDE.md evaluation pipeline.
+
+## Table of Contents
+
+1. [claims.json](#claimsjson) — Phase 1 output
+2. [coherence_report.json](#coherence_reportjson) — Phase 2 output
+3. [eval_tasks.json](#eval_tasksjson) — Phase 3 output
+4. [blind_results.json](#blind_resultsjson) — Phase 4 output
+5. [evaluation_summary.json](#evaluation_summaryjson) — Phase 5 output
+
+---
+
+## claims.json
+
+Output of Phase 1 (Claim Extraction). Every testable instruction from the CLAUDE.md is parsed into a structured claim.
+
+```json
+{
+  "source_file": "CLAUDE.md",
+  "rules_files": ["rules/code-style.md", "rules/testing.md"],
+  "total_claims": 42,
+  "claims": [
+    {
+      "id": "cmd-1",
+      "type": "command",
+      "raw_text": "`pnpm dev` — start dev server on localhost:3000",
+      "source_file": "CLAUDE.md",
+      "source_line": 15,
+      "source_section": "Build & Run",
+      "extracted": {
+        "command": "pnpm dev",
+        "description": "start dev server on localhost:3000"
+      },
+      "testable": true
+    },
+    {
+      "id": "path-3",
+      "type": "path_reference",
+      "raw_text": "API handlers live in `src/api/handlers/`",
+      "source_file": "CLAUDE.md",
+      "source_line": 34,
+      "source_section": "Architecture",
+      "extracted": {
+        "path": "src/api/handlers/",
+        "assertion": "API handlers live here"
+      },
+      "testable": true
+    },
+    {
+      "id": "conv-7",
+      "type": "convention",
+      "raw_text": "Named exports only (no default exports except pages)",
+      "source_file": "rules/code-style.md",
+      "source_line": 12,
+      "source_section": "Code Style",
+      "extracted": {
+        "rule": "Use named exports, not default exports",
+        "exception": "page.tsx and layout.tsx files",
+        "check_pattern": "export default"
+      },
+      "testable": true
+    },
+    {
+      "id": "fw-2",
+      "type": "framework_reference",
+      "raw_text": "Database queries through Prisma; schema at `prisma/schema.prisma`",
+      "source_file": "CLAUDE.md",
+      "source_line": 52,
+      "source_section": "Architecture",
+      "extracted": {
+        "framework": "prisma",
+        "config_path": "prisma/schema.prisma"
+      },
+      "testable": true
+    },
+    {
+      "id": "vague-1",
+      "type": "vague",
+      "raw_text": "Write clean, maintainable code",
+      "source_file": "CLAUDE.md",
+      "source_line": 60,
+      "source_section": "Code Style",
+      "extracted": {
+        "issue": "Too vague to verify — replace with specific rules"
+      },
+      "testable": false
+    }
+  ]
+}
+```
+
+### Claim fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Unique identifier, prefixed by type: `cmd-`, `path-`, `conv-`, `fw-`, `name-`, `arch-`, `env-`, `wf-`, `vague-`, `generic-` |
+| `type` | string | One of the types from claim-taxonomy.md |
+| `raw_text` | string | Original text from the CLAUDE.md |
+| `source_file` | string | Which file the claim came from |
+| `source_line` | number | Line number in the source file |
+| `source_section` | string | Section header the claim falls under |
+| `extracted` | object | Type-specific structured data |
+| `testable` | boolean | Whether this claim can be verified against the codebase |
+
+---
+
+## coherence_report.json
+
+Output of Phase 2 (Codebase Coherence Verification). Each claim is checked against the real project.
+
+```json
+{
+  "project_root": "/path/to/project",
+  "total_claims": 42,
+  "testable_claims": 38,
+  "verified": 32,
+  "stale": 4,
+  "unverifiable": 2,
+  "coherence_score": 84.2,
+  "results": [
+    {
+      "claim_id": "cmd-1",
+      "type": "command",
+      "claim_text": "`pnpm dev` — start dev server",
+      "status": "verified",
+      "evidence": "Found in package.json scripts: \"dev\": \"next dev\"",
+      "confidence": 1.0
+    },
+    {
+      "claim_id": "path-3",
+      "type": "path_reference",
+      "claim_text": "API handlers live in `src/api/handlers/`",
+      "status": "stale",
+      "evidence": "Directory src/api/handlers/ does not exist. Similar: src/app/api/ (exists, 12 files)",
+      "confidence": 0.0,
+      "suggestion": "Update path reference to `src/app/api/`"
+    },
+    {
+      "claim_id": "conv-7",
+      "type": "convention",
+      "claim_text": "Named exports only",
+      "status": "verified",
+      "evidence": "Sampled 20 .ts files: 18/20 use named exports (90%). 2 default exports are page.tsx files (allowed exception).",
+      "confidence": 0.9,
+      "adherence_ratio": 0.9
+    }
+  ]
+}
+```
+
+### Result statuses
+
+| Status | Meaning |
+|--------|---------|
+| `verified` | Claim matches the codebase |
+| `stale` | Claim references something that no longer exists or is wrong |
+| `partial` | Claim is partially correct (e.g., convention followed 60% of the time) |
+| `unverifiable` | Cannot be checked programmatically |
+
+---
+
+## eval_tasks.json
+
+Output of Phase 3 (Dynamic Eval Task Generation). Coding tasks designed to test whether Claude follows CLAUDE.md conventions.
+
+```json
+{
+  "project_root": "/path/to/project",
+  "total_tasks": 5,
+  "tasks": [
+    {
+      "id": "task-1",
+      "tests_claims": ["conv-7"],
+      "description": "Tests whether named export convention is followed",
+      "task_prompt": "Create a new utility function called `formatCurrency` in src/utils/ that formats a number as USD currency (e.g., 1234.56 -> '$1,234.56'). Include TypeScript types.",
+      "expected_behaviors": [
+        {
+          "claim_id": "conv-7",
+          "description": "Uses named export, not default export",
+          "check_type": "code_pattern",
+          "pattern": "export (function|const) formatCurrency",
+          "anti_pattern": "export default"
+        }
+      ]
+    },
+    {
+      "id": "task-2",
+      "tests_claims": ["path-3", "fw-2"],
+      "description": "Tests API handler placement and Prisma usage",
+      "task_prompt": "Add a new API endpoint POST /api/users/invite that accepts an email and creates an invitation record.",
+      "expected_behaviors": [
+        {
+          "claim_id": "path-3",
+          "description": "Creates handler in correct API directory",
+          "check_type": "file_location",
+          "expected_dir": "src/app/api/"
+        },
+        {
+          "claim_id": "fw-2",
+          "description": "Uses Prisma for database operations",
+          "check_type": "code_pattern",
+          "pattern": "prisma\\."
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Check types
+
+| check_type | Description | Fields |
+|------------|-------------|--------|
+| `code_pattern` | Regex match in generated code | `pattern`, optional `anti_pattern` |
+| `file_location` | File created in expected directory | `expected_dir` |
+| `file_naming` | File follows naming convention | `pattern` (regex for filename) |
+| `import_style` | Import follows stated convention | `pattern` |
+| `code_absence` | Certain pattern should NOT appear | `pattern` |
+
+---
+
+## blind_results.json
+
+Output of Phase 4 (Effectiveness Blind Test). Paired comparison of with/without CLAUDE.md.
+
+```json
+{
+  "total_tasks": 5,
+  "tasks": [
+    {
+      "task_id": "task-1",
+      "programmatic_checks": {
+        "with_claude_md": {
+          "passed": 2,
+          "total": 2,
+          "details": [
+            {"claim_id": "conv-7", "check": "named export", "passed": true, "evidence": "Found: export function formatCurrency"}
+          ]
+        },
+        "without_claude_md": {
+          "passed": 0,
+          "total": 2,
+          "details": [
+            {"claim_id": "conv-7", "check": "named export", "passed": false, "evidence": "Found: export default function formatCurrency"}
+          ]
+        }
+      },
+      "blind_judgment": {
+        "assignment": {"A": "without_claude_md", "B": "with_claude_md"},
+        "winner": "B",
+        "reasoning": "Output B uses named exports consistently and follows the project's existing patterns.",
+        "scores": {
+          "A": {"naming": 3, "structure": 4, "style": 3, "overall": 3.3},
+          "B": {"naming": 5, "structure": 5, "style": 4, "overall": 4.7}
+        }
+      },
+      "claude_md_won": true
+    }
+  ],
+  "summary": {
+    "claude_md_wins": 4,
+    "ties": 1,
+    "claude_md_losses": 0,
+    "programmatic_pass_rate_with": 0.9,
+    "programmatic_pass_rate_without": 0.4,
+    "effectiveness_score": 85.0
+  }
+}
+```
+
+---
+
+## evaluation_summary.json
+
+Final output of Phase 5. Aggregates all phase results.
+
+```json
+{
+  "overall_score": 84,
+  "grade": "B",
+  "coherence": {
+    "score": 84,
+    "total_claims": 42,
+    "verified": 32,
+    "stale": 4,
+    "partial": 2,
+    "unverifiable": 4
+  },
+  "effectiveness": {
+    "score": 85,
+    "total_tasks": 5,
+    "claude_md_wins": 4,
+    "ties": 1,
+    "losses": 0,
+    "programmatic_delta": "+50%"
+  },
+  "top_issues": [
+    {
+      "severity": "high",
+      "claim_id": "path-3",
+      "issue": "Stale path: `src/api/handlers/` does not exist",
+      "suggestion": "Update to `src/app/api/`"
+    },
+    {
+      "severity": "medium",
+      "claim_id": "vague-1",
+      "issue": "Vague instruction: 'Write clean, maintainable code'",
+      "suggestion": "Replace with specific rules like '2-space indentation' or 'max 150 lines per component'"
+    }
+  ],
+  "recommendations": {
+    "remove": ["vague-1", "generic-2"],
+    "fix": [{"claim_id": "path-3", "current": "src/api/handlers/", "suggested": "src/app/api/"}],
+    "add": ["No test command found — add test runner instructions"],
+    "strengthen": ["conv-7 adherence is 90% — add linting rule to enforce"]
+  }
+}
+```

--- a/skills/claude-md-creator/scripts/aggregate_results.py
+++ b/skills/claude-md-creator/scripts/aggregate_results.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""
+Phase 5: Aggregate coherence and blind test results into a final evaluation summary.
+
+Combines Phase 2 (coherence_report.json) and Phase 4 (blind_results.json)
+into a single evaluation_summary.json with overall score, grade, top issues,
+and actionable recommendations.
+
+Usage:
+    python -m scripts.aggregate_results <coherence.json> [--blind <blind_results.json>] [--output <path>]
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Grading
+# ---------------------------------------------------------------------------
+
+GRADE_THRESHOLDS = [
+    (90, "A"),
+    (80, "B"),
+    (70, "C"),
+    (60, "D"),
+    (0, "F"),
+]
+
+
+def score_to_grade(score: float) -> str:
+    for threshold, grade in GRADE_THRESHOLDS:
+        if score >= threshold:
+            return grade
+    return "F"
+
+
+# ---------------------------------------------------------------------------
+# Issue extraction
+# ---------------------------------------------------------------------------
+
+SEVERITY_MAP = {
+    "stale": "high",
+    "partial": "medium",
+}
+
+
+def extract_issues(coherence_data: dict, claims_lookup: dict | None = None) -> list[dict]:
+    """Extract top issues from coherence report."""
+    issues = []
+
+    for result in coherence_data.get("results", []):
+        status = result.get("status")
+        if status not in ("stale", "partial"):
+            continue
+
+        severity = SEVERITY_MAP.get(status, "low")
+        issue = {
+            "severity": severity,
+            "claim_id": result["claim_id"],
+            "type": result.get("type", "unknown"),
+            "issue": result.get("evidence", "Unknown issue"),
+        }
+        if result.get("suggestion"):
+            issue["suggestion"] = result["suggestion"]
+
+        issues.append(issue)
+
+    # Add vague/generic claims as low-severity issues
+    if claims_lookup:
+        for claim_id, claim in claims_lookup.items():
+            if claim["type"] in ("vague", "generic"):
+                issues.append({
+                    "severity": "low",
+                    "claim_id": claim_id,
+                    "type": claim["type"],
+                    "issue": claim["extracted"].get("issue", f"{claim['type']} instruction"),
+                    "suggestion": claim["extracted"].get("suggestion", "Replace with specific instruction"),
+                })
+
+    # Sort by severity (high > medium > low)
+    severity_order = {"high": 0, "medium": 1, "low": 2}
+    issues.sort(key=lambda x: severity_order.get(x["severity"], 3))
+
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# Recommendation generation
+# ---------------------------------------------------------------------------
+
+
+def generate_recommendations(
+    coherence_data: dict,
+    blind_data: dict | None,
+    issues: list[dict],
+) -> dict:
+    """Generate actionable recommendations."""
+    recommendations: dict[str, list] = {
+        "remove": [],
+        "fix": [],
+        "add": [],
+        "strengthen": [],
+    }
+
+    for result in coherence_data.get("results", []):
+        claim_id = result["claim_id"]
+        status = result.get("status")
+        claim_type = result.get("type", "")
+
+        # Remove: vague/generic claims
+        if status == "not_applicable" and claim_type in ("vague", "generic"):
+            recommendations["remove"].append(claim_id)
+
+        # Fix: stale claims with suggestions
+        elif status == "stale" and result.get("suggestion"):
+            recommendations["fix"].append({
+                "claim_id": claim_id,
+                "issue": result.get("evidence", ""),
+                "suggested": result["suggestion"],
+            })
+
+        # Strengthen: partial adherence
+        elif status == "partial":
+            adherence = result.get("adherence_ratio")
+            msg = f"{claim_id} partially followed"
+            if adherence is not None:
+                msg += f" ({adherence:.0%} adherence)"
+            msg += " — consider adding linter rules to enforce"
+            recommendations["strengthen"].append(msg)
+
+    # Check for missing sections
+    section_types = set()
+    for result in coherence_data.get("results", []):
+        section_types.add(result.get("type"))
+
+    if "command" not in section_types:
+        recommendations["add"].append("No build/test commands found — add Build & Run section")
+
+    # Blind test insights
+    if blind_data:
+        summary = blind_data.get("summary", {})
+        losses = summary.get("claude_md_losses", 0)
+        if losses > 0:
+            recommendations["add"].append(
+                f"CLAUDE.md lost {losses} blind test(s) — review conventions that "
+                "may conflict with Claude's default behavior"
+            )
+
+    return recommendations
+
+
+# ---------------------------------------------------------------------------
+# Main aggregation
+# ---------------------------------------------------------------------------
+
+
+def aggregate(
+    coherence_data: dict,
+    blind_data: dict | None = None,
+    claims_data: dict | None = None,
+) -> dict:
+    """Aggregate all results into evaluation_summary.json."""
+    # Build claims lookup
+    claims_lookup = {}
+    if claims_data:
+        for claim in claims_data.get("claims", []):
+            claims_lookup[claim["id"]] = claim
+
+    # Coherence scores
+    coherence_score = coherence_data.get("coherence_score", 0)
+    coherence_summary = {
+        "score": coherence_score,
+        "total_claims": coherence_data.get("total_claims", 0),
+        "verified": coherence_data.get("verified", 0),
+        "stale": coherence_data.get("stale", 0),
+        "partial": coherence_data.get("partial", 0),
+        "unverifiable": coherence_data.get("unverifiable", 0),
+    }
+
+    # Effectiveness scores (from blind test)
+    effectiveness_summary = None
+    effectiveness_score = 0
+    if blind_data and blind_data.get("summary"):
+        summary = blind_data["summary"]
+        total = summary.get("claude_md_wins", 0) + summary.get("ties", 0) + summary.get("claude_md_losses", 0)
+        if total > 0:
+            # Score: wins count full, ties count half
+            effectiveness_score = round(
+                (summary["claude_md_wins"] + summary.get("ties", 0) * 0.5) / total * 100,
+                1,
+            )
+        else:
+            effectiveness_score = 0
+
+        pass_with = summary.get("programmatic_pass_rate_with", 0)
+        pass_without = summary.get("programmatic_pass_rate_without", 0)
+        delta = pass_with - pass_without
+
+        effectiveness_summary = {
+            "score": effectiveness_score,
+            "total_tasks": summary.get("total_tasks", total),
+            "claude_md_wins": summary.get("claude_md_wins", 0),
+            "ties": summary.get("ties", 0),
+            "losses": summary.get("claude_md_losses", 0),
+            "programmatic_delta": f"+{delta:.0%}" if delta >= 0 else f"{delta:.0%}",
+        }
+
+    # Overall score: weighted average
+    if effectiveness_summary:
+        # 50% coherence + 50% effectiveness
+        overall_score = round(coherence_score * 0.5 + effectiveness_score * 0.5, 1)
+    else:
+        # Quick eval: coherence only
+        overall_score = round(coherence_score, 1)
+
+    grade = score_to_grade(overall_score)
+
+    # Issues and recommendations
+    issues = extract_issues(coherence_data, claims_lookup)
+    recommendations = generate_recommendations(coherence_data, blind_data, issues)
+
+    result = {
+        "overall_score": overall_score,
+        "grade": grade,
+        "coherence": coherence_summary,
+        "top_issues": issues[:10],
+        "recommendations": recommendations,
+    }
+
+    if effectiveness_summary:
+        result["effectiveness"] = effectiveness_summary
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Aggregate evaluation results")
+    parser.add_argument("coherence_json", type=Path, help="Path to coherence_report.json")
+    parser.add_argument("--blind", type=Path, default=None, help="Path to blind_results.json")
+    parser.add_argument("--claims", type=Path, default=None, help="Path to claims.json (for vague/generic detection)")
+    parser.add_argument("--output", type=Path, default=None)
+    parser.add_argument("--pretty", action="store_true")
+    args = parser.parse_args()
+
+    coherence_data = json.loads(args.coherence_json.read_text(encoding="utf-8"))
+
+    blind_data = None
+    if args.blind:
+        blind_data = json.loads(args.blind.read_text(encoding="utf-8"))
+
+    claims_data = None
+    if args.claims:
+        claims_data = json.loads(args.claims.read_text(encoding="utf-8"))
+
+    result = aggregate(coherence_data, blind_data, claims_data)
+
+    output_json = json.dumps(result, indent=2 if args.pretty else None, ensure_ascii=False)
+
+    if args.output:
+        args.output.write_text(output_json, encoding="utf-8")
+        grade = result["grade"]
+        score = result["overall_score"]
+        print(f"Evaluation summary → {args.output}")
+        print(f"Overall: {score}/100 (Grade {grade})")
+        print(f"Issues: {len(result['top_issues'])} found")
+    else:
+        print(output_json)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/claude-md-creator/scripts/extract_claims.py
+++ b/skills/claude-md-creator/scripts/extract_claims.py
@@ -1,0 +1,524 @@
+#!/usr/bin/env python3
+"""
+Phase 1: Extract testable claims from CLAUDE.md and .claude/rules/ files.
+
+Parses every instruction into a structured claim with type, source location,
+and extracted data. The output (claims.json) feeds into Phase 2 (coherence
+verification) and Phase 3 (eval task generation).
+
+Usage:
+    python -m scripts.extract_claims <path-to-claude-md> [--rules-dir <path>] [--output <path>]
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Known patterns for detection
+# ---------------------------------------------------------------------------
+
+COMMAND_PREFIXES = {
+    "npm", "pnpm", "yarn", "npx", "pip", "pip3", "python", "python3",
+    "cargo", "make", "go", "ruby", "bundle", "docker", "docker-compose",
+    "kubectl", "terraform", "gradle", "mvn", "dotnet", "mix", "composer",
+    "php", "jest", "vitest", "pytest", "ruff", "black", "eslint",
+    "prettier", "tsc", "turbo", "nx", "lerna", "bun",
+}
+
+FRAMEWORK_NAMES = {
+    # JS/TS
+    "react", "next.js", "next", "nextjs", "vue", "angular", "svelte",
+    "express", "fastify", "nestjs", "nest", "nuxt", "remix", "astro",
+    "vite", "webpack", "esbuild", "rollup", "parcel",
+    "tailwind", "tailwindcss", "emotion", "styled-components",
+    "prisma", "drizzle", "typeorm", "sequelize", "mongoose", "knex",
+    "jest", "vitest", "playwright", "cypress", "testing-library",
+    "eslint", "prettier", "storybook", "msw", "zod",
+    "tanstack", "react-query", "swr", "axios", "trpc",
+    "zustand", "jotai", "recoil", "redux", "mobx",
+    # Python
+    "django", "flask", "fastapi", "sqlalchemy", "alembic", "pytest",
+    "pydantic", "celery", "redis", "ruff", "black", "mypy",
+    "poetry", "pipenv", "uvicorn", "gunicorn",
+    # Rust
+    "tokio", "actix", "axum", "diesel", "seaorm", "serde", "clap",
+    # Go
+    "gin", "echo", "fiber", "gorm", "sqlx",
+    # Ruby
+    "rails", "sinatra", "rspec", "sidekiq",
+    # General
+    "docker", "kubernetes", "k8s", "terraform",
+    "postgresql", "postgres", "mysql", "mongodb", "sqlite",
+    "redis", "elasticsearch", "opensearch",
+    "graphql", "grpc", "kafka", "rabbitmq",
+    "sentry", "datadog", "grafana",
+}
+
+VAGUE_PATTERNS = [
+    (r"(?i)\bwrite clean\b", "write clean ..."),
+    (r"(?i)\bfollow best practices\b", "follow best practices"),
+    (r"(?i)\bformat code properly\b", "format code properly"),
+    (r"(?i)\btest your changes\b", "test your changes"),
+    (r"(?i)\bkeep files organized\b", "keep files organized"),
+    (r"(?i)\buse good naming\b", "use good naming"),
+    (r"(?i)\bhandle errors well\b", "handle errors well"),
+    (r"(?i)\bwrite meaningful\b", "write meaningful ..."),
+    (r"(?i)\bcode should be\s+(clean|readable|maintainable)\b", "code should be clean/readable"),
+    (r"(?i)\bproperly\s+(handle|format|structure|organize)\b", "properly ..."),
+    (r"(?i)\bensure\s+quality\b", "ensure quality"),
+    (r"(?i)\bmaintain\s+consistency\b", "maintain consistency"),
+]
+
+GENERIC_PATTERNS = [
+    (r"(?i)\bdon'?t repeat yourself\b", "DRY principle"),
+    (r"(?i)\bDRY\s+principle\b", "DRY principle"),
+    (r"(?i)\bKISS\s+principle\b", "KISS principle"),
+    (r"(?i)\bSOLID\s+principles?\b", "SOLID principles"),
+    (r"(?i)\bkeep functions small\b", "keep functions small"),
+    (r"(?i)\buse meaningful variable names\b", "meaningful variable names"),
+    (r"(?i)\bsingle responsibility\b", "single responsibility"),
+    (r"(?i)\bseparation of concerns\b", "separation of concerns"),
+]
+
+NAMING_KEYWORDS = [
+    "PascalCase", "camelCase", "snake_case", "kebab-case",
+    "UPPER_SNAKE_CASE", "SCREAMING_SNAKE_CASE",
+]
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def read_file(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (FileNotFoundError, PermissionError):
+        return ""
+
+
+def parse_sections(content: str) -> list[dict]:
+    """Split markdown content into sections by headers."""
+    sections: list[dict] = []
+    current_section = "Top"
+    current_lines: list[tuple[int, str]] = []
+
+    for i, line in enumerate(content.splitlines(), 1):
+        header_match = re.match(r"^(#{1,4})\s+(.+)", line)
+        if header_match:
+            if current_lines:
+                sections.append({"name": current_section, "lines": current_lines})
+            current_section = header_match.group(2).strip()
+            current_lines = [(i, line)]
+        else:
+            current_lines.append((i, line))
+
+    if current_lines:
+        sections.append({"name": current_section, "lines": current_lines})
+
+    return sections
+
+
+# ---------------------------------------------------------------------------
+# Extractors — each returns a list of claim dicts
+# ---------------------------------------------------------------------------
+
+
+def extract_commands(sections: list[dict], source_file: str) -> list[dict]:
+    """Extract CLI commands from backtick-enclosed text."""
+    claims = []
+    cmd_id = 0
+
+    for section in sections:
+        for line_num, line in section["lines"]:
+            # Pattern: `command args` — description  OR  - `command args` — description
+            matches = re.finditer(r"`([^`]+)`", line)
+            for m in matches:
+                text = m.group(1).strip()
+                first_word = text.split()[0] if text.split() else ""
+
+                # Check if first word is a known command prefix
+                if first_word.lower() in COMMAND_PREFIXES:
+                    cmd_id += 1
+                    # Try to extract description after — or -
+                    desc_match = re.search(r"[—–\-]\s*(.+)$", line[m.end():])
+                    description = desc_match.group(1).strip() if desc_match else ""
+
+                    claims.append({
+                        "id": f"cmd-{cmd_id}",
+                        "type": "command",
+                        "raw_text": line.strip(),
+                        "source_file": source_file,
+                        "source_line": line_num,
+                        "source_section": section["name"],
+                        "extracted": {
+                            "command": text,
+                            "description": description,
+                        },
+                        "testable": True,
+                    })
+
+    return claims
+
+
+def extract_paths(sections: list[dict], source_file: str) -> list[dict]:
+    """Extract file/directory path references."""
+    claims = []
+    path_id = 0
+    seen_paths = set()
+
+    for section in sections:
+        for line_num, line in section["lines"]:
+            matches = re.finditer(r"`([^`]+)`", line)
+            for m in matches:
+                text = m.group(1).strip()
+
+                # Skip if it looks like a command (already handled)
+                first_word = text.split()[0] if text.split() else ""
+                if first_word.lower() in COMMAND_PREFIXES:
+                    continue
+
+                # Check if it looks like a path
+                if re.match(r"^\.?/?[\w@.-]+(/[\w@.*{}\[\]-]+)+/?$", text):
+                    # Skip URLs
+                    if text.startswith("http") or text.startswith("//"):
+                        continue
+                    if text in seen_paths:
+                        continue
+                    seen_paths.add(text)
+
+                    path_id += 1
+                    claims.append({
+                        "id": f"path-{path_id}",
+                        "type": "path_reference",
+                        "raw_text": line.strip(),
+                        "source_file": source_file,
+                        "source_line": line_num,
+                        "source_section": section["name"],
+                        "extracted": {
+                            "path": text,
+                            "is_directory": text.endswith("/"),
+                        },
+                        "testable": True,
+                    })
+
+    return claims
+
+
+def extract_frameworks(sections: list[dict], source_file: str) -> list[dict]:
+    """Extract framework/library references."""
+    claims = []
+    fw_id = 0
+    seen_frameworks = set()
+
+    for section in sections:
+        section_text = " ".join(line for _, line in section["lines"])
+
+        for fw_name in FRAMEWORK_NAMES:
+            # Case-insensitive search with word boundary
+            pattern = r"(?i)\b" + re.escape(fw_name) + r"\b"
+            match = re.search(pattern, section_text)
+            if match and fw_name.lower() not in seen_frameworks:
+                # Find the actual line
+                matched_line_num = section["lines"][0][0]
+                for ln, lt in section["lines"]:
+                    if re.search(pattern, lt):
+                        matched_line_num = ln
+                        break
+
+                seen_frameworks.add(fw_name.lower())
+                fw_id += 1
+
+                # Check for config path reference nearby
+                config_path = None
+                config_match = re.search(
+                    r"`([^`]*" + re.escape(fw_name.lower().replace(".", "")) + r"[^`]*)`",
+                    section_text, re.IGNORECASE
+                )
+                if config_match:
+                    candidate = config_match.group(1)
+                    if "/" in candidate:
+                        config_path = candidate
+
+                claims.append({
+                    "id": f"fw-{fw_id}",
+                    "type": "framework_reference",
+                    "raw_text": match.group(0),
+                    "source_file": source_file,
+                    "source_line": matched_line_num,
+                    "source_section": section["name"],
+                    "extracted": {
+                        "framework": fw_name.lower(),
+                        **({"config_path": config_path} if config_path else {}),
+                    },
+                    "testable": True,
+                })
+
+    return claims
+
+
+def extract_conventions(sections: list[dict], source_file: str) -> list[dict]:
+    """Extract coding conventions and rules from directive language."""
+    claims = []
+    conv_id = 0
+
+    directive_patterns = [
+        # "Use X" / "Always use X"
+        r"(?i)^\s*[-*]?\s*(?:always\s+)?use\s+(.+)",
+        # "No X" / "Never X" / "Avoid X" / "X forbidden/prohibited"
+        r"(?i)^\s*[-*]?\s*(?:no|never|avoid|don'?t)\s+(.+)",
+        # "X only" / "only X"
+        r"(?i)^\s*[-*]?\s*(.+?)\s+only\b",
+        # "Prefer X over Y"
+        r"(?i)^\s*[-*]?\s*prefer\s+(.+)",
+        # "X should/must be Y"
+        r"(?i)^\s*[-*]?\s*\w+\s+(?:should|must)\s+(?:be|have|use|follow)\s+(.+)",
+        # "X instead of Y" / "X, not Y"
+        r"(?i)^\s*[-*]?\s*(.+?)\s+instead of\s+(.+)",
+    ]
+
+    for section in sections:
+        for line_num, line in section["lines"]:
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+
+            # Check directive patterns
+            for pattern in directive_patterns:
+                if re.search(pattern, stripped):
+                    # Skip if it's a command or path (already extracted)
+                    first_backtick = re.search(r"`[^`]+`", stripped)
+                    if first_backtick:
+                        inner = first_backtick.group(0).strip("`")
+                        first_word = inner.split()[0] if inner.split() else ""
+                        if first_word.lower() in COMMAND_PREFIXES:
+                            continue
+
+                    conv_id += 1
+                    claims.append({
+                        "id": f"conv-{conv_id}",
+                        "type": "convention",
+                        "raw_text": stripped,
+                        "source_file": source_file,
+                        "source_line": line_num,
+                        "source_section": section["name"],
+                        "extracted": {
+                            "rule": stripped.lstrip("-* "),
+                        },
+                        "testable": True,
+                    })
+                    break  # One match per line is enough
+
+    return claims
+
+
+def extract_naming_patterns(sections: list[dict], source_file: str) -> list[dict]:
+    """Extract naming convention claims."""
+    claims = []
+    name_id = 0
+
+    for section in sections:
+        for line_num, line in section["lines"]:
+            for keyword in NAMING_KEYWORDS:
+                if keyword in line:
+                    name_id += 1
+                    claims.append({
+                        "id": f"name-{name_id}",
+                        "type": "naming_pattern",
+                        "raw_text": line.strip(),
+                        "source_file": source_file,
+                        "source_line": line_num,
+                        "source_section": section["name"],
+                        "extracted": {
+                            "pattern": keyword,
+                            "context": line.strip().lstrip("-* "),
+                        },
+                        "testable": True,
+                    })
+                    break  # One match per line
+
+    return claims
+
+
+def extract_env_references(sections: list[dict], source_file: str) -> list[dict]:
+    """Extract environment variable references."""
+    claims = []
+    env_id = 0
+    seen_vars = set()
+
+    for section in sections:
+        for line_num, line in section["lines"]:
+            # Match UPPER_SNAKE_CASE with known prefixes or standalone
+            matches = re.finditer(
+                r"`?(NEXT_PUBLIC_|VITE_|REACT_APP_|NODE_|DATABASE_|API_|AWS_|REDIS_)[\w]*`?|"
+                r"(?<![`\w])([A-Z][A-Z0-9_]{3,})(?![`\w])",
+                line
+            )
+            for m in matches:
+                var_name = m.group(0).strip("`")
+                if var_name in seen_vars:
+                    continue
+                # Filter out common non-env words
+                if var_name in {"TODO", "NOTE", "FIXME", "HACK", "ALWAYS", "NEVER",
+                                "MUST", "SHALL", "SHOULD", "TRUE", "FALSE", "NULL",
+                                "YAML", "JSON", "HTML", "HTTP", "HTTPS", "POST",
+                                "DELETE", "PATCH", "IMPORTANT", "WARNING", "SKILL"}:
+                    continue
+                seen_vars.add(var_name)
+                env_id += 1
+                claims.append({
+                    "id": f"env-{env_id}",
+                    "type": "env_reference",
+                    "raw_text": line.strip(),
+                    "source_file": source_file,
+                    "source_line": line_num,
+                    "source_section": section["name"],
+                    "extracted": {
+                        "variable": var_name,
+                    },
+                    "testable": True,
+                })
+
+    return claims
+
+
+def extract_vague_and_generic(sections: list[dict], source_file: str) -> list[dict]:
+    """Flag vague and generic instructions."""
+    claims = []
+    vague_id = 0
+    generic_id = 0
+
+    for section in sections:
+        for line_num, line in section["lines"]:
+            # Check vague
+            for pattern, label in VAGUE_PATTERNS:
+                if re.search(pattern, line):
+                    vague_id += 1
+                    claims.append({
+                        "id": f"vague-{vague_id}",
+                        "type": "vague",
+                        "raw_text": line.strip(),
+                        "source_file": source_file,
+                        "source_line": line_num,
+                        "source_section": section["name"],
+                        "extracted": {
+                            "issue": f"Too vague to verify: '{label}'",
+                            "suggestion": "Replace with a specific, verifiable instruction",
+                        },
+                        "testable": False,
+                    })
+                    break
+
+            # Check generic
+            for pattern, label in GENERIC_PATTERNS:
+                if re.search(pattern, line):
+                    generic_id += 1
+                    claims.append({
+                        "id": f"generic-{generic_id}",
+                        "type": "generic",
+                        "raw_text": line.strip(),
+                        "source_file": source_file,
+                        "source_line": line_num,
+                        "source_section": section["name"],
+                        "extracted": {
+                            "issue": f"Generic advice Claude already knows: '{label}'",
+                            "suggestion": "Remove or replace with project-specific instruction",
+                        },
+                        "testable": False,
+                    })
+                    break
+
+    return claims
+
+
+# ---------------------------------------------------------------------------
+# Main extraction pipeline
+# ---------------------------------------------------------------------------
+
+
+def extract_from_file(file_path: Path, source_name: str | None = None) -> list[dict]:
+    """Extract all claims from a single file."""
+    content = read_file(file_path)
+    if not content.strip():
+        return []
+
+    source = source_name or file_path.name
+    sections = parse_sections(content)
+
+    all_claims = []
+    all_claims.extend(extract_commands(sections, source))
+    all_claims.extend(extract_paths(sections, source))
+    all_claims.extend(extract_frameworks(sections, source))
+    all_claims.extend(extract_conventions(sections, source))
+    all_claims.extend(extract_naming_patterns(sections, source))
+    all_claims.extend(extract_env_references(sections, source))
+    all_claims.extend(extract_vague_and_generic(sections, source))
+
+    return all_claims
+
+
+def extract_claims(claude_md_path: Path, rules_dir: Path | None = None) -> dict:
+    """Extract claims from CLAUDE.md and optional .claude/rules/ directory."""
+    claims = extract_from_file(claude_md_path, "CLAUDE.md")
+
+    rules_files = []
+    if rules_dir and rules_dir.exists():
+        for rule_file in sorted(rules_dir.glob("**/*.md")):
+            rel_path = str(rule_file.relative_to(rules_dir.parent))
+            rules_files.append(rel_path)
+            file_claims = extract_from_file(rule_file, rel_path)
+
+            # Re-number IDs to avoid collisions
+            for claim in file_claims:
+                prefix = claim["id"].rsplit("-", 1)[0]
+                existing_max = max(
+                    (int(c["id"].rsplit("-", 1)[1]) for c in claims if c["id"].startswith(prefix + "-")),
+                    default=0,
+                )
+                claim["id"] = f"{prefix}-{existing_max + 1}"
+                existing_max += 1  # noqa: Not needed but makes intent clear
+
+            claims.extend(file_claims)
+
+    # Deduplicate by raw_text (keep first occurrence)
+    seen_texts = set()
+    unique_claims = []
+    for claim in claims:
+        normalized = claim["raw_text"].strip().lower()
+        if normalized not in seen_texts:
+            seen_texts.add(normalized)
+            unique_claims.append(claim)
+
+    return {
+        "source_file": str(claude_md_path),
+        "rules_files": rules_files,
+        "total_claims": len(unique_claims),
+        "claims": unique_claims,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Extract claims from CLAUDE.md")
+    parser.add_argument("claude_md", type=Path, help="Path to CLAUDE.md")
+    parser.add_argument("--rules-dir", type=Path, default=None)
+    parser.add_argument("--output", type=Path, default=None, help="Output JSON path")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON")
+    args = parser.parse_args()
+
+    result = extract_claims(args.claude_md, args.rules_dir)
+
+    output_json = json.dumps(result, indent=2 if args.pretty else None, ensure_ascii=False)
+
+    if args.output:
+        args.output.write_text(output_json, encoding="utf-8")
+        print(f"Extracted {result['total_claims']} claims → {args.output}")
+    else:
+        print(output_json)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/claude-md-creator/scripts/extract_claims.py
+++ b/skills/claude-md-creator/scripts/extract_claims.py
@@ -102,20 +102,41 @@ def read_file(path: Path) -> str:
 
 
 def parse_sections(content: str) -> list[dict]:
-    """Split markdown content into sections by headers."""
+    """Split markdown content into sections by headers.
+
+    Each line is stored as (line_number, text, in_code_block) so that
+    extractors can skip fenced code blocks when appropriate.
+    """
     sections: list[dict] = []
     current_section = "Top"
-    current_lines: list[tuple[int, str]] = []
+    current_lines: list[tuple[int, str, bool]] = []
+    in_code_block = False
+    code_fence_char = ""
 
     for i, line in enumerate(content.splitlines(), 1):
+        # Detect fenced code block boundaries (``` or ~~~)
+        # Track which fence character opened the block so that
+        # ``` and ~~~ don't incorrectly close each other.
+        stripped = line.strip()
+        if not in_code_block and (stripped.startswith("```") or stripped.startswith("~~~")):
+            in_code_block = True
+            code_fence_char = stripped[:3]
+            current_lines.append((i, line, True))
+            continue
+        if in_code_block and stripped.startswith(code_fence_char) and stripped.strip(code_fence_char[0]) == "":
+            in_code_block = False
+            code_fence_char = ""
+            current_lines.append((i, line, True))
+            continue
+
         header_match = re.match(r"^(#{1,4})\s+(.+)", line)
-        if header_match:
+        if header_match and not in_code_block:
             if current_lines:
                 sections.append({"name": current_section, "lines": current_lines})
             current_section = header_match.group(2).strip()
-            current_lines = [(i, line)]
+            current_lines = [(i, line, False)]
         else:
-            current_lines.append((i, line))
+            current_lines.append((i, line, in_code_block))
 
     if current_lines:
         sections.append({"name": current_section, "lines": current_lines})
@@ -129,13 +150,38 @@ def parse_sections(content: str) -> list[dict]:
 
 
 def extract_commands(sections: list[dict], source_file: str) -> list[dict]:
-    """Extract CLI commands from backtick-enclosed text."""
+    """Extract CLI commands from backtick-enclosed text and code blocks."""
     claims = []
     cmd_id = 0
 
     for section in sections:
-        for line_num, line in section["lines"]:
-            # Pattern: `command args` — description  OR  - `command args` — description
+        for line_num, line, in_code in section["lines"]:
+            if in_code:
+                # Inside code blocks, look for bare commands (e.g., "pnpm run watch")
+                stripped = line.strip()
+                if stripped.startswith("#"):  # skip comments in code blocks
+                    continue
+                first_word = stripped.split()[0] if stripped.split() else ""
+                if first_word.lower() in COMMAND_PREFIXES:
+                    cmd_id += 1
+                    desc_match = re.search(r"[—–#]\s*(.+)$", stripped)
+                    description = desc_match.group(1).strip() if desc_match else ""
+                    claims.append({
+                        "id": f"cmd-{cmd_id}",
+                        "type": "command",
+                        "raw_text": stripped,
+                        "source_file": source_file,
+                        "source_line": line_num,
+                        "source_section": section["name"],
+                        "extracted": {
+                            "command": stripped,
+                            "description": description,
+                        },
+                        "testable": True,
+                    })
+                continue
+
+            # Outside code blocks: look for backtick-enclosed commands
             matches = re.finditer(r"`([^`]+)`", line)
             for m in matches:
                 text = m.group(1).strip()
@@ -165,14 +211,90 @@ def extract_commands(sections: list[dict], source_file: str) -> list[dict]:
     return claims
 
 
+_TREE_CHAR_RE = re.compile(r"[├└│─]")
+_CODE_FRAGMENT_RE = re.compile(r"[()?\[\]!={}]|^\.\.\.")
+_TEMPLATE_PATH_RE = re.compile(r"\{[^}]+\}|XXX|ComponentName")
+
+
+def _extract_tree_path(line: str) -> str | None:
+    """Extract a file/directory path from a tree diagram line.
+
+    Returns the path string if found, None otherwise.
+    """
+    # Require at least one tree character (├└│─)
+    if not _TREE_CHAR_RE.search(line):
+        return None
+
+    # Try file pattern: ├── filename.ext
+    m = re.search(r"[├└│─][├└│─\s]*(\S+\.\w+)", line)
+    if m:
+        candidate = m.group(1)
+        if not _CODE_FRAGMENT_RE.search(candidate) and not _TEMPLATE_PATH_RE.search(candidate):
+            return candidate
+
+    # Try directory pattern: ├── dirName/
+    m = re.search(r"[├└│─][├└│─\s]*([\w.-]+/)", line)
+    if m:
+        candidate = m.group(1).strip()
+        if not _TEMPLATE_PATH_RE.search(candidate):
+            return candidate
+
+    return None
+
+
 def extract_paths(sections: list[dict], source_file: str) -> list[dict]:
-    """Extract file/directory path references."""
+    """Extract file/directory path references from prose and tree diagrams."""
     claims = []
     path_id = 0
     seen_paths = set()
 
     for section in sections:
-        for line_num, line in section["lines"]:
+        for line_num, line, in_code in section["lines"]:
+            if in_code:
+                # Inside code blocks: extract paths from tree diagrams
+                tree_path = _extract_tree_path(line)
+                if tree_path and tree_path not in seen_paths and not tree_path.startswith("#"):
+                    seen_paths.add(tree_path)
+                    path_id += 1
+                    claims.append({
+                        "id": f"path-{path_id}",
+                        "type": "path_reference",
+                        "raw_text": line.strip(),
+                        "source_file": source_file,
+                        "source_line": line_num,
+                        "source_section": section["name"],
+                        "extracted": {
+                            "path": tree_path,
+                            "is_directory": tree_path.endswith("/"),
+                            "from_tree_diagram": True,
+                        },
+                        "testable": True,
+                    })
+
+                # Also extract import paths: import { x } from '@/some/path'
+                import_match = re.search(r"""from\s+['"](@/[^'"]+)['"]""", line)
+                if import_match:
+                    text = import_match.group(1)
+                    if text not in seen_paths:
+                        seen_paths.add(text)
+                        path_id += 1
+                        claims.append({
+                            "id": f"path-{path_id}",
+                            "type": "path_reference",
+                            "raw_text": line.strip(),
+                            "source_file": source_file,
+                            "source_line": line_num,
+                            "source_section": section["name"],
+                            "extracted": {
+                                "path": text,
+                                "is_directory": False,
+                                "from_import": True,
+                            },
+                            "testable": True,
+                        })
+                continue
+
+            # Outside code blocks: look for backtick-enclosed paths
             matches = re.finditer(r"`([^`]+)`", line)
             for m in matches:
                 text = m.group(1).strip()
@@ -186,6 +308,18 @@ def extract_paths(sections: list[dict], source_file: str) -> list[dict]:
                 if re.match(r"^\.?/?[\w@.-]+(/[\w@.*{}\[\]-]+)+/?$", text):
                     # Skip URLs
                     if text.startswith("http") or text.startswith("//"):
+                        continue
+                    # Skip domain-like patterns (e.g., api3.example.com/path)
+                    if re.match(r"[\w-]+\.[\w-]+\.\w+/", text):
+                        continue
+                    # Skip template/placeholder paths (e.g., {subDomain}.ts)
+                    if re.search(r"\{[^}]+\}|XXX|ComponentName|icon-name|image-name", text):
+                        continue
+                    # Skip non-path strings (e.g., Y/N, true/false)
+                    if re.match(r"^[A-Z]/[A-Z]$", text):
+                        continue
+                    # Skip naming convention lists (e.g., validate/check/is/has)
+                    if re.match(r"^[a-z]+(/[a-z]+){2,}$", text):
                         continue
                     if text in seen_paths:
                         continue
@@ -216,7 +350,7 @@ def extract_frameworks(sections: list[dict], source_file: str) -> list[dict]:
     seen_frameworks = set()
 
     for section in sections:
-        section_text = " ".join(line for _, line in section["lines"])
+        section_text = " ".join(line for _, line, _ in section["lines"])
 
         for fw_name in FRAMEWORK_NAMES:
             # Case-insensitive search with word boundary
@@ -225,7 +359,7 @@ def extract_frameworks(sections: list[dict], source_file: str) -> list[dict]:
             if match and fw_name.lower() not in seen_frameworks:
                 # Find the actual line
                 matched_line_num = section["lines"][0][0]
-                for ln, lt in section["lines"]:
+                for ln, lt, _ in section["lines"]:
                     if re.search(pattern, lt):
                         matched_line_num = ln
                         break
@@ -282,7 +416,11 @@ def extract_conventions(sections: list[dict], source_file: str) -> list[dict]:
     ]
 
     for section in sections:
-        for line_num, line in section["lines"]:
+        for line_num, line, in_code in section["lines"]:
+            # Skip code blocks — directives inside code are examples, not rules
+            if in_code:
+                continue
+
             stripped = line.strip()
             if not stripped or stripped.startswith("#"):
                 continue
@@ -322,7 +460,11 @@ def extract_naming_patterns(sections: list[dict], source_file: str) -> list[dict
     name_id = 0
 
     for section in sections:
-        for line_num, line in section["lines"]:
+        for line_num, line, in_code in section["lines"]:
+            # Skip code blocks
+            if in_code:
+                continue
+
             for keyword in NAMING_KEYWORDS:
                 if keyword in line:
                     name_id += 1
@@ -344,29 +486,74 @@ def extract_naming_patterns(sections: list[dict], source_file: str) -> list[dict
     return claims
 
 
+# Common English words and markdown terms that match UPPER_SNAKE_CASE
+# but are NOT environment variables.
+_ENV_EXCLUDE_WORDS = {
+    # Markdown / document keywords
+    "TODO", "NOTE", "FIXME", "HACK", "IMPORTANT", "WARNING", "SKILL",
+    "CLAUDE", "README", "BEFORE", "AFTER", "NEVER", "ALWAYS",
+    "MUST", "SHALL", "SHOULD", "CHECK", "WARN", "FIRST",
+    # HTTP / protocol
+    "TRUE", "FALSE", "NULL", "YAML", "JSON", "HTML", "HTTP", "HTTPS",
+    "POST", "DELETE", "PATCH", "REST", "VOID", "NONE",
+    # Common single-word identifiers that are NOT env vars
+    "IMMEDIATELY", "MODIFY", "CANCELLED", "REQUESTED", "CONFIRM",
+    "FAILURE", "EXPIRED", "BASIC", "STANDARD", "PREMIUM", "CUSTOM",
+    "REQUEST", "MALE", "FEMALE", "TICKETED", "XXXX",
+    # File-related
+    "WEB", "INF", "JSP", "CSS", "DOM", "INT", "MBL", "AAA",
+}
+
+# Substrings that indicate a real environment variable.
+# Tier 2 matches MUST contain at least one of these parts (split on '_')
+# OR appear in a line with env-contextual keywords.
+_ENV_CHARACTERISTIC_PARTS = {
+    "KEY", "TOKEN", "SECRET", "URL", "HOST", "PORT", "PASSWORD", "PASS",
+    "PATH", "DIR", "FILE", "CONFIG", "DB", "API", "AUTH", "DSN",
+    "BUCKET", "REGION", "ENDPOINT", "TIMEOUT", "USER", "ADDR",
+    "CONN", "CERT", "TLS", "SSL", "SMTP", "MONGO", "MYSQL", "POSTGRES",
+    "ENV", "LOG", "DEBUG", "MODE", "LEVEL",
+}
+
+_ENV_LINE_CONTEXT = re.compile(
+    r"\.env|process\.env|import\.meta\.env|os\.environ|os\.getenv|"
+    r"\benv\b|\benvironment\b|\bvariable\b|\bcredential",
+    re.IGNORECASE,
+)
+
+
 def extract_env_references(sections: list[dict], source_file: str) -> list[dict]:
-    """Extract environment variable references."""
+    """Extract environment variable references.
+
+    Improvements over naive UPPER_SNAKE_CASE matching:
+    - Skips fenced code blocks entirely (constants, type literals, etc.)
+    - Skips strings inside quotes ('UPPER' or "UPPER")
+    - Expanded exclusion list for common English/markdown words
+    - Requires env-like prefixes OR underscore in standalone matches
+    """
     claims = []
     env_id = 0
     seen_vars = set()
 
     for section in sections:
-        for line_num, line in section["lines"]:
-            # Match UPPER_SNAKE_CASE with known prefixes or standalone
-            matches = re.finditer(
-                r"`?(NEXT_PUBLIC_|VITE_|REACT_APP_|NODE_|DATABASE_|API_|AWS_|REDIS_)[\w]*`?|"
-                r"(?<![`\w])([A-Z][A-Z0-9_]{3,})(?![`\w])",
-                line
+        for line_num, line, in_code in section["lines"]:
+            # ── SKIP code blocks entirely ──
+            # Code blocks contain constants, type literals, enum values,
+            # sample data etc. that look like UPPER_SNAKE_CASE but are
+            # not environment variables.
+            if in_code:
+                continue
+
+            # ── Tier 1: Known env-var prefixes (high confidence) ──
+            prefix_matches = re.finditer(
+                r"`?(NEXT_PUBLIC_|VITE_|REACT_APP_|DATABASE_|AWS_|REDIS_|"
+                r"VERCEL_|CI_|GITHUB_|SECRET_|PRIVATE_)[\w]+`?"
+                r"|`?NODE_ENV`?",
+                line,
             )
-            for m in matches:
+            for m in prefix_matches:
                 var_name = m.group(0).strip("`")
                 if var_name in seen_vars:
-                    continue
-                # Filter out common non-env words
-                if var_name in {"TODO", "NOTE", "FIXME", "HACK", "ALWAYS", "NEVER",
-                                "MUST", "SHALL", "SHOULD", "TRUE", "FALSE", "NULL",
-                                "YAML", "JSON", "HTML", "HTTP", "HTTPS", "POST",
-                                "DELETE", "PATCH", "IMPORTANT", "WARNING", "SKILL"}:
                     continue
                 seen_vars.add(var_name)
                 env_id += 1
@@ -377,9 +564,46 @@ def extract_env_references(sections: list[dict], source_file: str) -> list[dict]
                     "source_file": source_file,
                     "source_line": line_num,
                     "source_section": section["name"],
-                    "extracted": {
-                        "variable": var_name,
-                    },
+                    "extracted": {"variable": var_name},
+                    "testable": True,
+                })
+
+            # ── Tier 2: Standalone UPPER_SNAKE_CASE with underscore ──
+            # Must contain at least one underscore to reduce false positives
+            # (e.g., "BOOKING_WAITING" → needs underscore, "BASIC" → skipped)
+            standalone_matches = re.finditer(
+                r"(?<![`'\"\w])([A-Z][A-Z0-9]*_[A-Z0-9_]{2,})(?![`'\"\w])",
+                line,
+            )
+            for m in standalone_matches:
+                var_name = m.group(1)
+                if var_name in seen_vars:
+                    continue
+                if var_name in _ENV_EXCLUDE_WORDS:
+                    continue
+                # Skip if it looks like a known non-env pattern
+                # (e.g., page module names like AIRRES_MYPAGE)
+                if re.match(r"^AIR[A-Z]{3}_", var_name):
+                    continue
+                # Tier 2 extra filter: require env-characteristic substrings
+                # in the variable name OR env-context words on the same line.
+                # This filters domain constants like BOOKING_WAITING,
+                # TICKETING_COMPLETE that are UPPER_SNAKE_CASE but not env vars.
+                var_parts = set(var_name.split("_"))
+                has_env_parts = bool(var_parts & _ENV_CHARACTERISTIC_PARTS)
+                has_env_context = bool(_ENV_LINE_CONTEXT.search(line))
+                if not has_env_parts and not has_env_context:
+                    continue
+                seen_vars.add(var_name)
+                env_id += 1
+                claims.append({
+                    "id": f"env-{env_id}",
+                    "type": "env_reference",
+                    "raw_text": line.strip(),
+                    "source_file": source_file,
+                    "source_line": line_num,
+                    "source_section": section["name"],
+                    "extracted": {"variable": var_name},
                     "testable": True,
                 })
 
@@ -393,7 +617,11 @@ def extract_vague_and_generic(sections: list[dict], source_file: str) -> list[di
     generic_id = 0
 
     for section in sections:
-        for line_num, line in section["lines"]:
+        for line_num, line, in_code in section["lines"]:
+            # Skip code blocks
+            if in_code:
+                continue
+
             # Check vague
             for pattern, label in VAGUE_PATTERNS:
                 if re.search(pattern, line):

--- a/skills/claude-md-creator/scripts/generate_eval_tasks.py
+++ b/skills/claude-md-creator/scripts/generate_eval_tasks.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""
+Phase 3 helper: Generate eval task skeletons from verified claims.
+
+Reads claims.json and coherence_report.json to produce a skeleton
+eval_tasks.json. The eval_generator agent enriches this with natural
+task prompts and additional checks, but this script handles the
+mechanical grouping and check-type inference.
+
+Usage:
+    python -m scripts.generate_eval_tasks <claims.json> <coherence.json> <project-root> [--output <path>]
+"""
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Claim grouping heuristics
+# ---------------------------------------------------------------------------
+
+# Claim types eligible for blind-test eval tasks
+TESTABLE_TYPES = {
+    "convention",
+    "naming_pattern",
+    "import_rule",
+    "architecture",
+    "path_reference",
+}
+
+# Maximum number of eval tasks to generate
+MAX_TASKS = 7
+MIN_TASKS = 3
+
+
+def _section_key(claim: dict) -> str:
+    """Normalize section name for grouping."""
+    return claim.get("source_section", "Other").strip().lower()
+
+
+def _infer_check_type(claim: dict) -> dict:
+    """Infer the best check_type and parameters for a claim."""
+    claim_type = claim["type"]
+    extracted = claim.get("extracted", {})
+
+    if claim_type == "path_reference":
+        path = extracted.get("path", "")
+        if extracted.get("is_directory"):
+            return {
+                "check_type": "file_location",
+                "expected_dir": path,
+            }
+        return {
+            "check_type": "file_location",
+            "expected_dir": str(Path(path).parent) + "/",
+        }
+
+    if claim_type == "naming_pattern":
+        pattern = extracted.get("pattern", "")
+        # Map naming conventions to regex patterns
+        naming_regexes = {
+            "PascalCase": r"^[A-Z][a-zA-Z0-9]*$",
+            "camelCase": r"^[a-z][a-zA-Z0-9]*$",
+            "snake_case": r"^[a-z][a-z0-9_]*$",
+            "kebab-case": r"^[a-z][a-z0-9-]*$",
+            "UPPER_SNAKE_CASE": r"^[A-Z][A-Z0-9_]*$",
+            "SCREAMING_SNAKE_CASE": r"^[A-Z][A-Z0-9_]*$",
+        }
+        regex = naming_regexes.get(pattern, pattern)
+        return {
+            "check_type": "file_naming",
+            "pattern": regex,
+        }
+
+    if claim_type == "import_rule":
+        rule = extracted.get("rule", "")
+        return {
+            "check_type": "import_style",
+            "pattern": rule,
+        }
+
+    if claim_type == "convention":
+        rule = extracted.get("rule", "").lower()
+
+        # Detect "no X" / "avoid X" → code_absence check
+        if re.match(r"^(no |never |avoid |don'?t )", rule):
+            # Try to extract what to check for
+            anti_match = re.search(r"(no |never |avoid |don'?t )(use )?(.*)", rule)
+            anti_subject = anti_match.group(3).strip() if anti_match else rule
+            return {
+                "check_type": "code_absence",
+                "pattern": anti_subject,
+            }
+
+        # Detect "use X" / "always X" → code_pattern check
+        check_pattern = extracted.get("check_pattern")
+        if check_pattern:
+            return {
+                "check_type": "code_pattern",
+                "pattern": check_pattern,
+            }
+
+        return {
+            "check_type": "code_pattern",
+            "pattern": "",  # Agent will fill this
+        }
+
+    if claim_type == "architecture":
+        return {
+            "check_type": "code_pattern",
+            "pattern": "",  # Agent will fill this
+        }
+
+    return {
+        "check_type": "code_pattern",
+        "pattern": "",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Task generation pipeline
+# ---------------------------------------------------------------------------
+
+
+def filter_eligible_claims(claims: list[dict], coherence_results: list[dict]) -> list[dict]:
+    """Filter claims to those eligible for eval tasks."""
+    # Build status lookup from coherence report
+    status_map = {r["claim_id"]: r["status"] for r in coherence_results}
+
+    eligible = []
+    for claim in claims:
+        # Must be a testable type
+        if claim["type"] not in TESTABLE_TYPES:
+            continue
+        # Must be testable
+        if not claim.get("testable", True):
+            continue
+        # Must be verified or partial in coherence (not stale)
+        status = status_map.get(claim["id"], "unknown")
+        if status not in ("verified", "partial", "unverifiable"):
+            continue
+
+        eligible.append(claim)
+
+    return eligible
+
+
+def group_claims(claims: list[dict]) -> list[list[dict]]:
+    """Group related claims that can be tested together."""
+    # Group by section first
+    section_groups: dict[str, list[dict]] = {}
+    for claim in claims:
+        key = _section_key(claim)
+        section_groups.setdefault(key, []).append(claim)
+
+    # If too many groups, merge small ones
+    groups = list(section_groups.values())
+
+    # Split groups larger than 4 claims
+    split_groups = []
+    for group in groups:
+        if len(group) <= 4:
+            split_groups.append(group)
+        else:
+            # Split into chunks of 2-3
+            for i in range(0, len(group), 3):
+                chunk = group[i:i + 3]
+                if chunk:
+                    split_groups.append(chunk)
+
+    # Merge groups smaller than 2 claims
+    merged = []
+    small_buffer: list[dict] = []
+    for group in split_groups:
+        if len(group) < 2:
+            small_buffer.extend(group)
+            if len(small_buffer) >= 2:
+                merged.append(small_buffer[:3])
+                small_buffer = small_buffer[3:]
+        else:
+            merged.append(group)
+
+    if small_buffer:
+        if merged:
+            merged[-1].extend(small_buffer)
+        else:
+            merged.append(small_buffer)
+
+    # Enforce MIN/MAX bounds
+    if len(merged) > MAX_TASKS:
+        # Combine excess groups
+        while len(merged) > MAX_TASKS:
+            smallest = min(range(len(merged)), key=lambda i: len(merged[i]))
+            target = (smallest + 1) % len(merged) if smallest + 1 < len(merged) else smallest - 1
+            if target < 0:
+                break
+            merged[target].extend(merged.pop(smallest))
+
+    return merged
+
+
+def generate_task_skeleton(task_id: int, claim_group: list[dict]) -> dict:
+    """Generate a single eval task skeleton from a group of claims."""
+    # Determine which claims are tested
+    tests_claims = [c["id"] for c in claim_group]
+
+    # Build description from claim types
+    claim_types = set(c["type"] for c in claim_group)
+    section_names = set(c.get("source_section", "Unknown") for c in claim_group)
+    description = f"Tests {', '.join(sorted(claim_types))} from {', '.join(sorted(section_names))}"
+
+    # Generate expected behaviors
+    expected_behaviors = []
+    for claim in claim_group:
+        check_info = _infer_check_type(claim)
+        expected_behaviors.append({
+            "claim_id": claim["id"],
+            "description": claim["raw_text"][:100],
+            **check_info,
+        })
+
+    return {
+        "id": f"task-{task_id}",
+        "tests_claims": tests_claims,
+        "description": description,
+        "task_prompt": "",  # Agent fills this with a natural coding task
+        "expected_behaviors": expected_behaviors,
+    }
+
+
+def generate_eval_tasks(claims_data: dict, coherence_data: dict, project_root: str) -> dict:
+    """Generate the eval_tasks.json skeleton."""
+    eligible = filter_eligible_claims(
+        claims_data["claims"],
+        coherence_data.get("results", []),
+    )
+
+    if not eligible:
+        return {
+            "project_root": project_root,
+            "total_tasks": 0,
+            "tasks": [],
+            "note": "No eligible claims found for eval task generation",
+        }
+
+    groups = group_claims(eligible)
+    tasks = []
+    for i, group in enumerate(groups, 1):
+        task = generate_task_skeleton(i, group)
+        tasks.append(task)
+
+    return {
+        "project_root": project_root,
+        "total_tasks": len(tasks),
+        "eligible_claims": len(eligible),
+        "tasks": tasks,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate eval task skeletons from claims")
+    parser.add_argument("claims_json", type=Path, help="Path to claims.json")
+    parser.add_argument("coherence_json", type=Path, help="Path to coherence_report.json")
+    parser.add_argument("project_root", type=str, help="Project root path")
+    parser.add_argument("--output", type=Path, default=None)
+    parser.add_argument("--pretty", action="store_true")
+    args = parser.parse_args()
+
+    claims_data = json.loads(args.claims_json.read_text(encoding="utf-8"))
+    coherence_data = json.loads(args.coherence_json.read_text(encoding="utf-8"))
+
+    result = generate_eval_tasks(claims_data, coherence_data, args.project_root)
+
+    output_json = json.dumps(result, indent=2 if args.pretty else None, ensure_ascii=False)
+
+    if args.output:
+        args.output.write_text(output_json, encoding="utf-8")
+        print(f"Generated {result['total_tasks']} eval task skeletons → {args.output}")
+        print(f"Eligible claims: {result.get('eligible_claims', 0)}")
+    else:
+        print(output_json)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/claude-md-creator/scripts/generate_report.py
+++ b/skills/claude-md-creator/scripts/generate_report.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""
+Phase 5: Generate an HTML evaluation report from evaluation_summary.json.
+
+Produces a self-contained 3-tab HTML report:
+  Tab 1: Coherence — codebase alignment details
+  Tab 2: Effectiveness — blind test results (if available)
+  Tab 3: Recommendations — actionable fixes
+
+Usage:
+    python -m scripts.generate_report <evaluation_summary.json> [--output <path>]
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+HTML_TEMPLATE = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>CLAUDE.md Evaluation Report</title>
+<style>
+  :root {{
+    --bg: #0d1117; --surface: #161b22; --border: #30363d;
+    --text: #e6edf3; --muted: #8b949e; --accent: #58a6ff;
+    --green: #3fb950; --red: #f85149; --yellow: #d29922; --purple: #bc8cff;
+  }}
+  * {{ margin: 0; padding: 0; box-sizing: border-box; }}
+  body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+    background: var(--bg); color: var(--text); line-height: 1.6; padding: 2rem; }}
+  .container {{ max-width: 960px; margin: 0 auto; }}
+
+  /* Header */
+  .header {{ text-align: center; margin-bottom: 2rem; padding: 2rem;
+    background: var(--surface); border: 1px solid var(--border); border-radius: 12px; }}
+  .header h1 {{ font-size: 1.6rem; margin-bottom: 0.5rem; }}
+  .grade {{ display: inline-block; font-size: 3rem; font-weight: 700;
+    width: 80px; height: 80px; line-height: 80px; border-radius: 50%;
+    margin: 1rem 0; }}
+  .grade-A {{ background: var(--green); color: #000; }}
+  .grade-B {{ background: #238636; color: #fff; }}
+  .grade-C {{ background: var(--yellow); color: #000; }}
+  .grade-D {{ background: #da3633; color: #fff; }}
+  .grade-F {{ background: var(--red); color: #fff; }}
+  .score {{ font-size: 1.2rem; color: var(--muted); }}
+
+  /* Tabs */
+  .tabs {{ display: flex; gap: 0; margin-bottom: 0; }}
+  .tab {{ padding: 0.75rem 1.5rem; cursor: pointer; border: 1px solid var(--border);
+    border-bottom: none; border-radius: 8px 8px 0 0; background: var(--bg);
+    color: var(--muted); font-weight: 500; transition: all 0.2s; }}
+  .tab.active {{ background: var(--surface); color: var(--text); border-bottom-color: var(--surface); }}
+  .tab-content {{ display: none; padding: 1.5rem; background: var(--surface);
+    border: 1px solid var(--border); border-radius: 0 8px 8px 8px; }}
+  .tab-content.active {{ display: block; }}
+
+  /* Cards */
+  .card {{ background: var(--bg); border: 1px solid var(--border); border-radius: 8px;
+    padding: 1rem; margin-bottom: 1rem; }}
+  .card h3 {{ font-size: 0.95rem; margin-bottom: 0.5rem; color: var(--accent); }}
+
+  /* Stats */
+  .stats {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); gap: 1rem; margin-bottom: 1.5rem; }}
+  .stat {{ text-align: center; padding: 1rem; background: var(--bg); border: 1px solid var(--border); border-radius: 8px; }}
+  .stat-value {{ font-size: 1.8rem; font-weight: 700; }}
+  .stat-label {{ font-size: 0.8rem; color: var(--muted); margin-top: 0.25rem; }}
+  .stat-green .stat-value {{ color: var(--green); }}
+  .stat-red .stat-value {{ color: var(--red); }}
+  .stat-yellow .stat-value {{ color: var(--yellow); }}
+  .stat-purple .stat-value {{ color: var(--purple); }}
+
+  /* Issues */
+  .issue {{ display: flex; gap: 0.75rem; align-items: flex-start; padding: 0.75rem; border-radius: 6px;
+    margin-bottom: 0.5rem; background: var(--bg); border: 1px solid var(--border); }}
+  .badge {{ font-size: 0.7rem; padding: 0.15rem 0.5rem; border-radius: 12px; font-weight: 600;
+    text-transform: uppercase; white-space: nowrap; }}
+  .badge-high {{ background: rgba(248, 81, 73, 0.2); color: var(--red); }}
+  .badge-medium {{ background: rgba(210, 153, 34, 0.2); color: var(--yellow); }}
+  .badge-low {{ background: rgba(139, 148, 158, 0.2); color: var(--muted); }}
+  .issue-text {{ flex: 1; font-size: 0.9rem; }}
+  .issue-suggestion {{ color: var(--green); font-size: 0.85rem; margin-top: 0.25rem; }}
+
+  /* Recommendations */
+  .rec-section {{ margin-bottom: 1.5rem; }}
+  .rec-section h3 {{ margin-bottom: 0.75rem; }}
+  .rec-item {{ padding: 0.5rem 0.75rem; margin-bottom: 0.4rem; font-size: 0.9rem;
+    background: var(--bg); border-left: 3px solid; border-radius: 0 4px 4px 0; }}
+  .rec-remove {{ border-color: var(--red); }}
+  .rec-fix {{ border-color: var(--yellow); }}
+  .rec-add {{ border-color: var(--green); }}
+  .rec-strengthen {{ border-color: var(--purple); }}
+
+  /* Blind test */
+  .result-row {{ display: grid; grid-template-columns: 1fr 80px 80px 120px;
+    gap: 0.5rem; padding: 0.6rem; font-size: 0.85rem; border-bottom: 1px solid var(--border); }}
+  .result-header {{ font-weight: 600; color: var(--muted); text-transform: uppercase; font-size: 0.75rem; }}
+  .win {{ color: var(--green); font-weight: 600; }}
+  .loss {{ color: var(--red); font-weight: 600; }}
+  .tie {{ color: var(--yellow); }}
+
+  .empty-state {{ text-align: center; padding: 3rem; color: var(--muted); }}
+  code {{ background: rgba(110, 118, 129, 0.2); padding: 0.15rem 0.4rem; border-radius: 4px; font-size: 0.85rem; }}
+</style>
+</head>
+<body>
+<div class="container">
+
+  <!-- Header -->
+  <div class="header">
+    <h1>CLAUDE.md Evaluation Report</h1>
+    <div class="grade grade-{grade_class}">{grade}</div>
+    <div class="score">{score} / 100</div>
+  </div>
+
+  <!-- Tabs -->
+  <div class="tabs">
+    <div class="tab active" onclick="showTab('coherence')">Coherence</div>
+    <div class="tab" onclick="showTab('effectiveness')">Effectiveness</div>
+    <div class="tab" onclick="showTab('recommendations')">Recommendations</div>
+  </div>
+
+  <!-- Tab 1: Coherence -->
+  <div id="coherence" class="tab-content active">
+    <div class="stats">
+      <div class="stat stat-green"><div class="stat-value">{verified}</div><div class="stat-label">Verified</div></div>
+      <div class="stat stat-red"><div class="stat-value">{stale}</div><div class="stat-label">Stale</div></div>
+      <div class="stat stat-yellow"><div class="stat-value">{partial}</div><div class="stat-label">Partial</div></div>
+      <div class="stat stat-purple"><div class="stat-value">{unverifiable}</div><div class="stat-label">Unverifiable</div></div>
+    </div>
+    <div class="card">
+      <h3>Coherence Score: {coherence_score}%</h3>
+      <p style="color:var(--muted);font-size:0.9rem">
+        Measures how well your CLAUDE.md matches the actual codebase.
+        {total_claims} total claims extracted, {testable_claims} testable.
+      </p>
+    </div>
+    {issues_html}
+  </div>
+
+  <!-- Tab 2: Effectiveness -->
+  <div id="effectiveness" class="tab-content">
+    {effectiveness_html}
+  </div>
+
+  <!-- Tab 3: Recommendations -->
+  <div id="recommendations" class="tab-content">
+    {recommendations_html}
+  </div>
+
+</div>
+
+<script>
+function showTab(id) {{
+  document.querySelectorAll('.tab-content').forEach(t => t.classList.remove('active'));
+  document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+  document.getElementById(id).classList.add('active');
+  event.target.classList.add('active');
+}}
+</script>
+</body>
+</html>"""
+
+
+# ---------------------------------------------------------------------------
+# HTML builders
+# ---------------------------------------------------------------------------
+
+
+def build_issues_html(issues: list[dict]) -> str:
+    if not issues:
+        return '<div class="card"><p style="color:var(--muted)">No issues found.</p></div>'
+
+    html_parts = ['<h3 style="margin-bottom:0.75rem">Top Issues</h3>']
+    for issue in issues:
+        severity = issue.get("severity", "low")
+        badge_class = f"badge-{severity}"
+        suggestion = ""
+        if issue.get("suggestion"):
+            suggestion = f'<div class="issue-suggestion">Fix: {_escape(issue["suggestion"])}</div>'
+
+        html_parts.append(f"""
+    <div class="issue">
+      <span class="badge {badge_class}">{severity}</span>
+      <div class="issue-text">
+        <code>{_escape(issue.get('claim_id', ''))}</code> {_escape(issue.get('issue', ''))}
+        {suggestion}
+      </div>
+    </div>""")
+
+    return "\n".join(html_parts)
+
+
+def build_effectiveness_html(effectiveness: dict | None) -> str:
+    if not effectiveness:
+        return """<div class="empty-state">
+      <p>No blind test results available.</p>
+      <p style="margin-top:0.5rem;font-size:0.85rem">Run a Full Eval to get effectiveness data.</p>
+    </div>"""
+
+    wins = effectiveness.get("claude_md_wins", 0)
+    ties = effectiveness.get("ties", 0)
+    losses = effectiveness.get("losses", 0)
+    delta = effectiveness.get("programmatic_delta", "+0%")
+    score = effectiveness.get("score", 0)
+
+    return f"""
+    <div class="stats">
+      <div class="stat stat-green"><div class="stat-value">{wins}</div><div class="stat-label">CLAUDE.md Wins</div></div>
+      <div class="stat"><div class="stat-value">{ties}</div><div class="stat-label">Ties</div></div>
+      <div class="stat stat-red"><div class="stat-value">{losses}</div><div class="stat-label">Losses</div></div>
+    </div>
+    <div class="card">
+      <h3>Effectiveness Score: {score}%</h3>
+      <p style="color:var(--muted);font-size:0.9rem">
+        Blind test comparison: code with CLAUDE.md vs without.
+        Programmatic check pass-rate delta: <strong>{delta}</strong>
+      </p>
+    </div>
+    <div class="card">
+      <h3>What This Means</h3>
+      <p style="font-size:0.9rem">
+        {"Your CLAUDE.md is highly effective — Claude produces noticeably better code when it has these instructions." if score >= 80
+         else "Your CLAUDE.md shows moderate effectiveness — some conventions are followed better with instructions." if score >= 50
+         else "Your CLAUDE.md shows limited effectiveness — consider revising conventions that don't change Claude's behavior."}
+      </p>
+    </div>"""
+
+
+def build_recommendations_html(recommendations: dict) -> str:
+    sections = []
+
+    # Remove
+    removes = recommendations.get("remove", [])
+    if removes:
+        items = "".join(f'<div class="rec-item rec-remove">Remove <code>{_escape(r)}</code> — vague/generic instruction</div>' for r in removes)
+        sections.append(f'<div class="rec-section"><h3 style="color:var(--red)">Remove ({len(removes)})</h3>{items}</div>')
+
+    # Fix
+    fixes = recommendations.get("fix", [])
+    if fixes:
+        items = []
+        for f in fixes:
+            if isinstance(f, dict):
+                items.append(f'<div class="rec-item rec-fix"><code>{_escape(f.get("claim_id", ""))}</code>: {_escape(f.get("suggested", ""))}</div>')
+            else:
+                items.append(f'<div class="rec-item rec-fix">{_escape(str(f))}</div>')
+        sections.append(f'<div class="rec-section"><h3 style="color:var(--yellow)">Fix ({len(fixes)})</h3>{"".join(items)}</div>')
+
+    # Add
+    adds = recommendations.get("add", [])
+    if adds:
+        items = "".join(f'<div class="rec-item rec-add">{_escape(a)}</div>' for a in adds)
+        sections.append(f'<div class="rec-section"><h3 style="color:var(--green)">Add ({len(adds)})</h3>{items}</div>')
+
+    # Strengthen
+    strengthens = recommendations.get("strengthen", [])
+    if strengthens:
+        items = "".join(f'<div class="rec-item rec-strengthen">{_escape(s)}</div>' for s in strengthens)
+        sections.append(f'<div class="rec-section"><h3 style="color:var(--purple)">Strengthen ({len(strengthens)})</h3>{items}</div>')
+
+    if not sections:
+        return '<div class="empty-state"><p>No recommendations — your CLAUDE.md looks great!</p></div>'
+
+    return "\n".join(sections)
+
+
+def _escape(text: str) -> str:
+    """Escape HTML special characters."""
+    return (
+        text.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main report generation
+# ---------------------------------------------------------------------------
+
+
+def generate_report(summary: dict) -> str:
+    """Generate full HTML report from evaluation_summary.json."""
+    grade = summary.get("grade", "?")
+    score = summary.get("overall_score", 0)
+    coherence = summary.get("coherence", {})
+
+    grade_class = grade if grade in ("A", "B", "C", "D", "F") else "F"
+
+    return HTML_TEMPLATE.format(
+        grade=grade,
+        grade_class=grade_class,
+        score=score,
+        verified=coherence.get("verified", 0),
+        stale=coherence.get("stale", 0),
+        partial=coherence.get("partial", 0),
+        unverifiable=coherence.get("unverifiable", 0),
+        coherence_score=coherence.get("score", 0),
+        total_claims=coherence.get("total_claims", 0),
+        testable_claims=coherence.get("verified", 0) + coherence.get("stale", 0) + coherence.get("partial", 0),
+        issues_html=build_issues_html(summary.get("top_issues", [])),
+        effectiveness_html=build_effectiveness_html(summary.get("effectiveness")),
+        recommendations_html=build_recommendations_html(summary.get("recommendations", {})),
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate HTML evaluation report")
+    parser.add_argument("summary_json", type=Path, help="Path to evaluation_summary.json")
+    parser.add_argument("--output", type=Path, default=None, help="Output HTML path (default: /tmp/claude-md-eval.html)")
+    args = parser.parse_args()
+
+    summary = json.loads(args.summary_json.read_text(encoding="utf-8"))
+    html = generate_report(summary)
+
+    output_path = args.output or Path("/tmp/claude-md-eval.html")
+    output_path.write_text(html, encoding="utf-8")
+    print(f"Report generated → {output_path}")
+    print(f"Grade: {summary.get('grade', '?')} ({summary.get('overall_score', 0)}/100)")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/claude-md-creator/scripts/verify_coherence.py
+++ b/skills/claude-md-creator/scripts/verify_coherence.py
@@ -1,0 +1,542 @@
+#!/usr/bin/env python3
+"""
+Phase 2: Verify extracted claims against the actual codebase.
+
+Takes claims.json from Phase 1 and checks each claim against the real project:
+commands in package.json, paths on filesystem, frameworks in dependencies, etc.
+
+Usage:
+    python -m scripts.verify_coherence <claims.json> <project-root> [--output <path>]
+"""
+
+import argparse
+import json
+import os
+import re
+import shutil
+import sys
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Dependency file parsers
+# ---------------------------------------------------------------------------
+
+
+def parse_package_json(project_root: Path) -> dict:
+    """Parse package.json for scripts and dependencies."""
+    pkg_path = project_root / "package.json"
+    if not pkg_path.exists():
+        return {}
+    try:
+        data = json.loads(pkg_path.read_text(encoding="utf-8"))
+        return {
+            "scripts": data.get("scripts", {}),
+            "dependencies": {
+                **data.get("dependencies", {}),
+                **data.get("devDependencies", {}),
+                **data.get("peerDependencies", {}),
+            },
+            "type": "node",
+        }
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def parse_pyproject_toml(project_root: Path) -> dict:
+    """Parse pyproject.toml for dependencies and scripts."""
+    toml_path = project_root / "pyproject.toml"
+    if not toml_path.exists():
+        return {}
+    try:
+        # Try tomllib (Python 3.11+) or fall back to regex
+        try:
+            import tomllib
+            data = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+        except ImportError:
+            # Fallback: simple regex extraction
+            content = toml_path.read_text(encoding="utf-8")
+            deps = set(re.findall(r'^\s*"?(\w[\w-]*)"?\s*[=><]', content, re.MULTILINE))
+            return {"dependencies": {d: "*" for d in deps}, "scripts": {}, "type": "python"}
+
+        deps = {}
+        # Poetry
+        for section in ["tool.poetry.dependencies", "tool.poetry.dev-dependencies"]:
+            parts = section.split(".")
+            d = data
+            for p in parts:
+                d = d.get(p, {})
+            if isinstance(d, dict):
+                deps.update(d)
+        # PEP 621
+        for dep_str in data.get("project", {}).get("dependencies", []):
+            name = re.split(r"[><=!\[;]", dep_str)[0].strip()
+            if name:
+                deps[name.lower()] = "*"
+
+        scripts = {}
+        for section in ["tool.poetry.scripts", "project.scripts"]:
+            parts = section.split(".")
+            d = data
+            for p in parts:
+                d = d.get(p, {})
+            if isinstance(d, dict):
+                scripts.update(d)
+
+        return {"dependencies": deps, "scripts": scripts, "type": "python"}
+    except Exception:
+        return {}
+
+
+def parse_requirements_txt(project_root: Path) -> dict:
+    """Parse requirements.txt for dependencies."""
+    req_path = project_root / "requirements.txt"
+    if not req_path.exists():
+        return {}
+    try:
+        content = req_path.read_text(encoding="utf-8")
+        deps = {}
+        for line in content.splitlines():
+            line = line.strip()
+            if line and not line.startswith("#") and not line.startswith("-"):
+                name = re.split(r"[><=!\[;]", line)[0].strip()
+                if name:
+                    deps[name.lower()] = "*"
+        return {"dependencies": deps, "scripts": {}, "type": "python"}
+    except OSError:
+        return {}
+
+
+def parse_cargo_toml(project_root: Path) -> dict:
+    """Parse Cargo.toml for dependencies."""
+    cargo_path = project_root / "Cargo.toml"
+    if not cargo_path.exists():
+        return {}
+    try:
+        content = cargo_path.read_text(encoding="utf-8")
+        deps = set(re.findall(r'^\s*(\w[\w-]*)\s*=', content, re.MULTILINE))
+        return {"dependencies": {d: "*" for d in deps}, "scripts": {}, "type": "rust"}
+    except OSError:
+        return {}
+
+
+def parse_go_mod(project_root: Path) -> dict:
+    """Parse go.mod for dependencies."""
+    mod_path = project_root / "go.mod"
+    if not mod_path.exists():
+        return {}
+    try:
+        content = mod_path.read_text(encoding="utf-8")
+        deps = {}
+        for match in re.finditer(r"^\s+([\w./-]+)\s+v", content, re.MULTILINE):
+            parts = match.group(1).split("/")
+            deps[parts[-1].lower()] = "*"
+        return {"dependencies": deps, "scripts": {}, "type": "go"}
+    except OSError:
+        return {}
+
+
+def parse_makefile(project_root: Path) -> dict:
+    """Parse Makefile for target names."""
+    makefile = project_root / "Makefile"
+    if not makefile.exists():
+        return {}
+    try:
+        content = makefile.read_text(encoding="utf-8")
+        targets = set(re.findall(r"^([\w-]+)\s*:", content, re.MULTILINE))
+        return {"scripts": {t: t for t in targets}, "dependencies": {}, "type": "make"}
+    except OSError:
+        return {}
+
+
+def parse_gemfile(project_root: Path) -> dict:
+    """Parse Gemfile for dependencies."""
+    gemfile = project_root / "Gemfile"
+    if not gemfile.exists():
+        return {}
+    try:
+        content = gemfile.read_text(encoding="utf-8")
+        deps = {}
+        for match in re.finditer(r"""gem\s+['"](\w[\w-]*)['"]""", content):
+            deps[match.group(1).lower()] = "*"
+        return {"dependencies": deps, "scripts": {}, "type": "ruby"}
+    except OSError:
+        return {}
+
+
+def get_project_info(project_root: Path) -> dict:
+    """Gather all project dependency and script information."""
+    info = {"scripts": {}, "dependencies": {}, "types": []}
+
+    parsers = [
+        parse_package_json,
+        parse_pyproject_toml,
+        parse_requirements_txt,
+        parse_cargo_toml,
+        parse_go_mod,
+        parse_makefile,
+        parse_gemfile,
+    ]
+
+    for parser in parsers:
+        result = parser(project_root)
+        if result:
+            info["scripts"].update(result.get("scripts", {}))
+            info["dependencies"].update(result.get("dependencies", {}))
+            if result.get("type"):
+                info["types"].append(result["type"])
+
+    return info
+
+
+# ---------------------------------------------------------------------------
+# Verifiers — one per claim type
+# ---------------------------------------------------------------------------
+
+
+def verify_command(claim: dict, project_root: Path, project_info: dict) -> dict:
+    """Verify that a CLI command exists in the project."""
+    command = claim["extracted"]["command"]
+    tokens = command.split()
+    base_cmd = tokens[0]
+    sub_cmd = tokens[1] if len(tokens) > 1 else None
+
+    # Check package.json scripts (npm/pnpm/yarn run X or npm/pnpm/yarn X)
+    if base_cmd in ("npm", "pnpm", "yarn", "bun"):
+        script_name = None
+        if sub_cmd == "run" and len(tokens) > 2:
+            script_name = tokens[2]
+        elif sub_cmd and sub_cmd not in ("install", "add", "remove", "init", "create", "dlx", "exec", "i"):
+            script_name = sub_cmd
+
+        if script_name:
+            if script_name in project_info.get("scripts", {}):
+                return {
+                    "status": "verified",
+                    "evidence": f"Found in scripts: \"{script_name}\": \"{project_info['scripts'][script_name]}\"",
+                    "confidence": 1.0,
+                }
+            else:
+                available = list(project_info.get("scripts", {}).keys())
+                return {
+                    "status": "stale",
+                    "evidence": f"Script '{script_name}' not found in package.json. Available: {available[:10]}",
+                    "confidence": 0.0,
+                    "suggestion": f"Check if '{script_name}' was renamed or removed",
+                }
+
+    # Check make targets
+    if base_cmd == "make" and sub_cmd:
+        if sub_cmd in project_info.get("scripts", {}):
+            return {
+                "status": "verified",
+                "evidence": f"Found Makefile target: {sub_cmd}",
+                "confidence": 1.0,
+            }
+
+    # Check if base command is available on system
+    if shutil.which(base_cmd):
+        return {
+            "status": "verified",
+            "evidence": f"Command '{base_cmd}' is available on PATH",
+            "confidence": 0.7,
+        }
+
+    return {
+        "status": "unverifiable",
+        "evidence": f"Cannot verify command '{command}' — not in project scripts and not on PATH",
+        "confidence": 0.3,
+    }
+
+
+def verify_path(claim: dict, project_root: Path, project_info: dict) -> dict:
+    """Verify that a file/directory path exists."""
+    path_str = claim["extracted"]["path"]
+    # Remove leading ./ and trailing glob patterns
+    clean_path = re.sub(r"[*{}\[\]]+.*$", "", path_str.lstrip("./"))
+    full_path = project_root / clean_path
+
+    if full_path.exists():
+        if full_path.is_dir():
+            file_count = sum(1 for _ in full_path.iterdir())
+            return {
+                "status": "verified",
+                "evidence": f"Directory exists with {file_count} entries",
+                "confidence": 1.0,
+            }
+        else:
+            return {
+                "status": "verified",
+                "evidence": f"File exists ({full_path.stat().st_size} bytes)",
+                "confidence": 1.0,
+            }
+
+    # Try to find similar paths
+    parent = full_path.parent
+    if parent.exists():
+        siblings = [p.name for p in parent.iterdir()]
+        target_name = full_path.name
+        similar = [s for s in siblings if target_name.lower() in s.lower() or s.lower() in target_name.lower()]
+        if similar:
+            return {
+                "status": "stale",
+                "evidence": f"Path '{clean_path}' not found. Similar in {parent.relative_to(project_root)}/: {similar[:5]}",
+                "confidence": 0.0,
+                "suggestion": f"Check if path was renamed. Similar: {similar[:3]}",
+            }
+
+    # Check if any part of the path exists
+    parts = Path(clean_path).parts
+    existing_depth = 0
+    check_path = project_root
+    for part in parts:
+        check_path = check_path / part
+        if check_path.exists():
+            existing_depth += 1
+        else:
+            break
+
+    if existing_depth > 0:
+        existing = "/".join(parts[:existing_depth])
+        return {
+            "status": "stale",
+            "evidence": f"Path '{clean_path}' not found. Exists up to: {existing}/",
+            "confidence": 0.0,
+            "suggestion": f"Directory '{clean_path}' does not exist. Partial match: {existing}/",
+        }
+
+    return {
+        "status": "stale",
+        "evidence": f"Path '{clean_path}' does not exist",
+        "confidence": 0.0,
+        "suggestion": f"Remove or update reference to '{clean_path}'",
+    }
+
+
+def verify_framework(claim: dict, project_root: Path, project_info: dict) -> dict:
+    """Verify that a framework/library is in project dependencies."""
+    framework = claim["extracted"]["framework"]
+    deps = project_info.get("dependencies", {})
+
+    # Normalize: some frameworks have different package names
+    aliases = {
+        "next.js": ["next"],
+        "next": ["next"],
+        "nextjs": ["next"],
+        "react": ["react"],
+        "tailwind": ["tailwindcss"],
+        "tailwindcss": ["tailwindcss"],
+        "prisma": ["prisma", "@prisma/client"],
+        "drizzle": ["drizzle-orm"],
+        "jest": ["jest", "@jest/core"],
+        "vitest": ["vitest"],
+        "playwright": ["playwright", "@playwright/test"],
+        "storybook": ["storybook", "@storybook/react"],
+        "eslint": ["eslint"],
+        "prettier": ["prettier"],
+        "emotion": ["@emotion/react", "@emotion/styled"],
+        "styled-components": ["styled-components"],
+        "testing-library": ["@testing-library/react"],
+        "msw": ["msw"],
+        "zod": ["zod"],
+        "django": ["django"],
+        "flask": ["flask"],
+        "fastapi": ["fastapi"],
+        "pytest": ["pytest"],
+        "rails": ["rails"],
+    }
+
+    package_names = aliases.get(framework.lower(), [framework.lower()])
+
+    deps_lower = {k.lower(): k for k in deps}
+    for pkg in package_names:
+        if pkg.lower() in deps_lower:
+            original_key = deps_lower[pkg.lower()]
+            return {
+                "status": "verified",
+                "evidence": f"Found '{original_key}' in project dependencies",
+                "confidence": 1.0,
+            }
+
+    # Check config file if referenced
+    config_path = claim["extracted"].get("config_path")
+    if config_path and (project_root / config_path).exists():
+        return {
+            "status": "verified",
+            "evidence": f"Config file '{config_path}' exists (package may be transitive dependency)",
+            "confidence": 0.8,
+        }
+
+    return {
+        "status": "stale",
+        "evidence": f"'{framework}' not found in project dependencies. Checked: {package_names}",
+        "confidence": 0.0,
+        "suggestion": f"Remove '{framework}' reference or add it as a dependency",
+    }
+
+
+def verify_convention(claim: dict, project_root: Path, project_info: dict) -> dict:
+    """Verify a convention by sampling code files."""
+    # Convention verification requires understanding the rule semantically.
+    # The script does basic checks; the coherence_checker agent enriches.
+    return {
+        "status": "unverifiable",
+        "evidence": "Convention claims require agent-level semantic analysis for full verification",
+        "confidence": 0.5,
+        "note": "The coherence_checker agent will enrich this result",
+    }
+
+
+def verify_naming_pattern(claim: dict, project_root: Path, project_info: dict) -> dict:
+    """Verify naming conventions against actual file/identifier names."""
+    return {
+        "status": "unverifiable",
+        "evidence": "Naming pattern verification requires sampling project files",
+        "confidence": 0.5,
+        "note": "The coherence_checker agent will enrich this result",
+    }
+
+
+def verify_env_reference(claim: dict, project_root: Path, project_info: dict) -> dict:
+    """Verify environment variable references."""
+    var_name = claim["extracted"]["variable"]
+
+    # Check .env.example, .env.local.example, .env.sample
+    env_files = [".env.example", ".env.local.example", ".env.sample", ".env"]
+    for env_file in env_files:
+        env_path = project_root / env_file
+        if env_path.exists():
+            content = env_path.read_text(encoding="utf-8")
+            if var_name in content:
+                return {
+                    "status": "verified",
+                    "evidence": f"Found '{var_name}' in {env_file}",
+                    "confidence": 1.0,
+                }
+
+    # Check if it's a prefix pattern (like NEXT_PUBLIC_*)
+    if var_name.endswith("_") or "*" in var_name:
+        prefix = var_name.rstrip("_*")
+        for env_file in env_files:
+            env_path = project_root / env_file
+            if env_path.exists():
+                content = env_path.read_text(encoding="utf-8")
+                if prefix in content:
+                    return {
+                        "status": "verified",
+                        "evidence": f"Found variables with prefix '{prefix}' in {env_file}",
+                        "confidence": 0.8,
+                    }
+
+    return {
+        "status": "unverifiable",
+        "evidence": f"Cannot verify env var '{var_name}' — no .env example files found",
+        "confidence": 0.3,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Main verification pipeline
+# ---------------------------------------------------------------------------
+
+VERIFIERS = {
+    "command": verify_command,
+    "path_reference": verify_path,
+    "framework_reference": verify_framework,
+    "convention": verify_convention,
+    "naming_pattern": verify_naming_pattern,
+    "env_reference": verify_env_reference,
+}
+
+
+def verify_coherence(claims_data: dict, project_root: Path) -> dict:
+    """Verify all claims against the codebase."""
+    project_info = get_project_info(project_root)
+    results = []
+
+    for claim in claims_data["claims"]:
+        claim_type = claim["type"]
+
+        # Skip non-testable claims
+        if not claim.get("testable", True):
+            results.append({
+                "claim_id": claim["id"],
+                "type": claim_type,
+                "claim_text": claim["raw_text"],
+                "status": "not_applicable",
+                "evidence": claim["extracted"].get("issue", "Not testable"),
+                "confidence": 0.0,
+            })
+            continue
+
+        verifier = VERIFIERS.get(claim_type)
+        if verifier:
+            result = verifier(claim, project_root, project_info)
+            results.append({
+                "claim_id": claim["id"],
+                "type": claim_type,
+                "claim_text": claim["raw_text"],
+                **result,
+            })
+        else:
+            results.append({
+                "claim_id": claim["id"],
+                "type": claim_type,
+                "claim_text": claim["raw_text"],
+                "status": "unverifiable",
+                "evidence": f"No verifier for claim type '{claim_type}'",
+                "confidence": 0.0,
+            })
+
+    # Compute summary
+    testable = [r for r in results if r["status"] != "not_applicable"]
+    verified = sum(1 for r in testable if r["status"] == "verified")
+    stale = sum(1 for r in testable if r["status"] == "stale")
+    partial = sum(1 for r in testable if r["status"] == "partial")
+    unverifiable = sum(1 for r in testable if r["status"] == "unverifiable")
+
+    verifiable_count = len(testable) - unverifiable
+    coherence_score = round((verified / verifiable_count * 100), 1) if verifiable_count > 0 else 0
+
+    return {
+        "project_root": str(project_root),
+        "project_info": {
+            "ecosystems": project_info.get("types", []),
+            "scripts_count": len(project_info.get("scripts", {})),
+            "dependencies_count": len(project_info.get("dependencies", {})),
+        },
+        "total_claims": len(claims_data["claims"]),
+        "testable_claims": len(testable),
+        "verified": verified,
+        "stale": stale,
+        "partial": partial,
+        "unverifiable": unverifiable,
+        "coherence_score": coherence_score,
+        "results": results,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Verify CLAUDE.md claims against codebase")
+    parser.add_argument("claims_json", type=Path, help="Path to claims.json")
+    parser.add_argument("project_root", type=Path, help="Project root directory")
+    parser.add_argument("--output", type=Path, default=None)
+    parser.add_argument("--pretty", action="store_true")
+    args = parser.parse_args()
+
+    claims_data = json.loads(args.claims_json.read_text(encoding="utf-8"))
+    result = verify_coherence(claims_data, args.project_root)
+
+    output_json = json.dumps(result, indent=2 if args.pretty else None, ensure_ascii=False)
+
+    if args.output:
+        args.output.write_text(output_json, encoding="utf-8")
+        print(f"Coherence report → {args.output}")
+        print(f"Score: {result['coherence_score']}/100 "
+              f"({result['verified']} verified, {result['stale']} stale, {result['unverifiable']} unverifiable)")
+    else:
+        print(output_json)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/claude-md-creator/scripts/verify_coherence.py
+++ b/skills/claude-md-creator/scripts/verify_coherence.py
@@ -14,6 +14,7 @@ import json
 import os
 import re
 import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -249,11 +250,76 @@ def verify_command(claim: dict, project_root: Path, project_info: dict) -> dict:
     }
 
 
+def _resolve_alias_path(path_str: str, project_root: Path) -> Path | None:
+    """Resolve @/ alias paths by checking tsconfig.json and common source dirs."""
+    if not path_str.startswith("@/"):
+        return None
+
+    relative = path_str[2:]  # strip @/
+
+    # Try common source directories for @/ alias
+    candidates = ["src", ".", "app", "lib"]
+    seen_candidates = set(candidates)
+
+    # Also try to read tsconfig.json for paths configuration
+    for tsconfig_name in ("tsconfig.json", "tsconfig.app.json"):
+        tsconfig_path = project_root / tsconfig_name
+        if tsconfig_path.exists():
+            try:
+                # Strip comments for JSON parsing
+                text = tsconfig_path.read_text(encoding="utf-8")
+                text = re.sub(r"//.*$", "", text, flags=re.MULTILINE)
+                text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
+                config = json.loads(text)
+                paths = config.get("compilerOptions", {}).get("paths", {})
+                for alias_pattern, target_patterns in paths.items():
+                    if alias_pattern.startswith("@/"):
+                        for target in target_patterns:
+                            base = target.replace("/*", "").replace("*", "")
+                            if base and base not in seen_candidates:
+                                seen_candidates.add(base)
+                                candidates.insert(0, base)
+            except (json.JSONDecodeError, OSError):
+                pass
+
+    for base_dir in candidates:
+        resolved = project_root / base_dir / relative
+        if resolved.exists():
+            return resolved
+        # Try with common extensions
+        for ext in (".ts", ".tsx", ".js", ".jsx"):
+            if (project_root / base_dir / (relative + ext)).exists():
+                return project_root / base_dir / (relative + ext)
+            if (project_root / base_dir / relative / ("index" + ext)).exists():
+                return project_root / base_dir / relative / ("index" + ext)
+
+    return None
+
+
 def verify_path(claim: dict, project_root: Path, project_info: dict) -> dict:
     """Verify that a file/directory path exists."""
     path_str = claim["extracted"]["path"]
     # Remove leading ./ and trailing glob patterns
     clean_path = re.sub(r"[*{}\[\]]+.*$", "", path_str.lstrip("./"))
+
+    # Handle @/ alias paths
+    if clean_path.startswith("@/"):
+        resolved = _resolve_alias_path(clean_path, project_root)
+        if resolved and resolved.exists():
+            if resolved.is_dir():
+                file_count = sum(1 for _ in resolved.iterdir())
+                return {
+                    "status": "verified",
+                    "evidence": f"Alias path resolved: {resolved.relative_to(project_root)} ({file_count} entries)",
+                    "confidence": 1.0,
+                }
+            else:
+                return {
+                    "status": "verified",
+                    "evidence": f"Alias path resolved: {resolved.relative_to(project_root)} ({resolved.stat().st_size} bytes)",
+                    "confidence": 1.0,
+                }
+
     full_path = project_root / clean_path
 
     if full_path.exists():
@@ -270,6 +336,31 @@ def verify_path(claim: dict, project_root: Path, project_info: dict) -> dict:
                 "evidence": f"File exists ({full_path.stat().st_size} bytes)",
                 "confidence": 1.0,
             }
+
+    # For short relative paths (e.g., _common/StatusBar.tsx, entity/),
+    # try finding them anywhere in the project tree
+    if not clean_path.startswith("/") and ".." not in clean_path and len(Path(clean_path).parts) <= 3:
+        search_name = clean_path.rstrip("/")
+        # Use -name for simple names, -path for multi-segment paths
+        if "/" in search_name:
+            find_args = ["-path", f"*/{search_name}"]
+        else:
+            find_args = ["-name", search_name]
+        try:
+            result = subprocess.run(
+                ["find", str(project_root), "-maxdepth", "8"] + find_args,
+                capture_output=True, text=True, timeout=5,
+            )
+            matches = [l for l in result.stdout.strip().splitlines() if l]
+            if matches:
+                rel = Path(matches[0]).relative_to(project_root)
+                return {
+                    "status": "verified",
+                    "evidence": f"Found at {rel}" + (f" (+{len(matches)-1} more)" if len(matches) > 1 else ""),
+                    "confidence": 0.8,
+                }
+        except (subprocess.TimeoutExpired, OSError):
+            pass
 
     # Try to find similar paths
     parent = full_path.parent


### PR DESCRIPTION
## Summary

- Add `claude-md-creator` skill that creates, evaluates, and improves CLAUDE.md files
- 5-phase evaluation pipeline: claim extraction → coherence verification → dynamic eval task generation → blind A/B effectiveness testing → HTML report
- Supports Quick Eval (~1 min, coherence only) and Full Eval (~5-10 min, with blind testing)

## Architecture

### Scripts (Python)
- `extract_claims.py` — Parses CLAUDE.md into structured claims (commands, paths, frameworks, conventions, naming patterns, env vars)
- `verify_coherence.py` — Verifies claims against actual codebase (package.json, filesystem, dependencies)
- `generate_eval_tasks.py` — Creates eval task skeletons from verified claims
- `aggregate_results.py` — Combines coherence + blind test results into final summary
- `generate_report.py` — Generates self-contained 3-tab HTML report

### Agents
- `claim_extractor` — Enriches script-extracted claims with semantic analysis
- `coherence_checker` — Verifies conventions by sampling actual code files
- `eval_generator` — Creates natural coding tasks from claims
- `blind_coder` — Executes coding tasks (with or without CLAUDE.md context)
- `blind_judge` — Blind comparison of two code outputs

### References
- `schemas.md` — JSON schemas for all data structures
- `claim-taxonomy.md` — 11 claim type definitions with extraction patterns
- `best-practices.md` — Official CLAUDE.md best practices

## Test plan

- [x] E2E pipeline test: Phase 1→2→3→5 with sample CLAUDE.md
- [x] All 16 files validated
- [x] HTML report generation verified
- [x] Mock blind results aggregation tested
- [ ] Manual test: run Quick Eval against a real project
- [ ] Manual test: run Full Eval with actual blind testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)