### PR TITLE
Add dataset-cleaner skill

### DIFF
--- a/skills/dataset-cleaner/README.md
+++ b/skills/dataset-cleaner/README.md
@@ -1,0 +1,162 @@
+# dataset-cleaner
+
+A complete pipeline for cleaning, validating, balancing, splitting, and formatting text datasets for AI model training and fine-tuning.
+
+Works on any labeled text dataset — sentiment analysis, intent classification, spam detection, Q&A pairs, chatbot training data, and more. If your data has a text column and a label column, this skill handles it.
+
+---
+
+## What it does
+
+Takes a raw, messy dataset and produces clean, validated, training-ready files in five steps:
+
+1. **Inspect** — full quality audit before touching anything
+2. **Clean** — remove duplicates, label noise, empty rows, encoding corruption
+3. **Balance** — fix class imbalance so your model does not favor the majority class
+4. **Split** — stratified train / val / test split
+5. **Convert** — export to JSONL with schema validation for OpenAI or Anthropic fine-tuning
+
+---
+
+## Scripts
+
+| File | Purpose |
+|------|---------|
+| `scripts/utils.py` | Shared utilities — encoding detection, file I/O, token counting, schema validation |
+| `scripts/inspect.py` | Audit dataset for issues before cleaning |
+| `scripts/clean.py` | Fix duplicates, label noise, encoding, whitespace, length issues |
+| `scripts/balance.py` | Fix class imbalance via oversample, undersample, or hybrid |
+| `scripts/split.py` | Stratified train / val / test split |
+| `scripts/to_jsonl.py` | Convert to training-ready JSONL with schema validation |
+
+---
+
+## Supported formats
+
+- Input: `.csv`, `.jsonl`, `.json`
+- Output: `.csv`, `.jsonl`
+- Encodings: auto-detected (UTF-8, UTF-8-BOM, Latin-1, CP1252, UTF-16)
+- Delimiters: auto-detected (comma, semicolon, tab, pipe)
+
+---
+
+## Installation
+
+```bash
+pip install tiktoken pandas
+```
+
+All other dependencies (`json`, `csv`, `hashlib`, `collections`, `random`) are Python standard library.
+
+---
+
+## Usage
+
+### Inspect
+```bash
+python scripts/inspect.py data.csv
+python scripts/inspect.py data.csv --max-tokens 512 --token-model cl100k_base
+```
+
+### Clean
+```bash
+python scripts/clean.py data.csv data_clean.csv
+python scripts/clean.py data.csv data_clean.csv --drop-long 512 --drop-short 5
+```
+
+### Balance
+```bash
+python scripts/balance.py data_clean.csv data_balanced.csv --label-col label --strategy oversample
+python scripts/balance.py data_clean.csv data_balanced.csv --label-col label --strategy undersample
+python scripts/balance.py data_clean.csv data_balanced.csv --label-col label --strategy hybrid
+```
+
+### Split
+```bash
+python scripts/split.py data_balanced.csv ./splits/ --train 0.8 --val 0.1 --test 0.1 --prefix my_dataset
+```
+
+### Convert to JSONL
+```bash
+# Anthropic fine-tuning format
+python scripts/to_jsonl.py splits/my_dataset_train.csv train.jsonl \
+  --format anthropic --system-prompt "You are a helpful assistant."
+
+# OpenAI fine-tuning format
+python scripts/to_jsonl.py splits/my_dataset_train.csv train.jsonl \
+  --format openai --system-prompt "You are a helpful assistant."
+```
+
+### Full pipeline
+```bash
+python scripts/inspect.py data.csv && \
+python scripts/clean.py data.csv data_clean.csv --drop-long 512 && \
+python scripts/balance.py data_clean.csv data_balanced.csv --label-col label && \
+python scripts/split.py data_balanced.csv ./splits/ --prefix data && \
+python scripts/to_jsonl.py splits/data_train.csv train.jsonl --format anthropic
+```
+
+---
+
+## What it detects
+
+- Exact duplicate rows
+- Label noise — same text mapped to multiple different labels
+- Class imbalance with severity ratio
+- Missing values per column
+- Empty text or label fields
+- Token length distribution (min, max, mean, p50, p95, p99)
+- Rows exceeding tokenizer limits
+- Unicode encoding corruption
+- Schema inconsistencies across rows
+- Malformed JSONL rows
+
+---
+
+## Output formats
+
+**raw** — preserves original columns, outputs clean JSONL
+
+**openai** — OpenAI fine-tuning format:
+```json
+{"messages": [{"role": "system", "content": "..."}, {"role": "user", "content": "..."}, {"role": "assistant", "content": "..."}]}
+```
+
+**anthropic** — Anthropic Messages API format:
+```json
+{"system": "...", "messages": [{"role": "user", "content": "..."}, {"role": "assistant", "content": "..."}]}
+```
+
+Both formats are validated against the official spec before saving.
+
+---
+
+## Column auto-detection
+
+Text and label columns are detected automatically from common naming patterns.
+
+Text column candidates: `text`, `input`, `prompt`, `content`, `sentence`, `question`, `utterance`, `body`, `message`
+
+Label column candidates: `label`, `output`, `target`, `class`, `category`, `answer`, `response`, `intent`, `tag`
+
+To override: `--text-col my_column --label-col my_label`
+
+---
+
+## Who this is for
+
+- Developers fine-tuning language models for the first time
+- Researchers preparing labeled classification datasets
+- Teams where multiple annotators labeled the same data (label noise is common)
+- Anyone whose fine-tuning job failed or performed poorly due to data quality issues
+
+---
+
+## Recommended dataset sizes for fine-tuning
+
+| Size | Recommendation |
+|------|---------------|
+| Under 50 rows | Too small — collect more data first |
+| 50 to 500 rows | Few-shot prompting or LoRA fine-tuning |
+| 500 to 10,000 rows | Standard fine-tuning |
+| Over 10,000 rows | Full fine-tuning, consider data augmentation |

--- a/skills/dataset-cleaner/SKILL.md
+++ b/skills/dataset-cleaner/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: dataset-cleaner
+description: >
+  Clean, validate, balance, split, and format datasets for AI/ML training and fine-tuning.
+  Use this skill whenever a user has a dataset (CSV or JSONL) they want to prepare for model
+  training or fine-tuning. Automatically detects and fixes: duplicate rows, label noise, class
+  imbalance, missing values, encoding corruption, empty texts, over-length rows, and schema
+  inconsistencies. Converts to training-ready JSONL for OpenAI or Anthropic fine-tuning with
+  full schema validation. Handles large files, non-UTF-8 encodings, and non-standard delimiters.
+  Trigger for: "clean my dataset", "prepare data for fine-tuning", "fix class imbalance",
+  "convert to JSONL", "my training data has duplicates", "validate my training data",
+  "label noise in my dataset", "split into train and test", or any time a user wants to improve
+  data quality before training or fine-tuning an AI model.
+---
+
+# Dataset Cleaner
+
+A complete pipeline for cleaning and preparing AI training datasets.
+Five Python scripts handle every stage. Always run via bash — never reimplement their logic.
+
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `scripts/utils.py` | Shared utilities — auto-loaded by all scripts, never call directly |
+| `scripts/inspect.py` | Full quality audit: duplicates, label noise, class imbalance, token lengths, encoding issues |
+| `scripts/clean.py` | Remove duplicates, empty rows, label noise, encoding corruption; filter by token length |
+| `scripts/balance.py` | Fix class imbalance via oversample / undersample / hybrid strategy |
+| `scripts/to_jsonl.py` | Convert to training-ready JSONL with schema validation (raw / OpenAI / Anthropic format) |
+| `scripts/split.py` | Stratified train / val / test split |
+
+**Supported formats**: `.csv`, `.jsonl`, `.json`
+**Supported encodings**: auto-detected (UTF-8, UTF-8-BOM, Latin-1, CP1252, UTF-16)
+**Supported delimiters**: auto-detected (comma, semicolon, tab, pipe)
+
+---
+
+## Install dependencies
+
+```bash
+pip install pandas tiktoken --break-system-packages
+```
+
+---
+
+## Standard Workflow
+
+### Step 1 — Copy uploaded file
+```bash
+cp /mnt/user-data/uploads/<filename> /home/claude/<filename>
+```
+
+### Step 2 — Inspect
+```bash
+python scripts/inspect.py /home/claude/<filename>
+# With options:
+python scripts/inspect.py /home/claude/<filename> --max-tokens 512 --token-model cl100k_base
+```
+
+Parse the JSON output and report to the user:
+- `total_rows`, `encoding_detected`, `columns`
+- `issues` — critical blockers that **must** be fixed before training
+- `warnings` — non-critical issues worth reviewing
+- `stats.label_distribution` + `stats.class_imbalance_ratio`
+- `stats.token_analysis` — p50/p95/p99 token counts, over-limit rows
+- `summary.ready_for_training` — true/false
+- `summary.recommended_actions` — exact commands to run next
+
+**Always run inspect first. Never skip.**
+
+### Step 3 — Clean
+```bash
+python scripts/clean.py /home/claude/<file> /home/claude/<file>_cleaned.<ext>
+```
+
+Options:
+```
+--text-col TEXT        Text column name (auto-detected if omitted)
+--label-col LABEL      Label column name (auto-detected if omitted)
+--drop-short N         Drop rows with fewer than N tokens
+--drop-long N          Drop rows exceeding N tokens (use inspect p95/p99 as guide)
+--no-dedup             Skip duplicate removal
+--no-drop-empty-text   Keep rows with empty text
+--no-drop-empty-label  Keep rows with empty labels
+--no-label-noise       Skip label noise removal
+--token-model MODEL    Tiktoken model (default: cl100k_base)
+```
+
+Report every item in `changes` to the user in plain language.
+
+### Step 4 — Balance (only if imbalance ratio > 3)
+```bash
+# Oversample minority classes — best for small datasets
+python scripts/balance.py /home/claude/<file>_cleaned.<ext> /home/claude/<file>_balanced.<ext> \
+  --label-col <label_col> --strategy oversample
+
+# Undersample majority classes — use when dataset is large (100k+)
+python scripts/balance.py ... --strategy undersample
+
+# Hybrid: geometric mean — balanced middle ground
+python scripts/balance.py ... --strategy hybrid
+```
+
+Report `original_distribution` → `final_distribution` and `improvement` ratio.
+
+### Step 5 — Split
+```bash
+python scripts/split.py /home/claude/<file>_balanced.<ext> /home/claude/splits/ \
+  --train 0.8 --val 0.1 --test 0.1 --prefix my_dataset
+```
+
+Stratified by default — preserves class distribution in each split.
+Output: `my_dataset_train.csv`, `my_dataset_val.csv`, `my_dataset_test.csv`
+
+### Step 6 — Convert to JSONL (for fine-tuning)
+```bash
+# OpenAI fine-tuning format
+python scripts/to_jsonl.py /home/claude/splits/my_dataset_train.csv /home/claude/train.jsonl \
+  --format openai --system-prompt "You are a helpful assistant."
+
+# Anthropic Messages API format
+python scripts/to_jsonl.py /home/claude/splits/my_dataset_train.csv /home/claude/train.jsonl \
+  --format anthropic --system-prompt "You are a helpful assistant."
+```
+
+Schema is validated automatically before saving.
+If `validation_passed` is false, fix the listed errors before uploading.
+
+### Step 7 — Deliver output files
+```bash
+cp /home/claude/train.jsonl /mnt/user-data/outputs/
+cp /home/claude/splits/my_dataset_val.csv /mnt/user-data/outputs/
+```
+
+Use `present_files` to share all output files.
+
+---
+
+## Full pipeline example (one-liner chain)
+
+```bash
+python scripts/inspect.py /home/claude/data.csv && \
+python scripts/clean.py /home/claude/data.csv /home/claude/data_clean.csv --drop-long 512 && \
+python scripts/balance.py /home/claude/data_clean.csv /home/claude/data_balanced.csv --label-col label && \
+python scripts/split.py /home/claude/data_balanced.csv /home/claude/splits/ --prefix data && \
+python scripts/to_jsonl.py /home/claude/splits/data_train.csv /home/claude/train.jsonl --format anthropic
+```
+
+---
+
+## Output report to user
+
+Structure your final response as:
+
+**Dataset Audit**
+- File name, row count, encoding detected, columns found
+- Every issue found — explain what it means, why it hurts training
+- Every warning — explain the risk
+
+**Cleaning Summary**
+- Rows removed and exact reason for each
+- Before → after counts
+
+**Class Balance** (if run)
+- Distribution table before and after
+- Ratio improvement
+
+**Train / Val / Test Split**
+- Row counts per split
+- Whether stratified
+
+**Final Output**
+- File list with row counts and formats
+- Token stats: avg, p50, p95, total tokens
+- `ready_for_training: true/false` verdict
+
+**Next Steps**
+- Specific fine-tuning recommendations based on dataset size:
+  - < 50 rows: too small, suggest data collection strategies
+  - 50–500 rows: few-shot or LoRA fine-tuning
+  - 500–10k rows: standard fine-tuning
+  - 10k+ rows: full fine-tuning, consider data augmentation
+
+---
+
+## Important rules
+
+- Always run `inspect.py` first — never clean blind.
+- Clean before balancing — duplicates skew class counts.
+- Balance before splitting — ensures all splits get representative samples.
+- Split before converting — convert each split separately (train, val).
+- If `ready_for_training` is already `true` after inspect, tell the user and skip cleaning.
+- Translate every technical finding into plain language the user can act on.
+- Never guess column names — scripts auto-detect; only specify manually if auto-detection fails.

--- a/skills/dataset-cleaner/balance.py
+++ b/skills/dataset-cleaner/balance.py
@@ -1,0 +1,131 @@
+"""
+dataset-cleaner: balance.py
+Fixes class imbalance in AI training datasets.
+Strategies: oversample (random), undersample (random), hybrid (geometric mean).
+For text data, oversampling uses simple duplication — pair with augmentation
+tools for richer synthetic samples.
+
+Usage:
+  python balance.py <input> <output> --label-col LABEL
+                    [--strategy oversample|undersample|hybrid]
+                    [--seed 42]
+"""
+
+import sys
+import json
+import argparse
+import random
+from pathlib import Path
+from collections import Counter, defaultdict
+
+sys.path.insert(0, str(Path(__file__).parent))
+from utils import load_file, save_file, detect_columns
+
+
+def balance(input_path, output_path, label_col=None, strategy="oversample", seed=42):
+    random.seed(seed)
+    rows, _, fmt, encoding, delimiter = load_file(input_path)
+
+    if not rows:
+        print(json.dumps({"error": "Input file is empty."}))
+        sys.exit(1)
+
+    all_keys = list(rows[0].keys())
+    _, label_col = detect_columns(all_keys, label_col=label_col)
+
+    if not label_col:
+        print(json.dumps({"error": "Could not detect label column. Specify --label-col."}))
+        sys.exit(1)
+
+    # partition rows into labeled groups
+    groups = defaultdict(list)
+    unlabeled = []
+    for r in rows:
+        lbl = str(r.get(label_col, "")).strip()
+        if lbl:
+            groups[lbl].append(r)
+        else:
+            unlabeled.append(r)
+
+    if not groups:
+        print(json.dumps({"error": "No labeled rows found."}))
+        sys.exit(1)
+
+    counts = Counter({k: len(v) for k, v in groups.items()})
+    max_n = counts.most_common(1)[0][1]
+    min_n = counts.most_common()[-1][1]
+    original_dist = dict(counts.most_common())
+    original_ratio = round(max_n / min_n, 2) if min_n > 0 else float("inf")
+
+    if strategy == "oversample":
+        target = max_n
+        balanced = []
+        for lbl, group in groups.items():
+            if len(group) < target:
+                extra = target - len(group)
+                group = group + random.choices(group, k=extra)
+            balanced.extend(group)
+
+    elif strategy == "undersample":
+        target = min_n
+        balanced = []
+        for lbl, group in groups.items():
+            balanced.extend(random.sample(group, target))
+
+    elif strategy == "hybrid":
+        import math
+        target = max(min_n, int(math.sqrt(max_n * min_n)))
+        balanced = []
+        for lbl, group in groups.items():
+            if len(group) > target:
+                balanced.extend(random.sample(group, target))
+            elif len(group) < target:
+                extra = target - len(group)
+                balanced.extend(group + random.choices(group, k=extra))
+            else:
+                balanced.extend(group)
+    else:
+        print(json.dumps({"error": f"Unknown strategy '{strategy}'. Use: oversample, undersample, hybrid"}))
+        sys.exit(1)
+
+    random.shuffle(balanced)
+    balanced.extend(unlabeled)
+
+    out_ext = Path(output_path).suffix.lower()
+    out_fmt = "jsonl" if out_ext == ".jsonl" else "csv"
+    try:
+        save_file(balanced, output_path, out_fmt, delimiter or ",")
+    except IOError as e:
+        print(json.dumps({"error": str(e)}))
+        sys.exit(1)
+
+    final_counts = Counter(str(r.get(label_col, "")).strip() for r in balanced if str(r.get(label_col, "")).strip())
+    final_min = min(final_counts.values())
+    final_max = max(final_counts.values())
+    final_ratio = round(final_max / final_min, 2) if final_min > 0 else 1.0
+
+    print(json.dumps({
+        "input_file": str(input_path),
+        "output_file": str(output_path),
+        "strategy": strategy,
+        "label_col": label_col,
+        "seed": seed,
+        "original_distribution": original_dist,
+        "final_distribution": dict(final_counts.most_common()),
+        "original_total": len(rows),
+        "final_total": len(balanced),
+        "original_imbalance_ratio": original_ratio,
+        "final_imbalance_ratio": final_ratio,
+        "improvement": f"{original_ratio}:1 → {final_ratio}:1",
+    }, indent=2))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Balance class distribution in a training dataset.")
+    parser.add_argument("input_file")
+    parser.add_argument("output_file")
+    parser.add_argument("--label-col", default=None)
+    parser.add_argument("--strategy", default="oversample", choices=["oversample", "undersample", "hybrid"])
+    parser.add_argument("--seed", type=int, default=42)
+    args = parser.parse_args()
+    balance(args.input_file, args.output_file, args.label_col, args.strategy, args.seed)

--- a/skills/dataset-cleaner/clean.py
+++ b/skills/dataset-cleaner/clean.py
@@ -1,0 +1,185 @@
+"""
+dataset-cleaner: clean.py
+Cleans a dataset (CSV or JSONL) for AI training.
+Fixes: duplicates, empty rows, label noise, encoding corruption,
+whitespace, and over/under length rows (by token count).
+
+Usage:
+  python clean.py <input> <output>
+                  [--text-col TEXT] [--label-col LABEL]
+                  [--drop-short N]  [--drop-long N]
+                  [--no-dedup] [--no-drop-empty-text] [--no-drop-empty-label]
+                  [--no-fix-encoding] [--no-label-noise]
+                  [--token-model cl100k_base]
+"""
+
+import sys
+import json
+import argparse
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from utils import load_file, save_file, detect_columns, count_tokens, row_hash, text_hash
+
+
+def clean(input_path, output_path,
+          text_col=None, label_col=None,
+          drop_duplicates=True, drop_empty_text=True, drop_empty_label=True,
+          drop_short=None, drop_long=None,
+          fix_encoding=True, remove_label_noise=True,
+          token_model="cl100k_base"):
+
+    rows, parse_errors, fmt, encoding, delimiter = load_file(input_path)
+    original_count = len(rows)
+    log = []
+
+    if not rows:
+        print(json.dumps({"error": "Input file is empty or could not be parsed."}))
+        sys.exit(1)
+
+    all_keys = list(rows[0].keys())
+    text_col, label_col = detect_columns(all_keys, text_col, label_col)
+
+    # ── Fix encoding corruption ───────────────────────────────────────────────
+    if fix_encoding:
+        fixed_fields = 0
+        for r in rows:
+            for k, v in r.items():
+                if isinstance(v, str) and "\ufffd" in v:
+                    r[k] = v.replace("\ufffd", "").strip()
+                    fixed_fields += 1
+        if fixed_fields:
+            log.append(f"Fixed encoding corruption in {fixed_fields} field(s).")
+
+    # ── Strip whitespace ──────────────────────────────────────────────────────
+    stripped = 0
+    for r in rows:
+        for k, v in r.items():
+            if isinstance(v, str):
+                clean_v = v.strip()
+                if clean_v != v:
+                    r[k] = clean_v
+                    stripped += 1
+    if stripped:
+        log.append(f"Stripped leading/trailing whitespace from {stripped} field(s).")
+
+    # ── Drop empty text ───────────────────────────────────────────────────────
+    if drop_empty_text and text_col:
+        before = len(rows)
+        rows = [r for r in rows if str(r.get(text_col, "")).strip()]
+        dropped = before - len(rows)
+        if dropped:
+            log.append(f"Dropped {dropped} rows with empty '{text_col}'.")
+
+    # ── Drop empty labels ─────────────────────────────────────────────────────
+    if drop_empty_label and label_col:
+        before = len(rows)
+        rows = [r for r in rows if str(r.get(label_col, "")).strip()]
+        dropped = before - len(rows)
+        if dropped:
+            log.append(f"Dropped {dropped} rows with empty '{label_col}'.")
+
+    # ── Drop short texts (by token count) ────────────────────────────────────
+    if drop_short is not None and text_col:
+        before = len(rows)
+        rows = [r for r in rows
+                if count_tokens(str(r.get(text_col, "")), token_model) >= drop_short]
+        dropped = before - len(rows)
+        if dropped:
+            log.append(f"Dropped {dropped} rows with fewer than {drop_short} tokens in '{text_col}'.")
+
+    # ── Drop long texts (by token count) ─────────────────────────────────────
+    if drop_long is not None and text_col:
+        before = len(rows)
+        rows = [r for r in rows
+                if count_tokens(str(r.get(text_col, "")), token_model) <= drop_long]
+        dropped = before - len(rows)
+        if dropped:
+            log.append(f"Dropped {dropped} rows exceeding {drop_long} tokens in '{text_col}'.")
+
+    # ── Remove exact duplicates ───────────────────────────────────────────────
+    if drop_duplicates:
+        before = len(rows)
+        seen = set()
+        deduped = []
+        for r in rows:
+            h = row_hash(r)
+            if h not in seen:
+                seen.add(h)
+                deduped.append(r)
+        rows = deduped
+        dropped = before - len(rows)
+        if dropped:
+            log.append(f"Removed {dropped} exact duplicate rows.")
+
+    # ── Remove label noise ────────────────────────────────────────────────────
+    if remove_label_noise and text_col and label_col:
+        text_to_labels = {}
+        for r in rows:
+            th = text_hash(str(r.get(text_col, "")))
+            lbl = str(r.get(label_col, "")).strip()
+            if th not in text_to_labels:
+                text_to_labels[th] = set()
+            if lbl:
+                text_to_labels[th].add(lbl)
+        noisy = {th for th, lbls in text_to_labels.items() if len(lbls) > 1}
+        if noisy:
+            before = len(rows)
+            rows = [r for r in rows
+                    if text_hash(str(r.get(text_col, ""))) not in noisy]
+            dropped = before - len(rows)
+            log.append(
+                f"Removed {dropped} rows with label noise "
+                f"({len(noisy)} texts had conflicting labels)."
+            )
+
+    # ── Save ──────────────────────────────────────────────────────────────────
+    out_ext = Path(output_path).suffix.lower()
+    out_fmt = "jsonl" if out_ext == ".jsonl" else "csv"
+    try:
+        save_file(rows, output_path, out_fmt, delimiter or ",")
+    except IOError as e:
+        print(json.dumps({"error": str(e)}))
+        sys.exit(1)
+
+    print(json.dumps({
+        "input_file": str(input_path),
+        "output_file": str(output_path),
+        "original_rows": original_count,
+        "cleaned_rows": len(rows),
+        "rows_removed": original_count - len(rows),
+        "removal_pct": round((original_count - len(rows)) / original_count * 100, 2) if original_count else 0,
+        "detected_text_col": text_col,
+        "detected_label_col": label_col,
+        "token_model_used": token_model,
+        "changes": log if log else ["No issues found — dataset was already clean."],
+    }, indent=2))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Clean a dataset for AI training.")
+    parser.add_argument("input_file")
+    parser.add_argument("output_file")
+    parser.add_argument("--text-col", default=None)
+    parser.add_argument("--label-col", default=None)
+    parser.add_argument("--drop-short", type=int, default=None, help="Drop rows with fewer than N tokens")
+    parser.add_argument("--drop-long", type=int, default=None, help="Drop rows exceeding N tokens")
+    parser.add_argument("--no-dedup", action="store_true")
+    parser.add_argument("--no-drop-empty-text", action="store_true")
+    parser.add_argument("--no-drop-empty-label", action="store_true")
+    parser.add_argument("--no-fix-encoding", action="store_true")
+    parser.add_argument("--no-label-noise", action="store_true")
+    parser.add_argument("--token-model", default="cl100k_base")
+    args = parser.parse_args()
+
+    clean(
+        args.input_file, args.output_file,
+        text_col=args.text_col, label_col=args.label_col,
+        drop_duplicates=not args.no_dedup,
+        drop_empty_text=not args.no_drop_empty_text,
+        drop_empty_label=not args.no_drop_empty_label,
+        drop_short=args.drop_short, drop_long=args.drop_long,
+        fix_encoding=not args.no_fix_encoding,
+        remove_label_noise=not args.no_label_noise,
+        token_model=args.token_model,
+    )

--- a/skills/dataset-cleaner/inspect.py
+++ b/skills/dataset-cleaner/inspect.py
@@ -1,0 +1,204 @@
+"""
+dataset-cleaner: inspect.py
+Full quality audit for AI training datasets.
+Detects: duplicates, label noise, class imbalance, missing values,
+token length issues, encoding corruption, malformed rows, schema problems.
+
+Usage:
+  python inspect.py <file> [--text-col TEXT] [--label-col LABEL]
+                           [--token-model cl100k_base] [--max-tokens 512]
+"""
+
+import sys
+import json
+import argparse
+from pathlib import Path
+from collections import Counter
+
+sys.path.insert(0, str(Path(__file__).parent))
+from utils import load_file, detect_columns, count_tokens, row_hash, text_hash
+
+
+def inspect(path, text_col=None, label_col=None, token_model="cl100k_base", max_tokens=512):
+    rows, parse_errors, fmt, encoding, delimiter = load_file(path)
+
+    report = {
+        "file": Path(path).name,
+        "format": fmt,
+        "encoding_detected": encoding,
+        "total_rows": len(rows),
+        "parse_errors": parse_errors[:10],  # cap at 10
+        "issues": [],
+        "warnings": [],
+        "stats": {},
+        "columns": [],
+    }
+
+    if parse_errors:
+        report["issues"].append(f"{len(parse_errors)} rows failed to parse — file may be malformed.")
+
+    if not rows:
+        report["issues"].append("File is empty or could not be parsed.")
+        report["summary"] = {"total_issues": 1, "total_warnings": 0, "ready_for_training": False}
+        print(json.dumps(report, indent=2))
+        return
+
+    all_keys = list(rows[0].keys())
+    report["columns"] = all_keys
+    text_col, label_col = detect_columns(all_keys, text_col, label_col)
+    report["detected_text_col"] = text_col
+    report["detected_label_col"] = label_col
+
+    # ── Missing values ────────────────────────────────────────────────────────
+    missing_by_col = {}
+    for key in all_keys:
+        count = sum(1 for r in rows if not str(r.get(key, "")).strip())
+        if count > 0:
+            pct = round(count / len(rows) * 100, 2)
+            missing_by_col[key] = {"count": count, "pct": pct}
+            target = "issues" if pct > 10 else "warnings"
+            report[target].append(f"'{key}' has {pct}% missing values ({count} rows).")
+    report["stats"]["missing_values"] = missing_by_col
+
+    # ── Exact duplicates ──────────────────────────────────────────────────────
+    hashes = [row_hash(r) for r in rows]
+    dup_count = len(hashes) - len(set(hashes))
+    report["stats"]["duplicate_rows"] = dup_count
+    if dup_count > 0:
+        pct = round(dup_count / len(rows) * 100, 2)
+        report["issues"].append(f"{dup_count} exact duplicate rows ({pct}% of dataset).")
+
+    # ── Label noise ───────────────────────────────────────────────────────────
+    if text_col and label_col:
+        text_to_labels = {}
+        for r in rows:
+            th = text_hash(str(r.get(text_col, "")))
+            lbl = str(r.get(label_col, "")).strip()
+            if th not in text_to_labels:
+                text_to_labels[th] = set()
+            if lbl:
+                text_to_labels[th].add(lbl)
+        noisy_texts = {th for th, lbls in text_to_labels.items() if len(lbls) > 1}
+        noisy_rows = sum(1 for r in rows if text_hash(str(r.get(text_col, ""))) in noisy_texts)
+        report["stats"]["label_noise_rows"] = noisy_rows
+        report["stats"]["label_noise_texts"] = len(noisy_texts)
+        if noisy_rows > 0:
+            report["issues"].append(
+                f"{noisy_rows} rows have label noise — same text mapped to multiple labels "
+                f"({len(noisy_texts)} unique texts affected). This will directly hurt model accuracy."
+            )
+
+    # ── Class imbalance ───────────────────────────────────────────────────────
+    if label_col:
+        labels = [str(r.get(label_col, "")).strip() for r in rows if str(r.get(label_col, "")).strip()]
+        label_counts = Counter(labels)
+        report["stats"]["label_distribution"] = dict(label_counts.most_common())
+        report["stats"]["num_classes"] = len(label_counts)
+
+        if label_counts:
+            most_n = label_counts.most_common(1)[0][1]
+            least_n = label_counts.most_common()[-1][1]
+            ratio = round(most_n / least_n, 2) if least_n > 0 else float("inf")
+            report["stats"]["class_imbalance_ratio"] = ratio
+
+            if ratio > 10:
+                report["issues"].append(
+                    f"Severe class imbalance (ratio {ratio}:1). "
+                    f"Most common: '{label_counts.most_common(1)[0][0]}' ({most_n}), "
+                    f"least common: '{label_counts.most_common()[-1][0]}' ({least_n}). "
+                    "Model will be heavily biased toward majority class."
+                )
+            elif ratio > 3:
+                report["warnings"].append(
+                    f"Moderate class imbalance (ratio {ratio}:1). Consider running balance.py."
+                )
+
+        empty_labels = sum(1 for r in rows if not str(r.get(label_col, "")).strip())
+        if empty_labels > 0:
+            report["issues"].append(f"{empty_labels} rows have empty or missing labels.")
+
+    # ── Token analysis ────────────────────────────────────────────────────────
+    over_limit = 0
+    if text_col:
+        token_counts = []
+        empty_texts = 0
+        for r in rows:
+            t = str(r.get(text_col, "")).strip()
+            if not t:
+                empty_texts += 1
+                token_counts.append(0)
+            else:
+                token_counts.append(count_tokens(t, token_model))
+
+        over_limit = sum(1 for tc in token_counts if tc > max_tokens)
+        very_short = sum(1 for tc in token_counts if 0 < tc < 5)
+        sorted_tc = sorted(token_counts)
+        n = len(sorted_tc)
+
+        report["stats"]["token_analysis"] = {
+            "tokenizer": token_model,
+            "max_tokens_threshold": max_tokens,
+            "min": sorted_tc[0],
+            "max": sorted_tc[-1],
+            "mean": round(sum(token_counts) / n, 1),
+            "p50": sorted_tc[n // 2],
+            "p95": sorted_tc[int(n * 0.95)],
+            "p99": sorted_tc[int(n * 0.99)],
+            "empty_texts": empty_texts,
+            "over_limit": over_limit,
+            "very_short_under_5_tokens": very_short,
+        }
+
+        if empty_texts > 0:
+            report["issues"].append(f"{empty_texts} rows have empty text in '{text_col}'.")
+        if over_limit > 0:
+            pct = round(over_limit / n * 100, 1)
+            report["warnings"].append(
+                f"{over_limit} rows ({pct}%) exceed {max_tokens} tokens and will be truncated by most tokenizers."
+            )
+        if very_short > 0:
+            report["warnings"].append(f"{very_short} rows have fewer than 5 tokens — likely junk or noise.")
+
+    # ── Encoding corruption ───────────────────────────────────────────────────
+    encoding_issues = sum(1 for r in rows if any("\ufffd" in str(v) for v in r.values()))
+    report["stats"]["encoding_issues"] = encoding_issues
+    if encoding_issues > 0:
+        report["issues"].append(
+            f"{encoding_issues} rows contain Unicode replacement characters — encoding corruption."
+        )
+
+    # ── Schema consistency ────────────────────────────────────────────────────
+    expected_keys = set(all_keys)
+    schema_errors = sum(1 for r in rows if set(r.keys()) != expected_keys)
+    report["stats"]["schema_inconsistencies"] = schema_errors
+    if schema_errors > 0:
+        report["issues"].append(f"{schema_errors} rows have inconsistent schema (missing or extra columns).")
+
+    # ── Summary + recommendations ─────────────────────────────────────────────
+    actions = []
+    if dup_count > 0 or report["stats"].get("label_noise_rows", 0) > 0:
+        actions.append("Run clean.py to remove duplicates and label noise.")
+    if report["stats"].get("class_imbalance_ratio", 1) > 3:
+        actions.append("Run balance.py to fix class imbalance.")
+    if over_limit > 0:
+        actions.append(f"Run clean.py --drop-long {max_tokens} to remove over-limit rows.")
+
+    report["summary"] = {
+        "total_issues": len(report["issues"]),
+        "total_warnings": len(report["warnings"]),
+        "ready_for_training": len(report["issues"]) == 0,
+        "recommended_actions": actions,
+    }
+
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Audit a dataset for AI training quality issues.")
+    parser.add_argument("file")
+    parser.add_argument("--text-col", default=None)
+    parser.add_argument("--label-col", default=None)
+    parser.add_argument("--token-model", default="cl100k_base")
+    parser.add_argument("--max-tokens", type=int, default=512)
+    args = parser.parse_args()
+    inspect(args.file, args.text_col, args.label_col, args.token_model, args.max_tokens)

--- a/skills/dataset-cleaner/split.py
+++ b/skills/dataset-cleaner/split.py
@@ -1,0 +1,145 @@
+"""
+dataset-cleaner: split.py
+Splits a dataset into train / validation / test sets.
+Supports stratified splitting to preserve class distribution.
+
+Usage:
+  python split.py <input> <output_dir>
+                  [--train 0.8] [--val 0.1] [--test 0.1]
+                  [--label-col LABEL] [--stratify]
+                  [--seed 42] [--prefix my_dataset]
+"""
+
+import sys
+import json
+import argparse
+import random
+from pathlib import Path
+from collections import defaultdict
+
+sys.path.insert(0, str(Path(__file__).parent))
+from utils import load_file, save_file, detect_columns
+
+
+def split(input_path, output_dir,
+          train_ratio=0.8, val_ratio=0.1, test_ratio=0.1,
+          label_col=None, stratify=True, seed=42, prefix="dataset"):
+
+    random.seed(seed)
+
+    # validate ratios
+    total = round(train_ratio + val_ratio + test_ratio, 6)
+    if abs(total - 1.0) > 0.001:
+        print(json.dumps({"error": f"Train + val + test must sum to 1.0, got {total}"}))
+        sys.exit(1)
+
+    rows, _, fmt, encoding, delimiter = load_file(input_path)
+
+    if not rows:
+        print(json.dumps({"error": "Input file is empty."}))
+        sys.exit(1)
+
+    all_keys = list(rows[0].keys())
+    _, label_col = detect_columns(all_keys, label_col=label_col)
+
+    out_ext = Path(input_path).suffix.lower()
+    out_fmt = "jsonl" if out_ext == ".jsonl" else "csv"
+    Path(output_dir).mkdir(parents=True, exist_ok=True)
+
+    def do_split(data):
+        random.shuffle(data)
+        n = len(data)
+        train_end = int(n * train_ratio)
+        val_end = train_end + int(n * val_ratio)
+        return data[:train_end], data[train_end:val_end], data[val_end:]
+
+    if stratify and label_col:
+        # split within each class, then combine
+        groups = defaultdict(list)
+        unlabeled = []
+        for r in rows:
+            lbl = str(r.get(label_col, "")).strip()
+            if lbl:
+                groups[lbl].append(r)
+            else:
+                unlabeled.append(r)
+
+        train_rows, val_rows, test_rows = [], [], []
+        class_splits = {}
+
+        for lbl, group in groups.items():
+            tr, va, te = do_split(group)
+            train_rows.extend(tr)
+            val_rows.extend(va)
+            test_rows.extend(te)
+            class_splits[lbl] = {"train": len(tr), "val": len(va), "test": len(te)}
+
+        # distribute unlabeled proportionally
+        utr, uva, ute = do_split(unlabeled)
+        train_rows.extend(utr)
+        val_rows.extend(uva)
+        test_rows.extend(ute)
+
+    else:
+        train_rows, val_rows, test_rows = do_split(list(rows))
+        class_splits = None
+
+    # shuffle final splits
+    random.shuffle(train_rows)
+    random.shuffle(val_rows)
+    random.shuffle(test_rows)
+
+    # save
+    splits = {
+        "train": (train_rows, f"{prefix}_train.{out_ext.lstrip('.')}"),
+        "val":   (val_rows,   f"{prefix}_val.{out_ext.lstrip('.')}"),
+        "test":  (test_rows,  f"{prefix}_test.{out_ext.lstrip('.')}"),
+    }
+
+    # skip empty splits
+    saved = {}
+    for name, (split_rows, filename) in splits.items():
+        if not split_rows:
+            continue
+        path = str(Path(output_dir) / filename)
+        try:
+            save_file(split_rows, path, out_fmt, delimiter or ",")
+            saved[name] = {"file": path, "rows": len(split_rows)}
+        except IOError as e:
+            print(json.dumps({"error": str(e)}))
+            sys.exit(1)
+
+    result = {
+        "input_file": str(input_path),
+        "output_dir": str(output_dir),
+        "total_rows": len(rows),
+        "stratified": stratify and bool(label_col),
+        "label_col": label_col,
+        "seed": seed,
+        "splits": saved,
+        "ratios": {"train": train_ratio, "val": val_ratio, "test": test_ratio},
+    }
+    if class_splits:
+        result["class_splits"] = class_splits
+
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Split a dataset into train/val/test sets.")
+    parser.add_argument("input_file")
+    parser.add_argument("output_dir")
+    parser.add_argument("--train", type=float, default=0.8)
+    parser.add_argument("--val", type=float, default=0.1)
+    parser.add_argument("--test", type=float, default=0.1)
+    parser.add_argument("--label-col", default=None)
+    parser.add_argument("--no-stratify", action="store_true")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--prefix", default="dataset")
+    args = parser.parse_args()
+    split(
+        args.input_file, args.output_dir,
+        train_ratio=args.train, val_ratio=args.val, test_ratio=args.test,
+        label_col=args.label_col, stratify=not args.no_stratify,
+        seed=args.seed, prefix=args.prefix,
+    )

--- a/skills/dataset-cleaner/to_jsonl.py
+++ b/skills/dataset-cleaner/to_jsonl.py
@@ -1,0 +1,155 @@
+"""
+dataset-cleaner: to_jsonl.py
+Converts CSV/JSON to training-ready JSONL with schema validation.
+Formats: raw, openai (fine-tune), anthropic (Messages API fine-tune).
+Validates output against official spec before saving.
+
+Usage:
+  python to_jsonl.py <input> <o>
+                     [--format raw|openai|anthropic]
+                     [--text-col TEXT] [--label-col LABEL]
+                     [--system-prompt "You are a helpful assistant."]
+                     [--validate]
+"""
+
+import sys
+import json
+import argparse
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from utils import (load_file, save_file, detect_columns,
+                   count_tokens, validate_openai_jsonl, validate_anthropic_jsonl)
+
+
+def convert(input_path, output_path,
+            fmt="raw", text_col=None, label_col=None,
+            system_prompt=None, validate=True,
+            token_model="cl100k_base"):
+
+    rows, parse_errors, in_fmt, encoding, delimiter = load_file(input_path)
+
+    if not rows:
+        print(json.dumps({"error": "Input file is empty or could not be parsed."}))
+        sys.exit(1)
+
+    all_keys = list(rows[0].keys())
+    text_col, label_col = detect_columns(all_keys, text_col, label_col)
+
+    if not text_col:
+        print(json.dumps({
+            "error": "Could not detect text column. Specify --text-col.",
+            "available_columns": all_keys
+        }))
+        sys.exit(1)
+
+    converted = []
+    skipped = 0
+    total_tokens = 0
+    over_limit = 0
+
+    for r in rows:
+        text = str(r.get(text_col, "")).strip()
+        label = str(r.get(label_col, "")).strip() if label_col else ""
+
+        if not text:
+            skipped += 1
+            continue
+
+        tc = count_tokens(text, token_model)
+        total_tokens += tc
+        if tc > 4096:
+            over_limit += 1
+
+        if fmt == "raw":
+            out = {text_col: text}
+            if label_col and label:
+                out[label_col] = label
+            converted.append(out)
+
+        elif fmt == "openai":
+            messages = []
+            if system_prompt:
+                messages.append({"role": "system", "content": system_prompt})
+            messages.append({"role": "user", "content": text})
+            if label:
+                messages.append({"role": "assistant", "content": label})
+            converted.append({"messages": messages})
+
+        elif fmt == "anthropic":
+            messages = [{"role": "user", "content": text}]
+            if label:
+                messages.append({"role": "assistant", "content": label})
+            entry = {"messages": messages}
+            if system_prompt:
+                entry["system"] = system_prompt
+            converted.append(entry)
+
+    if not converted:
+        print(json.dumps({"error": "No rows were converted. Check --text-col value."}))
+        sys.exit(1)
+
+    # ── Schema validation ─────────────────────────────────────────────────────
+    validation_errors = []
+    if validate:
+        if fmt == "openai":
+            validation_errors = validate_openai_jsonl(converted)
+        elif fmt == "anthropic":
+            validation_errors = validate_anthropic_jsonl(converted)
+
+    if validation_errors:
+        print(json.dumps({
+            "error": "Output failed schema validation. Fix these issues before uploading for fine-tuning.",
+            "validation_errors": validation_errors[:20],
+        }, indent=2))
+        sys.exit(1)
+
+    # ── Save ──────────────────────────────────────────────────────────────────
+    try:
+        save_file(converted, output_path, "jsonl")
+    except IOError as e:
+        print(json.dumps({"error": str(e)}))
+        sys.exit(1)
+
+    avg_tokens = round(total_tokens / len(converted), 1) if converted else 0
+
+    print(json.dumps({
+        "input_file": str(input_path),
+        "output_file": str(output_path),
+        "format": fmt,
+        "total_input_rows": len(rows),
+        "converted_rows": len(converted),
+        "skipped_rows": skipped,
+        "detected_text_col": text_col,
+        "detected_label_col": label_col,
+        "system_prompt_used": bool(system_prompt),
+        "schema_validated": validate,
+        "validation_passed": len(validation_errors) == 0,
+        "token_stats": {
+            "model": token_model,
+            "total_tokens": total_tokens,
+            "avg_tokens_per_row": avg_tokens,
+            "rows_over_4096_tokens": over_limit,
+        },
+    }, indent=2))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Convert dataset to training-ready JSONL.")
+    parser.add_argument("input_file")
+    parser.add_argument("output_file")
+    parser.add_argument("--format", default="raw", choices=["raw", "openai", "anthropic"])
+    parser.add_argument("--text-col", default=None)
+    parser.add_argument("--label-col", default=None)
+    parser.add_argument("--system-prompt", default=None)
+    parser.add_argument("--no-validate", action="store_true", help="Skip schema validation")
+    parser.add_argument("--token-model", default="cl100k_base")
+    args = parser.parse_args()
+    convert(
+        args.input_file, args.output_file,
+        fmt=args.format,
+        text_col=args.text_col, label_col=args.label_col,
+        system_prompt=args.system_prompt,
+        validate=not args.no_validate,
+        token_model=args.token_model,
+    )

--- a/skills/dataset-cleaner/utils.py
+++ b/skills/dataset-cleaner/utils.py
@@ -1,0 +1,213 @@
+"""
+dataset-cleaner: utils.py
+Shared utilities: file I/O, encoding detection, token counting, progress, validation.
+"""
+
+import sys
+import json
+import csv
+import os
+import hashlib
+from pathlib import Path
+
+
+# ── Encoding detection ─────────────────────────────────────────────────────────
+
+ENCODINGS_TO_TRY = ["utf-8", "utf-8-sig", "latin-1", "cp1252", "utf-16"]
+
+def detect_encoding(path):
+    """Try common encodings and return the first one that works."""
+    try:
+        import chardet
+        with open(path, "rb") as f:
+            raw = f.read(100_000)
+        result = chardet.detect(raw)
+        if result["confidence"] > 0.7:
+            return result["encoding"]
+    except ImportError:
+        pass
+    for enc in ENCODINGS_TO_TRY:
+        try:
+            with open(path, "r", encoding=enc) as f:
+                f.read(10_000)
+            return enc
+        except (UnicodeDecodeError, LookupError):
+            continue
+    return "utf-8"
+
+
+def detect_delimiter(path, encoding):
+    """Detect CSV delimiter: comma, semicolon, tab, or pipe."""
+    try:
+        with open(path, "r", encoding=encoding, errors="replace") as f:
+            sample = f.read(4096)
+        dialect = csv.Sniffer().sniff(sample, delimiters=",;\t|")
+        return dialect.delimiter
+    except csv.Error:
+        return ","
+
+
+# ── File I/O ───────────────────────────────────────────────────────────────────
+
+def load_file(path, show_progress=True):
+    """Load CSV or JSONL file. Returns (rows, parse_errors, format, encoding, delimiter)."""
+    path = str(path)
+    ext = Path(path).suffix.lower()
+    encoding = detect_encoding(path)
+    parse_errors = []
+
+    if ext == ".jsonl":
+        rows = []
+        total_bytes = os.path.getsize(path)
+        bytes_read = 0
+        with open(path, "r", encoding=encoding, errors="replace") as f:
+            for i, line in enumerate(f):
+                bytes_read += len(line.encode(encoding, errors="replace"))
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rows.append(json.loads(line))
+                except json.JSONDecodeError as e:
+                    parse_errors.append({"line": i + 1, "error": str(e), "content": line[:100]})
+                if show_progress and i % 10_000 == 0 and i > 0:
+                    pct = min(100, int(bytes_read / total_bytes * 100))
+                    print(f"[progress] Loading... {pct}%", file=sys.stderr)
+        return rows, parse_errors, "jsonl", encoding, None
+
+    elif ext == ".csv":
+        delimiter = detect_delimiter(path, encoding)
+        rows = []
+        with open(path, "r", encoding=encoding, errors="replace", newline="") as f:
+            reader = csv.DictReader(f, delimiter=delimiter)
+            for i, row in enumerate(reader):
+                rows.append(dict(row))
+                if show_progress and i % 10_000 == 0 and i > 0:
+                    print(f"[progress] Loading... {i:,} rows", file=sys.stderr)
+        return rows, parse_errors, "csv", encoding, delimiter
+
+    elif ext == ".json":
+        with open(path, "r", encoding=encoding, errors="replace") as f:
+            data = json.load(f)
+        rows = data if isinstance(data, list) else [data]
+        return rows, parse_errors, "json", encoding, None
+
+    else:
+        print(json.dumps({"error": f"Unsupported file type '{ext}'. Supported: .csv, .jsonl, .json"}))
+        sys.exit(1)
+
+
+def save_file(rows, path, fmt, delimiter=","):
+    """Save rows to CSV or JSONL."""
+    path = str(path)
+    os.makedirs(Path(path).parent, exist_ok=True)
+
+    if fmt == "jsonl":
+        with open(path, "w", encoding="utf-8") as f:
+            for row in rows:
+                f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+    elif fmt in ("csv", "json"):
+        if not rows:
+            open(path, "w").close()
+            return
+        with open(path, "w", encoding="utf-8", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=rows[0].keys(), delimiter=delimiter)
+            writer.writeheader()
+            writer.writerows(rows)
+
+    # verify file was written
+    if not os.path.exists(path) or os.path.getsize(path) == 0:
+        raise IOError(f"Output file was not written correctly: {path}")
+
+
+# ── Column auto-detection ──────────────────────────────────────────────────────
+
+TEXT_CANDIDATES  = ["text", "input", "prompt", "content", "sentence", "question", "utterance", "body", "message"]
+LABEL_CANDIDATES = ["label", "output", "target", "class", "category", "answer", "response", "intent", "tag"]
+
+def detect_columns(keys, text_col=None, label_col=None):
+    """Auto-detect text and label columns from a list of keys."""
+    keys_lower = {k.lower(): k for k in keys}
+    if not text_col:
+        for c in TEXT_CANDIDATES:
+            if c in keys_lower:
+                text_col = keys_lower[c]
+                break
+    if not label_col:
+        for c in LABEL_CANDIDATES:
+            if c in keys_lower:
+                label_col = keys_lower[c]
+                break
+    return text_col, label_col
+
+
+# ── Token counting ─────────────────────────────────────────────────────────────
+
+_tokenizer_cache = {}
+
+def count_tokens(text, model="cl100k_base"):
+    """Count tokens using tiktoken. Falls back to word count if unavailable."""
+    try:
+        import tiktoken
+        if model not in _tokenizer_cache:
+            _tokenizer_cache[model] = tiktoken.get_encoding(model)
+        return len(_tokenizer_cache[model].encode(str(text)))
+    except Exception:
+        return len(str(text).split())
+
+
+# ── Row hashing ────────────────────────────────────────────────────────────────
+
+def row_hash(r):
+    return hashlib.md5(json.dumps(r, sort_keys=True, ensure_ascii=False).encode()).hexdigest()
+
+def text_hash(text):
+    return hashlib.md5(str(text).lower().strip().encode()).hexdigest()
+
+
+# ── JSONL validation ───────────────────────────────────────────────────────────
+
+def validate_openai_jsonl(rows):
+    """Validate rows against OpenAI fine-tuning JSONL spec."""
+    errors = []
+    for i, row in enumerate(rows):
+        if "messages" not in row:
+            errors.append(f"Row {i+1}: missing 'messages' key.")
+            continue
+        msgs = row["messages"]
+        if not isinstance(msgs, list) or len(msgs) < 2:
+            errors.append(f"Row {i+1}: 'messages' must be a list with at least 2 items.")
+            continue
+        roles = [m.get("role") for m in msgs]
+        if roles[-1] != "assistant":
+            errors.append(f"Row {i+1}: last message must have role 'assistant'.")
+        for j, m in enumerate(msgs):
+            if "role" not in m or "content" not in m:
+                errors.append(f"Row {i+1}, message {j+1}: missing 'role' or 'content'.")
+            if m.get("role") not in ("system", "user", "assistant"):
+                errors.append(f"Row {i+1}, message {j+1}: invalid role '{m.get('role')}'.")
+    return errors
+
+
+def validate_anthropic_jsonl(rows):
+    """Validate rows against Anthropic Messages fine-tuning spec."""
+    errors = []
+    for i, row in enumerate(rows):
+        if "messages" not in row:
+            errors.append(f"Row {i+1}: missing 'messages' key.")
+            continue
+        msgs = row["messages"]
+        if not isinstance(msgs, list) or len(msgs) < 2:
+            errors.append(f"Row {i+1}: 'messages' must be a list with at least 2 items.")
+            continue
+        if msgs[0].get("role") != "user":
+            errors.append(f"Row {i+1}: first message must have role 'user'.")
+        if msgs[-1].get("role") != "assistant":
+            errors.append(f"Row {i+1}: last message must have role 'assistant'.")
+        for j, m in enumerate(msgs):
+            if "role" not in m or "content" not in m:
+                errors.append(f"Row {i+1}, message {j+1}: missing 'role' or 'content'.")
+            if not str(m.get("content", "")).strip():
+                errors.append(f"Row {i+1}, message {j+1}: 'content' is empty.")
+    return errors


### PR DESCRIPTION
Adds a new dataset-cleaner skill — a complete pipeline for cleaning and preparing text datasets for AI model training and fine-tuning.
What it does:
Five Python scripts handle every stage of data preparation:

inspect.py — full quality audit: duplicates, label noise, class imbalance, token length distribution, encoding corruption, schema inconsistencies
clean.py — removes duplicates, empty rows, label noise, encoding corruption; filters by real token count via tiktoken
balance.py — fixes class imbalance via oversample, undersample, or hybrid strategy
split.py — stratified train / val / test split that preserves class distribution
to_jsonl.py — converts to training-ready JSONL with full schema validation for OpenAI and Anthropic fine-tuning formats
utils.py — shared utilities: auto encoding detection, delimiter detection, token counting, file I/O

Works on any labeled text dataset — sentiment analysis, intent classification, spam detection, Q&A pairs, chatbot training data, and more.
Supported formats: .csv, .jsonl, .json — auto-detects encoding and delimiter.