### PR TITLE
docs: Add Cognee Agent Memory Skills to Partner Skills section

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,4 @@ The markdown content below contains the instructions, examples, and guidelines t
 Skills are a great way to teach Claude how to get better at using specific pieces of software. As we see awesome example skills from partners, we may highlight some of them here:
 
 - **Notion** - [Notion Skills for Claude](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0)
+- **Cognee** - [Cognee Agent Memory Skills](https://github.com/topoteretes/cognee/blob/36b3508732f3c5298232eb4759d2bc703f5afd09/cognee/skill.md)


### PR DESCRIPTION
## Add Cognee Agent Memory Skills to Partner Skills

Adds a link to [Cognee Agent Memory Skills](https://github.com/topoteretes/cognee/blob/36b3508732f3c5298232eb4759d2bc703f5afd09/cognee/skill.md) in the Partner Skills section of the README.

Cognee is an open-source memory engine for AI agents. This skill file shows how to use Cognee to give Claude persistent, queryable memory across sessions.

### Changes
- Added Cognee entry to the Partner Skills section in `README.md`