### PR TITLE
feat: add APIClaw Amazon seller data analysis skill

### DIFF
--- a/skills/apiclaw-analysis/SKILL.md
+++ b/skills/apiclaw-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: apiclaw-analysis
-version: 1.1.4
+version: 1.1.5
 description: >
   Finds winning Amazon products with 14 battle-tested selection strategies
   & 6-dimension risk assessment. Backed by 200M+ product database.

--- a/skills/apiclaw-analysis/SKILL.md
+++ b/skills/apiclaw-analysis/SKILL.md
@@ -1,0 +1,417 @@
+---
+name: apiclaw-analysis
+version: 1.1.4
+description: >
+  Finds winning Amazon products with 14 battle-tested selection strategies
+  & 6-dimension risk assessment. Backed by 200M+ product database.
+  Use when user asks about: product selection, finding products to sell, ASIN lookup,
+  BSR analysis, competitor lookup, market opportunity, risk assessment, category research,
+  pricing strategy, review analysis, listing optimization, or any Amazon seller data needs.
+  Powered by APIClaw API (requires APICLAW_API_KEY).
+author: SerendipityOneInc
+homepage: https://github.com/SerendipityOneInc/Amazon-analysis-skill
+metadata: {"openclaw": {"requires": {"env": ["APICLAW_API_KEY"]}, "primaryEnv": "APICLAW_API_KEY"}}
+---
+
+# APIClaw — Amazon Seller Data Analysis
+
+> AI-powered Amazon product research. From market discovery to daily operations.
+>
+> **Language rule**: Always respond in the user's language. If the user asks in Chinese, reply in Chinese. If in English, reply in English. The language of this skill document does not affect output language.
+> All API calls go through `scripts/apiclaw.py` — one script, 5 endpoints, built-in error handling.
+
+## Credentials
+
+- Required: `APICLAW_API_KEY`
+- Scope: used only for `https://api.apiclaw.io`
+- Resolution order:
+  1. **Environment variable** `APICLAW_API_KEY` (preferred, most secure)
+  2. **Config file** `config.json` in the skill root directory (fallback)
+
+```json
+{ "api_key": "hms_live_xxxxxx" }
+```
+
+When user provides a Key, write it to `config.json`. New keys may need 3-5 seconds to activate — if first call returns 403, wait 3 seconds and retry (max 2 retries).
+
+## File Map
+
+| File | When to Load |
+|------|-------------|
+| `SKILL.md` (this file) | Start here — covers 80% of tasks |
+| `scripts/apiclaw.py` | **Execute** for all API calls (do NOT read into context) |
+| `references/reference.md` | Need exact field names or filter parameter details |
+| `references/scenarios-composite.md` | Comprehensive recommendations (2.10) or Chinese seller cases (3.4) |
+| `references/scenarios-eval.md` | Product evaluation, risk assessment, review analysis (4.x) |
+| `references/scenarios-pricing.md` | Pricing strategy, profit estimation, listing reference (5.x) |
+| `references/scenarios-ops.md` | Market monitoring, competitor tracking, anomaly alerts (6.x) |
+| `references/scenarios-expand.md` | Product expansion, trends, discontinuation decisions (7.x) |
+| `references/scenarios-listing.md` | Listing writing, optimization, content creation (8.x) |
+
+**Don't guess field names** — if uncertain, load `reference.md` first.
+
+---
+
+## Execution Mode
+
+| Task Type | Mode | Behavior |
+|-----------|------|----------|
+| Single ASIN lookup, simple data query | **Quick** | Execute command, return key data. Skip evaluation criteria and output standard block. |
+| Market analysis, product selection, competitor comparison, risk assessment | **Full** | Complete flow: command → analysis → evaluation criteria → output standard block. |
+
+**Quick mode trigger:** User asks for a single specific data point ("B09XXX monthly sales?", "how many brands in cat litter?") — no decision analysis needed.
+
+---
+
+## Execution Standards
+
+**Prioritize script execution for API calls.** The script includes:
+- Parameter format conversion (e.g. topN auto-converted to string)
+- Retry logic (429/timeout auto-retry)
+- Standardized error messages
+- `_query` metadata injection (for query traceability)
+
+**Fallback:** If script fails and can't be quickly fixed, use curl directly. Note "using curl direct call" in output.
+
+---
+
+## Realtime Data Supplementation
+
+When `products` or `competitors` returns ASINs in Full-mode analysis, **automatically call `product --asin` for the top 3-5 most relevant ASINs** to get current real-time data.
+
+| Scenario | Supplement? | How many ASINs |
+|----------|-------------|----------------|
+| Single ASIN lookup (Quick mode) | Already using realtime | — |
+| Market overview (no specific ASINs) | ❌ No | — |
+| Product selection / competitor analysis | ✅ Yes | Top 3 by sales |
+| Risk assessment | ✅ Yes | Target ASIN + top 2 competitors |
+| Multi-product comparison | ✅ Yes | All compared ASINs (max 5) |
+| Listing analysis | Already using realtime | — |
+
+**Handling data conflicts** — `products`/`competitors` has ~T+1 delay; `realtime/product` is live:
+
+| Field | Use from | Reason |
+|-------|----------|--------|
+| Price | **realtime** (`buyboxWinner.price`) | Changes frequently |
+| BSR | **realtime** (`bestsellersRank`) | Updates hourly |
+| Rating / ratingCount | **realtime** | More current |
+| Monthly Sales | **products/competitors** | Realtime doesn't have this |
+| Profit Margin / FBA Fee | **products/competitors** | Realtime doesn't have this |
+
+When realtime data differs significantly, note it: e.g. "⚡ Price updated: database $29.99 → realtime $24.99 (likely promotion)"
+
+---
+
+## Script Usage
+
+All commands output JSON. Progress messages go to stderr.
+
+### categories — Category tree lookup
+
+```bash
+python3 scripts/apiclaw.py categories --keyword "pet supplies"
+python3 scripts/apiclaw.py categories --parent "Pet Supplies"
+```
+
+Common fields: `categoryName` (not `name`), `categoryPath`, `productCount`, `hasChildren`
+
+### market — Market-level aggregate data
+
+```bash
+python3 scripts/apiclaw.py market --category "Pet Supplies,Dogs" --topn 10
+```
+
+Key output fields: `sampleAvgMonthlySales`, `sampleAvgPrice`, `topSalesRate` (concentration), `topBrandSalesRate`, `sampleNewSkuRate`, `sampleFbaRate`, `sampleBrandCount`
+
+### products — Product selection with filters
+
+```bash
+# Preset mode (14 built-in)
+python3 scripts/apiclaw.py products --keyword "yoga mat" --mode beginner
+
+# Explicit filters
+python3 scripts/apiclaw.py products --keyword "yoga mat" --sales-min 300 --reviews-max 50
+
+# Mode + overrides (overrides win)
+python3 scripts/apiclaw.py products --keyword "yoga mat" --mode beginner --price-max 30
+```
+
+Available modes: `fast-movers`, `emerging`, `single-variant`, `high-demand-low-barrier`, `long-tail`, `underserved`, `new-release`, `fbm-friendly`, `low-price`, `broad-catalog`, `selective-catalog`, `speculative`, `beginner`, `top-bsr`
+
+**Keyword matching:** Default is `fuzzy` (matches brand names too — e.g. "smart ring" matches "Smart Color Art" pens). Use `--keyword-match-type exact` or `phrase` for precise results. Always combine with `--category` when possible to reduce noise.
+
+**Category path with commas:** Some category names contain commas (e.g. "Pacifiers, Teethers & Teething Relief"). Use ` > ` separator instead of `,` to avoid parsing errors:
+```bash
+# ❌ Wrong — comma in name breaks parsing
+--category "Baby Products,Baby Care,Pacifiers, Teethers & Teething Relief"
+# ✅ Correct — use ' > ' separator
+--category "Baby Products > Baby Care > Pacifiers, Teethers & Teething Relief"
+```
+
+### competitors — Competitor lookup
+
+```bash
+python3 scripts/apiclaw.py competitors --keyword "wireless earbuds"
+python3 scripts/apiclaw.py competitors --asin B09V3KXJPB
+```
+
+**Easily confused fields (products/competitors shared)**:
+
+| ❌ Wrong | ✅ Correct | Note |
+|----------|-----------|------|
+| `reviewCount` | `ratingCount` | Review count |
+| `bsr` | `bsrRank` | BSR ranking (integer, only in products/competitors) |
+| `monthlySales` / `salesMonthly` | `atLeastMonthlySales` | Monthly sales (lower bound estimate, NOT in realtime/product) |
+| `bestsellersRank` | `bsrRank` | `bestsellersRank` is realtime/product only (array format); use `bsrRank` for products/competitors |
+| `price` (in realtime) | `buyboxWinner.price` | realtime/product nests price inside buyboxWinner object |
+| `profitMargin` (in realtime) | ❌ N/A | realtime/product does NOT return profitMargin; use products/competitors |
+
+> Complete field list: `reference.md` → Shared Product Object
+
+### product — Single ASIN real-time detail
+
+```bash
+python3 scripts/apiclaw.py product --asin B09V3KXJPB
+```
+
+Returns: title, brand, rating, ratingBreakdown, features, topReviews, specifications, variants, bestsellersRank, buyboxWinner
+
+### analyze — Review analysis (sentiment + consumer insights)
+
+```bash
+# Single ASIN
+python3 scripts/apiclaw.py analyze --asin B09V3KXJPB
+
+# Multiple ASINs (competitive review comparison)
+python3 scripts/apiclaw.py analyze --asins B09V3KXJPB,B08YYYYY,B07ZZZZZ
+
+# Category-level insights
+python3 scripts/apiclaw.py analyze --category "Pet Supplies,Dogs,Toys" --period 90d
+
+# Specific insight dimension
+python3 scripts/apiclaw.py analyze --asin B09V3KXJPB --label-type painPoints,buyingFactors
+```
+
+Returns: `totalReviews`, `avgRating`, `sentimentDistribution`, `ratingDistribution`, `consumerInsights` (by labelType), `topKeywords`, `verifiedRatio`
+
+Available labelType: `scenarios`, `issues`, `positives`, `improvements`, `buyingFactors`, `painPoints`, `keywords`, `userProfiles`, `usageTimes`, `usageLocations`, `behaviors`
+
+### report — Full market analysis (composite)
+
+```bash
+python3 scripts/apiclaw.py report --keyword "pet supplies"
+```
+
+Runs: categories → market → products (top 50) → realtime detail (top 1).
+
+### opportunity — Product opportunity discovery (composite)
+
+```bash
+python3 scripts/apiclaw.py opportunity --keyword "pet supplies" --mode fast-movers
+```
+
+Runs: categories → market → products (filtered) → realtime detail (top 3).
+
+---
+
+## ⚠️ Interface Data Differences
+
+The 4 types of interfaces return **different fields**. Do NOT assume they share the same structure.
+
+| Data | `market` | `products`/`competitors` | `realtime/product` | `reviews/analyze` |
+|------|----------|--------------------------|--------------------|--------------------|
+| Monthly Sales | `sampleAvgMonthlySales` | ✅ `atLeastMonthlySales` | ❌ | ❌ |
+| Revenue | `sampleAvgMonthlyRevenue` | `salesRevenue` | ❌ | ❌ |
+| Price | `sampleAvgPrice` | `price` | `buyboxWinner.price` | ❌ |
+| BSR | `sampleAvgBsr` | `bsrRank` (integer) | `bestsellersRank` (array) | ❌ |
+| Rating | `sampleAvgRating` | `rating` | `rating` | `avgRating` |
+| Review Count | `sampleAvgReviewCount` | `ratingCount` | `ratingCount` | `totalReviews` |
+| Review Details | ❌ | ❌ | ✅ `topReviews` + `ratingBreakdown` | ❌ (no raw reviews) |
+| Sentiment Analysis | ❌ | ❌ | ❌ | ✅ `sentimentDistribution` |
+| Consumer Insights | ❌ | ❌ | ❌ | ✅ `consumerInsights` (11 dimensions) |
+| Pain Points/Issues | ❌ | ❌ | ❌ (manual from topReviews) | ✅ AI-analyzed |
+| Top Keywords | ❌ | ❌ | ❌ | ✅ `topKeywords` |
+| Seller | ❌ | `buyboxSeller` (string) | `buyboxWinner` (object) | ❌ |
+| Profit Margin | ❌ | `profitMargin` | ❌ | ❌ |
+| FBA Fee | ❌ | `fbaFee` | ❌ | ❌ |
+| Seller Count | ❌ | `sellerCount` | ❌ | ❌ |
+| Features/Bullets | ❌ | ❌ | ✅ `features` | ❌ |
+| Variants | ❌ | `variantCount` (integer) | `variants` (full list) | ❌ |
+
+**Usage rule:**
+- Use `products` / `competitors` for **sales, pricing, and competition data**
+- Use `realtime/product` for **review details, listing content, and seller info**
+- Use `market` for **category-level aggregate metrics**
+- Use `reviews/analyze` for **AI-powered review insights** (sentiment, pain points, buying factors — covers all reviews, not just topReviews)
+- For reports: combine `products`/`competitors` (quantitative) + `realtime/product` (qualitative) + `reviews/analyze` (consumer insights) as evidence
+
+## Data Structure Reminder
+
+All interfaces return `.data` as an **array**. Use `.data[0]` to get the first record, NOT `.data.fieldName`.
+
+---
+
+## Intent Routing
+
+| User Says | Run This | Scenario File? |
+|-----------|----------|----------------|
+| "which category has opportunity" | `market` + `categories` | No |
+| "check B09XXX" / "analyze ASIN" | `product --asin XXX` | No |
+| "Chinese seller cases" | `competitors --keyword XXX --page-size 50` | `scenarios-composite.md` → 3.4 |
+| "pain points" / "negative reviews" / "consumer insights" | `analyze --asin XXX` + `product --asin XXX` | `scenarios-eval.md` → 4.2 |
+| "category pain points" / "category user portrait" | `analyze --category XXX` | `scenarios-eval.md` → 4.6 |
+| "compare products" | `competitors` or multiple `product` | `scenarios-eval.md` → 4.3 |
+| "risk assessment" / "can I do this" | `product` + `market` + `competitors` | `scenarios-eval.md` → 4.4 |
+| "monthly sales" / "estimate sales" | `competitors --asin XXX` | `scenarios-eval.md` → 4.5 |
+| "help me select products" / "find products" | `products --mode XXX` (see mode table) | No |
+| "comprehensive recommendations" / "what should I sell" | `products` (multi-mode) + `market` | `scenarios-composite.md` → 2.10 |
+| "pricing strategy" / "how much to price" | `market` + `products` | `scenarios-pricing.md` → 5.1 |
+| "profit estimation" | `competitors` | `scenarios-pricing.md` → 5.2 |
+| "listing reference" | `product --asin XXX` | `scenarios-pricing.md` → 5.3 |
+| "market changes" / "recent changes" | `market` + `products` | `scenarios-ops.md` → 6.1 |
+| "competitor updates" | `competitors --brand XXX` | `scenarios-ops.md` → 6.2 |
+| "anomaly alerts" | `market` + `products` | `scenarios-ops.md` → 6.4 |
+| "what else can I sell" / "related products" | `categories` + `market` | `scenarios-expand.md` → 7.1 |
+| "trends" | `products --growth-min 0.2` | `scenarios-expand.md` → 7.3 |
+| "should I delist" | `competitors --asin XXX` + `market` | `scenarios-expand.md` → 7.4 |
+| "write listing" / "generate bullet points" / "write title" | `product --asin XXX` (competitors) | `scenarios-listing.md` → 8.2 |
+| "analyze competitor listing" / "their selling points" | `product --asin XXX` (multiple) | `scenarios-listing.md` → 8.1 |
+| "optimize my listing" / "listing diagnosis" | `product --asin XXX` + `competitors` | `scenarios-listing.md` → 8.3 |
+| Need exact filters or field names | — | Load `reference.md` |
+
+**Product Selection Mode Mapping (14 types)**:
+
+| User Intent | Mode | Key Filters |
+|-------------|------|-------------|
+| "beginner friendly" / "new seller" | `--mode beginner` | Sales≥300, growth≥3%, $15-60, FBA, ≤1yr, auto-excludes 150+ red ocean keywords |
+| "fast turnover" / "hot selling" | `--mode fast-movers` | Sales≥300, growth≥10% |
+| "emerging" / "rising" | `--mode emerging` | Sales≤600, growth≥10%, ≤180d |
+| "single variant" / "small but beautiful" | `--mode single-variant` | Growth≥20%, variants=1, ≤180d |
+| "high demand low barrier" / "easy entry" | `--mode high-demand-low-barrier` | Sales≥300, reviews≤50, ≤180d |
+| "long tail" / "niche" | `--mode long-tail` | Sales≤300, BSR 10K-50K, ≤$30, sellers≤1 |
+| "underserved" / "has pain points" | `--mode underserved` | Sales≥300, rating≤3.7, ≤180d |
+| "new products" / "new release" | `--mode new-release` | Sales≤500, NR tag, FBA+FBM |
+| "FBM" / "self-fulfillment" / "low stock" | `--mode fbm-friendly` | Sales≥300, FBM, ≤180d |
+| "low price" / "cheap" | `--mode low-price` | ≤$10 |
+| "broad catalog" / "cast wide net" | `--mode broad-catalog` | BSR growth≥99%, reviews≤10, ≤90d |
+| "selective catalog" | `--mode selective-catalog` | BSR growth≥99%, ≤90d |
+| "speculative" / "piggyback" | `--mode speculative` | Sales≥600, sellers≥3, ≤180d |
+| "top sellers" / "best sellers" | `--mode top-bsr` | Sub-category BSR≤1000 |
+
+---
+
+## Quick Evaluation Criteria
+
+### Market Viability (from `market` output)
+
+| Metric | Good | Medium | Warning |
+|--------|------|--------|---------|
+| Market value (avgRevenue × skuCount) | > $10M | $5–10M | < $5M |
+| Concentration (topSalesRate, topN=10) | < 40% | 40–60% | > 60% |
+| New SKU rate (sampleNewSkuRate) | > 15% | 5–15% | < 5% |
+| FBA rate (sampleFbaRate) | > 50% | 30–50% | < 30% |
+| Brand count (sampleBrandCount) | > 50 | 20–50 | < 20 |
+
+### Product Potential (from `product` output)
+
+| Metric | High | Medium | Low |
+|--------|------|--------|-----|
+| BSR | Top 1000 | 1000–5000 | > 5000 |
+| Reviews | < 200 | 200–1000 | > 1000 |
+| Rating | > 4.3 | 4.0–4.3 | < 4.0 |
+| Negative reviews (1-2★ %) | < 10% | 10–20% | > 20% |
+
+### Sales Estimation Fallback
+
+When `atLeastMonthlySales` is null: **Monthly sales ≈ 300,000 / BSR^0.65**
+
+---
+
+## Output Standards (Full Mode Only)
+
+**MUST include data source block after every Full-mode analysis:**
+
+```markdown
+---
+**Data Source & Conditions**
+| Item | Value |
+|----|-----|
+| Data Source | APIClaw API |
+| Interface | [interfaces used] |
+| Category | [category path] |
+| Time Range | [dateRange] |
+| Sampling | [sampleType] |
+| Top N | [topN value] |
+| Sort | [sortBy + sortOrder] |
+| Filters | [specific parameter values] |
+
+**Data Notes**
+- Monthly sales are **lower bound estimates** (Amazon displays "10,000+ bought"), actual may be higher
+- Database data has ~T+1 delay; realtime/product is current real-time data
+- Concentration metrics based on Top N sample; different topN → different results
+```
+
+**Rules**:
+1. Every Full-mode analysis MUST end with this block
+2. Filter conditions MUST list specific parameter values
+3. If multiple interfaces used, list each one
+4. If data has limitations, proactively explain
+
+### API Usage Summary (All Modes)
+
+Every response (Quick or Full mode) MUST end with an API usage summary:
+
+```markdown
+**API Usage**
+| Interface | Calls |
+|-----------|-------|
+| categories | 1 |
+| markets/search | 1 |
+| products/search | 2 |
+| realtime/product | 3 |
+| **Total** | **7** |
+| **Credits consumed** | **7** |
+| **Credits remaining** | **493** |
+```
+
+**Tracking rules:**
+1. Count each `apiclaw.py` execution as 1 call to the corresponding interface
+2. Sum `_credits.consumed` from every API response for total consumed
+3. Use `_credits.remaining` from the **last** API response as remaining balance
+4. If `_credits` fields are null, show "N/A"
+
+---
+
+## Limitations
+
+### What This Skill Cannot Do
+
+- Keyword research / reverse ASIN / ABA data
+- Traffic source analysis
+- Historical sales trends (14-month curves)
+- Historical price / BSR charts
+- Raw individual review text export (use `realtime/product` topReviews for specific review quotes)
+
+### API Coverage Boundaries
+
+| Scenario | Coverage | Suggestion |
+|----------|----------|------------|
+| Market data: Popular keywords | ✅ Has data | Use `--keyword` directly |
+| Market data: Niche/long-tail keywords | ⚠️ May be empty | Use `--category` instead |
+| Product data: Active ASIN | ✅ Has data | — |
+| Product data: Delisted/variant ASIN | ❌ No data | Try parent ASIN or realtime |
+| Real-time data: US site | ✅ Full support | — |
+| Real-time data: Non-US sites | ⚠️ Partial | Core fields OK, sales may be null |
+
+---
+
+## Error Handling
+
+HTTP errors (401/402/403/404/429) are handled by the script with structured JSON output.
+Self-check: `python3 scripts/apiclaw.py check`
+
+| Error | Fix |
+|-------|-----|
+| `Cannot index array with string` | Use `.data[0].fieldName` (`.data` is array) |
+| Empty `data: []` | Use `categories` to confirm category exists |
+| `atLeastMonthlySales: null` | BSR estimate: 300,000 / BSR^0.65 |

--- a/skills/apiclaw-analysis/SKILL.md
+++ b/skills/apiclaw-analysis/SKILL.md
@@ -63,6 +63,23 @@ When user provides a Key, write it to `config.json`. New keys may need 3-5 secon
 
 ---
 
+## ⚠️ Pre-Execution Checklist (MANDATORY for Full Mode)
+
+Before running any Full-mode product selection or market analysis, **complete this checklist**:
+
+- [ ] **Step 1 — Mode Selection:** Check the Product Selection Mode Mapping table below. If ANY of the 14 preset modes matches the user's intent, **USE IT** (`--mode xxx`). Do NOT manually piece together filters when a preset mode exists. Common mappings:
+  - Small/lightweight/cheap products → `--mode low-price`
+  - New seller / beginner → `--mode beginner`
+  - Niche / long-tail → `--mode long-tail`
+  - Trending / rising → `--mode emerging`
+- [ ] **Step 2 — Realtime Supplement:** Plan to call `product --asin` for the top 3-5 ASINs from results (see Realtime Data Supplementation below).
+- [ ] **Step 3 — Review Analysis:** Plan to call `analyze --asins` for top ASINs to get consumer insights (especially painPoints, improvements, buyingFactors).
+- [ ] **Step 4 — Output Blocks:** Prepare to include both `📋 Data Source & Conditions` and `📊 API Usage` at the end.
+
+> **Why this exists:** In testing, AI agents repeatedly skipped preset modes, realtime supplements, and review analysis — even though the instructions below clearly describe them. This checklist forces a pause-and-verify before execution.
+
+---
+
 ## Execution Standards
 
 **Prioritize script execution for API calls.** The script includes:
@@ -327,13 +344,15 @@ When `atLeastMonthlySales` is null: **Monthly sales ≈ 300,000 / BSR^0.65**
 
 ---
 
-## Output Standards (Full Mode Only)
+## ⚠️ Output Standards (Full Mode — MANDATORY, DO NOT SKIP)
 
-**MUST include data source block after every Full-mode analysis:**
+> **Two blocks are REQUIRED at the end of every Full-mode analysis: ① Data Source & Conditions, ② API Usage. Missing either one = violating the skill contract.**
+
+### ① Data Source & Conditions (Full Mode Only)
 
 ```markdown
 ---
-**Data Source & Conditions**
+📋 **Data Source & Conditions**
 | Item | Value |
 |----|-----|
 | Data Source | APIClaw API |
@@ -356,22 +375,24 @@ When `atLeastMonthlySales` is null: **Monthly sales ≈ 300,000 / BSR^0.65**
 2. Filter conditions MUST list specific parameter values
 3. If multiple interfaces used, list each one
 4. If data has limitations, proactively explain
+5. ⚠️ **Self-check:** scan your response — if you don't see `📋 **Data Source & Conditions**`, ADD IT before replying
 
-### API Usage Summary (All Modes)
+### ⚠️ API Usage Summary (All Modes — MANDATORY, DO NOT SKIP)
 
-Every response (Quick or Full mode) MUST end with an API usage summary:
+> **This block is NON-NEGOTIABLE.** Every single response — Quick or Full mode — MUST end with this table. No exceptions. If you forget, you are violating the skill contract.
 
 ```markdown
-**API Usage**
+📊 **API Usage**
 | Interface | Calls |
 |-----------|-------|
 | categories | 1 |
 | markets/search | 1 |
 | products/search | 2 |
 | realtime/product | 3 |
-| **Total** | **7** |
-| **Credits consumed** | **7** |
-| **Credits remaining** | **493** |
+| reviews/analyze | 1 |
+| **Total** | **8** |
+| **Credits consumed** | **8** |
+| **Credits remaining** | **492** |
 ```
 
 **Tracking rules:**
@@ -379,6 +400,7 @@ Every response (Quick or Full mode) MUST end with an API usage summary:
 2. Sum `_credits.consumed` from every API response for total consumed
 3. Use `_credits.remaining` from the **last** API response as remaining balance
 4. If `_credits` fields are null, show "N/A"
+5. ⚠️ **Self-check before sending:** scan your response — if you don't see `📊 **API Usage**` at the bottom, ADD IT before replying
 
 ---
 

--- a/skills/apiclaw-analysis/references/reference.md
+++ b/skills/apiclaw-analysis/references/reference.md
@@ -1,0 +1,357 @@
+# APIClaw API Reference
+
+> Load this file only when you need exact field names, filter parameters, or response structure details.
+> For most tasks, the SKILL.md quick reference is sufficient.
+>
+> **OpenAPI Spec (live)**: https://apiclaw.io/api/v1/openapi-spec
+
+---
+
+## Endpoints
+
+| # | Endpoint | Purpose |
+|---|----------|---------|
+| 1 | `categories` | Category tree lookup |
+| 2 | `markets/search` | Market-level aggregate metrics |
+| 3 | `products/competitor-lookup` | Competitor discovery |
+| 4 | `products/search` | Product selection with filters |
+| 5 | `realtime/product` | Live single-ASIN detail |
+| 6 | `reviews/analyze` | AI review analysis (sentiment + insights) |
+
+Base URL: `https://api.apiclaw.io/openapi/v2`
+Auth: `Bearer $APICLAW_API_KEY`
+Method: All POST with JSON body
+
+---
+
+## 1. categories
+
+Query modes (mutually exclusive):
+- No params → root categories
+- `categoryKeyword` → keyword search
+- `categoryPath` → exact path lookup
+- `parentCategoryPath` → child categories
+
+Response fields: `categoryId`, `categoryName`, `categoryPath`, `hasChildren`, `isRoot`, `level`, `productCount`, `link`
+
+---
+
+## 2. markets/search
+
+### Core parameters
+
+| Parameter | Type | Note |
+|-----------|------|------|
+| categoryPath | List\<String\> | e.g. `["Pet Supplies", "Dogs"]` |
+| categoryKeyword | String | keyword match across all levels |
+| topN | **String** | `"3"` / `"5"` / `"10"` / `"20"` — must be string, not integer |
+| newProductPeriod | **String** | `"1"` / `"3"` / `"6"` / `"12"` — must be string |
+| sampleType | String | `by_sale_100` / `by_bsr_100` / `avg` |
+| dateRange | String | default `30d` |
+| pageSize | Integer | default 20 |
+| sortBy | String | default `sampleAvgMonthlySaleAmt` |
+| sortOrder | String | `asc` / `desc` |
+
+### Filter parameters (all Min/Max pairs, optional)
+
+| Filter pair | Meaning |
+|-------------|---------|
+| sampleAvgMonthlySalesMin/Max | Avg monthly unit sales |
+| sampleAvgMonthlyRevenueMin/Max | Avg monthly revenue |
+| sampleAvgPriceMin/Max | Avg price |
+| sampleAvgBsrMin/Max | Avg BSR |
+| sampleAvgRatingMin/Max | Avg rating |
+| sampleAvgReviewCountMin/Max | Avg review count |
+| sampleAvgGrossMarginMin/Max | Avg gross margin |
+| totalSkuCountMin/Max | Total SKU count |
+| sampleSkuCountMin/Max | Sample SKU count |
+| topAvgMonthlySalesMin/Max | Top N avg monthly sales |
+| topAvgMonthlyRevenueMin/Max | Top N avg monthly revenue |
+| topSalesRateMin/Max | Product concentration (Top N sales / total) |
+| topBrandSalesRateMin/Max | Brand concentration |
+| topSellerSalesRateMin/Max | Seller concentration |
+| sampleBrandCountMin/Max | Brand count |
+| sampleSellerCountMin/Max | Seller count |
+| sampleFbaRateMin/Max | FBA rate |
+| sampleAmzRateMin/Max | Amazon direct rate |
+| sampleNewSkuCountMin/Max | New SKU count |
+| sampleNewSkuRateMin/Max | New SKU rate |
+
+### Key response fields
+
+| Field | Meaning |
+|-------|---------|
+| categories | Category path array |
+| totalSkuCount | Active SKUs in category |
+| sampleAvgPrice | Average price (USD) |
+| sampleAvgMonthlySales | Average monthly units per product |
+| sampleAvgMonthlyRevenue | Average monthly revenue per product |
+| sampleAvgRating | Average rating |
+| sampleAvgReviewCount | Average reviews |
+| sampleBrandCount | Number of brands |
+| sampleSellerCount | Number of sellers |
+| sampleFbaRate | FBA ratio (decimal) |
+| sampleNewSkuRate | New product ratio |
+| **topSalesRate** | **Product concentration** — Top N share of total sales |
+| **topBrandSalesRate** | **Brand concentration** — Top N brands' share |
+| **topSellerSalesRate** | **Seller concentration** — Top N sellers' share |
+
+### sortBy values
+
+`totalSkuCnt`, `sampleSkuCnt`, `sampleAvgPrice`, `sampleAvgMonthlySaleCnt`, `sampleAvgMonthlySaleAmt`, `sampleAvgBigCategoryBsr`, `sampleAvgRatingAmt`, `sampleAvgRatingCnt`, `sampleAvgGrossMarginRate`, `sampleBrandCnt`, `sampleSellerCnt`, `sampleFbaSkuRate`, `sampleNewSkuRate`, `topAvgMonthlySaleCnt`, `topAvgMonthlySaleAmt`, `topSaleCntRate`, `topBrandSaleCntRate`, `topSellerSaleCntRate`
+
+---
+
+## 3. products/competitor-lookup
+
+| Parameter | Type | Note |
+|-----------|------|------|
+| keyword | String | Search keyword |
+| brand | String | Brand filter |
+| seller | String | Seller filter |
+| asin | String | ASIN filter |
+| categoryPath | List\<String\> | Category filter |
+| sortBy | String | `atLeastMonthlySales` / `atLeastMonthlyRevenue` / `bsr` / `price` / `rating` / `reviewCount` / `listingDate` |
+| sortOrder | String | `asc` / `desc` |
+| pageSize | Integer | default 20 |
+
+Response: List of Product objects (see shared fields below).
+
+---
+
+## 4. products/search
+
+### Core parameters
+
+Same as competitor-lookup plus:
+
+| Parameter | Type | Note |
+|-----------|------|------|
+| mode | String | Search mode |
+| onlyCategoryRank | Boolean | Category-only ranking |
+| keywordMatchType | String | `fuzzy` / `phrase` / `exact` |
+
+### Filter parameters (all Min/Max pairs, optional)
+
+| Filter pair | Meaning |
+|-------------|---------|
+| monthlySalesMin/Max | Monthly unit sales |
+| revenueMin/Max | Monthly revenue |
+| childSalesMin/Max | Child ASIN sales |
+| salesGrowthRateMin/Max | Sales growth rate |
+| bsrMin/Max | BSR range |
+| subBsrMin/Max | Sub-category BSR |
+| bsrGrowthRateMin/Max | BSR growth rate |
+| priceMin/Max | Price range |
+| ratingMin/Max | Rating range |
+| reviewCountMin/Max | Review count range |
+| fbaShippingMin/Max | FBA shipping cost |
+| variantCountMin/Max | Variant count |
+| qaCountMin/Max | Q&A count |
+| monthlyNewReviewsMin/Max | Monthly new reviews |
+| reviewRateMin/Max | Review rate |
+| grossMarginMin/Max | Gross margin |
+| lqsMin/Max | Listing quality score |
+| sellerCountMin/Max | Seller count |
+
+### Additional filters
+
+| Parameter | Type | Note |
+|-----------|------|------|
+| listingAge | **String** | Max listing age in days |
+| includeBrands | String | Comma-separated brand names to include |
+| excludeBrands | String | Comma-separated brand names to exclude |
+| includeSellers | String | Comma-separated seller names |
+| excludeSellers | String | Comma-separated seller names |
+| fulfillment | List\<String\> | `["FBA"]`, `["FBM"]` |
+| badges | List\<String\> | `["New Release"]`, `["Best Seller"]` |
+| excludeKeywords | String | Keywords to exclude |
+| videoFilter | String | Video filter |
+
+---
+
+## 5. realtime/product
+
+| Parameter | Required | Note |
+|-----------|----------|------|
+| asin | **Yes** | Product ASIN |
+| marketplace | No | `US`/`UK`/`DE`/`FR`/`IT`/`ES`/`JP`/`CA`/`AU`/`IN`/`MX`/`BR` (default: US) |
+
+### Response fields
+
+| Field | Meaning |
+|-------|---------|
+| asin, title, brand | Basic product info |
+| rating, ratingCount | Rating data |
+| ratingBreakdown | Star distribution: `{five_star: {percentage, count}, ...}` |
+| features | Bullet points (list of strings) |
+| description | Product description |
+| specifications | Key-value tech specs |
+| categories | Category path |
+| variants | Variant list with dimensions |
+| topReviews | Top reviews with title, body, rating, date, helpful_votes |
+| bestsellersRank | BSR info: `[{category, rank}, ...]` |
+| buyboxWinner | Buy Box: price, fulfillment, seller |
+| images | All image URLs |
+| dimensions, weight | Physical attributes |
+
+---
+
+## 6. reviews/analyze
+
+AI-powered review analysis. Returns sentiment, rating distribution, and structured consumer insights.
+Requires at least 50 reviews for meaningful analysis.
+
+### Request parameters
+
+| Parameter | Type | Required | Note |
+|-----------|------|----------|------|
+| mode | String | **Yes** | `asin` or `category` |
+| asins | List\<String\> | When mode=asin | Max 100 ASINs |
+| categoryPath | String | When mode=category | Category path |
+| labelType | String | No | Filter to specific dimension. Omit for all |
+| period | String | No | Analysis time range (e.g. `90d`) |
+
+### labelType values
+
+`scenarios`, `issues`, `positives`, `improvements`, `buyingFactors`, `painPoints`, `keywords`, `userProfiles`, `usageTimes`, `usageLocations`, `behaviors`
+
+### Response fields
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| queryMode | String | `asin` or `category` |
+| asins | List | ASINs analyzed |
+| category | String | Category analyzed |
+| totalReviews | Integer | Total reviews analyzed |
+| avgRating | Float | Average rating |
+| verifiedRatio | Float | Verified purchase ratio (decimal) |
+| dateRangeStart | Date | Analysis start date |
+| dateRangeEnd | Date | Analysis end date |
+| ratingDistribution | Object | `{"1": count, "2": count, ..., "5": count}` |
+| sentimentDistribution | Object | `{"positive": ratio, "neutral": ratio, "negative": ratio}` |
+| consumerInsights | List\<InsightItem\> | Structured insights by dimension |
+| topKeywords | List\<InsightItem\> | Top keywords with counts |
+
+### InsightItem fields
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| element | String | Insight text |
+| labelType | String | Dimension (e.g. `painPoints`) |
+| count | Integer | Occurrence count |
+| reviewPercentage | Float | % of reviews mentioning this |
+| avgRating | Float | Avg rating for reviews with this element |
+
+---
+
+## Shared Product Object (competitor-lookup & products/search)
+
+### Core fields
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| asin | String | ASIN |
+| parentAsin | String | Parent ASIN |
+| title | String | Product title |
+| brand | String | Brand |
+| price | Float | Price (USD) |
+| listingDate | String | Listing date |
+| fulfillment | String | FBA/FBM/AMZ |
+| categories | List | Category path |
+
+### Sales fields
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| atLeastMonthlySales | Integer | Estimated monthly sales (lower bound, actual may be higher) |
+| salesRevenue | Float | Monthly revenue |
+| salesGrowthRate | Float | Sales growth rate |
+| childSalesMonthly | Integer | Child ASIN monthly sales |
+| bsrRank | Integer | BSR rank |
+| bsrGrowthRate | Float | BSR growth rate |
+| subBsrRank | Integer | Sub-category BSR |
+
+### Review & quality
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| rating | Float | Rating (0-5) |
+| ratingCount | Integer | Total ratings |
+| reviewMonthlyNew | Integer | Monthly new reviews |
+| isBestSeller | Boolean | Best Seller badge |
+| isAmazonChoice | Boolean | Amazon's Choice badge |
+| hasAPlus | Boolean | A+ content |
+| hasVideo | Boolean | Has video |
+| lqs | Float | Listing quality score |
+
+### Commercial fields
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| fbaFee | Float | FBA fee |
+| profitMargin | Float | Profit margin |
+| sellerCount | Integer | Number of sellers |
+| buyboxSeller | String | Buy Box winner |
+| sellerLocation | String | Seller location |
+| variantCount | Integer | Number of variants |
+
+---
+
+## Scoring Criteria
+
+### Market evaluation thresholds
+
+| Metric | Source | Good | Medium | Warning |
+|--------|--------|------|--------|---------|
+| Monthly market value | sampleAvgMonthlyRevenue × sampleSkuCount | > $10M | $5M–$10M | < $5M |
+| Product concentration | topSalesRate (topN=10) | < 40% | 40–60% | > 60% |
+| New SKU rate | sampleNewSkuRate | > 15% | 5–15% | < 5% |
+| FBA rate | sampleFbaRate | > 50% | 30–50% | < 30% |
+| Brand count | sampleBrandCount | > 50 | 20–50 | < 20 |
+
+### Product evaluation thresholds
+
+| Metric | Source | High potential | Medium | Low potential |
+|--------|--------|---------------|--------|---------------|
+| BSR rank | bestsellersRank | Top 1000 | 1000–5000 | > 5000 |
+| Review count | reviewCount | < 200 | 200–1000 | > 1000 |
+| Rating | rating | > 4.3 | 4.0–4.3 | < 4.0 |
+| Negative review % | ratingBreakdown (1+2 star) | < 10% | 10–20% | > 20% |
+
+### BSR to sales estimation
+
+When `atLeastMonthlySales` is null, estimate: **Monthly sales ≈ 300,000 / BSR^0.65**
+
+---
+
+## Common response structure
+
+```json
+{
+  "success": true,
+  "data": { ... },
+  "error": { "code": "...", "message": "..." },
+  "meta": {
+    "requestId": "...",
+    "timestamp": "...",
+    "total": 100,
+    "page": 1,
+    "pageSize": 20,
+    "totalPages": 5
+  }
+}
+```
+
+---
+
+## Known quirks
+
+1. `topN` and `newProductPeriod` are **strings** — use `"10"` not `10`
+2. `listingAge` is a **string** — use `"180"` not `180`
+3. All parameters are flat (top-level), no nested objects
+4. Database endpoints mainly support US; `realtime/product` supports 12 marketplaces
+5. Rate limit: 100 req/min, 10 req/sec burst
+6. Concentration = Top N sales / sample total sales (topN value matters)
+
+> The `scripts/apiclaw.py` script handles all these quirks automatically.

--- a/skills/apiclaw-analysis/references/scenarios-composite.md
+++ b/skills/apiclaw-analysis/references/scenarios-composite.md
@@ -1,0 +1,117 @@
+# APIClaw Scenarios — Composite & Case Study
+
+> Load when handling comprehensive product recommendations or Chinese seller case studies.
+> For API parameters, see `reference.md`.
+
+---
+
+## 2.10 Composite Product Recommendation (Comprehensive Decision Recommendations)
+
+> Trigger: "help me choose" / "comprehensive recommendations" / "what should I sell" / "most suitable for me"
+
+**First collect user information (if not provided, proactively ask):**
+
+| Element | Example |
+|------|------|
+| Target category | "Pet supplies" |
+| Budget range | < $10K / $10-50K / > $50K |
+| Experience level | Beginner / Experienced / Expert |
+| Preferences | Small & light items / High-ticket items / Fast turnover |
+
+**Workflow**
+
+```bash
+# Step 1: Confirm category
+python3 scripts/apiclaw.py categories --keyword "pet toys"
+
+# Step 2: Market conditions
+python3 scripts/apiclaw.py market --category "Pet Supplies,Dogs,Toys" --topn 10
+
+# Step 3: Run 2-3 modes based on user profile
+# Beginner → beginner + high-demand-low-barrier
+python3 scripts/apiclaw.py products --keyword "pet toys" --mode beginner --page-size 20
+python3 scripts/apiclaw.py products --keyword "pet toys" --mode high-demand-low-barrier --page-size 20
+
+# Step 4: AI weighted scoring → Top 5 recommendation
+```
+
+**AI Weighted Scoring Dimensions**:
+
+| Dimension | Weight | Field | Source Interface |
+|------|------|---------|---------|
+| Demand Strength | 25% | `atLeastMonthlySales` | `products` / `competitors` |
+| Competition Difficulty | 25% | `ratingCount` + `sellerCount` | `products` / `competitors` |
+| Profit Margin | 20% | `price` × `profitMargin` | `products` / `competitors` |
+| Differentiation Opportunity | 15% | `rating` < 4.3 or `ratingCount` < 200 | `products` / `competitors` |
+| User Match | 15% | Budget/Experience/Preferences | User input |
+
+**⚠️ All scoring fields come from `products`/`competitors` interface. Do NOT use `realtime/product` for scoring — it lacks sales, profitMargin, and sellerCount.**
+
+**Output Template**
+
+```markdown
+# 🎯 [Category] Comprehensive Product Selection Recommendations
+
+## User Profile
+| Item | Value |
+|----|-----|
+| Budget | ... |
+| Experience | ... |
+| Preferences | ... |
+
+## Top 5 Recommended Products
+| # | ASIN | Product | Price | Monthly Sales | Reviews | Comprehensive Score | Recommendation Reason |
+|---|------|------|------|-------|-------|---------|---------|
+
+## Action Recommendations
+[Specific recommendations based on user profile]
+```
+
+---
+
+## 3.4 Chinese Seller Case Study
+
+> Trigger: "Are there Chinese sellers who succeeded" / "Chinese sellers cases" / "Chinese sellers"
+
+```bash
+python3 scripts/apiclaw.py competitors --keyword "wireless earbuds" --page-size 50
+# → Filter results by sellerLocation field
+```
+
+**sellerLocation Filtering Logic**:
+- Primary: `sellerLocation` contains "CN" / "China" / Chinese city names: Shenzhen, Guangzhou, Hangzhou, Yiwu, Dongguan, Xiamen, Shanghai, Beijing, Ningbo, Fuzhou
+- Sort by `atLeastMonthlySales`, find Top 5 Chinese sellers by sales volume
+
+**⚠️ Fallback when sellerLocation is null** (common — many ASINs don't have this field):
+- Check `buyboxSeller` or `brand` for Chinese seller patterns: all-pinyin names, names ending in "-Direct"/"-Store"/"-Official", or gibberish letter combinations
+- Cross-reference with product categories typical of Chinese sellers (electronics accessories, phone cases, etc.)
+- If sellerLocation coverage is too low (<30% of results), note this limitation in output
+
+**Analysis Dimensions**:
+- Chinese sellers count ratio (vs total sellers)
+- Common traits of top Chinese sellers (price range, review count, listing time)
+- Listing strategies of successful Chinese sellers (can use `product --asin XXX` for details)
+- Replicable strategy points
+
+**Output Template**
+
+```markdown
+# 🇨🇳 [Category] Chinese Seller Case Analysis
+
+## Chinese Seller Overview
+| Metric | Value |
+|-----|------|
+| Chinese Seller Count | X / Total Y (Z% ratio) |
+| Top Chinese Seller Average Monthly Sales | X units |
+| Top Chinese Seller Average Price | $X |
+
+## Top 5 Chinese Seller Products
+| # | ASIN | Brand | Price | Monthly Sales | Rating | Reviews | Listing Date |
+|---|------|------|------|-------|------|------|---------|
+
+## Success Strategy Analysis
+[Common traits analysis + Replicable strategies]
+
+## Action Recommendations
+[Specific recommendations based on Chinese seller cases]
+```

--- a/skills/apiclaw-analysis/references/scenarios-eval.md
+++ b/skills/apiclaw-analysis/references/scenarios-eval.md
@@ -1,0 +1,236 @@
+# APIClaw Scenarios — Product Evaluation
+
+> Load when handling product evaluation, risk assessment, review analysis, or multi-product comparison.
+> For API parameters, see `reference.md`.
+
+---
+
+## 4.2 Review Insights
+
+> Trigger: "consumer pain points" / "negative review analysis" / "review insights" / "pain points"
+
+```bash
+# Step 1 (primary): AI-powered review analysis — covers ALL reviews
+python3 scripts/apiclaw.py analyze --asin B09V3KXJPB --label-type painPoints,issues,positives,improvements
+
+# Step 2 (supplement): Raw review samples for quoting specific examples
+python3 scripts/apiclaw.py product --asin B09V3KXJPB
+# → Use topReviews for specific review quotes to support analyze findings
+```
+
+**Data combination:**
+- Use `analyze` `consumerInsights` as primary structured findings (covers ALL reviews)
+- Use `realtime/product` `topReviews` for specific quotes to illustrate key pain points
+- Use `analyze` `sentimentDistribution` for overall sentiment overview
+
+**Key Information Extracted from analyze + topReviews**:
+
+| Analysis Dimension | Focus Points |
+|---------|-------|
+| Negative review keywords | broke, defect, quality, returned, disappointed, cheap, flimsy, doesn't work |
+| Positive review highlights | easy, great value, love, perfect, amazing, sturdy, well-made, exactly as described |
+| Negative review ratio | 1-2 star ratio in ratingBreakdown (> 20% is high risk) |
+| Improvement opportunities | Specific problems repeatedly mentioned in negative reviews → Product differentiation direction |
+
+**Output Template**
+
+```markdown
+# 💬 [ASIN] Review Insights
+
+## Rating Distribution
+| Star Rating | Percentage | Count |
+|------|------|------|
+
+## Positive Review Themes
+[Extract top 3 positive review themes from topReviews]
+
+## Negative Review Pain Points
+[Extract top 3 negative review themes → These are differentiation opportunities]
+
+## Improvement Suggestions
+[Product improvement directions based on pain points]
+```
+
+---
+
+## 4.3 Multi-Product Comparison
+
+> Trigger: "Which of these products is more worth pursuing" / "compare evaluation" / "compare products"
+
+```bash
+# Primary: use competitors for quantitative comparison (sales, price, margins)
+python3 scripts/apiclaw.py competitors --keyword "yoga mat" --page-size 20
+# Or for specific ASINs:
+python3 scripts/apiclaw.py competitors --asin B09XXXXX
+
+# Optional supplement: use realtime/product for qualitative details (reviews, features)
+python3 scripts/apiclaw.py product --asin B09XXXXX
+```
+
+**⚠️ Important:** Use `competitors` (not `product`) as the primary data source for comparison.
+`realtime/product` does NOT return sales, profitMargin, fbaFee, or sellerCount.
+
+**Horizontal Comparison Dimensions**:
+
+| Dimension | Field | Source |
+|------|------|------|
+| Price | `price` | competitors |
+| Monthly Sales | `atLeastMonthlySales` | competitors |
+| BSR | `bsrRank` | competitors |
+| Rating | `rating` | competitors |
+| Review Count | `ratingCount` | competitors |
+| Profit Margin | `profitMargin` | competitors |
+| Variant Count | `variantCount` | competitors |
+| FBA Fee | `fbaFee` | competitors |
+| Seller Count | `sellerCount` | competitors |
+| Tags | `isBestSeller` / `isAmazonChoice` | competitors |
+| A+/Video | `hasAPlus` / `hasVideo` | competitors |
+| Review Details | `topReviews` / `ratingBreakdown` | realtime/product (optional) |
+| Listing Quality | `features` / `description` | realtime/product (optional) |
+
+---
+
+## 4.4 Risk Assessment
+
+> Trigger: "What are the risks" / "can I do this" / "risk assessment"
+
+```bash
+# Step 1: Competitive landscape (primary data: sales, margins, seller count)
+python3 scripts/apiclaw.py competitors --keyword "product keyword" --page-size 20
+# Step 2: Market context (category-level metrics)
+python3 scripts/apiclaw.py market --category "category path" --topn 10
+# Step 3 (optional): Review details for the target ASIN
+python3 scripts/apiclaw.py product --asin B09XXXXX
+# Step 4 (recommended): Review sentiment for risk signal
+python3 scripts/apiclaw.py analyze --asin B09XXXXX --label-type issues,painPoints
+```
+
+**⚠️ Note:** Step 1 (`competitors`) provides sales, margins, and seller data needed for risk scoring.
+Step 3 (`product`) only adds review details and listing content — do NOT expect sales/profitMargin from it.
+Step 4 (`analyze`) provides AI-analyzed sentiment distribution and structured issues for risk assessment.
+
+**Six-Dimensional Risk Assessment Matrix**:
+
+| Risk Dimension | Data Source | 🟢 Low Risk | 🟡 Medium Risk | 🔴 High Risk |
+|---------|---------|---------|---------|---------|
+| Competition Intensity | topSalesRate | < 40% | 40-60% | > 60% |
+| Review Barrier | Top avg ratingCount | < 200 | 200-1000 | > 1000 |
+| Brand Barrier/Moat | topBrandSalesRate | < 30% | 30-50% | > 50% |
+| Price War Risk | Top price variance | High variance | Medium | Low variance |
+| Compliance Risk | categories | Regular | Requires certification | High-risk |
+| Review Sentiment | sentimentDistribution (negative) | < 15% | 15-30% | > 30% |
+| Seasonality | AI judgment | Year-round | Seasonal fluctuation | Strong seasonality |
+
+**High-risk Category Compliance Alerts**:
+
+| Category | Compliance Requirements |
+|------|---------|
+| Health/Supplements | FDA compliance |
+| Children's Products | CPSC certification (CPSIA) |
+| Electronics | FCC certification |
+| Food | FDA registration |
+| Cosmetics | FDA compliance |
+| Toys | ASTM F963 |
+
+**Output Template**
+
+```markdown
+# ⚠️ [ASIN/Category] Risk Assessment Report
+
+## Risk Matrix
+| Risk Dimension | Risk Level | Description |
+|---------|---------|------|
+
+## Overall Risk Level: 🟢/🟡/🔴
+[Analysis and recommendations]
+```
+
+---
+
+## 4.5 Sales Estimation
+
+> Trigger: "How much monthly sales does this product have" / "sales forecast" / "estimate sales"
+
+```bash
+python3 scripts/apiclaw.py competitors --asin B09XXXXX
+# → Get bsrRank and atLeastMonthlySales
+```
+
+**Three Estimation Methods**:
+
+| Method | Formula/Logic | Accuracy |
+|-----|---------|------|
+| API Direct Return | `atLeastMonthlySales` field | ⭐⭐⭐⭐ Most accurate (lower bound) |
+| BSR Rough Estimate | Monthly sales ≈ 300,000 / BSR^0.65 | ⭐⭐ Rough |
+| Review Reverse Calculation | Monthly sales ≈ reviewMonthlyNew / Review rate(1-3%) | ⭐⭐ Reference only |
+
+**Usage Priority**: atLeastMonthlySales → BSR estimate → Review reverse calculation
+
+**Note**: `atLeastMonthlySales` is a lower bound — Amazon shows "10,000+ bought in past month", so actual sales may be higher. Current API has no historical trends, only current snapshot.
+
+---
+
+## 4.6 Category Consumer Insights
+
+> Trigger: "category pain points" / "what do users want" / "consumer portrait" / "category user analysis" / "who is buying"
+
+```bash
+python3 scripts/apiclaw.py analyze --category "Pet Supplies,Dogs,Toys" --period 90d
+```
+
+**Use case:** Understand the consumer landscape of a category **before** product selection. Not about specific ASINs, but about what users in this category care about, complain about, and value.
+
+**Key dimensions to analyze:**
+
+| Dimension | labelType | Insight |
+|-----------|-----------|---------|
+| Who is buying | `userProfiles` | Target audience definition |
+| What they want | `buyingFactors` | Key purchase decision drivers |
+| Where/when they use it | `usageLocations`, `usageTimes` | Scene-based marketing angles |
+| What they hate | `painPoints` | Differentiation opportunities |
+| What they love | `positives` | Table-stakes features |
+| How to improve | `improvements` | Product development direction |
+
+**Output Template**
+
+```markdown
+# 👥 [Category] Consumer Insights
+
+## Overview
+| Metric | Value |
+|--------|-------|
+| Reviews Analyzed | [totalReviews] |
+| Avg Rating | [avgRating] |
+| Verified Purchase Ratio | [verifiedRatio] |
+| Sentiment | 👍 [positive]% / 😐 [neutral]% / 👎 [negative]% |
+
+## User Profiles
+[From userProfiles dimension — who is buying]
+
+## Top Pain Points
+| # | Pain Point | Mention % | Avg Rating |
+|---|-----------|-----------|------------|
+[From painPoints dimension]
+
+## Buying Decision Factors
+| # | Factor | Mention % |
+|---|--------|-----------|
+[From buyingFactors dimension]
+
+## Usage Scenarios
+[From scenarios dimension]
+
+## Product Opportunity Signals
+[Cross-reference painPoints + positives → gaps = opportunities]
+```
+
+---
+
+## Flow Guidance
+
+| Current Conclusion | Next Step | Load File |
+|-------------------|-----------|-----------|
+| Want to understand users first | → Category insights | This file → 4.6 |
+| Pain points identified | → Product selection | SKILL.md → products |
+| Product selected, need risk check | → Risk assessment | This file → 4.4 |
+| Need competitive analysis | → Competitor comparison | This file → 4.3 |

--- a/skills/apiclaw-analysis/references/scenarios-expand.md
+++ b/skills/apiclaw-analysis/references/scenarios-expand.md
@@ -1,0 +1,90 @@
+# APIClaw Scenarios — Expansion & Iteration
+
+> Load when handling product expansion, trend discovery, or discontinuation decisions.
+> For API parameters, see `reference.md`.
+>
+> **Limitation**: No historical data comparison. "Trends" based on current snapshot growth rate fields.
+
+---
+
+## 7.1 Related Products Discovery
+
+```bash
+# Step 1: Sibling categories
+python3 scripts/apiclaw.py categories --parent "Pet Supplies,Dogs"
+
+# Step 2: Evaluate each
+python3 scripts/apiclaw.py market --category "Pet Supplies,Dogs,Feeding & Watering" --topn 10
+```
+
+---
+
+## 7.2 New Category Evaluation
+
+```bash
+python3 scripts/apiclaw.py market --keyword "new category keyword" --topn 10
+```
+
+---
+
+## 7.3 Trend Discovery
+
+```bash
+python3 scripts/apiclaw.py products --keyword "pet supplies" --growth-min 0.2 --listing-age 180 --page-size 20
+```
+
+---
+
+## 7.4 Product Discontinuation Decision
+
+```bash
+# Step 1: Product current performance
+python3 scripts/apiclaw.py competitors --asin B09XXXXX
+
+# Step 2: Category market trend
+python3 scripts/apiclaw.py market --category "category path" --topn 10
+```
+
+**Discontinuation Signals**:
+
+⚠️ API provides current snapshot only. Growth rates (`salesGrowthRate`, `bsrGrowthRate`) reflect recent trends but are not historical time-series. Use them as directional indicators, not definitive proof of sustained decline.
+
+| Signal | Data Source | Trigger Condition |
+|--------|-------------|-------------------|
+| Sales decline | `salesGrowthRate` | Negative growth rate (current snapshot) |
+| Profit erosion | `profitMargin` | Margin < 10% |
+| High competition | `sellerCount` | Currently > 10 sellers |
+| BSR worsening | `bsrGrowthRate` | Negative BSR growth (rank number increasing) |
+| Weak market | `sampleAvgMonthlySales` | Category avg below viable threshold |
+
+**Note:** `salesGrowthRate` and `bsrGrowthRate` come from `products`/`competitors` interface. `realtime/product` does NOT provide these fields. For stronger evidence, run this analysis periodically and compare snapshots.
+
+**Output Template**
+
+```markdown
+# Product Discontinuation Evaluation - [ASIN]
+
+## Current Performance
+| Metric | Value | Trend |
+|--------|-------|-------|
+
+## Discontinuation Signals
+| Signal | Triggered? | Description |
+|--------|-----------|-------------|
+
+## Recommendation
+**[Continue / Adjust / Discontinue]**
+[Reasons and alternatives]
+```
+
+---
+
+## Flow Guidance (Smart Transitions)
+
+| Current Conclusion | Next Step | Load File |
+|-------------------|-----------|-----------|
+| Pricing done, ready to list | → Daily monitoring | `scenarios-ops.md` |
+| Found market anomaly | → Competitor analysis | SKILL.md → competitors |
+| Want to expand | → Related products | This file → 7.1 |
+| Product underperforming | → Evaluate discontinuation | This file → 7.4 |
+| Need to pivot category | → Market validation | SKILL.md → market |

--- a/skills/apiclaw-analysis/references/scenarios-listing.md
+++ b/skills/apiclaw-analysis/references/scenarios-listing.md
@@ -1,0 +1,230 @@
+# APIClaw Scenarios — Listing Optimization
+
+> Load when handling listing writing, bullet points optimization, or product page content creation.
+> For API parameters, see `reference.md`.
+>
+> **Data source:** `realtime/product` provides features, description, topReviews, ratingBreakdown.
+> `competitors`/`products` provides sales, pricing, and competitive data.
+> Combine both for data-driven listing creation.
+
+---
+
+## 8.1 Competitive Listing Analysis
+
+> Trigger: "analyze competitor listing" / "their selling points" / "listing comparison" / "what are they saying"
+
+```bash
+# Step 1: Pull 2-3 top competitor ASINs for listing content
+python3 scripts/apiclaw.py product --asin B09XXXXX
+python3 scripts/apiclaw.py product --asin B08YYYYY
+python3 scripts/apiclaw.py product --asin B07ZZZZZ
+
+# Step 2: AI review analysis across all competitors (one call)
+python3 scripts/apiclaw.py analyze --asins B09XXXXX,B08YYYYY,B07ZZZZZ --label-type positives,painPoints,buyingFactors
+```
+
+**Data source priority:** Use `analyze` consumerInsights for structured findings (covers ALL reviews). Use `realtime/product` features/topReviews for specific listing copy examples and quotes.
+
+**Extract from each ASIN:**
+
+| Data Point | Field | What to Analyze |
+|------------|-------|-----------------|
+| Bullet Points | `features` | Common selling points across competitors |
+| Negative Reviews | `topReviews` (1-2★) | Pain points = differentiation opportunities |
+| Star Distribution | `ratingBreakdown` | High 1★% = product flaw to avoid/solve |
+| Product Specs | `specifications` | Feature gaps competitors miss |
+| Image Count | `images` | Benchmark for visual content |
+
+**Analysis Framework:**
+
+1. **Shared selling points** — What do ALL competitors emphasize? (These are table stakes, must include)
+2. **Pain point mining** — What do negative reviews complain about? (These are your differentiation angle)
+3. **White space** — What does NO competitor mention? (These are untapped positioning opportunities)
+4. **AI-validated insights** — What does `analyze` confirm as top buying factors and pain points across all competitors? (data-driven, not manual impression)
+
+**Output Template**
+
+```markdown
+# 🔍 Competitive Listing Analysis — [Category/Product]
+
+## Competitor Overview
+| # | ASIN | Brand | Rating | Reviews | Bullet Points Count | Has A+ | Has Video |
+|---|------|-------|--------|---------|---------------------|--------|-----------|
+
+## Selling Points Matrix
+| Selling Point | Competitor A | Competitor B | Competitor C | Frequency |
+|---------------|:---:|:---:|:---:|-----------|
+| [e.g. Waterproof] | ✅ | ✅ | ❌ | 2/3 |
+
+## Top 5 Negative Review Pain Points
+| # | Pain Point | Frequency | Opportunity |
+|---|-----------|-----------|-------------|
+
+## Differentiation Opportunities
+[Specific angles competitors miss + evidence from reviews]
+```
+
+---
+
+## 8.2 Listing Copy Generation
+
+> Trigger: "write listing" / "generate bullet points" / "write title" / "listing optimization" / "help me write product page"
+
+```bash
+# Step 1: Pull top 3 competitors for reference
+python3 scripts/apiclaw.py product --asin B09XXXXX
+python3 scripts/apiclaw.py product --asin B08YYYYY
+python3 scripts/apiclaw.py product --asin B07ZZZZZ
+
+# Step 2: Get category competitive data
+python3 scripts/apiclaw.py competitors --keyword "product keyword" --page-size 20
+
+# Step 3: Consumer insights for data-driven copy
+python3 scripts/apiclaw.py analyze --asins B09XXXXX,B08YYYYY,B07ZZZZZ --label-type buyingFactors,scenarios,userProfiles
+```
+
+**⚠️ Important:** Use `realtime/product` for listing content (features, reviews). Use `competitors` for market positioning data (price range, review counts). Use `analyze` for consumer-driven copy direction (buying factors, scenarios, user profiles). Do NOT expect sales data from realtime/product.
+
+**Before generating, ask the user for:**
+
+| Info Needed | Why |
+|-------------|-----|
+| Product name & key features | Core content |
+| Target price point | Positioning |
+| Key differentiators vs competitors | Unique selling angles |
+| Target customer | Tone and language |
+| Brand name (if any) | Title prefix |
+
+**Generation Rules:**
+
+### Title (max 200 characters)
+- Format: `[Brand] + [Core Product] + [Top 2-3 Features] + [Use Case/Audience]`
+- Front-load the highest-search-volume keyword
+- Example: `BRANDX Wireless Earbuds — 40H Battery, ANC Noise Cancelling, IPX7 Waterproof — for Running & Gym`
+
+### Bullet Points (5 total)
+- Each bullet: **[BENEFIT IN CAPS]** — Supporting detail with keyword
+- Bullet 1: Primary differentiator (what you do better than competitors)
+- Bullet 2: Key feature addressing top pain point from reviews
+- Bullet 3-4: Important features (table stakes)
+- Bullet 5: Trust builder (warranty, compatibility, what's in the box)
+- Embed 1-2 search keywords naturally per bullet
+- Use `buyingFactors` from analyze to prioritize which benefits to lead with
+- Use `scenarios` from analyze to craft the product description opening
+- Use `userProfiles` to match tone and language to target audience
+
+### Product Description
+- Opening: Problem or scenario the customer relates to
+- Middle: How this product solves it (features → benefits)
+- Close: Brand story or trust statement
+- Length: 1000-2000 characters
+
+### Backend Search Terms (5 lines, each <500 chars)
+- Line 1: Primary keyword variations
+- Line 2: Synonym keywords
+- Line 3: Use case keywords
+- Line 4: Compatible product keywords
+- Line 5: Misspellings and alternate terms
+- Do NOT repeat words already in title/bullets
+
+**Output Template**
+
+```markdown
+# ✍️ Listing Copy — [Product Name]
+
+## Title
+[Generated title]
+
+## Bullet Points
+• **[BENEFIT 1]** — [Detail]
+• **[BENEFIT 2]** — [Detail]
+• **[BENEFIT 3]** — [Detail]
+• **[BENEFIT 4]** — [Detail]
+• **[BENEFIT 5]** — [Detail]
+
+## Product Description
+[Generated description]
+
+## Backend Search Terms
+1. [Line 1]
+2. [Line 2]
+3. [Line 3]
+4. [Line 4]
+5. [Line 5]
+
+---
+**Based on:** [X] competitor listings analyzed, [Y] reviews mined
+**Key differentiation angle:** [What makes this listing unique]
+```
+
+---
+
+## 8.3 Listing Optimization Diagnosis
+
+> Trigger: "optimize my listing" / "what's wrong with my listing" / "listing diagnosis" / "improve my listing"
+
+```bash
+# Step 1: Pull user's own ASIN
+python3 scripts/apiclaw.py product --asin B09XXXXX
+
+# Step 2: Pull top 3 competitors in same category
+python3 scripts/apiclaw.py competitors --keyword "product keyword" --page-size 10
+# Then pull realtime detail for top 3
+python3 scripts/apiclaw.py product --asin [competitor1]
+python3 scripts/apiclaw.py product --asin [competitor2]
+python3 scripts/apiclaw.py product --asin [competitor3]
+
+# Step 3: Review-based competitive intelligence
+python3 scripts/apiclaw.py analyze --asins B09XXXXX,[competitor1],[competitor2] --label-type positives,painPoints
+```
+
+**⚠️ Note:** `realtime/product` provides listing content for diagnosis. `competitors` provides competitive benchmarks (sales, reviews, price). `analyze` provides AI-analyzed consumer insights across your ASIN and competitors. All three are needed for a thorough diagnosis.
+
+**Diagnosis Scorecard:**
+
+| Dimension | Check | Scoring |
+|-----------|-------|---------|
+| Title | Length, keyword placement, readability | 🟢 >150 chars with keywords / 🟡 100-150 / 🔴 <100 or keyword-stuffed |
+| Bullet Points | Count, structure, keyword density | 🟢 5 bullets, benefit-led / 🟡 3-4 bullets / 🔴 <3 or feature-only |
+| Images | Count from `images` field | 🟢 7+ images / 🟡 4-6 / 🔴 <4 |
+| A+ Content | `hasAPlus` from competitors data | 🟢 Has A+ / 🔴 No A+ (competitors have it) |
+| Video | `hasVideo` from competitors data | 🟢 Has video / 🟡 No video but competitors don't either / 🔴 No video but competitors do |
+| Reviews | `ratingCount` vs competitor avg | 🟢 Above avg / 🟡 50-100% of avg / 🔴 Below 50% |
+| Rating | `rating` vs category avg | 🟢 >4.3 / 🟡 4.0-4.3 / 🔴 <4.0 |
+| Negative Review % | `ratingBreakdown` 1+2 star | 🟢 <10% / 🟡 10-20% / 🔴 >20% |
+| Pain Point Coverage | analyze painPoints vs your bullets | 🟢 Addresses top 3 / 🟡 Addresses 1-2 / 🔴 Ignores top pain points |
+
+**Output Template**
+
+```markdown
+# 🏥 Listing Diagnosis — [ASIN]
+
+## Overall Score: [X/10]
+
+## Scorecard
+| Dimension | Your ASIN | Top Competitor | Score | Action |
+|-----------|-----------|----------------|-------|--------|
+| Title | [length, keywords] | [benchmark] | 🟢/🟡/🔴 | [Fix] |
+| Bullet Points | [count, style] | [benchmark] | 🟢/🟡/🔴 | [Fix] |
+| Images | [count] | [avg count] | 🟢/🟡/🔴 | [Fix] |
+| ... | ... | ... | ... | ... |
+
+## Priority Fixes (Top 3)
+1. [Most impactful fix with specific suggestion]
+2. [Second fix]
+3. [Third fix]
+
+## Rewritten Listing (Optional)
+[If score < 6/10, offer to rewrite — see 8.2]
+```
+
+---
+
+## Flow Guidance
+
+| Current Conclusion | Next Step | Load File |
+|-------------------|-----------|-----------|
+| Listing generated | → Monitor performance | `scenarios-ops.md` |
+| Diagnosis score low | → Rewrite listing | This file → 8.2 |
+| Need competitive data first | → Competitor analysis | `scenarios-eval.md` → 4.3 |
+| Need product selection first | → Find products | SKILL.md → products |

--- a/skills/apiclaw-analysis/references/scenarios-ops.md
+++ b/skills/apiclaw-analysis/references/scenarios-ops.md
@@ -1,0 +1,78 @@
+# APIClaw Scenarios — Daily Operations
+
+> Load when handling market monitoring, competitor tracking, or anomaly detection.
+> For API parameters, see `reference.md`.
+>
+> **Limitation**: Snapshot data only, no historical comparison. Run periodically and compare manually for continuous monitoring.
+
+---
+
+## 6.1 Market Dynamics Monitoring
+
+```bash
+# Step 1: Market overview
+python3 scripts/apiclaw.py market --category "Pet Supplies,Dogs" --topn 10
+
+# Step 2: New products in last 90 days
+python3 scripts/apiclaw.py products --keyword "dog toys" --listing-age 90 --page-size 20
+```
+
+---
+
+## 6.2 Competitor Dynamics
+
+```bash
+python3 scripts/apiclaw.py competitors --brand "CompetitorBrand" --sort listingDate
+```
+
+---
+
+## 6.3 Top Products Changes
+
+```bash
+python3 scripts/apiclaw.py products --category "Pet Supplies,Dogs,Toys" --page-size 20
+```
+
+---
+
+## 6.4 Anomaly Alerts
+
+```bash
+# Step 1: Market indicators
+python3 scripts/apiclaw.py market --category "Pet Supplies,Dogs,Toys" --topn 10
+
+# Step 2: Current top products
+python3 scripts/apiclaw.py products --category "Pet Supplies,Dogs,Toys" --page-size 20
+
+# Step 3: High-growth new products (potential threats)
+python3 scripts/apiclaw.py products --category "Pet Supplies,Dogs,Toys" --listing-age 90 --growth-min 0.2 --page-size 10
+```
+
+**Alert Signal Detection**:
+
+⚠️ API provides snapshot data only (no historical comparison). Detect anomalies by comparing **current values against standard thresholds**, not by tracking changes over time.
+
+| Alert Type | Detection Method | Trigger Condition |
+|------------|-----------------|-------------------|
+| New blockbuster invasion | Step 3 results | New product (<90 days) already in Top 20 by sales |
+| Price war risk | Step 2 price distribution | Multiple top products clustered at same low price point |
+| High concentration | Step 1 `topSalesRate` | Currently > 60% (Warning threshold from evaluation criteria) |
+| Low new SKU rate | Step 1 `sampleNewSkuRate` | Currently < 5% (market may be frozen) or > 30% (flooding) |
+
+**For continuous monitoring:** Run this workflow periodically (weekly/monthly) and compare results manually across snapshots. The API does not provide historical trend data.
+
+**Output Template**
+
+```markdown
+# Anomaly Alert Report - [Category]
+
+## Alert Signals
+| Signal | Level | Description |
+|--------|-------|-------------|
+
+## Detailed Analysis
+[Each alert signal with specific data]
+
+## Recommended Actions
+[Response strategy for each alert]
+```

--- a/skills/apiclaw-analysis/references/scenarios-pricing.md
+++ b/skills/apiclaw-analysis/references/scenarios-pricing.md
@@ -1,0 +1,61 @@
+# APIClaw Scenarios — Pricing & Listing
+
+> Load when handling pricing strategy, profit estimation, or listing reference tasks.
+> For API parameters, see `reference.md`.
+
+---
+
+## 5.1 Price Analysis
+
+```bash
+# Step 1: Category pricing
+python3 scripts/apiclaw.py market --category "Electronics,Headphones" --topn 10
+
+# Step 2: Top 50 price distribution
+python3 scripts/apiclaw.py products --keyword "wireless earbuds" --page-size 50
+# → Analyze price bands: $0-20, $20-50, $50-100, $100+
+```
+
+**Output Template**
+
+```markdown
+# Price Analysis - [Category]
+
+## Market Average
+- Sample avg price: $XX
+- Sample avg gross margin: XX%
+
+## Price Band Distribution (Top 50)
+| Price Range | Count | % | Avg Monthly Sales | Recommendation |
+|-------------|-------|---|-------------------|----------------|
+
+## Pricing Strategy
+[Data-driven pricing recommendations]
+```
+
+---
+
+## 5.2 Profit Estimation
+
+```bash
+python3 scripts/apiclaw.py competitors --keyword "wireless earbuds" --page-size 20
+# → Compare: price, fbaFee, profitMargin across competitors
+```
+
+**Key fields**: `price`, `fbaFee`, `profitMargin`, `fulfillment`
+
+---
+
+## 5.3 Listing Reference
+
+```bash
+python3 scripts/apiclaw.py product --asin B09XXXXX
+# → Analyze: features (Bullet Points), description, images, specifications
+```
+
+**Analysis dimensions**:
+- Bullet Points count and structure
+- Key selling points extraction
+- Image count and types
+- A+ content presence
+- Variant strategy

--- a/skills/apiclaw-analysis/scripts/apiclaw.py
+++ b/skills/apiclaw-analysis/scripts/apiclaw.py
@@ -1,0 +1,756 @@
+#!/usr/bin/env python3
+"""
+APIClaw CLI — Amazon Product Research via APIClaw API
+
+Single-script interface for all 5 APIClaw endpoints + composite workflows.
+Handles authentication, retries, rate limits, parameter quirks, and output formatting.
+
+Usage:
+    python apiclaw.py categories --keyword "pet supplies"
+    python apiclaw.py market --category "Pet Supplies" --topn 10
+    python apiclaw.py products --keyword "yoga mat" --mode beginner
+    python apiclaw.py competitors --keyword "wireless earbuds"
+    python apiclaw.py product --asin B09V3KXJPB
+    python apiclaw.py analyze --asin B09V3KXJPB --label-type painPoints
+    python apiclaw.py report --keyword "pet supplies"
+    python apiclaw.py opportunity --keyword "pet supplies"
+
+Environment:
+    APICLAW_API_KEY — Required. Get one at https://apiclaw.io/api-keys
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.request
+import urllib.error
+
+# ─── Configuration ───────────────────────────────────────────────────────────
+
+BASE_URL = "https://api.apiclaw.io/openapi/v2"  # APIClaw API base URL
+API_DOCS = "https://api.apiclaw.io/api-docs"   # API documentation URL
+MAX_RETRIES = 2       # Maximum number of retry attempts for failed requests
+RETRY_DELAY = 2       # Initial retry delay in seconds; doubles on 429 (rate limit)
+REQUEST_TIMEOUT = 60  # Request timeout in seconds; realtime/product can be slow (up to 30s)
+
+# 14 built-in product selection modes
+# Each maps to a set of products/search filter parameters
+PRODUCT_MODES = {
+    "fast-movers":              {"monthlySalesMin": 300, "salesGrowthRateMin": 0.1},
+    "emerging":                 {"monthlySalesMax": 600, "salesGrowthRateMin": 0.1, "listingAge": "180"},
+    "single-variant":           {"salesGrowthRateMin": 0.2, "variantCountMax": 1, "listingAge": "180"},
+    "high-demand-low-barrier":  {"monthlySalesMin": 300, "reviewCountMax": 50, "listingAge": "180"},
+    "long-tail":                {"bsrMin": 10000, "bsrMax": 50000, "priceMax": 30, "sellerCountMax": 1, "monthlySalesMax": 300},
+    "underserved":              {"monthlySalesMin": 300, "ratingMax": 3.7, "listingAge": "180"},
+    "new-release":              {"monthlySalesMax": 500, "badges": ["New Release"], "fulfillment": ["FBA", "FBM"]},
+    "fbm-friendly":             {"monthlySalesMin": 300, "fulfillment": ["FBM"], "listingAge": "180"},
+    "low-price":                {"priceMax": 10},
+    "broad-catalog":            {"bsrGrowthRateMin": 0.99, "reviewCountMax": 10, "listingAge": "90"},
+    "selective-catalog":        {"bsrGrowthRateMin": 0.99, "listingAge": "90"},
+    "speculative":              {"monthlySalesMin": 600, "sellerCountMin": 3, "listingAge": "180"},
+    "beginner":                 {"monthlySalesMin": 300, "priceMin": 15, "priceMax": 60, "fulfillment": ["FBA"],
+                                 "salesGrowthRateMin": 0.03, "listingAge": "365",
+                                 "excludeKeywords": "Brow,Air Fryer,Body Fragrance Mist,Ornament,Ivory,Bed Comforter,Biker Shorts,Mens Dress Shoe,Charms,Dumbbell,Gaming Chair,Skipping Rope,Hoops,Plus Hoola,Kids Bike Helmet,Socks,Cushion,Camping Hammock,Double Leggings,Yoga,Hand Warmers,Trail Camera,Water Bottle,Insulated Food,Pillow,Pillows,iPhone,Dog Bark Collar,Leg Covers,Leg Cover,Laptop Stand,Pet Briefs,Brief,Hangers,Hanger,Slip Rug Pad,rossbody,Fanny Pack,Bedding,Dog Harness,Sweet Water Decor,Eyeshadow,Cotton Sleepsack,Swaddle,Chocolate Bra,Wireless Bed Sheet Set,Car Windshield Curtain,Curtains,Wallet,Green Tea,Picture Frame,Womens,Women Fan,Bottle,Essential Oil,Tumbler,YETI,Vitamin,Vitamins,Face Mask,Led Strip,Pocket,Women's Watch,Waffle Case,Gloves,Shorts,Short Yoga,StrawExpert,Wrap Around Pillowcases,Cup,Bath Mats,Bedsure,Pillowcase,Bathroom,Shower,Milk Frother,Masks,Bug Zapper,Touchless Thermometer,Cat Litter Mat,Probiotics,Smart Plug,Natural Vitality Bottle,Christmas,Sleeveless,Shape Shifting Box,Refrigerator Organizer,Hydration Multiplier,Standard Mouth,Gift Box,USB C,Superhero,Digital Caliper,Massage Gun,Fidget Toys,Garden Hose,Cookie,Blanket,Protein Bars,Caramel Cashew,String Lights,Umbrella,Wearable Blanket,Diapers,Halloween,Flying Toys,Laundry Basket,Kitchen Faucet,Citrulline Malate,Onesie,Pajamas,Nail Polish Kit,fairy finder,Allergy,Immune Supplement,Frying Pan,Tablecloth,Electric Knife,Butter Dish,Dancing Cactus,Maya Mint,ice Cream,Christmas Tree,Liquid Motion Lamp,Stuffed Animal,Plush Bed Comforter,Journal,Women's,Sleeveless Wrap,Supplement,Screen Magnifier,Foot Massager,Machine,Santa,Anime Heroes,Air Mattress,Three Barrel Curling,3D Printer Filament,Power Strip,Rechargeable Toothbrush,Hooded Bathrobe,Sleepwear,Baby Einstein,Vinyl,Plastic Plates,Doorbell,Month Planner,Wooden Balls,Arceus,Wipes,Perfume,Rings,Bore Sight,Fishing Lures,Ear Protection,Firewood Rack,Sling Bag,Resistance Bands,Belt,Backpacks,Silver Slides,Whiteboard,Sports Bra,Cover,Jade Stud,Earrings,Necklace,Snow Shovel,Computer Desk,Dog Pee Pads,Turtleneck,Glasses,Spa,Up Balancer"},
+    "top-bsr":                  {"subBsrMax": 1000},
+}
+
+
+# ─── API Client ──────────────────────────────────────────────────────────────
+
+def get_api_key():
+    """
+    Get API key from environment variable or config file.
+
+    Priority:
+    1. Environment variable APICLAW_API_KEY
+    2. Config file config.json in the skill directory (next to scripts/)
+    """
+    # Try environment variable first
+    key = os.environ.get("APICLAW_API_KEY", "").strip()
+    if key:
+        return key
+
+    # Try config file in skill directory (parent of scripts/)
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    skill_dir = os.path.dirname(script_dir)  # go up from scripts/ to skill root
+    config_path = os.path.join(skill_dir, "config.json")
+    if os.path.exists(config_path):
+        try:
+            with open(config_path, "r", encoding="utf-8") as f:
+                config = json.load(f)
+                key = config.get("api_key", "").strip()
+                if key:
+                    return key
+        except (json.JSONDecodeError, IOError) as e:
+            print(f"WARNING: Failed to read config file: {e}", file=sys.stderr)
+
+    # No key found
+    print("ERROR: API Key not found.", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("Please configure your API Key using one of these methods:", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("  Method 1: Environment variable (recommended)", file=sys.stderr)
+    print("    export APICLAW_API_KEY='hms_live_yourkey'", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("  Method 2: Config file", file=sys.stderr)
+    print(f"    Create config.json in the skill directory: {skill_dir}", file=sys.stderr)
+    print('    Content: {"api_key": "hms_live_yourkey"}', file=sys.stderr)
+    print("", file=sys.stderr)
+    print("Get a free key at https://apiclaw.io/api-keys", file=sys.stderr)
+    sys.exit(1)
+
+
+def api_call(endpoint: str, params: dict) -> dict:
+    """
+    Make a POST request to APIClaw API with retry and error handling.
+
+    Returns the parsed JSON response on success, with _query metadata injected.
+    Exits with a clear error message on failure.
+    """
+    url = f"{BASE_URL}/{endpoint}"
+    api_key = get_api_key()
+
+    # Clean params: remove None values
+    params = {k: v for k, v in params.items() if v is not None}
+
+    # Quirk: topN and newProductPeriod must be strings
+    for str_field in ("topN", "newProductPeriod"):
+        if str_field in params and not isinstance(params[str_field], str):
+            params[str_field] = str(params[str_field])
+
+    # Save the actual params sent to API (for _query metadata)
+    actual_params = dict(params)
+
+    body = json.dumps(params).encode("utf-8")
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "User-Agent": "APIClaw-CLI/1.0 (Python)",
+    }
+
+    delay = RETRY_DELAY
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+            with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
+                data = json.loads(resp.read().decode("utf-8"))
+                if data.get("success"):
+                    # Inject _query metadata so AI knows exactly what was sent
+                    data["_query"] = {
+                        "endpoint": endpoint,
+                        "params": actual_params,
+                    }
+                    # Inject _credits metadata for usage tracking
+                    data["_credits"] = {
+                        "consumed": data.get("creditsConsumed"),
+                        "remaining": data.get("creditsRemaining"),
+                    }
+                    return data
+                else:
+                    err = data.get("error", {})
+                    print(f"API error: {err.get('code', 'unknown')} — {err.get('message', json.dumps(err))}", file=sys.stderr)
+                    sys.exit(1)
+        except urllib.error.HTTPError as e:
+            status = e.code
+            if status == 401:
+                return _error_result(401, "API Key invalid or expired",
+                    "Check your API Key or get a new one at https://apiclaw.io/api-keys",
+                    endpoint, actual_params)
+            elif status == 402:
+                return _error_result(402, "API quota exhausted or subscription expired",
+                    "Check your plan at https://apiclaw.io/api-keys or provide a new Key",
+                    endpoint, actual_params)
+            elif status == 429:
+                if attempt < MAX_RETRIES:
+                    print(f"Rate limited (429). Waiting {delay}s before retry {attempt}/{MAX_RETRIES}...", file=sys.stderr)
+                    time.sleep(delay)
+                    delay *= 2
+                    continue
+                else:
+                    return _error_result(429, "Rate limit exceeded after retries",
+                        "Try again later or reduce request frequency",
+                        endpoint, actual_params)
+            elif status == 404:
+                return _error_result(404, f"Endpoint '{endpoint}' not found",
+                    f"Check {API_DOCS} for current endpoints",
+                    endpoint, actual_params)
+            else:
+                if attempt < MAX_RETRIES:
+                    print(f"HTTP {status}. Retrying {attempt}/{MAX_RETRIES}...", file=sys.stderr)
+                    time.sleep(delay)
+                    continue
+                else:
+                    return _error_result(status, f"HTTP {status} after {MAX_RETRIES} attempts",
+                        "Check network or try again later",
+                        endpoint, actual_params)
+        except Exception as e:
+            if attempt < MAX_RETRIES:
+                print(f"Request failed: {e}. Retrying {attempt}/{MAX_RETRIES}...", file=sys.stderr)
+                time.sleep(delay)
+                continue
+            else:
+                return _error_result(0, f"Request failed: {e}",
+                    "Check network connection",
+                    endpoint, actual_params)
+
+    return _error_result(0, "Unexpected retry loop exit", "This should not happen", endpoint, actual_params)
+
+
+def _error_result(status: int, message: str, action: str, endpoint: str, params: dict) -> dict:
+    """
+    Build a structured error result instead of sys.exit().
+    This lets AI read the error from JSON stdout and take appropriate action.
+    """
+    print(f"ERROR: {message}", file=sys.stderr)
+    return {
+        "success": False,
+        "error": {
+            "status": status,
+            "message": message,
+            "action": action,
+        },
+        "_query": {
+            "endpoint": endpoint,
+            "params": params,
+        },
+    }
+
+
+def output(data, fmt="json"):
+    """Print output in the requested format."""
+    if fmt == "json":
+        print(json.dumps(data, indent=2, ensure_ascii=False))
+    elif fmt == "compact":
+        print(json.dumps(data, ensure_ascii=False))
+    else:
+        print(json.dumps(data, indent=2, ensure_ascii=False))
+
+
+# ─── Helper: parse category string ──────────────────────────────────────────
+
+def parse_category(cat_str: str) -> list:
+    """Parse category path string into a list.
+
+    Supported formats (in priority order):
+    1. ' > ' separator: 'Pet Supplies > Dogs > Toys'  (recommended, handles commas in names)
+    2. ',' separator:   'Pet Supplies,Dogs,Toys'       (legacy, breaks on names with commas)
+
+    Use ' > ' when category names contain commas, e.g.:
+    'Baby Products > Baby Care > Pacifiers, Teethers & Teething Relief'
+    """
+    if not cat_str:
+        return []
+    # Prefer ' > ' separator — handles commas in category names correctly
+    if " > " in cat_str:
+        return [c.strip() for c in cat_str.split(" > ")]
+    return [c.strip() for c in cat_str.split(",")]
+
+
+# ─── Subcommands ─────────────────────────────────────────────────────────────
+
+def cmd_categories(args):
+    """Query the Amazon category tree."""
+    params = {}
+    if args.keyword:
+        params["categoryKeyword"] = args.keyword
+    elif args.category:
+        params["categoryPath"] = parse_category(args.category)
+    elif args.parent:
+        params["parentCategoryPath"] = parse_category(args.parent)
+    # else: no params → root categories
+
+    result = api_call("categories", params)
+    output(result, args.format)
+
+
+def cmd_market(args):
+    """Search market-level aggregate data for a category."""
+    params = {}
+    if args.category:
+        params["categoryPath"] = parse_category(args.category)
+    if args.keyword:
+        params["categoryKeyword"] = args.keyword
+    if args.topn:
+        params["topN"] = str(args.topn)
+    if args.page_size:
+        params["pageSize"] = args.page_size
+    if args.sort:
+        params["sortBy"] = args.sort
+    if args.order:
+        params["sortOrder"] = args.order
+
+    result = api_call("markets/search", params)
+    output(result, args.format)
+
+
+def cmd_products(args):
+    """Search products with filters (product selection / 选品)."""
+    params = {}
+    if args.keyword:
+        params["keyword"] = args.keyword
+    if args.category:
+        params["categoryPath"] = parse_category(args.category)
+
+    # Apply mode preset filters
+    if args.mode:
+        mode_key = args.mode.lower().replace(" ", "-").replace("_", "-")
+        if mode_key in PRODUCT_MODES:
+            params.update(PRODUCT_MODES[mode_key])
+        else:
+            print(f"ERROR: Unknown mode '{args.mode}'.", file=sys.stderr)
+            print(f"Available modes: {', '.join(sorted(PRODUCT_MODES.keys()))}", file=sys.stderr)
+            sys.exit(1)
+
+    # Override with explicit filters
+    for attr in ("monthlySalesMin", "monthlySalesMax", "reviewCountMin", "reviewCountMax",
+                 "priceMin", "priceMax", "ratingMin", "ratingMax", "bsrMin", "bsrMax",
+                 "salesGrowthRateMin", "salesGrowthRateMax", "sellerCountMin", "sellerCountMax",
+                 "variantCountMin", "variantCountMax"):
+        val = getattr(args, attr.replace("Min", "_min").replace("Max", "_max")
+                      .replace("monthly", "monthly_").replace("review", "review_")
+                      .replace("sales", "sales_").replace("Growth", "_growth_")
+                      .replace("Rate", "rate_").replace("price", "price_")
+                      .replace("rating", "rating_").replace("bsr", "bsr_")
+                      .replace("seller", "seller_").replace("Count", "_count_")
+                      .replace("variant", "variant_"), None)
+        # Simplified: just use the argparse names directly
+
+    if args.sales_min is not None:
+        params["monthlySalesMin"] = args.sales_min
+    if args.sales_max is not None:
+        params["monthlySalesMax"] = args.sales_max
+    if args.reviews_min is not None:
+        params["reviewCountMin"] = args.reviews_min
+    if args.reviews_max is not None:
+        params["reviewCountMax"] = args.reviews_max
+    if args.price_min is not None:
+        params["priceMin"] = args.price_min
+    if args.price_max is not None:
+        params["priceMax"] = args.price_max
+    if args.rating_min is not None:
+        params["ratingMin"] = args.rating_min
+    if args.rating_max is not None:
+        params["ratingMax"] = args.rating_max
+    if args.growth_min is not None:
+        params["salesGrowthRateMin"] = args.growth_min
+    if args.bsr_min is not None:
+        params["bsrMin"] = args.bsr_min
+    if args.bsr_max is not None:
+        params["bsrMax"] = args.bsr_max
+    if args.seller_count_min is not None:
+        params["sellerCountMin"] = args.seller_count_min
+    if args.seller_count_max is not None:
+        params["sellerCountMax"] = args.seller_count_max
+    if args.variant_count_max is not None:
+        params["variantCountMax"] = args.variant_count_max
+    if args.keyword_match_type:
+        params["keywordMatchType"] = args.keyword_match_type
+    if args.sub_bsr_max is not None:
+        params["subBsrMax"] = args.sub_bsr_max
+    if args.exclude_keywords:
+        params["excludeKeywords"] = args.exclude_keywords
+    if args.listing_age:
+        params["listingAge"] = args.listing_age
+    if args.badges:
+        params["badges"] = args.badges
+    if args.fulfillment:
+        params["fulfillment"] = args.fulfillment
+    if args.include_brands:
+        params["includeBrands"] = args.include_brands
+    if args.exclude_brands:
+        params["excludeBrands"] = args.exclude_brands
+
+    params["sortBy"] = args.sort or "atLeastMonthlySales"
+    params["sortOrder"] = args.order or "desc"
+    params["pageSize"] = args.page_size or 20
+
+    result = api_call("products/search", params)
+    output(result, args.format)
+
+
+def cmd_competitors(args):
+    """Look up competitors by keyword, brand, ASIN, or category."""
+    params = {}
+    if args.keyword:
+        params["keyword"] = args.keyword
+    if args.brand:
+        params["brand"] = args.brand
+    if args.asin:
+        params["asin"] = args.asin
+    if args.category:
+        params["categoryPath"] = parse_category(args.category)
+
+    params["sortBy"] = args.sort or "atLeastMonthlySales"
+    params["sortOrder"] = args.order or "desc"
+    params["pageSize"] = args.page_size or 20
+
+    result = api_call("products/competitor-lookup", params)
+    output(result, args.format)
+
+
+def cmd_product(args):
+    """Get real-time product details for a single ASIN."""
+    if not args.asin:
+        print("ERROR: --asin is required for product command.", file=sys.stderr)
+        sys.exit(1)
+    params = {"asin": args.asin}
+    if args.marketplace:
+        params["marketplace"] = args.marketplace
+
+    result = api_call("realtime/product", params)
+    output(result, args.format)
+
+
+def cmd_analyze(args):
+    """Analyze reviews for ASINs or category with AI-powered insights."""
+    params = {}
+
+    # Determine mode from arguments
+    if args.asin:
+        params["asins"] = [args.asin]
+        params["mode"] = "asin"
+    elif args.asins:
+        params["asins"] = [a.strip() for a in args.asins.split(",")]
+        params["mode"] = "asin"
+    elif args.category:
+        params["categoryPath"] = parse_category(args.category)
+        params["mode"] = "category"
+    elif args.mode:
+        params["mode"] = args.mode
+    else:
+        print("ERROR: --asin, --asins, or --category is required for analyze command.", file=sys.stderr)
+        sys.exit(1)
+
+    if args.label_type:
+        params["labelType"] = args.label_type
+    if args.period:
+        params["period"] = args.period
+
+    result = api_call("reviews/analyze", params)
+    output(result, args.format)
+
+
+def cmd_report(args):
+    """
+    Composite workflow: Full Market Report.
+    Runs categories → markets/search → products/search → realtime/product (top 1).
+    Outputs combined JSON with all results.
+    """
+    keyword = args.keyword
+    if not keyword:
+        print("ERROR: --keyword is required for report command.", file=sys.stderr)
+        sys.exit(1)
+
+    topn = str(args.topn or 10)
+    results = {}
+
+    # Step 1: Confirm category
+    print("Step 1/4: Confirming category...", file=sys.stderr)
+    cat_result = api_call("categories", {"categoryKeyword": keyword})
+    results["categories"] = cat_result
+    cat_data = cat_result.get("data", [])
+
+    # Use the first matching category path
+    category_path = None
+    if cat_data:
+        category_path = cat_data[0].get("categoryPath")
+
+    # Step 2: Market data
+    print("Step 2/4: Pulling market data...", file=sys.stderr)
+    market_params = {"topN": topn}
+    if category_path:
+        market_params["categoryPath"] = category_path
+    else:
+        market_params["categoryKeyword"] = keyword
+    market_result = api_call("markets/search", market_params)
+    results["market"] = market_result
+
+    # Step 3: Top products
+    print("Step 3/4: Searching top products...", file=sys.stderr)
+    products_result = api_call("products/search", {
+        "keyword": keyword,
+        "sortBy": "atLeastMonthlySales",
+        "sortOrder": "desc",
+        "pageSize": 50,
+    })
+    results["products"] = products_result
+
+    # Step 4: Top 1 ASIN detail
+    product_data = products_result.get("data", [])
+    if product_data:
+        top_asin = product_data[0].get("asin")
+        if top_asin:
+            print(f"Step 4/4: Getting details for top ASIN {top_asin}...", file=sys.stderr)
+            detail_result = api_call("realtime/product", {"asin": top_asin, "marketplace": "US"})
+            results["topProductDetail"] = detail_result
+    else:
+        print("Step 4/4: No products found, skipping detail.", file=sys.stderr)
+
+    print("Done.", file=sys.stderr)
+    output(results, args.format)
+
+
+def cmd_opportunity(args):
+    """
+    Composite workflow: Product Opportunity Discovery.
+    Runs categories → markets/search → products/search (filtered) → realtime/product (top 3).
+    """
+    keyword = args.keyword
+    if not keyword:
+        print("ERROR: --keyword is required for opportunity command.", file=sys.stderr)
+        sys.exit(1)
+
+    results = {}
+
+    # Step 1: Confirm category
+    print("Step 1/4: Confirming category...", file=sys.stderr)
+    cat_result = api_call("categories", {"categoryKeyword": keyword})
+    results["categories"] = cat_result
+    cat_data = cat_result.get("data", [])
+    category_path = cat_data[0].get("categoryPath") if cat_data else None
+
+    # Step 2: Market validation
+    print("Step 2/4: Validating market...", file=sys.stderr)
+    market_params = {"topN": "10"}
+    if category_path:
+        market_params["categoryPath"] = category_path
+    else:
+        market_params["categoryKeyword"] = keyword
+    results["market"] = api_call("markets/search", market_params)
+
+    # Step 3: Product candidates (high demand, low barrier)
+    print("Step 3/4: Discovering product candidates...", file=sys.stderr)
+    search_params = {
+        "keyword": keyword,
+        "monthlySalesMin": 300,
+        "reviewCountMax": 50,
+        "sortBy": "atLeastMonthlySales",
+        "sortOrder": "desc",
+        "pageSize": 20,
+    }
+    # Apply mode override if specified
+    if args.mode and args.mode in PRODUCT_MODES:
+        search_params.update(PRODUCT_MODES[args.mode])
+    results["products"] = api_call("products/search", search_params)
+
+    # Step 4: Detail for top 3 ASINs
+    product_data = results["products"].get("data", [])
+    details = []
+    for p in product_data[:3]:
+        asin = p.get("asin")
+        if asin:
+            print(f"Step 4/4: Getting details for {asin}...", file=sys.stderr)
+            details.append(api_call("realtime/product", {"asin": asin, "marketplace": "US"}))
+    results["topProductDetails"] = details
+
+    print("Done.", file=sys.stderr)
+    output(results, args.format)
+
+
+def cmd_check(args):
+    """
+    API self-check: verify API connectivity and available endpoints.
+    Tests each endpoint with a simple query.
+    """
+    print("APIClaw API Self-Check\n", file=sys.stderr)
+    print("=" * 50, file=sys.stderr)
+
+    # Check API key from environment variable
+    api_key = os.environ.get("APICLAW_API_KEY", "").strip()
+    key_source = "env"
+
+    # If not in env, check config file
+    if not api_key:
+        config_path = os.path.expanduser("~/.apiclaw/config.json")
+        if os.path.exists(config_path):
+            try:
+                with open(config_path, "r", encoding="utf-8") as f:
+                    config = json.load(f)
+                    api_key = config.get("api_key", "").strip()
+                    key_source = "config"
+            except (json.JSONDecodeError, IOError):
+                pass
+
+    if api_key:
+        source_label = "~/.apiclaw/config.json" if key_source == "config" else "environment variable"
+        print(f"✅ API Key found (source: {source_label})", file=sys.stderr)
+    else:
+        print("❌ API Key: Not found", file=sys.stderr)
+        print("   Checked: $APICLAW_API_KEY, ~/.apiclaw/config.json", file=sys.stderr)
+        print("   Get one at: https://apiclaw.io/api-keys", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"\nTesting endpoints on {BASE_URL}...\n", file=sys.stderr)
+
+    endpoints = [
+        ("categories", {}, "Category tree"),
+        ("markets/search", {"categoryKeyword": "pet", "pageSize": 1}, "Market search"),
+        ("products/search", {"keyword": "test", "pageSize": 1}, "Product search"),
+        ("products/competitor-lookup", {"keyword": "test", "pageSize": 1}, "Competitor lookup"),
+    ]
+
+    results = {}
+    all_ok = True
+
+    for endpoint, params, desc in endpoints:
+        try:
+            result = api_call(endpoint, params)
+            data_count = len(result.get("data", []))
+            print(f"✅ {endpoint:30} OK (returned {data_count} items)", file=sys.stderr)
+            results[endpoint] = {"status": "ok", "items": data_count}
+        except SystemExit:
+            print(f"❌ {endpoint:30} FAILED", file=sys.stderr)
+            results[endpoint] = {"status": "failed"}
+            all_ok = False
+        except Exception as e:
+            print(f"❌ {endpoint:30} ERROR: {e}", file=sys.stderr)
+            results[endpoint] = {"status": "error", "message": str(e)}
+            all_ok = False
+
+    # Note: realtime/product and reviews/analyze require valid ASINs, skip in self-check
+    print(f"⏭️  realtime/product            (skipped, requires valid ASIN)", file=sys.stderr)
+    print(f"⏭️  reviews/analyze             (skipped, requires valid ASIN or category)", file=sys.stderr)
+
+    print("\n" + "=" * 50, file=sys.stderr)
+    if all_ok:
+        print("✅ All endpoints operational", file=sys.stderr)
+    else:
+        print("⚠️  Some endpoints failed. Check API key or network.", file=sys.stderr)
+
+    print(f"\nAPI Docs: {API_DOCS}", file=sys.stderr)
+
+    output({"check": "complete", "endpoints": results}, args.format)
+
+
+# ─── CLI Setup ───────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="APIClaw CLI — Amazon Product Research",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s categories --keyword "pet supplies"
+  %(prog)s market --category "Pet Supplies,Dogs" --topn 10
+  %(prog)s products --keyword "yoga mat" --mode beginner
+  %(prog)s products --keyword "yoga mat" --sales-min 300 --reviews-max 50
+  %(prog)s competitors --keyword "wireless earbuds" --brand Anker
+  %(prog)s product --asin B09V3KXJPB
+  %(prog)s report --keyword "pet supplies"
+  %(prog)s opportunity --keyword "pet supplies" --mode high-demand-low-barrier
+  %(prog)s check                                            # API self-check
+        """,
+    )
+
+    # Common args
+    parser.add_argument("--format", choices=["json", "compact"], default="json",
+                        help="Output format (default: json)")
+
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # ── categories ──
+    p_cat = sub.add_parser("categories", help="Query Amazon category tree")
+    p_cat.add_argument("--keyword", help="Search categories by keyword")
+    p_cat.add_argument("--category", help="Exact category path (comma-separated)")
+    p_cat.add_argument("--parent", help="Get child categories (comma-separated parent path)")
+    p_cat.set_defaults(func=cmd_categories)
+
+    # ── market ──
+    p_mkt = sub.add_parser("market", help="Search market-level data for a category")
+    p_mkt.add_argument("--category", help="Category path (comma-separated)")
+    p_mkt.add_argument("--keyword", help="Category keyword")
+    p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
+    p_mkt.add_argument("--page-size", type=int, default=20)
+    p_mkt.add_argument("--sort", help="Sort field")
+    p_mkt.add_argument("--order", choices=["asc", "desc"], default="desc")
+    p_mkt.set_defaults(func=cmd_market)
+
+    # ── products ──
+    p_prod = sub.add_parser("products", help="Search products with filters (product selection)")
+    p_prod.add_argument("--keyword", help="Search keyword")
+    p_prod.add_argument("--category", help="Category path (comma-separated)")
+    p_prod.add_argument("--mode", help=f"Preset filter mode: {', '.join(sorted(PRODUCT_MODES.keys()))}")
+    p_prod.add_argument("--sales-min", type=int, help="Min monthly sales")
+    p_prod.add_argument("--sales-max", type=int, help="Max monthly sales")
+    p_prod.add_argument("--reviews-min", type=int, help="Min review count")
+    p_prod.add_argument("--reviews-max", type=int, help="Max review count")
+    p_prod.add_argument("--price-min", type=float, help="Min price")
+    p_prod.add_argument("--price-max", type=float, help="Max price")
+    p_prod.add_argument("--rating-min", type=float, help="Min rating")
+    p_prod.add_argument("--rating-max", type=float, help="Max rating")
+    p_prod.add_argument("--growth-min", type=float, help="Min sales growth rate")
+    p_prod.add_argument("--bsr-min", type=int, help="Min BSR rank")
+    p_prod.add_argument("--bsr-max", type=int, help="Max BSR rank")
+    p_prod.add_argument("--seller-count-min", type=int, help="Min seller count")
+    p_prod.add_argument("--seller-count-max", type=int, help="Max seller count")
+    p_prod.add_argument("--variant-count-max", type=int, help="Max variant count")
+    p_prod.add_argument("--keyword-match-type", choices=["fuzzy", "phrase", "exact"],
+                        help="Keyword match type (default: fuzzy)")
+    p_prod.add_argument("--sub-bsr-max", type=int, help="Max sub-category BSR rank")
+    p_prod.add_argument("--exclude-keywords", help="Keywords to exclude (comma-separated)")
+    p_prod.add_argument("--listing-age", help="Max listing age in days (string)")
+    p_prod.add_argument("--badges", nargs="+", help="Badge filters (e.g. 'New Release')")
+    p_prod.add_argument("--fulfillment", nargs="+", help="Fulfillment filter (FBA, FBM)")
+    p_prod.add_argument("--include-brands", help="Include brands (comma-separated)")
+    p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")
+    p_prod.add_argument("--page-size", type=int, default=20)
+    p_prod.add_argument("--sort", help="Sort field (default: atLeastMonthlySales)")
+    p_prod.add_argument("--order", choices=["asc", "desc"], default="desc")
+    p_prod.set_defaults(func=cmd_products)
+
+    # ── competitors ──
+    p_comp = sub.add_parser("competitors", help="Look up competitors")
+    p_comp.add_argument("--keyword", help="Search keyword")
+    p_comp.add_argument("--brand", help="Brand filter")
+    p_comp.add_argument("--asin", help="ASIN filter")
+    p_comp.add_argument("--category", help="Category path (comma-separated)")
+    p_comp.add_argument("--page-size", type=int, default=20)
+    p_comp.add_argument("--sort", help="Sort field (default: atLeastMonthlySales)")
+    p_comp.add_argument("--order", choices=["asc", "desc"], default="desc")
+    p_comp.set_defaults(func=cmd_competitors)
+
+    # ── product (single ASIN) ──
+    p_single = sub.add_parser("product", help="Get real-time details for one ASIN")
+    p_single.add_argument("--asin", required=True, help="ASIN (required)")
+    p_single.add_argument("--marketplace", default="US",
+                          help="Marketplace: US/UK/DE/FR/IT/ES/JP/CA/AU/IN/MX/BR (default: US)")
+    p_single.set_defaults(func=cmd_product)
+
+    # ── analyze (review analysis) ──
+    p_analyze = sub.add_parser("analyze", help="Analyze reviews (sentiment, insights, pain points)")
+    p_analyze.add_argument("--asin", help="Single ASIN to analyze")
+    p_analyze.add_argument("--asins", help="Multiple ASINs (comma-separated, max 100)")
+    p_analyze.add_argument("--category", help="Category path for category-level analysis")
+    p_analyze.add_argument("--label-type",
+                           help="Insight dimension filter: painPoints,issues,positives,improvements,"
+                                "buyingFactors,scenarios,keywords,userProfiles,usageTimes,"
+                                "usageLocations,behaviors")
+    p_analyze.add_argument("--period", help="Time period (e.g. 90d)")
+    p_analyze.add_argument("--mode", choices=["asin", "category"],
+                           help="Query mode (auto-detected from --asin/--category)")
+    p_analyze.set_defaults(func=cmd_analyze)
+
+    # ── report (composite) ──
+    p_report = sub.add_parser("report", help="Full market analysis report (composite workflow)")
+    p_report.add_argument("--keyword", required=True, help="Category/niche keyword")
+    p_report.add_argument("--topn", type=int, default=10, help="Top N (default: 10)")
+    p_report.set_defaults(func=cmd_report)
+
+    # ── opportunity (composite) ──
+    p_opp = sub.add_parser("opportunity", help="Product opportunity discovery (composite workflow)")
+    p_opp.add_argument("--keyword", required=True, help="Category/niche keyword")
+    p_opp.add_argument("--mode", help="Product search mode preset")
+    p_opp.set_defaults(func=cmd_opportunity)
+
+    # ── check (API self-check) ──
+    p_check = sub.add_parser("check", help="Fetch latest OpenAPI spec to verify available endpoints")
+    p_check.set_defaults(func=cmd_check)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## APIClaw — Amazon Seller Data Analysis Skill

**What it does:** AI-powered Amazon product research skill with 14 selection strategies, 6-dimension risk assessment, and consumer insights analysis. Backed by 200M+ product database.

**Use when:** Product selection, ASIN lookup, BSR analysis, competitor lookup, market opportunity assessment, risk assessment, pricing strategy, review analysis, or listing optimization.

**Structure:**
- `SKILL.md` — Main instructions (417 lines, under 500-line best practice)
- `scripts/apiclaw.py` — Single CLI script for all 6 API endpoints
- `references/` — Scenario-specific workflows (evaluation, listing, pricing, operations, expansion)

**Endpoints:** categories, markets/search, products/search, products/competitor-lookup, realtime/product, reviews/analyze

**Requires:** `APICLAW_API_KEY` (get at apiclaw.io/api-keys)

**Source:** https://github.com/SerendipityOneInc/Amazon-analysis-skill (v1.1.4)