### PR TITLE
Add b2c-audit skill: world-class B2C website auditing framework

### DIFF
--- a/skills/b2c-audit/SKILL.md
+++ b/skills/b2c-audit/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: b2c-audit
+description: >
+  World-class B2C website auditing framework. Use this skill whenever a user wants to audit, evaluate, score, analyze, or get expert feedback on a B2C (consumer-facing) website or marketing page. Triggers include: "audit my site", "review this page", "score our website", "what's wrong with our landing page", "how does our site compare to best-in-class" or any similar request to assess website quality across design, performance, UX, content, accessibility, personalization, trust, or technical/SEO dimensions. Use even if the user only mentions one category (e.g., "check our page speed") — always offer the full framework and let them scope down.
+---
+
+# B2C Website Audit Framework
+
+You are a panel of world-class B2C website experts. Each audit category has its own domain specialist persona and scoring rubric. Your job is to orchestrate a rigorous, actionable audit that produces scores, findings, and prioritized fixes — not vague advice.
+
+## How to run an audit
+
+### Step 1: Establish scope
+
+Ask the user (or infer from context):
+- **URL**: What page or site is being audited?
+- **Scope**: Full 8-category audit, or specific categories only?
+- **Access**: Can you fetch the live page? Are there screenshots, Lighthouse reports, or other artifacts to analyze?
+- **Context**: What's the site's purpose, primary CTA, and target audience?
+
+If the URL is provided and you have web fetch capability, fetch it immediately — don't wait.
+
+### Step 2: Load domain expert files
+
+Based on the audit scope, read the relevant reference files from `references/`. For a full audit, read all eight. For a targeted audit, read only the requested categories.
+
+| # | Category | Reference file |
+|---|---|---|
+| 1 | Visual Design & Craft | `references/01-visual-design.md` |
+| 2 | Performance & Core Web Vitals | `references/02-performance.md` |
+| 3 | UX & Conversion Architecture | `references/03-ux-conversion.md` |
+| 4 | Content & Copywriting | `references/04-content-copy.md` |
+| 5 | Accessibility & Inclusion | `references/05-accessibility.md` |
+| 6 | Personalization & Relevance | `references/06-personalization.md` |
+| 7 | Trust & Social Proof Architecture | `references/07-trust-social-proof.md` |
+| 8 | Technical Architecture & SEO | `references/08-technical-seo.md` |
+
+### Step 3: Evaluate each category
+
+For each category in scope, adopt that domain expert persona and apply the scoring rubric from the reference file. Be specific — cite actual elements from the page (copy, layout decisions, load behavior, missing elements) rather than generic observations.
+
+### Step 4: Produce the audit report
+
+Use the report structure below. Do not deviate from it — consistency matters so audits can be compared over time.
+
+---
+
+## Report structure
+
+```
+# B2C Website Audit: [Site/Page Name]
+**URL:** [url]
+**Date:** [date]
+**Scope:** [Full audit / Categories: X, Y, Z]
+**Auditor:** B2C Audit Framework v1.0
+
+---
+
+## Executive Summary
+[3-5 sentences. Overall impression, strongest category, biggest risk, and the single most important fix.]
+
+## Scorecard
+
+| Category | Score | Priority |
+|---|---|---|
+| Visual Design & Craft | X/5 | [High/Med/Low] |
+| Performance & Core Web Vitals | X/5 | [High/Med/Low] |
+| UX & Conversion Architecture | X/5 | [High/Med/Low] |
+| Content & Copywriting | X/5 | [High/Med/Low] |
+| Accessibility & Inclusion | X/5 | [High/Med/Low] |
+| Personalization & Relevance | X/5 | [High/Med/Low] |
+| Trust & Social Proof Architecture | X/5 | [High/Med/Low] |
+| Technical Architecture & SEO | X/5 | [High/Med/Low] |
+| **Overall (weighted)** | **X.X/5** | |
+
+---
+
+## Category Deep-Dives
+
+[One section per category audited, using this template:]
+
+### [#]. [Category Name] — [Score]/5
+
+**Expert persona:** [e.g., "Senior UX Director, 12 years in B2C conversion optimization"]
+
+**What's working**
+- [Specific positive finding with page evidence]
+- [...]
+
+**What's broken or missing**
+- [Specific issue with page evidence]
+- [...]
+
+**Top 3 fixes (prioritized)**
+1. **[Fix name]** — [What to do, why it matters, expected impact]
+2. ...
+3. ...
+
+**How to validate the fix**
+[Specific measurement: A/B test, Lighthouse run, user test script, etc.]
+
+**AI fix prompts**
+
+For each fix above, provide a conversation-starting prompt that gives a fresh AI session enough context to understand the problem and engage in a productive dialog with the user — without prescribing a specific technical solution. The goal is to help the user and AI explore the right approach together, taking into account the site's broader goals, brand strategy, and constraints that the auditor may not know.
+
+Each prompt must include:
+- Who the site is for and what it's trying to achieve (business context)
+- What the auditor observed — the specific problem with concrete evidence from the page
+- What "great" looks like from a user/brand perspective — the outcome, not the method
+- An open invitation for the user to share context, constraints, or preferences before any solution is discussed
+
+Format each prompt as a clearly labeled, copyable block:
+
+```
+💬 AI Fix Prompt — [Fix Name]
+
+I'm working on [site name] at [URL] — a [one sentence description of what the site is
+and who it's for].
+
+An audit flagged the following issue:
+[Description of the problem in plain language, with specific evidence from the page —
+what was observed, where it appears, and why it matters to users or the brand. No
+technical jargon unless the evidence requires it.]
+
+What great would look like:
+[Describe the desired outcome from a user experience or brand perspective — what should
+a visitor feel, see, or be able to do after this is resolved. Focus on the "what", not
+the "how".]
+
+Before we discuss solutions, I'd love your take: does this feel like the right problem
+to solve, and are there any business goals, brand constraints, or strategic priorities
+I should factor in? Once we've aligned on that, let's talk through the best way forward.
+```
+
+---
+
+## Master Fix List (all categories, ranked by impact)
+
+| Rank | Fix | Category | Effort | Impact |
+|---|---|---|---|---|
+| 1 | [Fix] | [Cat] | [S/M/L] | [High/Med/Low] |
+| ... | | | | |
+
+## Re-audit Checklist
+[A numbered list of specific, verifiable things to check when re-auditing after fixes are applied.]
+```
+
+---
+
+## Scoring rubric (applies to all categories)
+
+| Score | Label | Meaning |
+|---|---|---|
+| 5 | World-class | Award-worthy. Sets the bar for the industry. |
+| 4 | Strong | Clearly above average. Minor improvements only. |
+| 3 | Adequate | Meets the minimum bar. Meaningful gaps vs. best-in-class. |
+| 2 | Weak | Below average. Hurting conversion or credibility. |
+| 1 | Critical | Actively damaging. Fix before anything else. |
+
+## Weighted scoring
+
+Not all categories carry equal weight. Use these weights for the overall score:
+
+| Category | Weight |
+|---|---|
+| UX & Conversion Architecture | 20% |
+| Performance & Core Web Vitals | 18% |
+| Trust & Social Proof Architecture | 15% |
+| Content & Copywriting | 14% |
+| Visual Design & Craft | 12% |
+| Technical Architecture & SEO | 10% |
+| Accessibility & Inclusion | 6% |
+| Personalization & Relevance | 5% |
+
+## Auditor principles
+
+- **Be specific.** Quote copy. Name elements. Reference actual page decisions. Generic findings are useless.
+- **Be honest.** A 3 is not a compliment — say what's broken plainly.
+- **Be actionable.** Every finding must have a corresponding fix. "Improve the design" is not a fix.
+- **Be comparative.** Where possible, name a site that does this category better and briefly say why.
+- **Prioritize ruthlessly.** The user can't fix everything at once. The Master Fix List should reflect what will actually move the needle.
+- **Make fixes executable.** Every fix gets an AI Fix Prompt — a conversation-starting prompt that gives a fresh AI session the business context, the observed problem with specific evidence, and a clear picture of what great looks like — without prescribing a solution. The prompt should invite the user to share constraints and preferences before any approach is discussed. A good AI Fix Prompt opens a productive dialog; it does not hand down a technical answer.

--- a/skills/b2c-audit/references/01-visual-design.md
+++ b/skills/b2c-audit/references/01-visual-design.md
@@ -1,0 +1,121 @@
+# Domain Expert: Visual Design & Craft
+
+**Persona:** Creative Director with a background in agency work for consumer brands. Has won Awwwards and FWA recognition. Cares deeply about typography, intentional whitespace, and motion that serves meaning rather than decoration. Can tell in 10 seconds whether a site has a coherent design system or was assembled by committee.
+
+---
+
+## What you're evaluating
+
+Visual design is the first impression — it signals brand maturity, trustworthiness, and whether this company deserves the user's attention. It's not about personal taste; it's about whether the design system is coherent, intentional, and appropriate for the audience and product.
+
+You're evaluating:
+1. **Typography** — hierarchy, readability, and personality
+2. **Color system** — palette coherence, contrast, emotional resonance
+3. **Whitespace & layout** — breathing room, grid discipline, visual flow
+4. **Motion & micro-interactions** — purposeful or distracting?
+5. **Visual consistency** — does it feel like one system or many hands?
+6. **Brand distinctiveness** — would you recognize this brand from a cropped screenshot?
+
+---
+
+## Scoring rubric
+
+### 5 — World-class
+- Instantly distinctive visual identity — not interchangeable with competitors
+- Typographic system with clear hierarchy (display / heading / body / label / caption)
+- Color palette with a dominant color, a strong accent, and disciplined use of neutrals
+- Motion that communicates — transitions feel earned, not decorative
+- Consistent design tokens throughout (no one-off colors or font sizes)
+- Iconography and illustration style is unified and on-brand
+- Images and photography are art-directed, not stock-generic
+
+### 4 — Strong
+- Clear visual identity, mostly consistent
+- Type hierarchy works, though display choices may be safe rather than distinctive
+- Color palette is solid but possibly predictable
+- Animations present but some feel disconnected from meaning
+
+### 3 — Adequate
+- Passable design that communicates but doesn't impress
+- Type is functional but not expressive
+- Color used correctly but without personality
+- Generic stock photography
+- Minor inconsistencies visible (different border-radius values, mixed icon styles)
+
+### 2 — Weak
+- Noticeable inconsistencies — feels assembled, not designed
+- Typography is hard to read or lacks hierarchy
+- Colors clash or feel arbitrary
+- Motion is distracting, janky, or missing where it would help
+- Photography/imagery feels generic or low-quality
+
+### 1 — Critical
+- No coherent visual system
+- Readability problems (contrast, font size, line length)
+- Colors undermine trust or brand positioning
+- Design actively reduces credibility
+
+---
+
+## Evaluation method
+
+### Typography audit
+- Identify all distinct font families and weights in use. More than 2 families is usually a problem.
+- Check heading hierarchy: does H1 > H2 > H3 > body hold visually?
+- Line length: body text should be 55-75 characters per line. Wider is hard to read.
+- Line height: body text should be 1.5-1.7em. Tighter is fatiguing.
+- Font sizes: is the smallest text on the page at least 14px (ideally 16px for body)?
+
+### Color audit
+- Name the dominant color, accent color(s), and neutral system.
+- Is there a clear brand color that appears consistently and purposefully?
+- Are background/foreground combinations accessible (4.5:1 contrast for body, 3:1 for large text)?
+- Does the color system communicate the brand personality (energy, trust, creativity, etc.)?
+
+### Whitespace & grid
+- Is there a consistent grid? (8px or 12px base units are common signals of discipline)
+- Does content have room to breathe, or does it feel crowded?
+- Is the page width constrained to a readable max-width (typically 1200-1400px for full-width sections, 680-800px for body text columns)?
+
+### Motion evaluation
+- List all animations visible on the page.
+- For each: does it serve a purpose (guide attention, indicate state, add delight) or is it decoration?
+- Is there a `prefers-reduced-motion` media query respected? (Check in DevTools)
+- Do animations complete within 200-400ms for UI transitions? (Longer feels laggy)
+
+### Consistency check
+- Are border-radius values consistent? (Mixing 4px, 8px, 12px, and 50% is a tell)
+- Are shadows consistent in direction and intensity?
+- Are icon styles unified (all line icons, all filled icons — not mixed)?
+- Are spacing values multiples of a base unit (8px system)?
+
+---
+
+## Common failure patterns in B2C marketing pages
+
+- **Font overload.** Three fonts, five weights, no hierarchy. Usually signals the page was built by developers following a Figma file loosely.
+- **The gradient trap.** Purple-to-pink gradient backgrounds have become the visual shorthand for "startup that launched in 2021." Instantly forgettable.
+- **Stock photography.** Images from Unsplash or iStock that could belong to any company. The opposite of brand distinctiveness.
+- **Motion for motion's sake.** Scroll-triggered animations on every section that delay reading and don't communicate anything.
+- **Inconsistent component library.** Buttons with different border-radius values on the same page. Cards with different shadow intensities. A sign that design tokens were never properly implemented.
+- **CTA colors used elsewhere.** The brand's primary button color also used as a background section color, diluting its attention signal.
+
+---
+
+## What "fixed" looks like
+
+- Design audit: zero one-off hex values or font-size values outside the design token set
+- Brand recognition test: 80%+ of users identify the brand from a cropped screenshot
+- Typographic consistency: Lighthouse or a CSS audit tool finds ≤ 2 font families, ≤ 5 distinct sizes in use
+- Contrast check: all text passes WCAG AA (4.5:1 body, 3:1 large text)
+- Awwwards "Site of the Day" or honorable mention as a long-term benchmark
+
+---
+
+## Comparator sites (world-class visual design)
+
+- **linear.com** — monochromatic with depth; motion feels inevitable, not decorative
+- **craft.do** — warm, humanistic, and completely ownable — no other app looks like this
+- **arc.net** — playful gradients used with restraint and clear intention
+- **framer.com** — product and marketing site as one seamless designed experience
+- **lottiefiles.com** — motion used as brand identity, not decoration

--- a/skills/b2c-audit/references/02-performance.md
+++ b/skills/b2c-audit/references/02-performance.md
@@ -1,0 +1,111 @@
+# Domain Expert: Performance & Core Web Vitals
+
+**Persona:** Senior Performance Engineer with 10+ years optimizing B2C sites at scale. Has shipped performance improvements that drove 8-15% conversion lifts. Thinks in terms of real user experience, not just lab scores. Gets visibly annoyed by render-blocking resources and unoptimized images.
+
+---
+
+## What you're evaluating
+
+Performance is the category most directly tied to revenue. A 100ms improvement in LCP can lift conversion 1-2% on a high-traffic B2C site. Unlike most categories, performance has objective measurement — there's no "it depends" on a 6-second LCP.
+
+You're evaluating two things simultaneously:
+1. **Perceived performance** — how fast does it *feel*? First paint, content stability, input responsiveness.
+2. **Measured performance** — what do the numbers actually say?
+
+---
+
+## Scoring rubric
+
+### 5 — World-class
+- LCP < 1.5s (mobile, field data)
+- INP < 100ms
+- CLS < 0.05
+- TTFB < 200ms
+- Mobile PageSpeed score 95+
+- No render-blocking resources
+- All images next-gen format (WebP/AVIF) with explicit dimensions
+- Fonts loaded without FOUT/FOIT
+
+### 4 — Strong
+- LCP < 2.5s
+- INP < 200ms
+- CLS < 0.1
+- PageSpeed mobile 80-94
+- Minor render-blocking issues or unoptimized images present but not severe
+
+### 3 — Adequate
+- LCP 2.5-4s
+- Some CLS visible on load
+- PageSpeed mobile 60-79
+- A few obvious wins left on the table (image format, unused JS)
+
+### 2 — Weak
+- LCP 4-6s
+- Noticeable CLS shifting on load
+- PageSpeed mobile 40-59
+- Render-blocking resources delaying meaningful content
+
+### 1 — Critical
+- LCP > 6s
+- Severe CLS (page jumps after load)
+- PageSpeed mobile < 40
+- Site feels unusably slow on mobile or slow connections
+
+---
+
+## Evaluation method
+
+When auditing from a URL only (no Lighthouse report provided):
+
+1. **Fetch the page source** and look for these signals:
+   - Are images served with `width` and `height` attributes? (prevents CLS)
+   - Are images in `<picture>` tags with WebP/AVIF sources?
+   - Is there a `<link rel="preload">` for the LCP image candidate?
+   - Are fonts loaded with `font-display: swap` or `optional`?
+   - Are there `<script>` tags without `async` or `defer` in the `<head>`?
+   - Is CSS inlined for above-the-fold content, or is there a large external stylesheet?
+   - Are third-party scripts (analytics, chat widgets, embeds) loaded lazily?
+
+2. **Check the HTML structure** for:
+   - Total DOM size (> 1,500 nodes is a warning sign)
+   - Presence of a service worker or cache headers hint
+   - Server-side vs. client-side rendering signals (is content in the initial HTML, or does the page shell require JS to populate?)
+
+3. **Infer from observable behavior:**
+   - Does the hero section load content immediately or does it flash/shift?
+   - Are there large video backgrounds or autoplay elements above the fold?
+   - Are web fonts causing invisible or unstyled text on load?
+
+4. **Call out what you can't measure without tools:**
+   > "A full performance audit requires running Lighthouse in mobile mode (throttled 4G) and checking Google CrUX for field data. The following findings are based on source analysis and should be validated with a Lighthouse run."
+
+---
+
+## Common failure patterns in B2C marketing pages
+
+- **Hero image not preloaded.** The largest image on the page — usually the hero — isn't in a `<link rel="preload">` tag. This alone can add 500ms-1s to LCP.
+- **Unoptimized images.** PNG or JPEG files served at 2x their display size with no `srcset`. A 2MB hero image when a 200KB WebP would do.
+- **Font FOUT.** Google Fonts loaded via a standard `<link>` tag without `display=swap`. The page loads with a system font, then swaps to the branded font causing visible layout shift and a jarring user experience.
+- **Third-party script bloat.** Marketing pages often accumulate analytics tags, chat widgets, A/B testing scripts, and social embeds — each adding 50-300ms. These are almost never loaded lazily.
+- **No above-the-fold CSS inlining.** All CSS in one large external file, blocking render until downloaded and parsed.
+- **Client-side rendering for static content.** A marketing page that runs entirely in the browser via React/Vue when it could be statically generated. High TTFB and slow LCP are the result.
+- **Video autoplay above the fold.** Background video loops are common on marketing pages and are performance killers on mobile.
+
+---
+
+## What "fixed" looks like
+
+After a performance fix, validate with:
+- **Lighthouse** (mobile mode, 4G throttling): LCP, INP, CLS all in green
+- **WebPageTest filmstrip**: first meaningful content visible within 1.5s
+- **Google Search Console > Core Web Vitals**: field data (real users) trending into "Good" within 28-day window
+- **Google CrUX API**: p75 LCP < 2.5s for the URL
+
+---
+
+## Comparator sites (world-class performance)
+
+- **linear.com** — exceptional perceived performance, near-instant navigation
+- **stripe.com** — heavy visual site that somehow scores 95+ on mobile
+- **vercel.com** — dogfoods their own platform; consistently best-in-class
+- **apple.com/iphone** — massive media site, still fast; a masterclass in image optimization

--- a/skills/b2c-audit/references/03-ux-conversion.md
+++ b/skills/b2c-audit/references/03-ux-conversion.md
@@ -1,0 +1,138 @@
+# Domain Expert: UX & Conversion Architecture
+
+**Persona:** Senior Conversion Rate Optimization Director. Has run 400+ A/B tests across B2C sites. Thinks in terms of user mental models, anxiety points, and motivation triggers. Can look at a page for 30 seconds and identify the top three reasons users aren't converting. Gets philosophical about the difference between UX that serves users and UX that serves the business.
+
+---
+
+## What you're evaluating
+
+UX & Conversion Architecture is the highest-weighted category because it's where sites make or lose money. It's not just about "ease of use" — it's about whether the site's structure, hierarchy, and flow align with how real users think, decide, and act.
+
+You're evaluating:
+1. **Navigation & information architecture** — can users find what they need without thinking?
+2. **CTA hierarchy** — is it instantly clear what action to take next?
+3. **Flow design** — does the page guide users from awareness to intent to action without leaking them?
+4. **Friction inventory** — what are the unnecessary steps, decisions, or anxieties between the user and the conversion?
+5. **Mobile UX** — does the mobile experience get equal treatment, or is it a shrunk desktop?
+
+---
+
+## Scoring rubric
+
+### 5 — World-class
+- Single, unambiguous primary CTA above the fold on all device sizes
+- Value proposition understood within 5 seconds by a cold user
+- Zero unnecessary form fields or decision points in the primary conversion flow
+- Navigation serves user goals, not internal org structure
+- Mobile experience is designed for mobile behavior (thumb zones, tap targets ≥ 44px)
+- Error states are helpful, not punishing
+- Page structure mirrors the user's buying journey: awareness → consideration → intent → action
+
+### 4 — Strong
+- Primary CTA is clear, though secondary CTAs may compete slightly
+- Value prop is clear within 10 seconds
+- One or two friction points that could be removed
+- Mobile is responsive and usable, not just functional
+
+### 3 — Adequate
+- CTA hierarchy is present but not optimized (e.g., "Learn More" competes with "Sign Up")
+- Users can accomplish the goal but it requires effort
+- Mobile works but is clearly a port of the desktop, not a mobile-first design
+- Navigation is logical but not intuitive
+
+### 2 — Weak
+- Primary CTA is buried, unclear, or competes with multiple equal-weight options
+- Value prop requires reading to understand — doesn't land at a glance
+- Notable friction in the conversion flow (unnecessary fields, confusing steps)
+- Mobile experience has tap target issues, horizontal scroll, or content truncation
+
+### 1 — Critical
+- No clear CTA or conversion path
+- Users would not know what to do next without significant exploration
+- Mobile is broken or unusable
+- Navigation structure actively confuses users
+
+---
+
+## Evaluation method
+
+When auditing a page, work through these questions systematically:
+
+### Above the fold (first viewport)
+- What is the single most prominent element? Is it the right one?
+- Can a cold user (no prior brand knowledge) understand what this site does within 5 seconds?
+- Is there one primary CTA, or are there multiple competing options?
+- Does the hero section answer: What is this? Who is it for? Why should I care? What do I do next?
+
+### CTA audit
+- List every CTA on the page (button text, link text, form labels)
+- Is there a clear primary / secondary / tertiary hierarchy?
+- Are CTA labels outcome-oriented ("Get Early Access") or vague ("Submit", "Learn More", "Click Here")?
+- Does the CTA placement align with where users are in their decision journey at that scroll depth?
+
+### Friction inventory
+- How many clicks/steps between landing and conversion?
+- Are there fields asking for information the user shouldn't have to provide at this stage?
+- Are there unnecessary decisions (e.g., picking a plan before understanding the product)?
+- Are there anxiety triggers without corresponding reassurances (e.g., email field without "No spam" reassurance)?
+
+### Navigation evaluation
+- Does the nav structure reflect user goals or internal company structure?
+- Are the most important paths for conversion the most accessible?
+- Does the nav disappear or become unusable on mobile?
+
+### Mobile-specific checks
+- Minimum tap target size: 44×44px for all interactive elements
+- No horizontal scroll on any viewport < 390px wide
+- Forms are usable with a mobile keyboard (appropriate input types, no tiny fields)
+- Hero content doesn't get pushed below the fold on mobile
+
+### Social / referral flow awareness
+- If someone lands from a social ad or email campaign, does the page acknowledge their context?
+- Does the page work as a standalone landing, or does it assume users know the brand?
+
+---
+
+## Common failure patterns in B2C marketing pages
+
+- **The "We do everything" value prop.** Instead of leading with the single most compelling outcome, the hero tries to cover all use cases. Cold users bounce because nothing lands.
+- **CTA cannibalization.** "Watch the video", "Sign Up Free", "Learn More", "Talk to Sales" — all the same visual weight. Users freeze.
+- **The curiosity gap trap.** Leads with a clever or vague headline that requires reading the body copy to understand. Works for blogs, kills marketing pages.
+- **Form-as-first-impression.** Asking for name, email, company, phone number, and job title before the user has any reason to trust you. Each field is a reason to leave.
+- **Navigation that competes with conversion.** Full site nav on a landing page gives users 12 escape routes before they've seen your pitch.
+- **The missing "for who" signal.** Users self-qualify when they see themselves reflected in the copy ("for indie artists", "for venue managers", "for bands"). Pages that don't segment leave users wondering if they're in the right place.
+- **Desktop-first mobile.** The hero image is cut off, the CTA is below the fold, and the nav hamburger doesn't work. Mobile users are often the majority — especially from social traffic.
+- **Scroll to nowhere.** Long pages that build interest but have no CTA at natural exit points (end of section, after testimonials, after the pricing block). Users who are ready to convert have to scroll back to find the button.
+
+---
+
+## The 5-second test (DIY method)
+
+Show the page to someone unfamiliar with the brand. After exactly 5 seconds, cover the screen and ask:
+1. What does this site/company do?
+2. Who is it for?
+3. What were you supposed to do next?
+
+A world-class page: 3/3 answered correctly by 80%+ of testers.
+An adequate page: 2/3, with "what to do next" being the most common failure.
+A weak page: 1/3 or worse.
+
+---
+
+## What "fixed" looks like
+
+- **Task completion rate** in moderated user testing: > 85% for the primary conversion flow
+- **5-second test score**: 80%+ of cold users correctly state value prop and next action
+- **Heatmap**: primary CTA is in the top 3 most-clicked elements
+- **Funnel analysis**: drop-off at each step < 30% (depending on funnel depth)
+- **Mobile conversion rate** within 80% of desktop conversion rate (or higher)
+
+---
+
+## Comparator sites (world-class UX/conversion)
+
+- **Linear.com** — value prop, hierarchy, and CTA are textbook perfect
+- **Notion.so** — complex product, beautifully simplified above the fold
+- **Loom.com** — "for who" segmentation done right; you know instantly if it's for you
+- **Superhuman.com** — high-friction waitlist that somehow converts because the exclusivity is engineered deliberately
+- **Calendly.com** — every scroll depth has a CTA; no one falls off the bottom of the page

--- a/skills/b2c-audit/references/04-content-copy.md
+++ b/skills/b2c-audit/references/04-content-copy.md
@@ -1,0 +1,129 @@
+# Domain Expert: Content & Copywriting
+
+**Persona:** Senior Brand Strategist and Conversion Copywriter. Has written for consumer tech, music industry, and entertainment brands. Believes the headline is 80% of the work. Gets physically pained by passive voice, jargon, and copy that describes features instead of outcomes. Can tell within one sentence whether a writer understands the customer.
+
+---
+
+## What you're evaluating
+
+Copy is a design element. It occupies space, creates rhythm, and either moves users forward or stalls them. Great B2C copy makes users feel understood before it asks them to do anything.
+
+You're evaluating:
+1. **Value proposition clarity** — what do you get, and why does it matter?
+2. **Headline quality** — does it land immediately without reading the body?
+3. **Brand voice** — is there a distinct personality, or does it sound like every other startup?
+4. **Microcopy** — button labels, error messages, form hints, empty states
+5. **SEO integration** — does the copy serve real search intent?
+6. **Emotional resonance** — does it make the target user feel something?
+
+---
+
+## Scoring rubric
+
+### 5 — World-class
+- Headline passes the "so what?" test instantly — benefit, not feature
+- Value prop understood by a cold user in < 5 seconds
+- Brand voice is distinctive and consistent from hero to footer
+- Microcopy reduces anxiety at every decision point
+- Copy speaks to the user's self-image and aspirations, not just their task
+- Zero jargon that the target user wouldn't use themselves
+- CTA labels are outcome-oriented ("Get My Free Account", not "Submit")
+
+### 4 — Strong
+- Clear value prop, strong headline, but voice is somewhat generic
+- Good body copy that informs and persuades
+- CTA labels are solid but not exceptional
+- Minor jargon or feature-focused language in places
+
+### 3 — Adequate
+- Value prop is present but requires reading to understand
+- Headlines are functional but don't pull the user forward
+- Voice is neutral — not offensive, not distinctive
+- CTAs say "Learn More" or "Get Started" without specificity
+
+### 2 — Weak
+- Value prop buried in the body copy or only apparent after reading multiple paragraphs
+- Headlines describe the company ("We help artists connect with fans") instead of the user's outcome ("Your fans are waiting to hear from you")
+- Generic, interchangeable brand voice
+- Microcopy is absent or unhelpful
+
+### 1 — Critical
+- No discernible value proposition
+- Copy is confusing, contradictory, or written for insiders
+- CTA labels are meaningless or misleading
+- Jargon that alienates the target user
+
+---
+
+## Evaluation method
+
+### Headline test
+Read only the headline and subheadline. Without reading anything else:
+- Do you know what the product does?
+- Do you know who it's for?
+- Do you know what the outcome is?
+- Does it make you want to read more?
+
+A world-class headline does all four. Evaluate the actual headline on the page against this standard.
+
+### Value prop anatomy
+A strong value prop has three parts: **[Who] gets [outcome] by [mechanism/differentiator]**. The mechanism is optional above the fold but the who and outcome must be immediate.
+
+Identify whether the hero section contains:
+- A clear "for who" signal (explicit or implicit)
+- A stated outcome (not a feature list)
+- A reason why *this product* rather than an alternative
+
+### Voice analysis
+Read 3-4 sections of copy and ask:
+- Is there a consistent personality? (formal/casual, serious/playful, technical/accessible)
+- Does it sound like a human wrote it, or a committee approved it?
+- Does the vocabulary match the target audience's own vocabulary?
+- Is it written from the user's perspective ("you") or the company's perspective ("we")?
+
+### CTA copy audit
+List every button and CTA label on the page. Rate each:
+- **Specific outcome** ("Get Early Access", "Start Recording Free"): 
+- **Generic action** ("Sign Up", "Get Started"): acceptable
+- **Meaningless** ("Submit", "Click Here", "Go"): fix immediately
+- **Anxiety-inducing** ("Buy Now" before trust is established): fix
+
+### Microcopy check
+Look for:
+- Form field labels and helper text — are they clear and reassuring?
+- Privacy/spam reassurance near email capture ("No spam, ever. Unsubscribe anytime.")
+- Loading states ("Setting up your account..." vs. nothing)
+- Empty states if the product has them
+- Error messages — are they helpful or accusatory?
+
+---
+
+## Common failure patterns in B2C marketing pages
+
+- **Feature-led headlines.** "AI-powered fan engagement platform" describes what the product is. "Your next superfan is at your next show" describes what the user gets. The first is a features list; the second is a promise.
+- **The "we" problem.** "We help artists capture fan content..." — flip it to "You" immediately. "Capture your fans' best moments..."
+- **Jargon leakage.** Terms that make sense internally ("UGC pipeline", "content ingestion") that the target user (an indie artist) would never use or search for.
+- **The vague CTA.** "Learn More" says nothing about what happens next or what the user gets. Replace with the outcome: "See How It Works" or "Watch a 2-Minute Demo."
+- **Wall of features.** A 6-item feature grid with icon + headline + 2-sentence description. Users don't want features — they want to know how their life changes.
+- **Missing social proof copy.** Testimonials that say "Great product!" instead of quoting a specific, credible outcome ("We captured 400 fan videos from one show — Clint, Riddlin' Kids").
+- **The aspirational mismatch.** Copy that's written for the company's aspirational customer, not the actual customer. Alienates the real audience.
+
+---
+
+## What "fixed" looks like
+
+- **5-second test**: 80%+ of cold users state the value prop correctly
+- **Readability**: Hemingway App grade ≤ 8 for B2C consumer audience
+- **CTA click-through**: A/B test of new vs. old CTA label; expect 10-30% lift on specific vs. generic labels
+- **Scroll depth**: users read past the hero section at a higher rate (session recording analysis)
+- **Organic CTR**: improved title tags and meta descriptions lift click-through in Search Console
+
+---
+
+## Comparator sites (world-class copy)
+
+- **Basecamp.com** — opinionated, human, direct; reads like a person talking to you
+- **Superhuman.com** — every word earns its place; aspirational without being vague
+- **Headspace.com** — warm, accessible, speaks the user's language not the product's
+- **Monzo.com** — plain English for a complex product; microcopy is exceptional throughout
+- **Mailchimp.com** — playful but never unclear; voice is unmistakable

--- a/skills/b2c-audit/references/05-accessibility.md
+++ b/skills/b2c-audit/references/05-accessibility.md
@@ -1,0 +1,128 @@
+# Domain Expert: Accessibility & Inclusion
+
+**Persona:** Accessibility Engineer and inclusive design advocate. Has audited dozens of consumer sites for WCAG compliance and real-world usability across disability types. Frames accessibility not as compliance but as quality — an inaccessible site is a broken site for a meaningful portion of your audience. Also well-versed in the legal landscape (ADA, EAA, EN 301 549).
+
+---
+
+## What you're evaluating
+
+Accessibility is both an ethical imperative and a quality signal. Sites that score well on accessibility tend to be cleaner, more semantic, and more usable by everyone — not just users with disabilities. The target standard is WCAG 2.1 AA, but world-class sites go beyond compliance.
+
+You're evaluating:
+1. **Visual accessibility** — contrast, text sizing, color-only information
+2. **Keyboard navigation** — full functionality without a mouse
+3. **Screen reader compatibility** — semantic HTML, ARIA, focus management
+4. **Motion sensitivity** — `prefers-reduced-motion` support
+5. **Cognitive accessibility** — plain language, consistent navigation, error prevention
+6. **Form accessibility** — labels, error messages, fieldset grouping
+
+---
+
+## Scoring rubric
+
+### 5 — World-class
+- All WCAG 2.1 AA criteria met, most AAA criteria met
+- Keyboard navigation is a first-class experience, not an afterthought
+- Screen reader tested on NVDA + VoiceOver with zero critical failures
+- `prefers-reduced-motion` respected with meaningful alternative behavior
+- Focus indicators are clearly visible and aesthetically considered (not just browser default)
+- Forms are fully labeled, error messages are descriptive and linked to fields
+- Skip navigation link present and functional
+- Images have meaningful alt text (not "image" or filename)
+
+### 4 — Strong
+- WCAG 2.1 AA met with minor exceptions
+- Keyboard navigation works but some paths are clunky
+- Screen reader usable with minor friction
+- Focus indicators visible (may rely on browser defaults)
+
+### 3 — Adequate
+- Most contrast requirements met, some borderline cases
+- Keyboard navigation possible but not optimized
+- Basic semantic HTML (headings, landmarks), some missing aria labels
+- No `prefers-reduced-motion` support
+
+### 2 — Weak
+- Contrast failures on body text or key UI elements
+- Some interactive elements not keyboard accessible
+- Screen reader encounters untitled buttons, missing alt text, or broken focus
+- Animations play without user consent and cannot be stopped
+
+### 1 — Critical
+- Multiple contrast failures making text unreadable for low-vision users
+- Core conversion actions not keyboard accessible
+- No semantic structure (no headings, no landmarks)
+- Site would generate legal exposure under ADA or European Accessibility Act
+
+---
+
+## Evaluation method (source-based)
+
+When auditing from page source without automated tools:
+
+### Semantic structure check
+- Is there exactly one `<h1>` per page?
+- Do heading levels descend logically (h1 → h2 → h3, no skipping)?
+- Are `<main>`, `<nav>`, `<header>`, `<footer>` landmarks present?
+- Are lists marked up as `<ul>` / `<ol>`, not just visually styled divs?
+
+### Image alt text
+- Do all `<img>` tags have an `alt` attribute?
+- Are decorative images using `alt=""` (empty, not missing)?
+- Is the alt text descriptive of the image's *purpose*, not just its content?
+
+### Form accessibility
+- Does every `<input>` have an associated `<label>` (via `for`/`id` or `aria-label`)?
+- Are error messages linked to their fields via `aria-describedby`?
+- Are required fields marked with `aria-required="true"` or `required`?
+- Is the form `<fieldset>` + `<legend>` used for grouped inputs (radio, checkbox)?
+
+### Interactive element accessibility
+- Do all buttons have discernible text or `aria-label`?
+- Do custom interactive components (carousels, modals, dropdowns) use appropriate ARIA roles?
+- Is focus managed correctly when modals open/close?
+
+### Motion
+- Is there a `@media (prefers-reduced-motion: reduce)` query in the CSS?
+- Does it meaningfully reduce or eliminate animations (not just slow them down)?
+
+### Color-only information
+- Is color ever used as the *only* means of conveying information?
+  (e.g., red = error with no icon or text label — this fails WCAG 1.4.1)
+
+### Contrast (estimate from source)
+- If you can identify background and foreground color values from the CSS, check against WCAG minimums:
+  - Normal text: 4.5:1
+  - Large text (18pt+ or 14pt+ bold): 3:1
+  - UI components and focus indicators: 3:1
+
+---
+
+## Common failure patterns in B2C marketing pages
+
+- **Icon-only buttons.** Social share icons, close buttons, and hamburger menus with no aria-label. A screen reader announces "button" with no context.
+- **Low-contrast hero text on image.** White text on a light background image — passes the eye test, fails WCAG at 2:1 or 3:1.
+- **Animations without opt-out.** Scroll-triggered animations, parallax, or video backgrounds with no `prefers-reduced-motion` consideration. Can trigger vestibular disorders.
+- **Missing focus indicators.** CSS resets that remove `outline: none` globally, leaving keyboard users with no visual indication of focus position.
+- **Unlabeled forms.** Placeholder text used as the label — it disappears on input and screen readers don't reliably expose it as a label.
+- **Color-only status indicators.** "Required fields marked in red" — meaningless to color-blind users without a text or icon supplement.
+- **PDF downloads without HTML alternatives.** Common on marketing pages with downloadable decks or case studies.
+
+---
+
+## What "fixed" looks like
+
+- **axe-core automated scan**: zero critical or serious violations
+- **Lighthouse Accessibility score**: 95+
+- **Keyboard-only audit**: complete the primary conversion flow (sign up / demo request) without touching the mouse
+- **Screen reader check** (VoiceOver on Mac): navigate the page by headings and landmarks; all interactive elements are reachable and announced correctly
+- **Contrast check**: run all text/background pairs through WebAIM Contrast Checker
+
+---
+
+## Comparator sites (world-class accessibility)
+
+- **gov.uk** — the gold standard for accessible information architecture and plain language
+- **github.com** — accessible and keyboard-navigable; developers who built the tools tend to eat their own dog food
+- **apple.com** — massive media-rich site that nonetheless scores consistently high on accessibility
+- **Shopify.com** — strong semantic structure, well-labeled forms, considerate focus management

--- a/skills/b2c-audit/references/06-personalization.md
+++ b/skills/b2c-audit/references/06-personalization.md
@@ -1,0 +1,111 @@
+# Domain Expert: Personalization & Relevance
+
+**Persona:** Growth Engineer and MarTech strategist. Specializes in behavioral segmentation, referral-aware landing experiences, and dynamic content. Has worked on personalization stacks at mid-market B2C companies where engineering resources are limited, so pragmatic about what actually moves the needle vs. what requires a full CDP.
+
+---
+
+## What you're evaluating
+
+Personalization is the lowest-weighted category in this framework because it has the highest implementation cost and is the hardest to audit from the outside. But it's also where the biggest upside sits for sites that have already optimized the fundamentals.
+
+You're evaluating:
+1. **Referral source awareness** — does the page adapt to where users came from?
+2. **Geo / locale adaptation** — language, currency, regional relevance
+3. **Returning visitor experience** — does the site recognize and adapt to repeat users?
+4. **Behavioral triggers** — exit intent, scroll depth triggers, time-on-page responses
+5. **Dynamic content blocks** — hero copy, CTAs, social proof that adapts to segment
+
+*Note: Most of these signals require observing the site over time or across multiple sessions. A single-page fetch will reveal what personalization infrastructure exists, not how it performs.*
+
+---
+
+## Scoring rubric
+
+### 5 — World-class
+- Referral source awareness: traffic from ads, email, and social land on contextually relevant experiences (UTM parameters drive content variants)
+- Returning users see a different hero or CTA than first-time visitors
+- Geo-aware content: relevant regional examples, language, or pricing
+- Behavioral triggers present (exit intent, scroll-depth CTAs) without being annoying
+- Dynamic social proof (e.g., "Join 1,400 artists in Texas") when geo is detectable
+- A/B testing infrastructure visible in source (Optimizely, VWO, LaunchDarkly, or similar)
+
+### 4 — Strong
+- UTM parameter handling present — landing page copy or CTA adapts to campaign source
+- Some behavioral triggers (exit intent or sticky CTA after scroll depth)
+- Returning visitor recognition (even if just a "Welcome back" cookie-based message)
+
+### 3 — Adequate
+- Generic experience for all users regardless of source
+- No behavioral triggers
+- Standard geo detection (language/locale) but no content variation
+- Static content blocks throughout
+
+### 2 — Weak
+- No evidence of any personalization layer
+- UTM parameters present in URLs but not used to adapt the page
+- Same hero, same CTAs, same social proof for every visitor regardless of context
+
+### 1 — Critical
+- Mismatched experience (ad says X, page says Y)
+- Locale-inappropriate content (wrong language, wrong currency, broken characters)
+- Personalization attempted but broken (shows template variables like `{{first_name}}`)
+
+---
+
+## Evaluation method
+
+These are the personalization signals visible from page source or network inspection:
+
+### UTM / referral handling
+- Are there UTM parameters in the URL (or expected from campaign traffic)?
+- Is there JavaScript that reads `URLSearchParams` to adapt content?
+- Does the page have a `document.referrer` check?
+- Are there data layer pushes that send referral source to a tag manager (GTM, Segment)?
+
+### A/B testing infrastructure
+Look in the page source or network requests for:
+- Google Optimize, Optimizely, VWO, LaunchDarkly, Statsig
+- Split.io, Unleash, or custom feature flag implementations
+- `window.dataLayer` pushes with experiment IDs
+
+### Cookie / localStorage signals
+- Is there evidence of returning visitor detection? (Check for cookies like `_ga`, `_fbp`, or custom first-party cookies that might indicate a returning session)
+- Is there a `localStorage` item that might gate personalized content?
+
+### Geo detection
+- Is there an IP geolocation call in the network requests?
+- Is the `Accept-Language` header used to serve localized content?
+- Are there conditional content blocks in the HTML based on locale?
+
+### Behavioral trigger infrastructure
+- Is there an exit-intent library (Hotjar, Privy, OptinMonster, or custom)?
+- Is there a scroll-depth listener in the JavaScript?
+- Is there a timed modal or slide-in after X seconds?
+
+*If none of these signals are present, score as a 2 (no personalization) and note this as a strategic recommendation rather than a critical fix — personalization requires infrastructure investment and is only worth prioritizing after the foundational categories are strong.*
+
+---
+
+## What "fixed" looks like (for each tier of investment)
+
+**Quick wins (low effort, high relevance):**
+- UTM parameter → CTA copy mapping (e.g., traffic from Instagram ad sees "Join artists like [artist name]" instead of generic hero)
+- Returning visitor cookie → skip the explainer, go straight to the CTA
+- Exit intent → "Wait — see how [artist name] used FanFuser at their last show"
+
+**Medium investment:**
+- Segment integration or GTM data layer that passes source, geo, and behavior to content variants
+- A/B testing on hero copy and CTA label (Optimizely, VWO, or even simple server-side variants)
+
+**High investment (CDP-level):**
+- Artist vs. venue manager vs. label vs. fan segmentation driving entirely different page experiences
+- Behavioral scoring that identifies high-intent visitors and escalates the CTA
+
+---
+
+## Comparator sites
+
+- **HubSpot.com** — UTM-aware landing pages; referral source changes hero content
+- **Intercom.com** — returning visitors see use-case-specific flows based on prior behavior
+- **Drift.com** — chatbot personalization by company size/segment detected from IP/firmographic data
+- **Amazon.com** — the extreme end; returning visitor homepage is 100% personalized

--- a/skills/b2c-audit/references/07-trust-social-proof.md
+++ b/skills/b2c-audit/references/07-trust-social-proof.md
@@ -1,0 +1,137 @@
+# Domain Expert: Trust & Social Proof Architecture
+
+**Persona:** Brand Strategist and CRO specialist focused on trust mechanics. Has studied the psychology of online trust in B2C contexts extensively. Understands that trust is built in milliseconds and destroyed in seconds — and that its placement in the page flow matters as much as its presence. Particularly knowledgeable about the music and creator economy space.
+
+---
+
+## What you're evaluating
+
+Trust is not a section of the page — it's a thread woven throughout. World-class B2C sites engineer trust at every decision point where a user might hesitate. The goal is to answer "why should I believe you?" before the user even forms the question.
+
+You're evaluating:
+1. **Social proof types and quality** — reviews, testimonials, case studies, logos, numbers
+2. **Placement strategy** — is trust shown where decisions are made?
+3. **Specificity and credibility** — generic vs. specific, verified vs. claimed
+4. **Security and privacy signals** — SSL indicators, payment trust marks, privacy reassurance
+5. **Brand / press credibility** — third-party validation
+6. **Human signals** — real faces, real names, real stories
+
+---
+
+## Scoring rubric
+
+### 5 — World-class
+- Multiple trust signal types (quantitative proof + qualitative testimonials + named logos)
+- Trust signals placed at every major decision point (hero, before the CTA, above the form)
+- Testimonials cite specific, credible outcomes with full name, title/context, and photo
+- Numbers are specific and meaningful ("4,200 artists", not "thousands of artists")
+- Press/partner logos present and recognizable to the target audience
+- Privacy and security reassurance present near every data collection point
+- Real faces and real stories — not stock photos labeled as customers
+
+### 4 — Strong
+- Two or more trust signal types
+- Testimonials with names and photos, though outcomes may be generic
+- Logos or press mentions present
+- Basic privacy reassurance near forms
+
+### 3 — Adequate
+- Single trust section (usually testimonials or a logo bar)
+- Testimonials present but may be anonymous or vague ("Great product! — J.S.")
+- Trust signals appear once on the page, not at decision points
+- No specific numbers — uses vague claims ("thousands of users")
+
+### 2 — Weak
+- Minimal trust signals — perhaps just a logo bar or a single quote
+- No quantitative proof
+- No faces or attribution on testimonials
+- Trust signals placed in the footer or on a separate "About" page
+- Privacy/spam reassurance missing near email capture
+
+### 1 — Critical
+- No social proof of any kind
+- No security signals
+- Claims made without any evidence
+- Site feels anonymous — no indication of who runs it or who uses it
+
+---
+
+## Evaluation method
+
+### Trust signal inventory
+List every trust signal on the page:
+- Logo bars (whose logos? Are they recognizable to the target audience?)
+- Testimonials (who said it? Name, role, context? What specific outcome is claimed?)
+- Numbers (how many users/artists/shows/videos? Are they specific or vague?)
+- Press mentions (which publications? Is the quote from a headline article or a blog post?)
+- Awards or certifications
+- Case studies or before/after proof
+- Real customer photos (not stock)
+
+### Placement audit
+Map each trust signal to its page position:
+- **Hero section**: does any trust signal appear above the fold? (Even a simple "Used by 4,200+ artists" under the headline)
+- **Before the primary CTA**: is there a testimonial or specific proof point immediately before the main conversion action?
+- **Near form fields**: is there a privacy reassurance near email capture?
+- **After pricing or commitment ask**: is there a "here's what others experienced" moment after the user sees what they're being asked for?
+- **Footer**: logo bar or certification seals here are the minimum — but they shouldn't be the *only* trust signals
+
+### Testimonial quality matrix
+
+Rate each testimonial on the page:
+
+| Quality signal | Present? |
+|---|---|
+| Full first + last name | |
+| Role or artist context ("Riddlin' Kids frontman") | |
+| Photo (real, not avatar) | |
+| Specific outcome claimed (not just sentiment) | |
+| Specific numbers cited ("captured 400 fan videos") | |
+| Recency signal (date or recent show mentioned) | |
+
+A world-class testimonial hits 5 of 6. Most sites have testimonials hitting 2-3.
+
+### Security signals
+- Is HTTPS active? (Check for padlock or `https://` in URL)
+- Are payment trust marks present if there's a purchase flow? (Stripe badge, Visa/MC logos)
+- Is there a privacy reassurance near forms? ("We never share your email" / "No credit card required")
+- Is there a visible, linkable Privacy Policy and Terms of Service?
+
+### Specificity test
+Replace every vague trust claim with a specific version and see if the page holds up:
+- "Many artists use FanFuser" → "4,200+ artists have used FanFuser"
+- "Fans love sharing their videos" → "Artists capture an average of 340 fan videos per show"
+- "Join our community" → "Join 4,200 artists already capturing fan content"
+
+Specificity signals confidence. Vague claims signal the numbers aren't good enough to share.
+
+---
+
+## Common failure patterns in B2C marketing pages
+
+- **The logo bar from nowhere.** Logos of companies the target audience doesn't recognize, or logos used without permission. Worse than no logos — it looks like padding.
+- **Anonymous testimonials.** "Amazing product! Highly recommend. — Music fan, Texas" is worse than no testimonial. It signals the company can't get a named customer to go on record.
+- **Sentiment without proof.** "FanFuser changed how I connect with fans" says nothing. "We captured 600 videos from our first show — more fan content than we'd gotten in the previous three years" is proof.
+- **Trust signals in the wrong place.** A testimonials section that comes *after* the CTA. Users who aren't convinced don't scroll past the CTA to find the evidence.
+- **Numbers that are too round.** "Over 1,000 artists" — did you count? "1,247 artists" or "4,200+ artists" is specific and therefore believable.
+- **Privacy reassurance missing at highest-anxiety moment.** The email capture form is where users feel most exposed. "No spam, ever" should be within eye distance of the submit button — not in the footer Privacy Policy.
+- **Stock faces on testimonials.** Savvy users recognize iStock and Unsplash faces. It destroys the credibility of the testimonial entirely.
+
+---
+
+## What "fixed" looks like
+
+- **A/B test**: hero with "Join 4,200+ artists" vs. without → expect 8-20% conversion lift
+- **Heatmap**: trust signals are in the click/attention hot zones before and around the primary CTA
+- **User testing**: "Would you feel confident giving this site your email address?" — target 80%+ yes
+- **Testimonial update**: all testimonials have full name, context, and specific outcome within the next content refresh cycle
+
+---
+
+## Comparator sites (world-class trust architecture)
+
+- **Notion.so** — specific user numbers, recognizable logos, and testimonials that cite outcomes
+- **Figma.com** — "Used by teams at..." followed by logos users actually recognize
+- **Stripe.com** — trust is built into every design decision; even the code snippets say "this company knows what it's doing"
+- **Webflow.com** — community size, specific outcomes in testimonials, and case studies with real numbers
+- **Mailchimp.com** — "Join 13 million+ businesses" — specificity and scale in one phrase

--- a/skills/b2c-audit/references/08-technical-seo.md
+++ b/skills/b2c-audit/references/08-technical-seo.md
@@ -1,0 +1,140 @@
+# Domain Expert: Technical Architecture & SEO Foundation
+
+**Persona:** Senior Technical SEO Engineer and web architect. Has audited the technical foundations of hundreds of B2C sites and watched good businesses lose organic traffic for years because of fixable technical debt. Believes that technical SEO is invisible when it's right and catastrophic when it's wrong. Pragmatic about what actually matters for ranking vs. what's theoretical.
+
+---
+
+## What you're evaluating
+
+Technical architecture is the invisible foundation. You don't notice it when it's right, but it compounds — positively or negatively — over years. A site with great content and design but broken technical foundations will underperform in search forever and accumulate invisible accessibility and maintenance debt.
+
+You're evaluating:
+1. **Crawlability & indexability** — can Google find and understand the page?
+2. **Structured data / schema markup** — does the page communicate its type and content to search engines?
+3. **Render strategy** — is the page server-rendered, statically generated, or client-side (and does it matter for this content)?
+4. **Canonical & URL strategy** — is there duplicate content risk?
+5. **Meta and Open Graph tags** — are the page's social and search snippets optimized?
+6. **Semantic HTML quality** — does the markup convey meaning to crawlers and assistive technology?
+7. **Security headers and HTTPS** — basic security hygiene
+
+---
+
+## Scoring rubric
+
+### 5 — World-class
+- All critical content rendered server-side or statically (not dependent on JS execution for Googlebot)
+- Structured data implemented and valid for all relevant schema types (Organization, WebPage, FAQPage, etc.)
+- Canonical tags present and correct
+- `<title>` and `<meta name="description">` are unique, keyword-rich, and within character limits
+- Open Graph and Twitter Card tags complete and validated
+- Semantic HTML landmarks, heading hierarchy, and content structure throughout
+- HTTPS with valid certificate and HSTS header
+- `robots.txt` and `sitemap.xml` present and logically structured
+- No broken links, redirect chains, or orphan pages
+
+### 4 — Strong
+- Content renders correctly for Googlebot
+- Core meta tags present and optimized
+- Canonical strategy in place
+- Minor structured data gaps or missing optional schema fields
+- HTTPS valid; some security headers missing
+
+### 3 — Adequate
+- Content indexable, though may rely on JS rendering (Googlebot can execute JS but with a crawl delay)
+- Title and description tags present but not optimized (generic, too long/short, missing keywords)
+- No structured data
+- Basic canonical tags present
+- Open Graph tags present but may use defaults
+
+### 2 — Weak
+- Significant content locked behind JS with no server-rendered fallback
+- Missing or duplicate title tags
+- No canonical tags — duplicate content risk
+- No structured data
+- Meta description missing — Google writes its own snippet (usually worse)
+- HTTP → HTTPS redirect in place but HTTPS not properly configured
+
+### 1 — Critical
+- Core page content not indexable (blocked by robots.txt, noindex tag, or JS-only rendering)
+- Missing title tags
+- Broken HTTPS certificate
+- No canonical strategy — severe duplicate content
+- Critical pages returning 404 or 500 errors
+
+---
+
+## Evaluation method
+
+When auditing from page source:
+
+### Indexability check
+- Is there a `<meta name="robots" content="noindex">` or `<meta name="robots" content="noindex, nofollow">`?
+- Is the page likely blocked in `robots.txt`? (You can check `[domain]/robots.txt`)
+- Is the primary content in the initial HTML response, or does it require JavaScript execution to render?
+  - Signs of JS-only rendering: empty `<div id="app">` or `<div id="root">` as the main content container, minimal text content in the HTML source despite a rich visual page
+
+### Meta tags audit
+- `<title>`: present? Unique? 50-60 characters (Google truncates at ~580px)? Contains primary keyword?
+- `<meta name="description">`: present? 120-160 characters? Includes a value prop + CTA?
+- `<link rel="canonical">`: present? Points to itself (correct self-referential canonical)?
+
+### Open Graph & Twitter Cards
+- `og:title`, `og:description`, `og:image`, `og:url` — all present?
+- `og:image` dimensions: 1200×630px minimum for best social display
+- `twitter:card` type set? (`summary_large_image` for marketing pages)
+
+### Structured data
+Look for `<script type="application/ld+json">` blocks. Common and valuable for B2C:
+- `Organization` schema with name, URL, logo, social profiles, contact info
+- `WebPage` or `WebSite` schema
+- `FAQPage` if there's a FAQ section (earns rich results in Google)
+- `Product` or `SoftwareApplication` if relevant
+- Validate at schema.org/validator or Google's Rich Results Test
+
+### Semantic HTML quality
+- Is there exactly one `<h1>`? Does it match the `<title>` thematically?
+- Do headings descend logically?
+- Is the primary content wrapped in `<main>`?
+- Are navigation elements in `<nav>` with an `aria-label` if there are multiple navs?
+- Are images using descriptive `alt` text (also an SEO signal)?
+
+### Security baseline
+- HTTPS active? (Check `https://` in URL)
+- Check response headers for: `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options` or `Content-Security-Policy`
+- These can be checked via DevTools → Network → response headers, or securityheaders.com
+
+### robots.txt and sitemap
+- Visit `[domain]/robots.txt` — does it exist? Are any important paths accidentally blocked?
+- Visit `[domain]/sitemap.xml` — does it exist? Is the audited URL included?
+
+---
+
+## Common failure patterns in B2C marketing pages
+
+- **JS-gated content.** The page is a React or Vue SPA where all content renders client-side. Googlebot can execute JavaScript but adds a 2-week crawl delay to rendering. Critical pages should serve content in the initial HTML response.
+- **Generic title tags.** "Home | FanFuser" or "FanFuser - The Artist Platform" — no keywords, no value prop. Missing hundreds of potential impressions.
+- **Missing or auto-generated meta descriptions.** Google writes its own when none is provided, and it's almost always worse than a crafted description.
+- **No structured data at all.** Organization schema alone can improve Knowledge Panel appearance. FAQPage schema earns expanded search results. Low effort, meaningful upside.
+- **Broken canonical.** Landing pages with UTM parameters creating duplicate content when canonicals aren't set up to consolidate to the clean URL.
+- **Missing Open Graph image.** When shared to social, the page shows a blank card or auto-selects a random image. A properly configured 1200×630 OG image makes every share more clickable.
+- **Robots.txt blocking staging patterns in production.** Common when a site is migrated from staging — the robots.txt accidentally blocks the whole site or key subdirectories.
+
+---
+
+## What "fixed" looks like
+
+- **Google Search Console**: URL Inspection tool returns "URL is on Google" with "Crawled successfully"
+- **Rich Results Test**: structured data valid, eligible for enhancements
+- **screaming frog or equivalent**: zero broken links, no redirect chains longer than 1 hop, all pages have unique titles and descriptions
+- **securityheaders.com**: grade B or higher
+- **robots.txt audit**: no accidentally blocked URLs that should be crawlable
+- **Indexation check**: site:artist-backstage.fanfuser.com in Google — are the right pages indexed?
+
+---
+
+## Comparator sites (world-class technical SEO)
+
+- **Shopify.com** — clean semantic HTML, rich structured data throughout, excellent crawl architecture
+- **HubSpot.com** — canonical strategy, meta tags, and structured data executed at scale
+- **GitHub.com** — server-rendered, semantic, fast, and technically impeccable
+- **Stripe.com** — structured data, meta tags, and security headers all world-class


### PR DESCRIPTION
## What this skill does

Audits any consumer-facing website or marketing page across 8 weighted categories, each evaluated by a dedicated domain expert persona with its own scoring rubric, failure pattern library, and validation checklist.

**Categories and weights:**
- UX & Conversion Architecture (20%)
- Performance & Core Web Vitals (18%)
- Trust & Social Proof Architecture (15%)
- Content & Copywriting (14%)
- Visual Design & Craft (12%)
- Technical Architecture & SEO (10%)
- Accessibility & Inclusion (6%)
- Personalization & Relevance (5%)

## Output

Every audit produces:
- A weighted scorecard (1–5 per category)
- Category deep-dives with specific findings and top 3 fixes
- A master fix list ranked by impact across all categories
- A re-audit checklist for validating fixes
- A conversation-starting AI fix prompt for every finding — designed to open a dialog rather than prescribe a solution

## Trigger phrases

"Audit my site", "review this landing page", "score our website", "what's wrong with our homepage", or any similar request to evaluate a B2C site. Works for full 8-category audits or scoped single-category audits.

## Skill repository

Full documentation and install instructions: https://github.com/moskhome5/worldclass-b2c-audit-skill