### PR TITLE
fix(docx): open XML file in binary mode in XSD validator

### DIFF
--- a/skills/docx/scripts/office/validators/base.py
+++ b/skills/docx/scripts/office/validators/base.py
@@ -760,7 +760,7 @@ class BaseSchemaValidator:
                 )
                 schema = lxml.etree.XMLSchema(xsd_doc)
 
-            with open(xml_file, "r") as f:
+            with open(xml_file, "rb") as f:
                 xml_doc = lxml.etree.parse(f)
 
             xml_doc, _ = self._remove_template_tags_from_text_nodes(xml_doc)


### PR DESCRIPTION
Summary:

Windows bug: the XSD validator crashes with a charmap codec error on valid UTF-8 docx files.  Line 763 of base.py opens the XML file in text mode, which uses the default system encoding (cp1252 on Windows). This causes charmap codec errors on valid UTF-8 XML files.

File: skills/docx/scripts/office/validators/base.py, line 763

Problem:

In _validate_single_file_xsd, the XML file being validated is opened in text mode:
```
with open(xml_file, "r") as f:
    xml_doc = lxml.etree.parse(f)
```

Impact:

On Windows, the validator crashes with a charmap codec error when validating docx files containing non-ASCII UTF-8 characters (e.g. accented names). It never reaches the actual XSD validation. 

Fix:

Change line 763 from `open(xml_file, "r")` to `open(xml_file, "rb")`.

This lets lxml handle the encoding via the XML declaration, consistent with how the schema is already loaded.

