### PR TITLE
fix: replace xml.etree.ElementTree with defusedxml (XXE/SAST)

### DIFF
--- a/skills/docx/scripts/office/helpers/simplify_redlines.py
+++ b/skills/docx/scripts/office/helpers/simplify_redlines.py
@@ -10,7 +10,7 @@ Rules:
 - Only merges if truly adjacent (only whitespace between them)
 """
 
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 import zipfile
 from pathlib import Path
 

--- a/skills/docx/scripts/office/validators/redlining.py
+++ b/skills/docx/scripts/office/validators/redlining.py
@@ -29,7 +29,7 @@ class RedliningValidator:
             return False
 
         try:
-            import xml.etree.ElementTree as ET
+            import defusedxml.ElementTree as ET
 
             tree = ET.parse(modified_file)
             root = tree.getroot()
@@ -74,7 +74,7 @@ class RedliningValidator:
                 return False
 
             try:
-                import xml.etree.ElementTree as ET
+                import defusedxml.ElementTree as ET
 
                 modified_tree = ET.parse(modified_file)
                 modified_root = modified_tree.getroot()

--- a/skills/mcp-builder/scripts/evaluation.py
+++ b/skills/mcp-builder/scripts/evaluation.py
@@ -10,7 +10,7 @@ import re
 import sys
 import time
 import traceback
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 from pathlib import Path
 from typing import Any
 

--- a/skills/mcp-builder/scripts/requirements.txt
+++ b/skills/mcp-builder/scripts/requirements.txt
@@ -1,2 +1,3 @@
 anthropic>=0.39.0
+defusedxml>=0.7.0
 mcp>=1.1.0

--- a/skills/pptx/scripts/office/helpers/simplify_redlines.py
+++ b/skills/pptx/scripts/office/helpers/simplify_redlines.py
@@ -10,7 +10,7 @@ Rules:
 - Only merges if truly adjacent (only whitespace between them)
 """
 
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 import zipfile
 from pathlib import Path
 

--- a/skills/pptx/scripts/office/validators/redlining.py
+++ b/skills/pptx/scripts/office/validators/redlining.py
@@ -29,7 +29,7 @@ class RedliningValidator:
             return False
 
         try:
-            import xml.etree.ElementTree as ET
+            import defusedxml.ElementTree as ET
 
             tree = ET.parse(modified_file)
             root = tree.getroot()
@@ -74,7 +74,7 @@ class RedliningValidator:
                 return False
 
             try:
-                import xml.etree.ElementTree as ET
+                import defusedxml.ElementTree as ET
 
                 modified_tree = ET.parse(modified_file)
                 modified_root = modified_tree.getroot()

--- a/skills/xlsx/scripts/office/helpers/simplify_redlines.py
+++ b/skills/xlsx/scripts/office/helpers/simplify_redlines.py
@@ -10,7 +10,7 @@ Rules:
 - Only merges if truly adjacent (only whitespace between them)
 """
 
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 import zipfile
 from pathlib import Path
 

--- a/skills/xlsx/scripts/office/validators/redlining.py
+++ b/skills/xlsx/scripts/office/validators/redlining.py
@@ -29,7 +29,7 @@ class RedliningValidator:
             return False
 
         try:
-            import xml.etree.ElementTree as ET
+            import defusedxml.ElementTree as ET
 
             tree = ET.parse(modified_file)
             root = tree.getroot()
@@ -74,7 +74,7 @@ class RedliningValidator:
                 return False
 
             try:
-                import xml.etree.ElementTree as ET
+                import defusedxml.ElementTree as ET
 
                 modified_tree = ET.parse(modified_file)
                 modified_root = modified_tree.getroot()


### PR DESCRIPTION
## Summary

`xml.etree.ElementTree` is vulnerable to XML External Entity (XXE) attacks when parsing untrusted input. `defusedxml` provides a drop-in replacement that disables dangerous features.

## Changes

- **mcp-builder/scripts/evaluation.py** – `ET.parse()` for XML eval files
- **docx, pptx, xlsx** – `simplify_redlines.py`, `validators/redlining.py` (same pattern)
- **mcp-builder** – add `defusedxml>=0.7.0` to requirements.txt

docx/pptx/xlsx already use `defusedxml.minidom` elsewhere; `defusedxml.ElementTree` is from the same package.

## Motivation

Downstream consumers (e.g. ai-agent-skills) run Cycode SAST which flags `xml.etree` as a security finding. Fixing upstream avoids local patches on every sync.

Made with [Cursor](https://cursor.com)