### PR TITLE
feat: add agent-notify skill — cross-platform notification sound & taskbar flash

### DIFF
--- a/skills/agent-notify/LICENSE.txt
+++ b/skills/agent-notify/LICENSE.txt
@@ -1,0 +1,48 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can change it, and
+that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For the complete license text, see: https://www.gnu.org/licenses/gpl-3.0.txt
+
+  Copyright (C) 2025 Miluer-tcq
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/skills/agent-notify/SKILL.md
+++ b/skills/agent-notify/SKILL.md
@@ -1,0 +1,394 @@
+---
+name: agent-notify
+description: Cross-platform notification sound and taskbar flash for AI coding agents (Claude Code, OpenClaw, Codex, Kiro, Cursor, etc.). Plays alert sounds and visual notifications when the agent needs confirmation or completes tasks. Auto-detects the agent environment and configures hooks accordingly. Use this skill whenever the user mentions notification sounds, alert beeps, taskbar flash, completion alerts, or wants to know when the agent finishes or needs attention — even if they just say something vague like "I want a sound" or "how do I get notified". Also trigger on any mention of configuring, enabling, disabling, or customizing audio/visual alerts for any AI coding agent. Works on Windows, macOS, and Linux.
+license: Complete terms in LICENSE.txt
+---
+
+# Agent Notify Skill
+
+You are an assistant that helps users configure cross-platform notification sounds and taskbar/dock alerts for AI coding agents. When triggered, you MUST follow the instructions below precisely.
+
+## Language Detection
+
+Detect the user's language from their message. If they write in Chinese, respond in Chinese. If they write in English, respond in English. Match the user's language throughout the entire interaction.
+
+## Step 1: Offer Two Modes
+
+Present two options to the user:
+
+**English:**
+```
+🔔 Agent Notify — Setup
+
+Choose a setup mode:
+
+1️⃣  Quick Setup (recommended) — One-click install with default settings
+    • Notification on: confirmation requests + task completion
+    • Default system sounds
+    • Taskbar flash: 5 times
+
+2️⃣  Custom Setup — Choose your own settings
+    • Pick which events trigger notifications
+    • Configure custom sound files
+    • Adjust taskbar flash count
+
+Enter 1 or 2:
+```
+
+**Chinese:**
+```
+🔔 Agent Notify — 配置向导
+
+请选择配置模式：
+
+1️⃣  一键配置（推荐）— 使用默认设置快速安装
+    • 通知触发：确认请求 + 任务完成
+    • 默认系统提示音
+    • 任务栏闪烁：5 次
+
+2️⃣  自定义配置 — 自由选择设置
+    • 选择哪些事件触发通知
+    • 配置自定义提示音文件
+    • 调整任务栏闪烁次数
+
+请输入 1 或 2：
+```
+
+## Step 2A: Quick Setup
+
+If user chooses 1, proceed directly to **Step 3: Install**.
+
+Use these defaults:
+- Hooks: `Notification` (type: confirm), `Stop` (type: done)
+- Sounds: system defaults
+- Taskbar flash count: 5
+
+## Step 2B: Custom Setup
+
+If user chooses 2, walk through these options interactively:
+
+### 2B-1: Select Hook Events
+
+Present available hook events:
+
+```
+Available notification triggers:
+
+[1] ✅ Confirmation requests (Notification hook) — when Claude asks for permission
+[2] ✅ Task completion (Stop hook) — when Claude finishes responding
+[3] ❌ Error alerts — when a tool call fails
+[4] ❌ Pre-tool notification (PreToolUse) — before each tool execution
+[5] ❌ Post-tool notification (PostToolUse) — after each tool execution
+
+Enter numbers to toggle (e.g., 1,2,3), or press Enter to keep defaults:
+```
+
+### 2B-2: Custom Sounds
+
+Ask if user wants custom sound files:
+
+```
+Custom sound files (leave blank for system defaults):
+
+• Confirmation sound path: [blank = system default]
+• Completion sound path: [blank = system default]
+• Error sound path: [blank = system default]
+
+Supported formats:
+  Windows: .wav
+  macOS: .aiff, .mp3, .wav
+  Linux: .oga, .wav, .mp3
+```
+
+### 2B-3: Taskbar Flash Count
+
+```
+Taskbar flash count [default: 5]:
+```
+
+## Step 3: Install
+
+After collecting settings (default or custom), perform the installation:
+
+### 3.1 Detect OS and Agent Environment
+
+Run this command to detect the operating system:
+```bash
+uname -s 2>/dev/null || echo "Windows"
+```
+
+- If output contains `Darwin` → macOS
+- If output contains `Linux` → Linux
+- If output contains `MINGW`, `MSYS`, `CYGWIN`, or `Windows` → Windows
+
+Then detect which AI coding agent the user is running. This determines the config directory and hooks format:
+
+```bash
+# Detect agent config directory (first existing one wins)
+for dir in ~/.claude ~/.codex ~/.openclaw ~/.kiro ~/.cursor; do
+  if [ -d "$dir" ]; then echo "$dir"; break; fi
+done
+```
+
+On Windows, also check:
+```bash
+for dir in "$USERPROFILE/.claude" "$USERPROFILE/.codex" "$USERPROFILE/.openclaw"; do
+  if [ -d "$dir" ]; then echo "$dir"; break; fi
+done
+```
+
+Set `AGENT_HOME` to the detected directory (e.g., `~/.claude`). If none found, default to `~/.claude` and create it.
+
+The supported agents and their known config paths:
+| Agent | Config Dir | Settings File | Hooks Support |
+|-------|-----------|---------------|---------------|
+| Claude Code | `~/.claude` | `settings.json` | ✅ Full (Notification, Stop, PreToolUse, PostToolUse) |
+| OpenClaw | `~/.openclaw` | `settings.json` | ✅ Same hooks format as Claude Code |
+| Codex (OpenAI) | `~/.codex` | `settings.json` | ⚠️ May differ — check docs |
+| Kiro (AWS) | `~/.kiro` | `settings.json` | ⚠️ May differ — check docs |
+| Cursor | `~/.cursor` | varies | ⚠️ Different hooks system |
+
+If the detected agent is not Claude Code or OpenClaw, warn the user that hooks compatibility is not guaranteed and ask if they want to proceed. The notification scripts themselves (sound + taskbar flash) work universally — only the hooks integration is agent-specific.
+
+### 3.2 Copy Notification Script
+
+Find the skill directory by searching for this skill.md file:
+```bash
+for base in ~/.claude/skills ~/.codex/skills ~/.openclaw/skills ~/.kiro/skills ~/.cursor/skills; do
+  found=$(find "$base" -name "skill.md" -path "*/agent-notify/*" 2>/dev/null | head -1)
+  [ -n "$found" ] && echo "$(dirname "$found")" && break
+done
+```
+
+On Windows (Git Bash / MSYS2), also try:
+```bash
+for base in "$USERPROFILE/.claude/skills" "$USERPROFILE/.codex/skills" "$USERPROFILE/.openclaw/skills"; do
+  found=$(find "$base" -name "skill.md" -path "*/agent-notify/*" 2>/dev/null | head -1)
+  [ -n "$found" ] && echo "$(dirname "$found")" && break
+done
+```
+
+If the find command fails or returns nothing, ask the user where they installed the skill.
+
+Copy the script to `$AGENT_HOME/` (not hardcoded `~/.claude/`):
+
+**For Windows:**
+```bash
+cp "<skill_dir>/scripts/notify-windows.ps1" "$AGENT_HOME/notify.ps1"
+```
+
+**For macOS:**
+```bash
+cp "<skill_dir>/scripts/notify-macos.sh" "$AGENT_HOME/notify.sh"
+chmod +x "$AGENT_HOME/notify.sh"
+```
+
+**For Linux:**
+```bash
+cp "<skill_dir>/scripts/notify-linux.sh" "$AGENT_HOME/notify.sh"
+chmod +x "$AGENT_HOME/notify.sh"
+```
+
+### 3.3 Write Config
+
+Write the user's configuration to `$AGENT_HOME/notify-config.json`:
+
+Construct the config JSON from the user's chosen settings and write it. For example, with defaults:
+
+```bash
+cat > "$AGENT_HOME/notify-config.json" << 'EOF'
+{
+  "hooks": {
+    "Notification": { "enabled": true, "type": "confirm" },
+    "Stop": { "enabled": true, "type": "done" }
+  },
+  "sounds": {
+    "confirm": "",
+    "done": "",
+    "error": ""
+  },
+  "taskbar": {
+    "flashCount": 5,
+    "enabled": true
+  }
+}
+EOF
+```
+
+Substitute actual values from user's choices (sound paths, flash count, enabled hooks).
+
+### 3.4 Update Agent Settings
+
+Read the existing `$AGENT_HOME/settings.json` file, then merge the hooks configuration into it.
+
+**IMPORTANT:** Do NOT overwrite existing settings. Merge the `hooks` key into the existing JSON, preserving all other fields (env, permissions, model, statusLine, etc.).
+
+Build hook commands based on OS. Replace `$AGENT_HOME` with the actual detected path in the commands below:
+
+**Windows hooks:**
+```json
+{
+  "hooks": {
+    "Notification": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell.exe -ExecutionPolicy Bypass -File \"$AGENT_HOME/notify.ps1\" -Type confirm -ConfigPath \"$AGENT_HOME/notify-config.json\""
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell.exe -ExecutionPolicy Bypass -File \"$AGENT_HOME/notify.ps1\" -Type done -ConfigPath \"$AGENT_HOME/notify-config.json\""
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**macOS/Linux hooks:**
+```json
+{
+  "hooks": {
+    "Notification": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $AGENT_HOME/notify.sh confirm $AGENT_HOME/notify-config.json"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $AGENT_HOME/notify.sh done $AGENT_HOME/notify-config.json"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+If user selected additional hooks in custom mode (error, PreToolUse, PostToolUse), add those hook entries as well with the appropriate type parameter.
+
+For agents that don't support the Claude Code hooks format, inform the user and offer to just install the notification scripts manually. They can then integrate with their agent's own hook/event system.
+
+### 3.5 Test
+
+Run a test notification:
+
+**Windows:**
+```bash
+powershell.exe -ExecutionPolicy Bypass -File "$AGENT_HOME/notify.ps1" -Type confirm -ConfigPath "$AGENT_HOME/notify-config.json"
+```
+
+**macOS/Linux:**
+```bash
+bash "$AGENT_HOME/notify.sh" confirm "$AGENT_HOME/notify-config.json"
+```
+
+### 3.6 Report Success
+
+**English:**
+```
+✅ Agent Notify installed successfully!
+
+Agent: [detected agent name]
+Config: $AGENT_HOME/
+
+Configured notifications:
+  • 🔔 Confirmation requests → [sound type]
+  • ✅ Task completion → [sound type]
+
+Files installed:
+  • $AGENT_HOME/notify.[ps1|sh]
+  • $AGENT_HOME/notify-config.json
+  • $AGENT_HOME/settings.json (hooks added)
+
+⚠️  Please restart your agent for hooks to take effect.
+
+To uninstall, say: "disable notification" or "关闭提示音"
+To reconfigure, say: "configure notify" or "配置提示音"
+```
+
+**Chinese:**
+```
+✅ Agent Notify 安装成功！
+
+运行环境：[检测到的 agent 名称]
+配置目录：$AGENT_HOME/
+
+已配置的通知：
+  • 🔔 确认请求 → [提示音类型]
+  • ✅ 任务完成 → [提示音类型]
+
+已安装文件：
+  • $AGENT_HOME/notify.[ps1|sh]
+  • $AGENT_HOME/notify-config.json
+  • $AGENT_HOME/settings.json（已添加 hooks）
+
+⚠️  请重启你的 agent 使 hooks 生效。
+
+卸载请说："关闭提示音" 或 "disable notification"
+重新配置请说："配置提示音" 或 "configure notify"
+```
+
+## Important Notes
+
+- `$AGENT_HOME` refers to the detected agent config directory (e.g., `~/.claude`, `~/.codex`, `~/.openclaw`). Always use the actual resolved path in commands, not the variable name.
+- On Windows, `$HOME` in hook commands is expanded by the shell (Git Bash/MSYS2). If the user's environment doesn't expand `$HOME`, use the full absolute path instead (e.g., `C:/Users/username/.claude/notify.ps1`).
+- On macOS, the Dock bounce uses Python's `AppKit.NSApplication.requestUserAttention_()` which is available by default. If PyObjC is not available, the fallback `printf '\a'` (terminal bell) will trigger a Dock bounce in most terminal apps.
+- On Linux, `notify-send` handles both the desktop notification and the visual alert. If it's not installed, only the sound will play.
+- For agents other than Claude Code / OpenClaw, the hooks format may differ. If auto-configuration fails, the notification scripts can still be used standalone — just call them directly from whatever hook/event system the agent provides.
+
+## Uninstall / Disable
+
+When user triggers with disable-related keywords (`关闭提示音`, `disable notification`, etc.):
+
+1. Detect `$AGENT_HOME` using the same logic as Step 3.1
+2. Read `$AGENT_HOME/settings.json`
+3. Remove ALL hook entries that reference `notify.ps1` or `notify.sh`
+4. Write back the cleaned settings.json
+5. Remove `$AGENT_HOME/notify.ps1` or `$AGENT_HOME/notify.sh`
+6. Remove `$AGENT_HOME/notify-config.json`
+7. Confirm:
+
+**English:**
+```
+✅ Agent Notify has been uninstalled.
+
+Removed:
+  • $AGENT_HOME/notify.[ps1|sh]
+  • $AGENT_HOME/notify-config.json
+  • Notification hooks from $AGENT_HOME/settings.json
+
+⚠️  Please restart your agent for changes to take effect.
+```
+
+**Chinese:**
+```
+✅ Agent Notify 已卸载。
+
+已移除：
+  • $AGENT_HOME/notify.[ps1|sh]
+  • $AGENT_HOME/notify-config.json
+  • $AGENT_HOME/settings.json 中的通知 hooks
+
+⚠️  请重启你的 agent 使更改生效。
+```

--- a/skills/agent-notify/config/default.json
+++ b/skills/agent-notify/config/default.json
@@ -1,0 +1,23 @@
+{
+  "hooks": {
+    "Notification": {
+      "enabled": true,
+      "type": "confirm",
+      "description": "Plays sound when Claude asks for confirmation"
+    },
+    "Stop": {
+      "enabled": true,
+      "type": "done",
+      "description": "Plays sound when Claude completes a task"
+    }
+  },
+  "sounds": {
+    "confirm": "",
+    "done": "",
+    "error": ""
+  },
+  "taskbar": {
+    "flashCount": 5,
+    "enabled": true
+  }
+}

--- a/skills/agent-notify/scripts/notify-linux.sh
+++ b/skills/agent-notify/scripts/notify-linux.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Agent Notify - Linux Notification Script
+# Plays sound and shows desktop notification
+
+TYPE="${1:-default}"
+CONFIG_PATH="${2:-}"
+
+# Default values
+CUSTOM_SOUND=""
+URGENCY="normal"
+
+# Load config if provided
+if [ -n "$CONFIG_PATH" ] && [ -f "$CONFIG_PATH" ]; then
+    if command -v jq &>/dev/null; then
+        CUSTOM_SOUND=$(jq -r ".sounds.${TYPE} // empty" "$CONFIG_PATH" 2>/dev/null)
+    elif command -v python3 &>/dev/null; then
+        CUSTOM_SOUND=$(python3 -c "import json; c=json.load(open('$CONFIG_PATH')); print(c.get('sounds',{}).get('$TYPE',''))" 2>/dev/null)
+    fi
+fi
+
+# Determine notification message and sound
+case "$TYPE" in
+    confirm)
+        MSG="Waiting for your confirmation"
+        ICON="dialog-question"
+        URGENCY="critical"
+        SYSTEM_SOUND="/usr/share/sounds/freedesktop/stereo/dialog-warning.oga"
+        ;;
+    done)
+        MSG="Task completed"
+        ICON="dialog-information"
+        URGENCY="normal"
+        SYSTEM_SOUND="/usr/share/sounds/freedesktop/stereo/complete.oga"
+        ;;
+    error)
+        MSG="An error occurred"
+        ICON="dialog-error"
+        URGENCY="critical"
+        SYSTEM_SOUND="/usr/share/sounds/freedesktop/stereo/dialog-error.oga"
+        ;;
+    *)
+        MSG="Notification"
+        ICON="dialog-information"
+        URGENCY="normal"
+        SYSTEM_SOUND="/usr/share/sounds/freedesktop/stereo/message.oga"
+        ;;
+esac
+
+# Play sound
+play_sound() {
+    local sound_file="$1"
+    if [ -n "$sound_file" ] && [ -f "$sound_file" ]; then
+        if command -v paplay &>/dev/null; then
+            paplay "$sound_file" 2>/dev/null &
+        elif command -v aplay &>/dev/null; then
+            aplay "$sound_file" 2>/dev/null &
+        elif command -v pw-play &>/dev/null; then
+            pw-play "$sound_file" 2>/dev/null &
+        fi
+        return 0
+    fi
+    return 1
+}
+
+if [ -n "$CUSTOM_SOUND" ]; then
+    play_sound "$CUSTOM_SOUND" || play_sound "$SYSTEM_SOUND"
+else
+    play_sound "$SYSTEM_SOUND"
+fi
+
+# Show desktop notification
+if command -v notify-send &>/dev/null; then
+    notify-send -u "$URGENCY" -i "$ICON" "Agent Notify" "$MSG" 2>/dev/null &
+fi
+
+wait

--- a/skills/agent-notify/scripts/notify-macos.sh
+++ b/skills/agent-notify/scripts/notify-macos.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Agent Notify - macOS Notification Script
+# Plays system sound and shows notification center alert
+
+TYPE="${1:-default}"
+CONFIG_PATH="${2:-}"
+
+# Default values
+FLASH_COUNT=5
+CUSTOM_SOUND=""
+NOTIFICATION_TITLE="Agent Notify"
+
+# Load config if provided
+if [ -n "$CONFIG_PATH" ] && [ -f "$CONFIG_PATH" ]; then
+    if command -v jq &>/dev/null; then
+        FLASH_COUNT=$(jq -r '.taskbar.flashCount // 5' "$CONFIG_PATH" 2>/dev/null)
+        CUSTOM_SOUND=$(jq -r ".sounds.${TYPE} // empty" "$CONFIG_PATH" 2>/dev/null)
+    elif command -v python3 &>/dev/null; then
+        FLASH_COUNT=$(python3 -c "import json; c=json.load(open('$CONFIG_PATH')); print(c.get('taskbar',{}).get('flashCount',5))" 2>/dev/null || echo 5)
+        CUSTOM_SOUND=$(python3 -c "import json; c=json.load(open('$CONFIG_PATH')); print(c.get('sounds',{}).get('$TYPE',''))" 2>/dev/null)
+    fi
+fi
+
+# Determine notification message
+case "$TYPE" in
+    confirm)
+        MSG="Waiting for your confirmation"
+        MSG_CN="等待你的确认"
+        SOUND_NAME="Funk"
+        ;;
+    done)
+        MSG="Task completed"
+        MSG_CN="任务已完成"
+        SOUND_NAME="Glass"
+        ;;
+    error)
+        MSG="An error occurred"
+        MSG_CN="发生错误"
+        SOUND_NAME="Basso"
+        ;;
+    *)
+        MSG="Notification"
+        MSG_CN="通知"
+        SOUND_NAME="Tink"
+        ;;
+esac
+
+# Play sound
+if [ -n "$CUSTOM_SOUND" ] && [ -f "$CUSTOM_SOUND" ]; then
+    afplay "$CUSTOM_SOUND" &
+else
+    afplay "/System/Library/Sounds/${SOUND_NAME}.aiff" 2>/dev/null &
+fi
+
+# Show notification center alert (no sound name — afplay already handles audio)
+osascript -e "display notification \"${MSG}\" with title \"${NOTIFICATION_TITLE}\"" 2>/dev/null &
+
+# Bounce dock icon without stealing focus
+# Method 1: Use Python + PyObjC (available by default on macOS) for proper NSApplication bounce
+python3 -c "
+try:
+    from AppKit import NSApplication, NSInformationalRequest
+    app = NSApplication.sharedApplication()
+    app.requestUserAttention_(NSInformationalRequest)
+except:
+    pass
+" 2>/dev/null &
+
+# Method 2: Terminal bell — triggers Dock bounce on most terminal apps
+printf '\a'
+
+wait

--- a/skills/agent-notify/scripts/notify-windows.ps1
+++ b/skills/agent-notify/scripts/notify-windows.ps1
@@ -1,0 +1,94 @@
+# Agent Notify - Windows Notification Script
+# Plays system sound and flashes taskbar icon
+param(
+    [string]$Type = "default",
+    [string]$ConfigPath = ""
+)
+
+# Load config if provided
+$config = $null
+if ($ConfigPath -and (Test-Path $ConfigPath)) {
+    $config = Get-Content $ConfigPath -Raw | ConvertFrom-Json
+}
+
+# Get flash count from config or use default
+$flashCount = 5
+if ($config -and $config.taskbar -and $null -ne $config.taskbar.flashCount) {
+    $flashCount = [int]$config.taskbar.flashCount
+}
+
+# Get custom sound path from config
+$customSound = $null
+if ($config -and $config.sounds -and $config.sounds.$Type) {
+    $customSound = $config.sounds.$Type
+}
+
+# Add FlashWindow API
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+
+public class FlashWindow {
+    [StructLayout(LayoutKind.Sequential)]
+    public struct FLASHWINFO {
+        public UInt32 cbSize;
+        public IntPtr hwnd;
+        public UInt32 dwFlags;
+        public UInt32 uCount;
+        public UInt32 dwTimeout;
+    }
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool FlashWindowEx(ref FLASHWINFO pwfi);
+
+    [DllImport("user32.dll")]
+    public static extern IntPtr GetForegroundWindow();
+
+    public const UInt32 FLASHW_ALL = 3;
+    public const UInt32 FLASHW_TIMERNOFG = 12;
+
+    public static void Flash(IntPtr hwnd, UInt32 count) {
+        FLASHWINFO fw = new FLASHWINFO();
+        fw.cbSize = Convert.ToUInt32(Marshal.SizeOf(fw));
+        fw.hwnd = hwnd;
+        fw.dwFlags = FLASHW_ALL | FLASHW_TIMERNOFG;
+        fw.uCount = count;
+        fw.dwTimeout = 0;
+        FlashWindowEx(ref fw);
+    }
+}
+"@ -ErrorAction SilentlyContinue
+
+# Play sound
+if ($customSound -and (Test-Path $customSound)) {
+    # Play custom sound file
+    $player = New-Object System.Media.SoundPlayer
+    $player.SoundLocation = $customSound
+    $player.Play()
+} else {
+    # Play system sound based on type
+    switch ($Type) {
+        "confirm" {
+            [System.Media.SystemSounds]::Exclamation.Play()
+        }
+        "done" {
+            [System.Media.SystemSounds]::Asterisk.Play()
+        }
+        "error" {
+            [System.Media.SystemSounds]::Hand.Play()
+        }
+        default {
+            [System.Media.SystemSounds]::Beep.Play()
+        }
+    }
+}
+
+# Flash taskbar for terminal windows
+$terminalProcesses = @('WindowsTerminal', 'cmd', 'powershell', 'pwsh', 'Code', 'claude')
+$procs = Get-Process | Where-Object {
+    $_.MainWindowHandle -ne 0 -and ($terminalProcesses -contains $_.ProcessName)
+}
+foreach ($proc in $procs) {
+    [FlashWindow]::Flash($proc.MainWindowHandle, $flashCount)
+}


### PR DESCRIPTION
## Summary

Add `agent-notify` — a cross-platform notification sound & taskbar flash skill for AI coding agents.

## What it does

When the agent needs confirmation or completes a task, this skill configures hooks to:
- Play a system sound (or custom audio file)
- Flash the taskbar icon (Windows) / bounce Dock icon (macOS) / show desktop notification (Linux)

## Why it's useful

Users frequently switch to other windows while waiting for the agent. Without notifications, they keep checking back manually. This skill solves that pain point with a one-command setup wizard.

## Features

- Auto-detects OS (Windows/macOS/Linux) and agent environment (Claude Code, OpenClaw, Codex, Kiro, Cursor)
- Quick setup (one-click) and custom setup (interactive) modes
- Configurable custom sound files and taskbar flash count
- Bilingual (English + Chinese) interaction
- Uninstall command included

## Skill structure

```
skills/agent-notify/
├── SKILL.md
├── LICENSE.txt
├── scripts/
│   ├── notify-windows.ps1
│   ├── notify-macos.sh
│   └── notify-linux.sh
└── config/
    └── default.json
```

## Testing

Tested on Windows 11 with Claude Code. Sound plays and taskbar flashes correctly on Notification and Stop hooks.

## Author

**Miluer-tcq** — [GitHub](https://github.com/Miluer-tcq)
Repository: https://github.com/Miluer-tcq/agent-notify