### PR TITLE
fix(claude-api): shorten skill description for single-line display

### DIFF
--- a/skills/claude-api/SKILL.md
+++ b/skills/claude-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: claude-api
-description: "Build apps with the Claude API or Anthropic SDK. TRIGGER when: code imports `anthropic`/`@anthropic-ai/sdk`/`claude_agent_sdk`, or user asks to use Claude API, Anthropic SDKs, or Agent SDK. DO NOT TRIGGER when: code imports `openai`/other AI SDK, general programming, or ML/data-science tasks."
+description: "Build apps with the Claude API or Anthropic SDK. Triggers on anthropic/@anthropic-ai/sdk/claude_agent_sdk imports or Claude API usage requests."
 license: Complete terms in LICENSE.txt
 ---
 


### PR DESCRIPTION
## Summary

- Shorten the `claude-api` skill's frontmatter `description` to fit on a single line in the Claude Code skill list
- The verbose TRIGGER/DO NOT TRIGGER conditions are already present in the skill's system prompt body, so they don't need to be duplicated in the frontmatter description

### Before

```
/claude-api                     Build apps with the Claude API or Anthropic SDK.
TRIGGER when: code imports `anthropic`/`@anthropic-ai/sdk`/`claude_agent_sdk`,…
```

### After

```
/claude-api                     Build apps with the Claude API or Anthropic SDK. Triggers on anthropic/…
```

## Test plan

- [ ] Verify the skill still triggers correctly when importing `anthropic`, `@anthropic-ai/sdk`, or `claude_agent_sdk`
- [ ] Verify the skill does NOT trigger for `openai` or general programming tasks
- [ ] Confirm the description displays on a single line in the Claude Code skill list

🤖 Generated with [Claude Code](https://claude.com/claude-code)