### PR TITLE
Add session-wrap-up skill

### DIFF
--- a/skills/session-wrap-up/LICENSE.txt
+++ b/skills/session-wrap-up/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/session-wrap-up/SKILL.md
+++ b/skills/session-wrap-up/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: session-wrap-up
+description: "End-of-session wrap-up: token cost summary, session recap, and smart Skill/Plugin recommendations based on what you did. Use when: the user says \"wrap\", \"wrap up\", \"done\", \"bye\", \"finished\", or the conversation is clearly ending. Do NOT use for: mid-session summaries or general Q&A."
+license: Complete terms in LICENSE.txt
+---
+
+# Session Wrap-Up
+
+Summarize the session and recommend relevant skills/plugins when the conversation ends.
+
+## Execution Flow
+
+### Phase 1: Session Recap
+
+From the current conversation context (do NOT read files), extract:
+- What the user accomplished (3-5 bullet points)
+- Identify activity type keywords for Phase 2
+
+Activity keyword table:
+
+| Keyword | Trigger |
+|---------|---------|
+| coding | Wrote code, edited source files |
+| frontend | HTML/CSS/React/Next.js/Vue etc. |
+| debugging | Debugging, troubleshooting, fixing bugs |
+| git | Git operations, commits, PRs |
+| api | API development, HTTP requests |
+| data | Data processing, batch operations |
+| deploy | Deployment, CI/CD |
+| project | Project management, task tracking |
+| docs | Documentation writing |
+| skill_dev | Developing skills or plugins |
+| security | Security-related work |
+| testing | Testing-related work |
+| python | Python development |
+| typescript | TypeScript/JS development |
+
+### Phase 2: Smart Recommendations
+
+Run the recommendation script, passing in the activity keywords identified in Phase 1:
+
+```bash
+python3 SKILL_DIR/recommend.py <keywords...>
+```
+
+The script reads:
+- `~/.claude/plugins/installed_plugins.json` — installed plugins
+- `~/.claude/plugins/marketplaces/claude-plugins-official/.claude-plugin/marketplace.json` — official plugin registry
+- `~/.claude/plugins/install-counts-cache.json` — install counts
+- `~/.claude/skills/` — local skill list
+
+Returns JSON with `recommended_new` (not yet installed) and `reminder_installed` (already have).
+
+If any of these files are missing, the script gracefully degrades and still returns results.
+
+### Phase 3: Formatted Output
+
+Combine everything into this format:
+
+```markdown
+---
+## What you did
+- [bullet 1]
+- [bullet 2]
+- ...
+
+## Recommended for you
+1. **plugin-name** (official, XXK installs) — one-line explanation of why
+   → `claude plugin install plugin-name@claude-plugins-official`
+
+2. **plugin-name** (official) — one-line explanation
+   → `claude plugin install plugin-name@claude-plugins-official`
+
+3. **/skill-name** (installed) — you already have this! One-line reminder of how to use it
+---
+```
+
+## Recommendation Strategy
+
+Priority ordering:
+1. Official plugins > third-party > local skills
+2. High install count > obscure
+3. Strongly related to this session's activities > generic
+
+Each recommendation MUST include a **one-line explanation**: why it's recommended + how to use it.
+
+## Guidelines
+
+- Do NOT read files to generate the recap — extract directly from conversation context
+- Limit to 3 new recommendations + 1-2 installed reminders
+- Keep it concise — this is a wrap-up, not a report

--- a/skills/session-wrap-up/recommend.py
+++ b/skills/session-wrap-up/recommend.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+Session wrap-up recommender — reads the Claude Code plugin registry,
+installed list, install counts, and local skills directory, then outputs
+recommendations based on session activity keywords.
+
+Usage:
+    python3 recommend.py <activity_keywords...>
+    e.g. python3 recommend.py coding git debugging frontend
+
+Output: JSON with recommended_new (uninstalled) and reminder_installed (already have).
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+PLUGINS_DIR = Path.home() / ".claude" / "plugins"
+SKILLS_DIR = Path.home() / ".claude" / "skills"
+MARKETPLACE = (
+    PLUGINS_DIR
+    / "marketplaces"
+    / "claude-plugins-official"
+    / ".claude-plugin"
+    / "marketplace.json"
+)
+INSTALLED = PLUGINS_DIR / "installed_plugins.json"
+COUNTS = PLUGINS_DIR / "install-counts-cache.json"
+
+# Activity → candidate plugin/skill names
+ACTIVITY_MAP = {
+    "coding": ["code-review", "code-simplifier", "security-guidance", "superpowers"],
+    "frontend": ["frontend-design", "playwright", "figma", "stagehand"],
+    "debugging": ["explanatory-output-style", "sentry"],
+    "git": ["commit-commands", "github", "pr-review-toolkit"],
+    "api": ["postman", "context7", "firecrawl"],
+    "data": ["firecrawl"],
+    "deploy": ["vercel", "firebase"],
+    "project": ["linear", "asana", "atlassian"],
+    "docs": ["claude-md-management", "context7"],
+    "skill_dev": ["skill-creator", "plugin-dev", "hookify"],
+    "security": ["security-guidance", "semgrep"],
+    "testing": ["playwright"],
+    "python": ["pyright-lsp"],
+    "typescript": ["typescript-lsp"],
+}
+
+
+def load_json(path: Path):
+    """Load a JSON file, returning None on any error."""
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError, PermissionError):
+        return None
+
+
+def get_installed_set(data):
+    """Extract the set of installed plugin keys."""
+    if not data or "plugins" not in data:
+        return set()
+    return set(data["plugins"].keys())
+
+
+def get_install_counts(data):
+    """Build a dict of plugin_key -> install count."""
+    if not data or "counts" not in data:
+        return {}
+    return {item["plugin"]: item["unique_installs"] for item in data["counts"]}
+
+
+def get_marketplace_descriptions(data):
+    """Build a dict of plugin_name -> description."""
+    if not data or "plugins" not in data:
+        return {}
+    return {p["name"]: p.get("description", "") for p in data["plugins"]}
+
+
+def get_local_skills():
+    """List local skill directory names that contain a SKILL.md."""
+    skills = []
+    if not SKILLS_DIR.exists():
+        return skills
+    for d in SKILLS_DIR.iterdir():
+        if d.is_dir() and (d / "SKILL.md").exists():
+            skills.append(d.name)
+    return skills
+
+
+def normalize_plugin_key(name: str) -> str:
+    """Convert 'code-review' to 'code-review@claude-plugins-official'."""
+    if "@" in name:
+        return name
+    return f"{name}@claude-plugins-official"
+
+
+def recommend(activities: list[str]) -> dict:
+    """Generate recommendations based on activity keywords."""
+    installed_data = load_json(INSTALLED)
+    counts_data = load_json(COUNTS)
+    marketplace_data = load_json(MARKETPLACE)
+
+    installed_set = get_installed_set(installed_data)
+    install_counts = get_install_counts(counts_data)
+    descriptions = get_marketplace_descriptions(marketplace_data)
+    local_skills = get_local_skills()
+
+    # Collect candidate names from activities
+    candidates = set()
+    for act in activities:
+        act_lower = act.lower()
+        for key, plugins in ACTIVITY_MAP.items():
+            if act_lower in key or key in act_lower:
+                candidates.update(plugins)
+
+    # Classify: new vs already installed
+    recommended_new = []
+    reminder_installed = []
+
+    for name in candidates:
+        full_key = normalize_plugin_key(name)
+        is_installed = full_key in installed_set or any(
+            full_key.lower() == k.lower() for k in installed_set
+        )
+        is_local = name in local_skills
+        count = install_counts.get(full_key, 0)
+        desc = descriptions.get(name, "")
+
+        entry = {
+            "name": name,
+            "description": desc,
+            "installs": count,
+            "source": "local_skill" if is_local else "official_plugin",
+            "install_cmd": (
+                f"claude plugin install {full_key}"
+                if not is_local
+                else f"/{name}"
+            ),
+        }
+
+        if is_installed or is_local:
+            reminder_installed.append(entry)
+        else:
+            recommended_new.append(entry)
+
+    # Sort by install count descending
+    recommended_new.sort(key=lambda x: -x["installs"])
+    reminder_installed.sort(key=lambda x: -x["installs"])
+
+    return {
+        "recommended_new": recommended_new[:3],
+        "reminder_installed": reminder_installed[:2],
+    }
+
+
+if __name__ == "__main__":
+    activities = sys.argv[1:] if len(sys.argv) > 1 else ["coding"]
+    result = recommend(activities)
+    print(json.dumps(result, indent=2, ensure_ascii=False))


### PR DESCRIPTION
## Summary
- Adds a new **session-wrap-up** skill that provides end-of-session recap and smart plugin/skill recommendations
- Includes `recommend.py` which reads the plugin registry, install counts, and installed plugins to generate prioritized suggestions based on what the user did during the session
- Gracefully degrades when plugin data files are missing

## How it works
1. **Session recap**: Extracts what the user accomplished from conversation context (no file reads)
2. **Activity detection**: Maps session activities to keywords (coding, frontend, git, deploy, etc.)
3. **Smart recommendations**: `recommend.py` matches activities to relevant plugins, filters out already-installed ones, and sorts by install count
4. **Formatted output**: Returns top 3 new recommendations + 1-2 installed reminders with one-line explanations

## Files
| File | Description |
|------|-------------|
| `skills/session-wrap-up/SKILL.md` | Skill definition with execution flow and recommendation strategy |
| `skills/session-wrap-up/recommend.py` | Plugin recommendation engine |
| `skills/session-wrap-up/LICENSE.txt` | Apache 2.0 license |

## Test plan
- [ ] Run `python3 recommend.py coding git` and verify JSON output with correct recommendations
- [ ] Run with no plugin data files present — should return empty results without errors
- [ ] Verify SKILL.md frontmatter follows the template format
- [ ] Test with various activity keyword combinations (frontend, deploy, security, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)