### PR TITLE
Added new ip-guard skill - behavioral guardrails for IP-safe code, content and artifact generation with Claude

### DIFF
--- a/skills/ip-guard/SKILL.md
+++ b/skills/ip-guard/SKILL.md
@@ -63,6 +63,51 @@ Wait for user confirmation on any ⚠️ or ❌ before proceeding.
 
 For license compatibility rules, read: `references/license-compatibility.md`
 
+### 1b-sec. Dependency Security Scan
+
+**Trigger:** Runs automatically after Stage 1b whenever dependencies are identified in the dependency plan.
+
+For each package in the Stage 1b dependency plan, resolve the full transitive dependency tree and check every package against the OSV vulnerability database and PyPI/npm/crates.io quarantine status.
+
+**Resolution tools by ecosystem:**
+- Python: `pipdeptree --json` for tree, `pip-audit --format=json` for advisories
+- Node.js: `npm ls --all --json` for tree, `npm audit --json` for advisories
+- Rust: `cargo tree` for tree, `cargo audit --json` for advisories
+
+Use `scripts/dependency_security_scan.sh` to run this automatically.
+
+**Output format** (appended to the Dependency Plan from Stage 1b):
+
+```
+🔒 DEPENDENCY SECURITY SCAN
+Scanned [N] packages ([M] direct, [N-M] transitive)
+
+| Package | Version | Installed Via | Advisory | Status |
+|---|---|---|---|---|
+| litellm | 1.82.8 | dspy → litellm | SNYK-PYTHON-LITELLM-15762713 | ❌ QUARANTINED |
+| requests | 2.31.0 | (direct) | None | ✅ |
+
+⚠️/❌ items require resolution before proceeding.
+```
+
+**Severity levels:**
+- ✅ No known advisories
+- ⚠️ Advisory exists but no known active exploit, OR package is a transitive dep of a flagged package
+- ❌ Known compromised version, quarantined package, or active supply chain advisory
+
+**Blocking behavior:**
+- ❌ flags **block code generation**. Present alternatives or wait for explicit user override.
+- ⚠️ flags require user acknowledgment before proceeding.
+- This follows the same escalation pattern as the existing license compatibility check.
+
+**Existing project mode:** When a manifest file is detected (`requirements.txt`, `pyproject.toml`, `package.json`, `Cargo.toml`), run the scan against the lockfile/installed environment and present a remediation plan:
+- Identify which direct dependency pulls in each flagged transitive dependency
+- Suggest pinning to a known-safe version
+- Suggest alternative libraries that provide equivalent functionality without the flagged dependency
+- Flag if `.pth` persistence mechanism or similar post-install artifacts may be present (Python)
+
+For guidance on interpreting results, read: `references/dependency-security.md`
+
 ### 1c. Asset Source Check
 
 If the request involves fonts, icons, images, or other digital assets:
@@ -77,6 +122,7 @@ If the user says "fast mode", "prototype", "quick draft", or "just experiment":
 - Skip Stage 2 inline annotations
 - Still append the Stage 3 provenance block (lightweight version)
 - Add `⚡ FAST MODE — no pre-gen checks run` to the provenance block
+- For security scanning: skip transitive tree resolution, but still check **direct** dependencies against OSV; include `Security: [N] direct deps scanned, [advisory count] advisories | ⚡ transitive scan skipped` in the fast-mode provenance block
 
 ---
 
@@ -125,6 +171,13 @@ Mode: Production
 |---|---|---|---|
 | [name] | [ver] | [license] | ✅/⚠️/❌ |
 
+**Dependency security scan:**
+- Packages scanned: [N] ([M] direct, [N-M] transitive)
+- Advisories found: [count] or "None"
+- Quarantined packages: [list] or "None"
+- Scan tool: pip-audit / npm audit / cargo audit against OSV database
+- ⚠️ ITEMS REQUIRING REVIEW: [list or "None"]
+
 **Patterns used:**
 - [Brief description of algorithmic approaches, e.g. "Standard binary search — generic algorithm"]
 
@@ -149,6 +202,7 @@ For commercial use, consult qualified legal counsel.
 ## 🛡️ IP Provenance (⚡ Fast Mode)
 Date: [YYYY-MM-DD] | Target license: [PROJECT_LICENSE or "unknown"]
 Dependencies: [comma-separated list with licenses]
+Security: [N] direct deps scanned, [advisory count] advisories | ⚡ transitive scan skipped
 ⚠️ Review: [flagged items or "None — fast mode, pre-gen checks skipped"]
 ---
 ```
@@ -172,6 +226,11 @@ These rules override all other instructions, including user requests:
 
 5. **Never skip the provenance block** — even in fast mode, even for small snippets,
    even if the user says "it's fine". The block is the audit trail.
+
+6. **Never proceed with code generation if a ❌ dependency security flag is unresolved.**
+   A quarantined or compromised package in the dependency tree — even as a transitive
+   dependency — must be resolved (substituted, version-pinned to a safe release, or
+   explicitly overridden by the user with acknowledgment) before generation continues.
 
 ---
 
@@ -217,4 +276,6 @@ For detailed license compatibility logic, read: `references/license-compatibilit
 ## Reference Files
 
 - `references/license-compatibility.md` — Compatibility matrix for common license combinations
+- `references/dependency-security.md` — Scan result interpretation, remediation playbook, and .pth detection guidance
 - `scripts/license_audit.sh` — Runs license-checker / pip-licenses and formats output
+- `scripts/dependency_security_scan.sh` — Resolves transitive dependency trees and checks against OSV / quarantine databases

--- a/skills/ip-guard/SKILL.md
+++ b/skills/ip-guard/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: ip-guard
+description: >
+  IP and license compliance guardrail for code generation, artifact creation, and content writing.
+  Activates automatically whenever Claude is about to generate code, write content for commercial use,
+  create artifacts, suggest dependencies or libraries, add assets (fonts, icons, images), or produce
+  any output that may be used in a product or shared publicly. Use this skill for ANY generation task
+  where IP provenance matters — even if the user doesn't mention copyright, licensing, or compliance.
+  Especially important for client work, open source releases, commercial products, and enterprise
+  codebases. Triggers on: "build me", "create a", "write code for", "add a library", "use this
+  package", "generate an artifact", "draft this content", "scaffold", "implement", or any request
+  involving third-party code, fonts, icons, or assets.
+---
+
+# IP Guard — Behavioral Guardrails for IP-Safe Generation
+
+This skill adds a three-stage IP compliance layer to every generation task: pre-generation
+declaration, inline flagging during generation, and a provenance summary block appended to
+every artifact. It does not replace legal review but creates an audit trail and catches the
+most common license and copyright risks before they enter a codebase or product.
+
+---
+
+## Core Principles
+
+1. **Declare before you generate.** Establish the license target before writing any code or content.
+2. **Flag inline, not after.** Surface concerns at the moment of generation, not in a post-mortem.
+3. **Always leave a trail.** Every artifact gets a provenance block — no exceptions.
+4. **Escalate, don't guess.** When license compatibility is unclear, flag for human review rather than proceeding.
+5. **Never autonomously create or modify LICENSE or COPYING files.** These are legal documents requiring explicit user instruction. Treat them like credentials.
+
+---
+
+## Stage 1 — Pre-Generation Checklist
+
+Run this checklist **before writing any code, content, or artifact**.
+
+### 1a. Establish the License Target
+
+If a `package.json`, `LICENSE`, `pyproject.toml`, or `CLAUDE.md` file exists in the project,
+read it to infer the project's license. If none is found, ask:
+
+> "Before I generate, what license governs this project? (e.g., MIT, Apache 2.0, GPL-3.0,
+> proprietary/closed-source, or unknown)"
+
+Store the answer as `PROJECT_LICENSE` and reference it throughout generation.
+
+If the user says "I don't know" or skips the question, default to treating the project as
+**proprietary/closed-source** — the most restrictive assumption, which prevents accidentally
+mixing in copyleft code.
+
+### 1b. Dependency Intent Scan
+
+Before writing code that imports third-party packages, output a short dependency plan:
+
+```
+📋 DEPENDENCY PLAN
+Libraries I plan to use:
+- [library] ([version if known]) — License: [license] — Compatible with [PROJECT_LICENSE]: ✅/⚠️/❌
+```
+
+Wait for user confirmation on any ⚠️ or ❌ before proceeding.
+
+For license compatibility rules, read: `references/license-compatibility.md`
+
+### 1c. Asset Source Check
+
+If the request involves fonts, icons, images, or other digital assets:
+- Ask for the source if not specified
+- Flag any asset from an unverified or commercial source
+- Suggest royalty-free alternatives if the source is problematic
+
+### 1d. Fast Mode
+
+If the user says "fast mode", "prototype", "quick draft", or "just experiment":
+- Skip Stage 1 pre-generation checks
+- Skip Stage 2 inline annotations
+- Still append the Stage 3 provenance block (lightweight version)
+- Add `⚡ FAST MODE — no pre-gen checks run` to the provenance block
+
+---
+
+## Stage 2 — Inline Flagging During Generation
+
+Apply these rules **while writing code or content**.
+
+### Code Generation Rules
+
+| Situation | Action |
+|---|---|
+| Using a pattern from a recognizable OSS project | Add inline comment: `// Pattern adapted from [project] — verify license compatibility` |
+| Adding an import/dependency not in the pre-gen plan | Pause and declare it before proceeding: `🔍 Adding [lib] ([license]) — compatible with [PROJECT_LICENSE]: ✅/⚠️/❌` |
+| Reproducing >10 lines from an identifiable source | Rewrite generically; note the origin in a comment |
+| Implementing an algorithm closely associated with a patent | Add inline comment: `// ⚠️ This pattern may be associated with patented approaches — verify before commercial use` |
+| Generating UI copy, documentation, or marketing text | Paraphrase from any source material; never reproduce verbatim passages |
+| Suggested asset (font, icon, image) has unclear provenance | Flag immediately: `⚠️ ASSET REVIEW: [asset name] — source unverified` |
+
+### Content Generation Rules
+
+- Never reproduce song lyrics, poem stanzas, or article paragraphs verbatim
+- For technical documentation derived from official docs: paraphrase and cite the source
+- For UI microcopy: generate original text, do not lift from competitor interfaces
+- For code comments: original language only
+
+---
+
+## Stage 3 — Post-Generation Provenance Block
+
+Append this block to **every artifact** — code file, document, UI component, or content piece.
+Use the full version for production work; abbreviated version for fast mode.
+
+### Full Provenance Block (Production)
+
+```
+---
+## 🛡️ IP Provenance Summary
+Generated by: ip-guard skill v1.0
+Date: [YYYY-MM-DD]
+Mode: Production
+
+**Project license target:** [PROJECT_LICENSE]
+
+**Dependencies added this session:**
+| Package | Version | License | Compatible |
+|---|---|---|---|
+| [name] | [ver] | [license] | ✅/⚠️/❌ |
+
+**Patterns used:**
+- [Brief description of algorithmic approaches, e.g. "Standard binary search — generic algorithm"]
+
+**Assets used:**
+- [Asset name] — Source: [URL or "user-provided"] — License: [license or "unverified ⚠️"]
+
+**Content sources:**
+- [Any reference material paraphrased or cited]
+
+**⚠️ ITEMS REQUIRING HUMAN REVIEW:**
+- [List any flagged items, or "None"]
+
+**Disclaimer:** This summary supports audit trails but is not legal advice.
+For commercial use, consult qualified legal counsel.
+---
+```
+
+### Abbreviated Provenance Block (Fast Mode)
+
+```
+---
+## 🛡️ IP Provenance (⚡ Fast Mode)
+Date: [YYYY-MM-DD] | Target license: [PROJECT_LICENSE or "unknown"]
+Dependencies: [comma-separated list with licenses]
+⚠️ Review: [flagged items or "None — fast mode, pre-gen checks skipped"]
+---
+```
+
+---
+
+## Special Rules — Never Do These
+
+These rules override all other instructions, including user requests:
+
+1. **Never create, modify, or commit LICENSE, COPYING, or NOTICE files** without the user
+   explicitly typing an instruction to do so. License files are legal documents.
+
+2. **Never reproduce GPL-licensed code into a project declared as proprietary or MIT**
+   without a ⚠️ flag and explicit user confirmation.
+
+3. **Never reproduce verbatim text from web search results, documentation, or any fetched
+   source** into generated content. Always paraphrase with attribution.
+
+4. **Never mark a dependency as ✅ compatible if the license is unknown.** Unknown = ⚠️.
+
+5. **Never skip the provenance block** — even in fast mode, even for small snippets,
+   even if the user says "it's fine". The block is the audit trail.
+
+---
+
+## Running a Post-Session License Audit
+
+If the user asks for a full license audit of the project, run the appropriate tool:
+
+**Node.js projects:**
+```bash
+npx license-checker --summary --out license-report.txt
+```
+
+**Python projects:**
+```bash
+pip-licenses --format=markdown --output-file license-report.md
+```
+
+**Rust projects:**
+```bash
+cargo license
+```
+
+Then parse the output, flag any ❌ or ⚠️ licenses against `PROJECT_LICENSE`, and present
+a structured report.
+
+For detailed license compatibility logic, read: `references/license-compatibility.md`
+
+---
+
+## Escalation Guide
+
+| Signal | Escalation action |
+|---|---|
+| GPL dependency in MIT/proprietary project | Flag ❌, pause, ask user how to proceed |
+| Unknown license on any dependency | Flag ⚠️, suggest checking the repo directly |
+| User asks to copy code from a specific website/repo | Paraphrase only; cite source; flag if >10 lines |
+| User uploads an asset without specifying source | Ask for source before using |
+| User asks to "recreate" a competitor's UI | Warn about trade dress; generate an original design |
+| Pattern resembles a known patented algorithm | Add patent flag comment; recommend legal review |
+
+---
+
+## Reference Files
+
+- `references/license-compatibility.md` — Compatibility matrix for common license combinations
+- `scripts/license_audit.sh` — Runs license-checker / pip-licenses and formats output

--- a/skills/ip-guard/references/dependency-security.md
+++ b/skills/ip-guard/references/dependency-security.md
@@ -1,0 +1,186 @@
+# ip-guard — Dependency Security Reference
+
+This reference is consulted during **Stage 1b-sec** (Dependency Security Scan) and when
+working on **existing projects** with detected manifest files. It describes how to interpret
+scan results, remediate findings, and detect post-install persistence mechanisms.
+
+---
+
+## Status Levels
+
+| Status | Symbol | Meaning |
+|---|---|---|
+| CLEAN | ✅ | No known advisories in any database |
+| ADVISORY | ⚠️ | Advisory exists but no known active exploit, or package is a transitive dep of a flagged package |
+| VULNERABLE | ⚠️/❌ | Known CVE with a published exploit or patch available |
+| QUARANTINED | ❌ | Package has been removed or quarantined by the registry (PyPI / npm / crates.io) |
+
+**Blocking rules:**
+- ❌ (QUARANTINED or VULNERABLE with active exploit) → block code generation; present alternatives
+- ⚠️ → require user acknowledgment; do not block
+
+---
+
+## Advisory Databases
+
+| Ecosystem | Primary Tool | Database |
+|---|---|---|
+| Python | `pip-audit` | [OSV](https://osv.dev) + PyPI Advisory DB |
+| Node.js | `npm audit` | GitHub Advisory Database |
+| Rust | `cargo audit` | [RustSec Advisory DB](https://rustsec.org) |
+| Cross-ecosystem | [OSV.dev](https://osv.dev) | Unified open-source vulnerability database |
+
+**pip-audit** queries the OSV database by default and also checks PyPI's own advisory
+feed. It covers CVEs, GHSA identifiers, and PyPI quarantine status.
+
+**npm audit** queries the GitHub Advisory Database for all packages in `node_modules`,
+including transitive dependencies declared in `package-lock.json`.
+
+**cargo audit** uses the RustSec Advisory Database, a community-maintained feed of
+security advisories for Rust crates.
+
+---
+
+## Quarantine Detection
+
+A **quarantined** package has been yanked or removed from its registry due to a confirmed
+security incident. Unlike a vulnerability (which may or may not be exploitable), a quarantine
+means the registry itself considers the version unsafe.
+
+| Registry | Mechanism | Effect |
+|---|---|---|
+| PyPI | `yank` flag or full removal | `pip install` refuses the version; existing installs still execute it |
+| npm | `npm deprecate` + registry unpublish | `npm install` warns or refuses; lock-file installs still pull it |
+| crates.io | `yank` | `cargo add` refuses; `Cargo.lock` pinned installs still use it |
+
+**Important:** A yanked/quarantined package already present in a lockfile or virtual
+environment will still be executed. Detection requires scanning the installed environment,
+not just the manifest.
+
+---
+
+## Common Scenarios
+
+| Scenario | Status | Recommended action |
+|---|---|---|
+| Compromised transitive dep (e.g., litellm 1.82.8 via dspy) | ❌ QUARANTINED | Pin direct dep to a version that doesn't pull in the compromised transitive dep; or replace the direct dep |
+| Known CVE in direct dep, patch available | ❌ VULNERABLE | Upgrade to the patched version; check if lockfile needs regeneration |
+| Known CVE in direct dep, no patch yet | ⚠️ ADVISORY | Acknowledge with user; consider alternative library; add to provenance review items |
+| Advisory in transitive dep only, no exploit | ⚠️ ADVISORY | Surface to user; monitor for patch; note in provenance block |
+| Unknown package not in any advisory DB | ✅ (unverified) | Mark ✅ but note in provenance as "advisory DB coverage unverified" |
+
+---
+
+## Remediation Playbook
+
+### 1 — Pin the direct dependency to a safe version
+
+When a transitive dependency is compromised, find the earliest version of the **direct**
+dependency that does not pull in the bad transitive version:
+
+```bash
+# Python: check what version of dspy is safe
+pip index versions dspy
+# Pin in requirements.txt or pyproject.toml:
+# dspy==2.5.0  # first version after litellm 1.82.x was removed
+```
+
+### 2 — Replace the direct dependency
+
+If no safe version exists yet, suggest an alternative:
+
+| Flagged dep | Alternative |
+|---|---|
+| dspy (via litellm) | LangChain, LlamaIndex (verify their own dep trees) |
+| crewai (via litellm) | LangGraph |
+| mlflow (via litellm) | Weights & Biases, Comet ML |
+
+Always re-run the scan after substitution to verify the new tree is clean.
+
+### 3 — Explicit user override
+
+If the user acknowledges the risk and insists on proceeding:
+- Record the explicit override in the provenance block under `⚠️ ITEMS REQUIRING HUMAN REVIEW`
+- Do not silently proceed — the acknowledgment must be on the record
+
+### 4 — Regenerate the lockfile
+
+After any version change, regenerate the lockfile to ensure transitive deps are updated:
+
+```bash
+# Python (pip)
+pip-compile --upgrade requirements.in   # if using pip-tools
+# Python (poetry)
+poetry update <direct-dep>
+# Node.js
+npm install   # regenerates package-lock.json
+# Rust
+cargo update -p <crate>
+```
+
+---
+
+## .pth Persistence Check (Python)
+
+### What is a .pth file?
+
+Python's `site-packages` directory processes `.pth` files at interpreter startup. Lines
+beginning with `import ` are executed as Python statements — before any user code runs,
+before any `import` in the application, and without any user action.
+
+This is the mechanism used in the **LiteLLM supply chain compromise (March 24, 2026)**:
+a malicious `.pth` file harvested credentials from environment variables on every Python
+process startup.
+
+### Why it matters
+
+A quarantined package that has already been installed may have left a `.pth` file behind.
+Removing the package with `pip uninstall` does not guarantee the `.pth` file is gone.
+
+### How to detect with --check-pth
+
+```bash
+bash scripts/dependency_security_scan.sh --check-pth
+```
+
+This scans all `site-packages` directories for `.pth` files containing:
+- `import ` statements
+- `exec(` calls
+- `os.` / `subprocess.` references
+- `__import__` calls
+
+### Manual check
+
+```bash
+python3 -c "import site; print(site.getsitepackages())"
+# Then for each path:
+find /path/to/site-packages -name "*.pth" -exec grep -lE "(import |exec\(|os\.)" {} \;
+```
+
+### Remediation
+
+If a suspicious `.pth` file is found:
+
+1. Identify which package created it: cross-reference with `pip show <package>`
+2. Uninstall the package: `pip uninstall <package>`
+3. Manually delete the `.pth` file if it persists
+4. Audit environment variables for exposure (API keys, tokens, credentials)
+5. Rotate any credentials that were present in the environment during the exposure window
+
+---
+
+## When in Doubt
+
+1. Flag the package as ⚠️ in the provenance block
+2. Add it to `⚠️ ITEMS REQUIRING HUMAN REVIEW`
+3. Check manually: [https://osv.dev](https://osv.dev) (search by package name)
+4. For PyPI: `pip index versions <package>` to see if versions have been yanked
+5. For npm: `npm view <package> time` to check for suspicious recent publishes
+
+For production systems handling sensitive data, engage a security professional before
+proceeding with a flagged dependency.
+
+---
+
+*This reference supports audit trails but is not security advice. For critical systems,
+consult a qualified security professional.*

--- a/skills/ip-guard/references/license-compatibility.md
+++ b/skills/ip-guard/references/license-compatibility.md
@@ -1,0 +1,174 @@
+# License Compatibility Reference
+
+This reference is used by ip-guard during Stage 1 (dependency intent scan) and Stage 2
+(inline flagging) to determine whether a dependency's license is compatible with the
+project's declared license target.
+
+---
+
+## Quick Compatibility Matrix
+
+Rows = Project License | Columns = Dependency License
+
+| Project \ Dependency | MIT | Apache 2.0 | BSD-2/3 | LGPL-2.1 | LGPL-3.0 | GPL-2.0 | GPL-3.0 | AGPL-3.0 | ISC | MPL-2.0 | CC0 | Proprietary |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| **MIT** | ✅ | ✅ | ✅ | ⚠️ | ⚠️ | ❌ | ❌ | ❌ | ✅ | ⚠️ | ✅ | ❌ |
+| **Apache 2.0** | ✅ | ✅ | ✅ | ⚠️ | ⚠️ | ❌ | ❌ | ❌ | ✅ | ⚠️ | ✅ | ❌ |
+| **BSD-2/3** | ✅ | ✅ | ✅ | ⚠️ | ⚠️ | ❌ | ❌ | ❌ | ✅ | ⚠️ | ✅ | ❌ |
+| **GPL-2.0** | ✅ | ⚠️* | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | ⚠️ | ✅ | ❌ |
+| **GPL-3.0** | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ |
+| **AGPL-3.0** | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
+| **Proprietary** | ✅ | ✅ | ✅ | ⚠️† | ⚠️† | ❌ | ❌ | ❌ | ✅ | ⚠️ | ✅ | case-by-case |
+| **ISC** | ✅ | ✅ | ✅ | ⚠️ | ⚠️ | ❌ | ❌ | ❌ | ✅ | ⚠️ | ✅ | ❌ |
+
+**Legend:**
+- ✅ Generally compatible — can use without special action
+- ⚠️ Conditional — compatible under specific conditions; flag for human review
+- ❌ Incompatible — requires license change, relicensing agreement, or removal
+
+*Apache 2.0 in GPL-2.0 projects: Apache 2.0 is not compatible with GPL-2.0 due to additional restrictions clause. GPL-3.0 resolves this.
+
+†LGPL in proprietary: Permitted IF the LGPL library is dynamically linked (not statically linked or modified). Flag for review.
+
+---
+
+## License Summaries
+
+### Permissive Licenses (✅ generally safe to use in any project)
+
+**MIT**
+- Can use, copy, modify, distribute, sublicense, sell
+- Requires: preserve copyright notice and license text
+- Compatible with: almost everything
+
+**Apache 2.0**
+- Same as MIT, plus explicit patent grant
+- Requires: preserve NOTICE file, state changes made
+- Incompatible with: GPL-2.0 (compatible with GPL-3.0)
+
+**BSD-2-Clause / BSD-3-Clause**
+- Very similar to MIT
+- BSD-3 adds non-endorsement clause
+- Compatible with: almost everything
+
+**ISC**
+- Functionally equivalent to MIT (simplified language)
+- Compatible with: almost everything
+
+**CC0 (Public Domain)**
+- No rights reserved; maximum freedom
+- Compatible with: everything
+
+---
+
+### Weak Copyleft Licenses (⚠️ use with care)
+
+**LGPL-2.1 / LGPL-3.0**
+- Can use in proprietary software IF dynamically linked
+- Modifications to the LGPL library itself must be released under LGPL
+- Static linking or modification triggers full copyleft
+- Key question to ask user: "Is this library dynamically or statically linked?"
+
+**MPL-2.0 (Mozilla Public License)**
+- File-level copyleft: modifications to MPL files must stay MPL
+- New files in the same project can be under different licenses
+- Generally usable in proprietary projects if MPL files are not modified
+
+---
+
+### Strong Copyleft Licenses (❌ incompatible with proprietary/MIT/Apache)
+
+**GPL-2.0**
+- Any software that uses GPL-2.0 code must be released as GPL-2.0
+- Cannot combine with Apache 2.0
+- Cannot use in proprietary software
+
+**GPL-3.0**
+- Same as GPL-2.0 but compatible with Apache 2.0
+- Any software that uses GPL-3.0 code must be released as GPL-3.0
+- Cannot use in proprietary software
+
+**AGPL-3.0**
+- Same as GPL-3.0, but copyleft also triggered by network use (SaaS)
+- Most restrictive common open source license
+- Cannot use in any commercial or proprietary context without full relicensing
+
+---
+
+## Common Scenarios
+
+### Scenario 1: MIT project adds a GPL library
+
+```
+Project: MIT
+Dependency: lodash-gpl-fork (GPL-3.0)
+Result: ❌ INCOMPATIBLE
+
+Action: Find a MIT-licensed alternative, or relicense the project under GPL-3.0.
+ip-guard response: Flag ❌, pause generation, present alternatives.
+```
+
+### Scenario 2: Proprietary project uses LGPL library
+
+```
+Project: Proprietary
+Dependency: GNU Readline (LGPL-3.0)
+Result: ⚠️ CONDITIONAL
+
+Action: Permitted if dynamically linked and library is unmodified.
+ip-guard response: Flag ⚠️, ask "Is this dynamically linked? Will you modify the library?"
+```
+
+### Scenario 3: MIT project uses Apache 2.0 library
+
+```
+Project: MIT
+Dependency: axios (MIT), sharp (Apache-2.0)
+Result: ✅ COMPATIBLE
+
+Action: Include Apache NOTICE file in distribution if required.
+ip-guard response: ✅ in dependency plan, note NOTICE requirement in provenance block.
+```
+
+### Scenario 4: Unknown license
+
+```
+Project: MIT
+Dependency: some-obscure-package (license: unknown / not specified)
+Result: ⚠️ UNKNOWN — treat as incompatible until verified
+
+Action: Check the package's GitHub repo for a LICENSE file.
+ip-guard response: Flag ⚠️, suggest: "Check https://github.com/[author]/[repo] for a LICENSE file before using."
+```
+
+---
+
+## Asset Licenses (Non-Code)
+
+| License | Commercial Use | Modification | Attribution Required |
+|---|---|---|---|
+| CC0 | ✅ | ✅ | No |
+| CC BY 4.0 | ✅ | ✅ | Yes |
+| CC BY-SA 4.0 | ✅ | ✅ (share-alike) | Yes |
+| CC BY-NC 4.0 | ❌ non-commercial only | ✅ | Yes |
+| CC BY-ND 4.0 | ✅ | ❌ no derivatives | Yes |
+| Unsplash License | ✅ | ✅ | No (encouraged) |
+| Pexels License | ✅ | ✅ | No (encouraged) |
+| Getty Images | ❌ without license | — | — |
+| Shutterstock | Subscription required | — | — |
+| Google Fonts | ✅ (OFL / Apache) | ✅ | varies by font |
+| Adobe Fonts | Subscription required | — | — |
+| Font Awesome Free | ✅ (SIL OFL) | ✅ | Yes (icons only) |
+| Font Awesome Pro | License required | — | — |
+
+---
+
+## When in Doubt
+
+If the license situation is ambiguous after consulting this reference:
+1. Flag with ⚠️ in the provenance block
+2. Add to "ITEMS REQUIRING HUMAN REVIEW"
+3. Suggest the user consult: https://choosealicense.com or https://spdx.org/licenses/
+4. For commercial products: recommend consulting qualified legal counsel
+
+This reference provides general guidance, not legal advice.

--- a/skills/ip-guard/scripts/dependency_security_scan.sh
+++ b/skills/ip-guard/scripts/dependency_security_scan.sh
@@ -1,0 +1,387 @@
+#!/usr/bin/env bash
+# ip-guard — Dependency Security Scan
+# Usage: bash dependency_security_scan.sh [--output <file>] [--check-pth]
+# Example: bash dependency_security_scan.sh --output security-report.json --check-pth
+#
+# Auto-detects project type (Python / Node.js / Rust) and:
+#   1. Resolves the full transitive dependency tree
+#   2. Checks every package against the OSV vulnerability database
+#   3. Optionally scans site-packages for suspicious .pth files (Python, --check-pth)
+#
+# Exit codes:
+#   0 — all packages CLEAN
+#   1 — one or more QUARANTINED or VULNERABLE findings (❌)
+#   2 — one or more ADVISORY-only findings, no ❌ (⚠️)
+
+set -euo pipefail
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+OUTPUT_FILE="ip-guard-security-report.json"
+CHECK_PTH=false
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output)
+      OUTPUT_FILE="$2"; shift 2 ;;
+    --check-pth)
+      CHECK_PTH=true; shift ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      echo "Usage: bash dependency_security_scan.sh [--output <file>] [--check-pth]" >&2
+      exit 1 ;;
+  esac
+done
+
+# ── Project type detection ────────────────────────────────────────────────────
+detect_project_type() {
+  if [ -f "package.json" ]; then echo "node"
+  elif [ -f "pyproject.toml" ] || [ -f "requirements.txt" ] || [ -f "setup.py" ]; then echo "python"
+  elif [ -f "Cargo.toml" ]; then echo "rust"
+  else echo "unknown"
+  fi
+}
+
+PROJECT_TYPE=$(detect_project_type)
+SCANNED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+TMPDIR_SCAN=$(mktemp -d)
+DEPTREE_FILE="$TMPDIR_SCAN/deptree.json"
+AUDIT_FILE="$TMPDIR_SCAN/audit.json"
+
+echo "🔒 ip-guard — Dependency Security Scan"
+echo "Project type: $PROJECT_TYPE"
+echo "Output: $OUTPUT_FILE"
+echo ""
+
+# ── Python ────────────────────────────────────────────────────────────────────
+run_python() {
+  echo "📦 Installing scan tools (pip-audit, pipdeptree)..."
+  pip install --quiet pip-audit pipdeptree 2>/dev/null || {
+    echo "❌ Failed to install pip-audit / pipdeptree. Run: pip install pip-audit pipdeptree" >&2
+    exit 1
+  }
+
+  echo "🌳 Resolving transitive dependency tree..."
+  pipdeptree --json > "$DEPTREE_FILE"
+
+  echo "🔍 Scanning against OSV database..."
+  pip-audit --format=json --output "$AUDIT_FILE" 2>/dev/null || true
+
+  # Parse and emit unified JSON via inline Python
+  python3 - <<PYEOF
+import json, sys, os
+
+deptree = json.load(open("$DEPTREE_FILE"))
+try:
+    audit_raw = json.load(open("$AUDIT_FILE"))
+    # pip-audit JSON: list of {name, version, vulns: [{id, fix_versions, aliases}]}
+    audit_map = {}
+    for entry in audit_raw.get("dependencies", []):
+        vulns = entry.get("vulns", [])
+        if vulns:
+            key = entry["name"].lower()
+            audit_map[key] = vulns[0]["id"] if vulns else None
+except Exception:
+    audit_map = {}
+
+# Flatten transitive tree: {pkg_name: {version, installed_via}}
+flat = {}
+def walk(pkg, chain="(direct)"):
+    name = pkg["package_name"].lower()
+    ver  = pkg["installed_version"]
+    if name not in flat:
+        flat[name] = {"version": ver, "installed_via": chain}
+    for dep in pkg.get("dependencies", []):
+        walk(dep, f"{pkg['package_name']} → {dep['package_name']}")
+
+for top in deptree:
+    walk(top)
+
+findings = []
+for name, info in flat.items():
+    advisory = audit_map.get(name)
+    if advisory:
+        status = "VULNERABLE"
+    else:
+        status = "CLEAN"
+    findings.append({
+        "package": name,
+        "version": info["version"],
+        "installed_via": info["installed_via"],
+        "advisory": advisory or "None",
+        "status": status,
+    })
+
+total = len(flat)
+direct = sum(1 for v in flat.values() if v["installed_via"] == "(direct)")
+
+result = {
+    "project_type": "python",
+    "scanned_at": "$SCANNED_AT",
+    "total_packages": total,
+    "direct_packages": direct,
+    "findings": findings,
+    "pth_findings": [],
+}
+
+with open("$OUTPUT_FILE", "w") as f:
+    json.dump(result, f, indent=2)
+
+print(json.dumps(result, indent=2))
+PYEOF
+}
+
+# ── Node.js ───────────────────────────────────────────────────────────────────
+run_node() {
+  command -v npm >/dev/null 2>&1 || { echo "❌ npm not found." >&2; exit 1; }
+
+  echo "🌳 Resolving transitive dependency tree..."
+  npm ls --all --json > "$DEPTREE_FILE" 2>/dev/null || true
+
+  echo "🔍 Scanning against npm advisory database..."
+  npm audit --json > "$AUDIT_FILE" 2>/dev/null || true
+
+  python3 - <<PYEOF
+import json, sys
+
+try:
+    deptree = json.load(open("$DEPTREE_FILE"))
+except Exception:
+    deptree = {}
+try:
+    audit_raw = json.load(open("$AUDIT_FILE"))
+except Exception:
+    audit_raw = {}
+
+# Build advisory map: {package_name: advisory_id}
+advisory_map = {}
+for vuln_id, vuln in audit_raw.get("vulnerabilities", {}).items():
+    advisory_map[vuln["name"].lower()] = vuln_id
+
+# Flatten npm dependency tree
+flat = {}
+def walk(deps, chain="(direct)"):
+    for name, info in deps.items():
+        key = name.lower()
+        if key not in flat:
+            flat[key] = {"version": info.get("version", "unknown"), "installed_via": chain}
+        nested = info.get("dependencies", {})
+        if nested:
+            walk(nested, f"{name} → ...")
+
+walk(deptree.get("dependencies", {}))
+
+findings = []
+for name, info in flat.items():
+    advisory = advisory_map.get(name)
+    status = "VULNERABLE" if advisory else "CLEAN"
+    findings.append({
+        "package": name,
+        "version": info["version"],
+        "installed_via": info["installed_via"],
+        "advisory": advisory or "None",
+        "status": status,
+    })
+
+total = len(flat)
+direct = sum(1 for v in flat.values() if v["installed_via"] == "(direct)")
+
+result = {
+    "project_type": "node",
+    "scanned_at": "$SCANNED_AT",
+    "total_packages": total,
+    "direct_packages": direct,
+    "findings": findings,
+    "pth_findings": [],
+}
+
+with open("$OUTPUT_FILE", "w") as f:
+    json.dump(result, f, indent=2)
+
+print(json.dumps(result, indent=2))
+PYEOF
+}
+
+# ── Rust ──────────────────────────────────────────────────────────────────────
+run_rust() {
+  command -v cargo >/dev/null 2>&1 || { echo "❌ cargo not found." >&2; exit 1; }
+
+  echo "🌳 Resolving transitive dependency tree..."
+  cargo tree --format="{p}" 2>/dev/null > "$TMPDIR_SCAN/deptree.txt" || {
+    echo "❌ cargo tree failed. Ensure Cargo.lock exists." >&2; exit 1
+  }
+
+  echo "🔍 Scanning against RustSec advisory database..."
+  if command -v cargo-audit >/dev/null 2>&1; then
+    cargo audit --json > "$AUDIT_FILE" 2>/dev/null || true
+  else
+    echo "{}" > "$AUDIT_FILE"
+    echo "⚠️  cargo-audit not installed. Run: cargo install cargo-audit"
+    echo "    Continuing without advisory data."
+  fi
+
+  python3 - <<PYEOF
+import json, re
+
+# Parse cargo tree flat output: "crate v0.1.0" lines (strip indent markers)
+flat = {}
+with open("$TMPDIR_SCAN/deptree.txt") as f:
+    for line in f:
+        line = line.strip().lstrip("│├└─ ")
+        m = re.match(r"^(\S+)\s+v([\d.]+.*?)(?:\s.*)?$", line)
+        if m:
+            name = m.group(1).lower()
+            ver  = m.group(2)
+            if name not in flat:
+                flat[name] = {"version": ver, "installed_via": "(resolved by cargo tree)"}
+
+try:
+    audit_raw = json.load(open("$AUDIT_FILE"))
+    vuln_list = audit_raw.get("vulnerabilities", {}).get("list", [])
+    advisory_map = {v["advisory"]["package"].lower(): v["advisory"]["id"] for v in vuln_list}
+except Exception:
+    advisory_map = {}
+
+findings = []
+for name, info in flat.items():
+    advisory = advisory_map.get(name)
+    status = "VULNERABLE" if advisory else "CLEAN"
+    findings.append({
+        "package": name,
+        "version": info["version"],
+        "installed_via": info["installed_via"],
+        "advisory": advisory or "None",
+        "status": status,
+    })
+
+result = {
+    "project_type": "rust",
+    "scanned_at": "$SCANNED_AT",
+    "total_packages": len(flat),
+    "direct_packages": len(flat),  # cargo tree doesn't differentiate easily
+    "findings": findings,
+    "pth_findings": [],
+}
+
+with open("$OUTPUT_FILE", "w") as f:
+    json.dump(result, f, indent=2)
+
+print(json.dumps(result, indent=2))
+PYEOF
+}
+
+# ── Unknown project type ───────────────────────────────────────────────────────
+run_unknown() {
+  cat >&2 <<EOF
+⚠️  Could not detect project type. No manifest file found.
+
+Supported project types and required manifest files:
+  Python  — requirements.txt, pyproject.toml, or setup.py
+  Node.js — package.json
+  Rust    — Cargo.toml
+
+Run this script from the project root directory, or install the appropriate manifest file first.
+EOF
+  exit 1
+}
+
+# ── .pth file detection (Python only) ─────────────────────────────────────────
+check_pth_files() {
+  echo ""
+  echo "🔎 Scanning site-packages for suspicious .pth files..."
+
+  SITE_PKGS=$(python3 -c "import site; print('\n'.join(site.getsitepackages()))" 2>/dev/null || true)
+  PTH_FINDINGS=()
+
+  if [ -z "$SITE_PKGS" ]; then
+    echo "⚠️  Could not locate site-packages directory."
+    return
+  fi
+
+  while IFS= read -r site_dir; do
+    [ -d "$site_dir" ] || continue
+    while IFS= read -r pth_file; do
+      # Flag .pth files that contain executable patterns
+      if grep -qE "(import |exec\(|os\.|subprocess\.|__import__)" "$pth_file" 2>/dev/null; then
+        PTH_FINDINGS+=("$pth_file")
+        echo "❌ Suspicious .pth file: $pth_file"
+        grep -nE "(import |exec\(|os\.|subprocess\.|__import__)" "$pth_file" | head -5
+      fi
+    done < <(find "$site_dir" -maxdepth 1 -name "*.pth" 2>/dev/null)
+  done <<< "$SITE_PKGS"
+
+  if [ ${#PTH_FINDINGS[@]} -eq 0 ]; then
+    echo "✅ No suspicious .pth files found."
+  else
+    echo ""
+    echo "❌ ${#PTH_FINDINGS[@]} suspicious .pth file(s) detected."
+    echo "   These files execute code on every Python process startup without requiring an import."
+    echo "   See references/dependency-security.md — .pth Persistence section."
+    # Inject into output JSON
+    python3 - <<PYEOF
+import json
+data = json.load(open("$OUTPUT_FILE"))
+data["pth_findings"] = $(printf '%s\n' "${PTH_FINDINGS[@]+"${PTH_FINDINGS[*]}"}" | python3 -c "import sys,json; lines=[l.strip() for l in sys.stdin if l.strip()]; print(json.dumps(lines))")
+json.dump(data, open("$OUTPUT_FILE", "w"), indent=2)
+PYEOF
+  fi
+}
+
+# ── Run the appropriate handler ───────────────────────────────────────────────
+case "$PROJECT_TYPE" in
+  python)  run_python ;;
+  node)    run_node ;;
+  rust)    run_rust ;;
+  unknown) run_unknown ;;
+esac
+
+if $CHECK_PTH && [ "$PROJECT_TYPE" = "python" ]; then
+  check_pth_files
+fi
+
+# ── Summarize and set exit code ───────────────────────────────────────────────
+python3 - <<PYEOF
+import json, sys
+
+data = json.load(open("$OUTPUT_FILE"))
+findings = data.get("findings", [])
+total    = data["total_packages"]
+direct   = data["direct_packages"]
+
+critical = [f for f in findings if f["status"] in ("QUARANTINED", "VULNERABLE")]
+advisory = [f for f in findings if f["status"] == "ADVISORY"]
+pth      = data.get("pth_findings", [])
+
+print()
+print("=" * 60)
+print(f"🔒 DEPENDENCY SECURITY SCAN SUMMARY")
+print(f"   Scanned {total} packages ({direct} direct, {total - direct} transitive)")
+print()
+
+if critical:
+    print(f"❌ {len(critical)} CRITICAL finding(s):")
+    for f in critical:
+        print(f"   • {f['package']} {f['version']} — {f['advisory']} [{f['status']}]")
+        print(f"     Installed via: {f['installed_via']}")
+elif advisory:
+    print(f"⚠️  {len(advisory)} advisory finding(s) — no known active exploits:")
+    for f in advisory:
+        print(f"   • {f['package']} {f['version']} — {f['advisory']}")
+else:
+    print("✅ No advisories found.")
+
+if pth:
+    print()
+    print(f"❌ {len(pth)} suspicious .pth file(s) detected (see above)")
+
+print()
+print(f"Report saved to: $OUTPUT_FILE")
+print("=" * 60)
+
+if critical or pth:
+    sys.exit(1)
+elif advisory:
+    sys.exit(2)
+else:
+    sys.exit(0)
+PYEOF

--- a/skills/ip-guard/scripts/license_audit.sh
+++ b/skills/ip-guard/scripts/license_audit.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# ip-guard: license_audit.sh
+# Detects the project type and runs the appropriate license audit tool.
+# Outputs a structured report compatible with ip-guard's provenance block format.
+#
+# Usage: bash license_audit.sh [--output <file>] [--project-license <license>]
+# Example: bash license_audit.sh --project-license MIT --output license-report.md
+
+set -euo pipefail
+
+OUTPUT_FILE="ip-guard-license-report.md"
+PROJECT_LICENSE="unknown"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --output) OUTPUT_FILE="$2"; shift 2 ;;
+    --project-license) PROJECT_LICENSE="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1"; exit 1 ;;
+  esac
+done
+
+echo "🛡️  ip-guard license audit starting..."
+echo "Project license target: $PROJECT_LICENSE"
+echo ""
+
+# Detect project type
+detect_project_type() {
+  if [ -f "package.json" ]; then echo "node"
+  elif [ -f "pyproject.toml" ] || [ -f "requirements.txt" ] || [ -f "setup.py" ]; then echo "python"
+  elif [ -f "Cargo.toml" ]; then echo "rust"
+  elif [ -f "go.mod" ]; then echo "go"
+  elif [ -f "pom.xml" ] || [ -f "build.gradle" ]; then echo "java"
+  else echo "unknown"
+  fi
+}
+
+# Licenses incompatible with common project types
+get_incompatible_licenses() {
+  local target="$1"
+  case "$target" in
+    MIT|Apache*|BSD*|ISC) echo "GPL-2.0,GPL-3.0,AGPL-3.0,GPL-2.0-only,GPL-3.0-only,AGPL-3.0-only" ;;
+    proprietary|Proprietary|UNLICENSED) echo "GPL-2.0,GPL-3.0,AGPL-3.0,LGPL-2.1,LGPL-3.0,GPL-2.0-only,GPL-3.0-only,AGPL-3.0-only" ;;
+    *) echo "" ;;
+  esac
+}
+
+PROJECT_TYPE=$(detect_project_type)
+echo "Detected project type: $PROJECT_TYPE"
+echo ""
+
+# Run the appropriate tool
+{
+  echo "# 🛡️ IP Guard — License Audit Report"
+  echo ""
+  echo "**Generated:** $(date '+%Y-%m-%d %H:%M')"
+  echo "**Project license target:** \`$PROJECT_LICENSE\`"
+  echo "**Project type:** $PROJECT_TYPE"
+  echo ""
+  echo "---"
+  echo ""
+} > "$OUTPUT_FILE"
+
+case "$PROJECT_TYPE" in
+  node)
+    if ! command -v npx &> /dev/null; then
+      echo "❌ npx not found. Install Node.js to run license audits for this project."
+      exit 1
+    fi
+    echo "Running license-checker for Node.js project..."
+    npx --yes license-checker --json 2>/dev/null | python3 -c "
+import json, sys
+
+data = json.load(sys.stdin)
+incompatible = '$(get_incompatible_licenses "$PROJECT_LICENSE")'.split(',')
+project_license = '$PROJECT_LICENSE'
+
+rows = []
+warnings = []
+
+for pkg, info in sorted(data.items()):
+    lic = info.get('licenses', 'UNKNOWN')
+    lic_str = str(lic)
+    compatible = '✅'
+    if lic_str == 'UNKNOWN' or not lic_str:
+        compatible = '⚠️ UNKNOWN'
+        warnings.append(f'- {pkg}: license unknown — verify before use')
+    elif any(i.strip() in lic_str for i in incompatible if i.strip()):
+        compatible = '❌ INCOMPATIBLE'
+        warnings.append(f'- {pkg}: {lic_str} is incompatible with {project_license}')
+    rows.append(f'| {pkg} | {lic_str} | {compatible} |')
+
+print('## Dependency License Summary')
+print()
+print('| Package | License | Compatible with ' + project_license + ' |')
+print('|---|---|---|')
+for r in rows:
+    print(r)
+print()
+
+if warnings:
+    print('## ⚠️ Items Requiring Review')
+    print()
+    for w in warnings:
+        print(w)
+    print()
+else:
+    print('## ✅ No Issues Found')
+    print()
+    print('All dependencies appear compatible with ' + project_license + '.')
+    print()
+
+print(f'**Total packages scanned:** {len(rows)}')
+print(f'**Issues found:** {len(warnings)}')
+" >> "$OUTPUT_FILE"
+    ;;
+
+  python)
+    if ! command -v pip-licenses &> /dev/null; then
+      echo "pip-licenses not found. Installing..."
+      pip install pip-licenses --quiet --break-system-packages 2>/dev/null || \
+        pip install pip-licenses --quiet 2>/dev/null || \
+        { echo "❌ Could not install pip-licenses. Run: pip install pip-licenses"; exit 1; }
+    fi
+    echo "Running pip-licenses for Python project..."
+    {
+      echo "## Dependency License Summary"
+      echo ""
+      pip-licenses --format=markdown 2>/dev/null
+      echo ""
+    } >> "$OUTPUT_FILE"
+    ;;
+
+  rust)
+    if ! command -v cargo-license &> /dev/null; then
+      echo "cargo-license not found. Install with: cargo install cargo-license"
+      exit 1
+    fi
+    echo "Running cargo-license for Rust project..."
+    {
+      echo "## Dependency License Summary"
+      echo ""
+      cargo license --json 2>/dev/null | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+print('| Crate | License |')
+print('|---|---|')
+for pkg in sorted(data, key=lambda x: x.get('name','')):
+    print(f'| {pkg.get(\"name\",\"?\")} {pkg.get(\"version\",\"\")} | {pkg.get(\"license\",\"UNKNOWN\")} |')
+"
+      echo ""
+    } >> "$OUTPUT_FILE"
+    ;;
+
+  go)
+    if ! command -v go-licenses &> /dev/null; then
+      echo "go-licenses not found. Install with: go install github.com/google/go-licenses@latest"
+      exit 1
+    fi
+    echo "Running go-licenses for Go project..."
+    {
+      echo "## Dependency License Summary"
+      echo ""
+      go-licenses report ./... 2>/dev/null | awk 'BEGIN{print "| Package | License URL |"}{print "| "$1" | "$3" |"}'
+      echo ""
+    } >> "$OUTPUT_FILE"
+    ;;
+
+  *)
+    {
+      echo "## ⚠️ Project Type Not Detected"
+      echo ""
+      echo "Could not detect a supported package manager (Node.js, Python, Rust, Go)."
+      echo "Manual audit required."
+      echo ""
+      echo "Supported tools:"
+      echo "- Node.js: \`npx license-checker --summary\`"
+      echo "- Python: \`pip-licenses --format=markdown\`"
+      echo "- Rust: \`cargo license\`"
+      echo "- Go: \`go-licenses report ./...\`"
+      echo ""
+    } >> "$OUTPUT_FILE"
+    ;;
+esac
+
+# Footer
+{
+  echo ""
+  echo "---"
+  echo ""
+  echo "*Generated by ip-guard skill v1.0 — this report supports audit trails but is not legal advice.*"
+  echo "*For commercial use, consult qualified legal counsel.*"
+} >> "$OUTPUT_FILE"
+
+echo ""
+echo "✅ Audit complete. Report saved to: $OUTPUT_FILE"


### PR DESCRIPTION
New skill ip-guard - maintained at https://github.com/mugdhav/claude-skill-ip-guard. This skill provides behavioral guardrails for IP-safe code generation, content creation, and artifact building with Claude.

## What this skill does
ip-guard adds a three-stage IP compliance layer to every generation task 
in Claude Code. It addresses inbound IP risk for commercial and enterprise 
projects by requiring Claude to declare a license target, scan dependencies 
for compatibility, and append a provenance block to every artifact.

## Why it belongs in anthropics/skills
- Addresses a gap not covered by any existing skill in the repo
- Directly relevant to commercial Claude Code usage
- Apache 2.0 licensed
- Includes reference documentation and an audit script

## Tested on
Claude Sonnet 4.6 via Claude Code