### PR TITLE
Add ai-native-cli skill — CLI design spec for AI agents

### DIFF
--- a/skills/ai-native-cli/SKILL.md
+++ b/skills/ai-native-cli/SKILL.md
@@ -1,0 +1,434 @@
+---
+name: ai-native-cli
+description: >
+  AI-Native CLI design spec. Use when building CLI tools, designing
+  command-line interfaces, or scaffolding new CLI projects. Covers
+  structured JSON output, error handling, input contracts, safety
+  guardrails, exit codes, and agent self-description. Includes an
+  audit protocol for verifying CLI compliance.
+license: MIT
+metadata:
+  author: zhuanz
+  version: "0.1.0"
+---
+
+# Agent-Friendly CLI Spec v0.1
+
+When building or modifying CLI tools, follow these rules to make them safe and
+reliable for AI agents to use.
+
+## Core Philosophy
+
+1. **Agent-first** -- default output is JSON; human-friendly is opt-in via `--human`
+2. **Agent is untrusted** -- validate all input at the same level as a public API
+3. **Fail-Closed** -- when validation logic itself errors, deny by default
+4. **Verifiable** -- every rule is written so it can be automatically checked
+
+## Layer Model
+
+This spec now uses two orthogonal axes:
+
+- **Layer** answers rollout scope: `core`, `recommended`, `ecosystem`
+- **Priority** answers severity: `P0`, `P1`, `P2`
+
+Use layers for migration and certification:
+
+- **core** -- execution contract: JSON, errors, exit codes, stdout/stderr, safety
+- **recommended** -- better machine UX: self-description, explicit modes, richer schemas
+- **ecosystem** -- agent-native integration: `agent/`, `skills`, `issue`, inline context
+
+Certification maps to layers:
+
+- **Agent-Friendly** -- all `core` rules pass
+- **Agent-Ready** -- all `core` + `recommended` rules pass
+- **Agent-Native** -- all layers pass
+
+## Output Mode
+
+Default is agent mode (JSON). Explicit flags to switch:
+
+```bash
+$ mycli list              # default = JSON output (agent mode)
+$ mycli list --human      # human-friendly: colored, tables, formatted
+$ mycli list --agent      # explicit agent mode (override config if needed)
+```
+
+- **Default (no flag)** — JSON to stdout. Agent never needs to add a flag.
+- **--human** — human-friendly format (colors, tables, progress bars)
+- **--agent** — explicit JSON mode (useful when env/config overrides default)
+
+## agent/ Directory Convention
+
+Every CLI tool MUST have an `agent/` directory at its project root. This is the
+tool's identity and behavior contract for AI agents.
+
+```
+agent/
+├── brief.md          # One paragraph: who am I, what can I do
+├── rules/            # Behavior constraints (auto-registered)
+│   ├── trigger.md    # When should an agent use this tool
+│   ├── workflow.md   # Step-by-step usage flow
+│   └── writeback.md  # How to write feedback back
+└── skills/           # Extended capabilities (auto-registered)
+    └── getting-started.md
+```
+
+### File Format
+
+**agent/brief.md** — plain text, one paragraph. No frontmatter needed.
+
+**agent/rules/*.md** — each file MUST have YAML frontmatter:
+
+```yaml
+---
+name: trigger
+description: When should an agent use this tool
+---
+(content here)
+```
+
+**agent/skills/*.md** — each file MUST have YAML frontmatter:
+
+```yaml
+---
+name: getting-started
+description: Quick start guide for new users
+---
+(content here)
+```
+
+The `name` field is the canonical identifier. The `description` field tells agents
+when/why to read this rule or skill.
+
+### Auto-Registration
+
+Drop a `.md` file into `agent/rules/` or `agent/skills/` and it is automatically
+registered. The CLI reads these directories at runtime. No code changes needed.
+
+## Four Levels of Self-Description
+
+### Level 1: --brief (business card, injected into agent config)
+
+The smallest possible context. Output of `--brief` gets synced into CLAUDE.md /
+AGENTS.md by `cli-toolkit sync-agent`, so agents always know this tool exists.
+
+```bash
+$ mycli --brief
+mycli — task manager, add/list/show/done for local tasks
+```
+
+Source: `agent/brief.md`. Just one paragraph. Always in agent's system prompt.
+
+### Level 2: Every Command Response (always-on context)
+
+EVERY command's JSON output MUST include three fixed fields:
+
+```json
+{
+  "result": { "id": 1, "title": "Buy milk", "status": "todo" },
+
+  "rules": [
+    {"name": "trigger",   "content": "full content of trigger.md"},
+    {"name": "workflow",  "content": "full content of workflow.md"},
+    {"name": "writeback", "content": "full content of writeback.md"}
+  ],
+  "skills": [
+    {"name": "getting-started", "description": "Quick start guide", "command": "mycli skills getting-started"},
+    {"name": "batch-import",    "description": "Import from CSV",   "command": "mycli skills batch-import"}
+  ],
+  "issue": "Any problem, bad output, or confusion — run: mycli issue create --type <bug|requirement|suggestion|bad-output> --message '...'"
+}
+```
+
+- **rules** — full `.md` content inline (push: agent must know)
+- **skills** — name + description + command (pull: agent reads on demand)
+- **issue** — one-line guide, always present (fallback: can't figure it out? report it)
+
+These three fields form a closed loop:
+  rules tell you how -> skills teach you more -> issue catches what you can't handle
+
+### Level 3: --help (full self-description)
+
+Complete identity + capabilities. Only called for deep exploration.
+
+```json
+{
+  "help": "mycli — full description from agent/brief.md",
+  "commands": [
+    {"name": "add",  "description": "Create a new task"},
+    {"name": "list", "description": "List all tasks"},
+    {"name": "done", "description": "Mark task as done (destructive)"}
+  ],
+  "rules": [
+    {"name": "trigger",   "content": "..."},
+    {"name": "workflow",  "content": "..."},
+    {"name": "writeback", "content": "..."}
+  ],
+  "skills": [
+    {"name": "getting-started", "description": "Quick start guide", "command": "mycli skills getting-started"}
+  ],
+  "issue": "Any problem — run: mycli issue create ..."
+}
+```
+
+### Level 4: skills <name> (on-demand deep dive)
+
+```bash
+$ mycli skills getting-started
+{
+  "name": "getting-started",
+  "content": "full content of getting-started.md",
+  "rules": [ ... same rules for context ... ]
+}
+```
+
+### Summary: Information Architecture
+
+```
+--brief              → always in agent's prompt (via sync-agent)
+every command        → data + rules + skills list + issue (always attached)
+--help               → brief + commands + rules + skills + issue (first contact)
+skills <name>        → full skill content + rules (on demand)
+```
+
+## Certification Requirements
+
+Each level includes all rules from the previous level.
+Priority tag `[P0]`=agent breaks without it, `[P1]`=agent works but poorly, `[P2]`=nice to have.
+
+### Level 1: Agent-Friendly (core — 20 rules)
+
+Goal: CLI is a stable, callable API. Agent can invoke, parse, and handle errors.
+
+**Output** — default is JSON, stable schema
+- `[P0]` O1: Default output is JSON. No `--json` flag needed
+- `[P0]` O2: JSON MUST pass `jq .` validation
+- `[P0]` O3: JSON schema MUST NOT change within same version
+
+**Error** — structured, to stderr, never interactive
+- `[P0]` E1: Errors → `{"error":true, "code":"...", "message":"...", "suggestion":"..."}` to stderr
+- `[P0]` E4: Error has machine-readable `code` (e.g. `MISSING_REQUIRED`)
+- `[P0]` E5: Error has human-readable `message`
+- `[P0]` E7: On error, NEVER enter interactive mode — exit immediately
+- `[P0]` E8: Error codes are API contracts — MUST NOT rename across versions
+
+**Exit Code** — predictable failure signals
+- `[P0]` X3: Parameter/usage errors MUST exit 2
+- `[P0]` X9: Failures MUST exit non-zero — never exit 0 then report error in stdout
+
+**Composability** — clean pipe semantics
+- `[P0]` C1: stdout is for data ONLY
+- `[P0]` C2: logs, progress, warnings go to stderr ONLY
+
+**Input** — fail fast on bad input
+- `[P1]` I4: Missing required param → structured error, never interactive prompt
+- `[P1]` I5: Type mismatch → exit 2 + structured error
+
+**Safety** — protect against agent mistakes
+- `[P1]` S1: Destructive ops require `--yes` confirmation
+- `[P1]` S4: Reject `../../` path traversal, control chars
+
+**Guardrails** — runtime input protection
+- `[P1]` G1: Unknown flags rejected with exit 2
+- `[P1]` G2: Detect API key / token patterns in args, reject execution
+- `[P1]` G3: Reject sensitive file paths (*.env, *.key, *.pem)
+- `[P1]` G8: Reject shell metacharacters in arguments (; | && $())
+
+### Level 2: Agent-Ready (+ recommended — 59 rules)
+
+Goal: CLI is self-describing, well-named, and pipe-friendly. Agent discovers capabilities and chains commands without trial and error.
+
+**Self-Description** — agent discovers what CLI can do
+- `[P1]` D1: `--help` outputs structured JSON with `commands[]`
+- `[P1]` D3: Schema has required fields (help, commands)
+- `[P1]` D4: All parameters have type declarations
+- `[P1]` D7: Parameters annotated as required/optional
+- `[P1]` D9: Every command has a description
+- `[P1]` D11: `--help` outputs JSON with help, rules, skills, commands
+- `[P1]` D15: `--brief` outputs `agent/brief.md` content
+- `[P1]` D16: Default JSON (agent mode), `--human` for human-friendly
+- `[P2]` D2/D5/D6/D8/D10: per-command help, enums, defaults, output schema, version
+
+**Input** — unambiguous calling convention
+- `[P1]` I1: All flags use `--long-name` format
+- `[P1]` I2: No positional argument ambiguity
+- `[P2]` I3/I6/I7: --json-input, boolean --no-X, array params
+
+**Error**
+- `[P1]` E6: Error includes `suggestion` field
+- `[P2]` E2/E3: errors to stderr, error JSON valid
+
+**Safety**
+- `[P1]` S8: `--sanitize` flag for external input
+- `[P2]` S2/S3/S5/S6/S7: default deny, --dry-run, no auto-update, destructive marking
+
+**Exit Code**
+- `[P1]` X1: 0 = success
+- `[P2]` X2/X4-X8: 1=general, 10=auth, 11=permission, 20=not-found, 30=conflict
+
+**Composability**
+- `[P1]` C6: No interactive prompts in pipe mode
+- `[P2]` C3/C4/C5/C7: pipe-friendly, --quiet, pipe chain, idempotency
+
+**Naming** — predictable flag conventions
+- `[P1]` N4: Reserved flags (--agent, --human, --brief, --help, --version, --yes, --dry-run, --quiet, --fields)
+- `[P2]` N1/N2/N3/N5/N6: consistent naming, kebab-case, max 3 levels, --version semver
+
+**Guardrails**
+- `[P1]` I8/I9: no implicit state, non-interactive auth
+- `[P1]` G6/G9: precondition checks, fail-closed
+- `[P2]` G4/G5/G7: permission levels, PII redaction, batch limits
+
+#### Reserved Flags
+
+| Flag | Semantics | Notes |
+|------|-----------|-------|
+| `--agent` | JSON output (default) | Explicit override |
+| `--human` | Human-friendly output | Colors, tables, formatted |
+| `--brief` | One-paragraph identity | For sync into agent config |
+| `--help` | Full self-description JSON | Brief + commands + rules + skills + issue |
+| `--version` | Semver version string | |
+| `--yes` | Confirm destructive ops | Required for delete/destroy |
+| `--dry-run` | Preview without executing | |
+| `--quiet` | Suppress stderr output | |
+| `--fields` | Filter output fields | Save tokens |
+
+### Level 3: Agent-Native (+ ecosystem — 19 rules)
+
+Goal: CLI has identity, behavior contract, skill system, and feedback loop. Agent can learn the tool, extend its use, and report problems — full closed-loop collaboration.
+
+**Agent Directory** — tool identity and behavior contract
+- `[P1]` D12: `agent/brief.md` exists
+- `[P1]` D13: `agent/rules/` has trigger.md, workflow.md, writeback.md
+- `[P1]` D17: agent/rules/*.md have YAML frontmatter (name, description)
+- `[P1]` D18: agent/skills/*.md have YAML frontmatter (name, description)
+- `[P2]` D14: `agent/skills/` directory + `skills` subcommand
+
+**Response Structure** — inline context on every call
+- `[P1]` R1: Every response includes `rules[]` (full content from agent/rules/)
+- `[P1]` R2: Every response includes `skills[]` (name + description + command)
+- `[P1]` R3: Every response includes `issue` (feedback guide)
+
+**Meta** — project-level integration
+- `[P2]` M1: AGENTS.md at project root
+- `[P2]` M2: Optional MCP tool schema export
+- `[P2]` M3: CHANGELOG.md marks breaking changes
+
+**Feedback** — built-in issue system
+- `[P2]` F1: `issue` subcommand (create/list/show)
+- `[P2]` F2: Structured submission with version/context/exit_code
+- `[P2]` F3: Categories: bug / requirement / suggestion / bad-output
+- `[P2]` F4: Issues stored locally, no external service dependency
+- `[P2]` F5: `issue list` / `issue show <id>` queryable
+- `[P2]` F6: Issues have status tracking (open/in-progress/resolved/closed)
+- `[P2]` F7: Issue JSON has all required fields (id, type, status, message, created_at, updated_at)
+- `[P2]` F8: All issues have status field
+
+## Exit Code Table
+
+```
+0   success         10  auth failed       20  resource not found
+1   general error   11  permission denied 30  conflict/precondition
+2   param/usage error
+```
+
+## Error Format
+
+```json
+{
+  "error": true,
+  "code": "AUTH_EXPIRED",
+  "message": "Access token expired 2 hours ago",
+  "suggestion": "Run 'mycli auth refresh' to get a new token"
+}
+```
+
+## Quick Implementation Checklist
+
+Implement by layer — each phase gets you the next certification level.
+
+**Phase 1: Agent-Friendly (core)**
+1. Default output is JSON — no `--json` flag needed
+2. Error handler: `{ error, code, message, suggestion }` to stderr
+3. Exit codes: 0 success, 2 param error, 1 general
+4. stdout = data only, stderr = logs only
+5. Missing param → structured error (never interactive)
+6. `--yes` guard on destructive operations
+7. Guardrails: reject secrets, path traversal, shell metacharacters
+
+**Phase 2: Agent-Ready (+ recommended)**
+8. `--help` returns structured JSON (help, commands[], rules[], skills[])
+9. `--brief` reads and outputs `agent/brief.md` content
+10. `--human` flag switches to human-friendly format
+11. Reserved flags: --agent, --version, --dry-run, --quiet, --fields
+12. Exit codes: 20 not found, 30 conflict, 10 auth, 11 permission
+
+**Phase 3: Agent-Native (+ ecosystem)**
+13. Create `agent/` directory: `brief.md`, `rules/trigger.md`, `rules/workflow.md`, `rules/writeback.md`
+14. Every command response appends: rules[] + skills[] + issue
+15. `skills` subcommand: list all / show one with full content
+16. `issue` subcommand for feedback (create/list/show/close/transition)
+17. AGENTS.md at project root
+
+## Issue System Specification
+
+Every CLI tool MUST have a built-in issue system for agents to report problems,
+request features, and track feedback.
+
+### Storage
+
+Issues are stored in a dedicated directory:
+
+```
+~/.{toolname}/issues/       # or {TOOL_DIR}/issues/
+├── 001.json
+├── 002.json
+└── 003.json
+```
+
+Each issue is a single JSON file named `{id}.json`.
+
+### Issue Fields
+
+```json
+{
+  "id": "001",
+  "type": "bug",
+  "status": "open",
+  "message": "list command returns empty when tasks exist",
+  "context": {
+    "version": "0.1.0",
+    "command": "mycli list --json",
+    "exit_code": 0
+  },
+  "created_at": "2026-03-14T00:00:00Z",
+  "updated_at": "2026-03-14T00:00:00Z"
+}
+```
+
+Required fields:
+- **id** — unique identifier
+- **type** — one of: `bug`, `requirement`, `suggestion`, `bad-output`
+- **status** — one of: `open`, `in-progress`, `resolved`, `closed`
+- **message** — description of the issue
+- **context** — object with `version`, `command`, `exit_code`
+- **created_at** — ISO 8601 timestamp
+- **updated_at** — ISO 8601 timestamp
+
+### State Management
+
+| Command | Description |
+|---------|-------------|
+| `issue create --type <type> --message <msg>` | Create a new issue |
+| `issue list [--type <type>] [--status <status>]` | List issues, filterable |
+| `issue show <id>` | Show single issue detail |
+| `issue close <id>` | Close an issue |
+| `issue transition <id> --status <status>` | Change issue status |
+
+### Queryable
+
+Issues MUST be filterable by `--type` and `--status`:
+
+```bash
+$ mycli issue list --type bug --status open
+$ mycli issue list --status resolved

--- a/skills/ai-native-cli/references/audit.md
+++ b/skills/ai-native-cli/references/audit.md
@@ -1,0 +1,406 @@
+---
+name: audit
+description: >
+  Audit a CLI against the Agent-Friendly CLI Spec. Takes a CLI name,
+  runs it with various inputs, and produces a structured compliance report.
+  Use when you need to verify a CLI meets the spec before certification.
+---
+
+# CLI Spec Audit Protocol
+
+You are auditing a CLI tool against the Agent-Friendly CLI Spec v0.1.
+Follow this protocol exactly. Use Bash to call the CLI, Read/Glob to check files.
+
+## Input
+
+User provides: `<cli>` — the CLI command name or path.
+Optional: `--layer <core|recommended|ecosystem>` to limit scope.
+Optional: `--priority <p0|p1|p2>` to limit scope.
+
+## Step 1: Discovery
+
+Run these commands and record the results:
+
+```bash
+<cli> --help
+<cli> --brief
+<cli> --version
+```
+
+From `--help` output, extract:
+- List of commands (name + description)
+- Which commands are destructive (delete/remove/destroy/drop/purge)
+- Which commands accept parameters (and which params are required)
+- Whether output is JSON
+
+Also check:
+```bash
+ls <cli-project-root>/agent/
+ls <cli-project-root>/agent/rules/
+ls <cli-project-root>/agent/skills/
+ls <cli-project-root>/AGENTS.md
+```
+
+Save all discovery results. You'll reference them throughout the audit.
+
+## Step 2: Audit by Dimension
+
+Work through each dimension in order. For each rule:
+- Run the check described
+- Record: `pass`, `fail`, or `skip` (with reason)
+- On `fail`, record the evidence (actual output) and suggestion
+
+### Dimension 01: Discoverability (D1-D18)
+
+**D1 [P1] --help outputs structured JSON with commands[]**
+→ Check: `<cli> --help` output parses as JSON and has `commands` array.
+
+**D3 [P1] Schema has required fields**
+→ Check: --help JSON has `help` (string) and `commands` (array) fields.
+
+**D4 [P1] All parameters have type declarations**
+→ Check: In --help JSON, every item in `commands[].parameters[]` has a `type` field.
+
+**D7 [P1] Parameters annotated as required/optional**
+→ Check: Every parameter has a `required` field (boolean).
+
+**D9 [P1] Every command has a description**
+→ Check: Every item in `commands[]` has a non-empty `description`.
+
+**D11 [P1] --help JSON includes help, rules, skills, commands**
+→ Check: --help JSON has all four top-level keys.
+
+**D12 [P1] agent/brief.md exists**
+→ Check: File exists at `<project-root>/agent/brief.md`.
+
+**D13 [P1] agent/rules/ has trigger.md, workflow.md, writeback.md**
+→ Check: All three files exist.
+
+**D15 [P1] --brief outputs agent/brief.md content**
+→ Check: `<cli> --brief` output matches content of `agent/brief.md`.
+
+**D16 [P1] Default is JSON, --human for human-friendly**
+→ Check: `<cli> <any-command>` outputs JSON. `<cli> <any-command> --human` outputs non-JSON.
+
+**D17 [P1] agent/rules/*.md have YAML frontmatter (name, description)**
+→ Check: Read each file, verify frontmatter has both fields.
+
+**D18 [P1] agent/skills/*.md have YAML frontmatter (name, description)**
+→ Check: Read each file, verify frontmatter has both fields.
+
+**D2 [P2] Per-command help available**
+→ Check: `<cli> <command> --help` returns structured info for at least one command.
+
+**D5 [P2] Enum parameters list allowed values**
+→ Check: Any enum-type parameter has `enum` or `allowed_values` field.
+
+**D6 [P2] Parameters have default values documented**
+→ Check: Parameters with defaults have a `default` field.
+
+**D8 [P2] --help includes output schema**
+→ Check: Commands have `output_schema` or similar field.
+
+**D10 [P2] --version outputs semver**
+→ Check: `<cli> --version` output matches semver pattern `X.Y.Z`.
+
+**D14 [P2] agent/skills/ directory + skills subcommand**
+→ Check: Directory exists and `<cli> skills` returns a list.
+
+### Dimension 02: Output (R1-R3, O1-O10)
+
+**R1 [P1] Every response includes rules[]**
+→ Check: Run any normal command, check JSON output has `rules` array.
+
+**R2 [P1] Every response includes skills[]**
+→ Check: Same output has `skills` array.
+
+**R3 [P1] Every response includes issue**
+→ Check: Same output has `issue` string.
+
+**O1 [P0] Default output is JSON**
+→ Check: `<cli> <command>` (no flags) outputs valid JSON.
+
+**O2 [P0] JSON passes jq validation**
+→ Check: Pipe output through `jq .` — must exit 0.
+
+**O3 [P0] JSON schema stable within version**
+→ Check: Run same command twice, compare top-level keys. Must match.
+
+**O4 [P2] --fields for field filtering**
+→ Check: `<cli> <command> --fields id,name` returns only those fields.
+
+**O5 [P2] Empty result returns [], not error**
+→ Check: Run a list command that returns no results. Must get `[]` or `{"result":[]}`, not an error.
+
+**O6 [P2] --human flag for human-friendly output**
+→ Check: `<cli> <command> --human` outputs non-JSON formatted text.
+
+**O7 [P2] Multiple results in JSON array**
+→ Check: List command returns array, not single object.
+
+**O8 [P2] Pagination includes total/page/has_more**
+→ Skip if CLI has no pagination. Otherwise check those fields.
+
+**O9 [P2] NDJSON for streaming**
+→ Skip if not applicable. Otherwise check each line is valid JSON.
+
+**O10 [P2] Auto-detect TTY**
+→ Check: Pipe `<cli> <command> | cat` — must get JSON even without --agent flag.
+
+### Dimension 03: Error (E1-E8)
+
+**E1 [P0] Errors → structured JSON to stderr**
+→ Check: Trigger an error (e.g. invalid command), capture stderr, verify JSON with `error`, `code`, `message` fields.
+
+**E4 [P0] Error has machine-readable code**
+→ Check: Error JSON `code` field exists and is a string like `MISSING_REQUIRED`.
+
+**E5 [P0] Error has human-readable message**
+→ Check: Error JSON `message` field exists and is non-empty.
+
+**E7 [P0] Never enter interactive mode on error**
+→ Check: Trigger error, verify CLI exits immediately (doesn't hang).
+
+**E8 [P0] Error codes are stable API contracts**
+→ Check: Trigger same error twice, verify `code` is identical.
+
+**E6 [P1] Error includes suggestion field**
+→ Check: Error JSON has `suggestion` field.
+
+**E2 [P2] All errors go to stderr**
+→ Check: On error, stdout is empty, stderr has the error JSON.
+
+**E3 [P2] Error JSON is valid JSON**
+→ Check: Parse error stderr output with jq.
+
+### Dimension 04: Input (I1-I9)
+
+**I1 [P1] All flags use --long-name format**
+→ Check: In --help JSON, all parameter names use `--kebab-case`.
+
+**I2 [P1] No positional argument ambiguity**
+→ Check: Commands don't rely on positional arg order for different meanings.
+
+**I4 [P1] Missing required param → structured error**
+→ Check: Call a command missing a required param. Must get structured error, not a prompt.
+
+**I5 [P1] Type mismatch → exit 2 + structured error**
+→ Check: Pass wrong type (string where number expected). Must exit 2.
+
+**I8 [P1] No implicit state**
+→ Check: --help doesn't reference hidden state files that change behavior.
+
+**I9 [P1] Non-interactive auth**
+→ Check: If auth is needed, it's via flag/env, not interactive prompt.
+
+**I3 [P2] --json-input for batch operations**
+→ Check: `echo '{"items":[...]}' | <cli> <command> --json-input` works.
+
+**I6 [P2] Boolean flags explicit: --verbose / --no-verbose**
+→ Check: Boolean params in schema have --no-X counterpart.
+
+**I7 [P2] Array params: --tag a --tag b**
+→ Check: Array-type params accept repeated flags.
+
+### Dimension 05: Safety (S1-S8)
+
+**S1 [P1] Destructive ops require --yes**
+→ Check: Run destructive command WITHOUT --yes. Must reject (non-zero exit).
+
+**S4 [P1] Reject path traversal**
+→ Check: Pass `../../etc/passwd` as a path-type argument. Must reject.
+
+**S8 [P1] --sanitize flag for external input**
+→ Check: --help schema mentions --sanitize flag.
+
+**S2 [P2] Destructive default deny**
+→ Check: Same as S1, verify error message mentions --yes.
+
+**S3 [P2] --dry-run previews without executing**
+→ Check: `<cli> <command> --dry-run` exits 0 without side effects.
+
+**S5 [P2] CLI must not auto-update itself**
+→ Check: No `update` or `self-update` command in --help.
+
+**S6 [P2] Schema marks destructive commands**
+→ Check: --help JSON `commands[]` has `destructive: true` on delete-type commands.
+
+**S7 [P2] --quiet doesn't skip --yes requirement**
+→ Check: Destructive command with `--quiet` but no `--yes` still fails.
+
+### Dimension 06: Exit Code (X1-X9)
+
+**X3 [P0] Parameter/usage errors exit 2**
+→ Check: Pass invalid flag. Must exit 2.
+
+**X9 [P0] Failures exit non-zero**
+→ Check: Trigger any failure. Exit code must not be 0.
+
+**X1 [P1] 0 = success**
+→ Check: Successful command exits 0.
+
+**X2 [P2] 1 = general error**
+**X4 [P2] 10 = auth failure**
+**X5 [P2] 11 = permission denied**
+**X6 [P2] 20 = resource not found**
+**X7 [P2] 30 = conflict/precondition**
+→ Check: If you can trigger these error types, verify the exit code matches.
+
+**X8 [P2] Exit code corresponds to JSON error code**
+→ Check: Error JSON `code` and process exit code are semantically consistent.
+
+### Dimension 07: Composability (C1-C7)
+
+**C1 [P0] stdout is for data ONLY**
+→ Check: Successful command stdout contains only JSON data, no logs or warnings.
+
+**C2 [P0] Logs, progress, warnings go to stderr ONLY**
+→ Check: Any non-data output (if present) goes to stderr.
+
+**C6 [P1] No interactive prompts in pipe mode**
+→ Check: Pipe input to the CLI (`echo | <cli> <command>`), must not hang.
+
+**C3 [P2] stdout can be piped**
+→ Check: `<cli> list | jq .` works.
+
+**C4 [P2] --quiet suppresses non-essential stderr**
+→ Check: `<cli> <command> --quiet 2>/dev/null` produces less stderr.
+
+**C5 [P2] Upstream output feeds downstream input**
+→ Check: If --json-input exists, test pipe chain.
+
+**C7 [P2] Idempotent**
+→ Check: Run same read command twice, compare output.
+
+### Dimension 08: Naming (N1-N6)
+
+**N4 [P1] Reserved flags present**
+→ Check: --help schema supports --agent, --human, --brief, --help, --version, --yes, --dry-run, --quiet, --fields.
+
+**N1 [P2] Consistent verb/noun pattern**
+→ Check: All commands follow same pattern (e.g., all `noun verb` or all `verb noun`).
+
+**N2 [P2] Flags use kebab-case**
+→ Check: No camelCase or snake_case flags in schema.
+
+**N3 [P2] Max 3 command levels**
+→ Check: No command deeper than `cli level1 level2`.
+
+**N5 [P2] --version outputs semver**
+→ Same as D10.
+
+**N6 [P2] --version exists**
+→ Check: `<cli> --version` doesn't error.
+
+### Dimension 09: Meta (M1-M3)
+
+**M1 [P2] AGENTS.md at project root**
+→ Check: File exists.
+
+**M2 [P2] MCP tool schema export**
+→ Check: `<cli> --mcp-schema` or similar exists. Skip if not applicable.
+
+**M3 [P2] Changelog marks breaking changes**
+→ Check: CHANGELOG.md exists and mentions breaking changes if any.
+
+### Dimension 10: Feedback (F1-F8)
+
+**F1 [P2] issue subcommand exists**
+→ Check: `<cli> issue --help` or `<cli> issue list` works.
+
+**F2 [P2] Structured submission**
+→ Check: `<cli> issue create --type bug --message "test"` returns structured JSON.
+
+**F3 [P2] Categories: bug/requirement/suggestion/bad-output**
+→ Check: --type accepts all four values.
+
+**F4 [P2] Issues stored locally**
+→ Check: After creating an issue, a file appears in the issues directory.
+
+**F5 [P2] issue list / issue show queryable**
+→ Check: Both commands return JSON.
+
+**F6 [P2] Issues have status tracking**
+→ Check: `<cli> issue transition <id> --status in-progress` works.
+
+**F7 [P2] Issue JSON has required fields**
+→ Check: id, type, status, message, created_at, updated_at all present.
+
+**F8 [P2] All issues have status field**
+→ Check: Every issue in `issue list` has `status`.
+
+### Dimension 11: Guardrails (G1-G9)
+
+**G1 [P1] Unknown flags rejected with exit 2**
+→ Check: `<cli> <command> --nonexistent-flag-xyz` exits 2.
+
+**G2 [P1] Detect API key patterns, reject**
+→ Check: Pass `sk-abc123secretkey456789012345678901` as an argument value. Must reject.
+
+**G3 [P1] Reject sensitive file paths**
+→ Check: Pass `.env` or `id_rsa.key` as a file argument. Must reject.
+
+**G6 [P1] Precondition checks**
+→ Check: If a command needs preconditions (e.g., config exists), missing precondition → structured error.
+
+**G8 [P1] Reject shell metacharacters**
+→ Check: Pass `; rm -rf /` or `$(whoami)` as argument value. Must reject.
+
+**G9 [P1] Fail-closed**
+→ Check: If guardrail logic itself errors, CLI denies rather than allows.
+
+**G4 [P2] Operation whitelist**
+→ Check: --help schema has permission/scope annotations.
+
+**G5 [P2] Output redacts PII**
+→ Check: If output contains emails/phones, they should be masked.
+
+**G7 [P2] Batch limits**
+→ Check: If batch operations exist, there's a max limit.
+
+## Step 3: Progress Reporting
+
+After completing each dimension, report a progress line:
+
+```
+[03/11] Error: 5/8 pass, 2 fail (E6, E3), 1 skip (E8)
+```
+
+## Step 4: Final Report
+
+After all dimensions are checked, produce a summary:
+
+```markdown
+# Audit Report: <cli-name>
+
+## Summary
+- Total rules: <N>
+- Pass: <N>  Fail: <N>  Skip: <N>
+- Certification: <Agent-Friendly | Agent-Ready | Agent-Native | None>
+
+## By Dimension
+| Dimension | Pass | Fail | Skip |
+|-----------|------|------|------|
+| Discoverability | ... | ... | ... |
+| Output | ... | ... | ... |
+| ... | ... | ... | ... |
+
+## Failures
+| Rule | Evidence | Suggestion |
+|------|----------|------------|
+| E6 | Error output missing `suggestion` field | Add `suggestion` key to error JSON |
+| ... | ... | ... |
+
+## Certification Gate
+- core (Agent-Friendly): <pass/fail> — <N>/<total> rules
+- + recommended (Agent-Ready): <pass/fail> — <N>/<total> rules
+- + ecosystem (Agent-Native): <pass/fail> — <N>/<total> rules
+```
+
+## Notes
+
+- If a rule cannot be tested (e.g., no destructive commands exist), mark it `skip` with reason.
+- For behavioral checks, always capture both stdout and stderr separately: `<cli> cmd 2>/tmp/stderr.txt`
+- Prefer testing with real commands from --help, not made-up command names.
+- If the CLI has a test/sandbox mode, use it for destructive operation testing.
+- Time-box: if a command hangs for more than 5 seconds, kill it and mark the relevant rule as `fail` (likely E7/C6 violation).


### PR DESCRIPTION
## Summary

- Adds a new **ai-native-cli** skill that provides a comprehensive design specification for building CLI tools that are safe and reliable for AI agents to consume.
- The spec defines **98 rules across 11 dimensions**: Output, Error, Exit Code, Input, Safety, Guardrails, Composability, Naming, Discoverability, Meta, and Feedback.
- Includes a **three-tier certification model** (Agent-Friendly / Agent-Ready / Agent-Native) so teams can adopt incrementally.
- Ships with an **audit protocol** (`references/audit.md`) that walks an agent step-by-step through verifying a CLI's compliance, producing a structured pass/fail report per rule.

## What the skill covers

| Dimension | Key concerns |
|-----------|-------------|
| Output | Default JSON, schema stability, field filtering |
| Error | Structured errors to stderr, machine-readable codes, suggestion field |
| Safety | `--yes` guards, path traversal rejection, secret detection |
| Guardrails | Unknown flag rejection, shell metacharacter blocking, fail-closed |
| Composability | stdout = data only, no interactive prompts in pipes |
| Discoverability | Four-level self-description (`--brief` / response / `--help` / `skills`) |
| Feedback | Built-in issue system for agent-to-tool reporting |

## How to use

When building or scaffolding a new CLI, activate this skill. It tells Claude how to structure output, handle errors, validate input, and add safety guardrails — all optimized for AI agent consumption.

## Test plan

- [ ] Verify SKILL.md frontmatter has required `name` and `description` fields
- [ ] Verify the skill loads correctly when installed via Claude Code plugin
- [ ] Verify audit protocol in `references/audit.md` can be followed end-to-end against a sample CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)