### PR TITLE
Add Tidepool to Partner Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,4 @@ The markdown content below contains the instructions, examples, and guidelines t
 Skills are a great way to teach Claude how to get better at using specific pieces of software. As we see awesome example skills from partners, we may highlight some of them here:
 
 - **Notion** - [Notion Skills for Claude](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0)
+- **Tidepool** - [Tidepool Skill for Claude](https://github.com/greydanus/tidepool-skill) — Build and deploy production web apps (auth, payments, admin, email, db, file storage) with the `tidepool` CLI and `tp.*` runtime API


### PR DESCRIPTION
Hello Anthropic,

I built a minimalist web dev and deployment platform (mostly as a hobby project). It was built specifically with autonomous agents in mind. The goal is to give them a lot of flexibility and let them build and deploy sites that have databases, email, Stripe, auth, admin, etc -- without any clicks on any third party websites, and really just one email-based signup with the Tidepool platform. I've found it useful in my own dev work (here are a [few](https://moviescape.site) [hobby](https://drawduel.site) [projects](https://puritanreader.site) I built with it) - perhaps others will as well.

Skill at [github.com/greydanus/tidepool-skill](https://github.com/greydanus/tidepool-skill) and [ClawHub](https://clawhub.ai/skills/tidepool).

Project homepage: [tidepool.sh](https://tidepool.sh). [About me](https://greydanus.github.io/)