### PR TITLE
feat: add multi-backend LLM support for skill-creator scripts

### DIFF
--- a/skills/skill-creator/scripts/improve_description.py
+++ b/skills/skill-creator/scripts/improve_description.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 """Improve a skill description based on eval results.
 
-Takes eval results (from run_eval.py) and generates an improved description
-by calling `claude -p` as a subprocess (same auth pattern as run_eval.py —
-uses the session's Claude Code auth, no separate ANTHROPIC_API_KEY needed).
+Takes eval results (from run_eval.py) and generates an improved description.
+Supports multiple backends:
+- claude CLI (original, uses Claude Code auth)
+- Anthropic API (requires ANTHROPIC_API_KEY)
+- GitHub Models API (requires `gh auth login`)
 """
 
 import argparse
@@ -15,36 +17,15 @@ import sys
 from pathlib import Path
 
 from scripts.utils import parse_skill_md
+from scripts.llm_backend import detect_backend, complete_text
 
 
-def _call_claude(prompt: str, model: str | None, timeout: int = 300) -> str:
-    """Run `claude -p` with the prompt on stdin and return the text response.
+def _call_llm(prompt: str, model: str | None, backend: str | None = None, timeout: int = 300) -> str:
+    """Call the LLM with the given prompt and return the text response.
 
-    Prompt goes over stdin (not argv) because it embeds the full SKILL.md
-    body and can easily exceed comfortable argv length.
+    Uses the llm_backend module for backend selection and dispatch.
     """
-    cmd = ["claude", "-p", "--output-format", "text"]
-    if model:
-        cmd.extend(["--model", model])
-
-    # Remove CLAUDECODE env var to allow nesting claude -p inside a
-    # Claude Code session. The guard is for interactive terminal conflicts;
-    # programmatic subprocess usage is safe. Same pattern as run_eval.py.
-    env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
-
-    result = subprocess.run(
-        cmd,
-        input=prompt,
-        capture_output=True,
-        text=True,
-        env=env,
-        timeout=timeout,
-    )
-    if result.returncode != 0:
-        raise RuntimeError(
-            f"claude -p exited {result.returncode}\nstderr: {result.stderr}"
-        )
-    return result.stdout
+    return complete_text(prompt, model=model, backend=backend, timeout=timeout)
 
 
 def improve_description(
@@ -57,8 +38,9 @@ def improve_description(
     test_results: dict | None = None,
     log_dir: Path | None = None,
     iteration: int | None = None,
+    backend: str | None = None,
 ) -> str:
-    """Call Claude to improve the description based on eval results."""
+    """Call the LLM to improve the description based on eval results."""
     failed_triggers = [
         r for r in eval_results["results"]
         if r["should_trigger"] and not r["pass"]
@@ -141,7 +123,7 @@ I'd encourage you to be creative and mix up the style in different iterations si
 
 Please respond with only the new description text in <new_description> tags, nothing else."""
 
-    text = _call_claude(prompt, model)
+    text = _call_llm(prompt, model, backend=backend)
 
     match = re.search(r"<new_description>(.*?)</new_description>", text, re.DOTALL)
     description = match.group(1).strip().strip('"') if match else text.strip().strip('"')
@@ -171,7 +153,7 @@ Please respond with only the new description text in <new_description> tags, not
             f"important trigger words and intent coverage. Respond with only "
             f"the new description in <new_description> tags."
         )
-        shorten_text = _call_claude(shorten_prompt, model)
+        shorten_text = _call_llm(shorten_prompt, model, backend=backend)
         match = re.search(r"<new_description>(.*?)</new_description>", shorten_text, re.DOTALL)
         shortened = match.group(1).strip().strip('"') if match else shorten_text.strip().strip('"')
 

--- a/skills/skill-creator/scripts/llm_backend.py
+++ b/skills/skill-creator/scripts/llm_backend.py
@@ -1,0 +1,450 @@
+"""LLM backend abstraction for skill-creator scripts.
+
+Provides a unified interface for making LLM calls across multiple backends:
+1. GitHub Models API (gh auth token) -- OpenAI-compatible, no extra setup
+2. claude CLI -- original Claude Code approach
+3. Anthropic API (ANTHROPIC_API_KEY) -- direct API access
+
+Backend selection order:
+- If `claude` CLI is in PATH, use it (original behavior)
+- If ANTHROPIC_API_KEY is set, use Anthropic API
+- If `gh auth token` succeeds, use GitHub Models API
+- Otherwise, raise an error
+
+For trigger evaluation (tool-use detection), the API backends construct a
+system prompt with available_skills and a mock `use_skill` tool, then check
+whether the model calls the tool for the target skill.
+
+For text completion (description improvement), the API backends send the
+prompt as a user message and return the text response.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import shutil
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from typing import Any
+
+
+def _get_gh_token() -> str | None:
+    """Get GitHub auth token via `gh auth token`."""
+    if not shutil.which("gh"):
+        return None
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "token"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except Exception:
+        pass
+    return None
+
+
+def _has_claude_cli() -> bool:
+    """Check if the claude CLI binary is available."""
+    return shutil.which("claude") is not None
+
+
+def _has_anthropic_key() -> bool:
+    """Check if ANTHROPIC_API_KEY is set."""
+    return bool(os.environ.get("ANTHROPIC_API_KEY"))
+
+
+def detect_backend() -> str:
+    """Detect the best available backend.
+
+    Returns one of: 'claude_cli', 'anthropic_api', 'github_models'
+    Raises RuntimeError if no backend is available.
+    """
+    if _has_claude_cli():
+        return "claude_cli"
+    if _has_anthropic_key():
+        return "anthropic_api"
+    if _get_gh_token():
+        return "github_models"
+    raise RuntimeError(
+        "No LLM backend available. Install the claude CLI, set ANTHROPIC_API_KEY, "
+        "or authenticate with `gh auth login`."
+    )
+
+
+def _urlopen_with_retry(
+    req: urllib.request.Request,
+    timeout: int,
+    max_retries: int = 5,
+    base_delay: float = 2.0,
+) -> Any:
+    """Make an HTTP request with exponential backoff on 429/5xx errors."""
+    last_error = None
+    for attempt in range(max_retries):
+        try:
+            return urllib.request.urlopen(req, timeout=timeout)
+        except urllib.error.HTTPError as e:
+            if e.code == 429 or e.code >= 500:
+                last_error = e
+                delay = base_delay * (2 ** attempt) + random.uniform(0, 1)
+                print(f"  Retry {attempt + 1}/{max_retries} after HTTP {e.code}, waiting {delay:.1f}s", file=sys.stderr)
+                time.sleep(delay)
+                # Re-create the request since the data stream may be consumed
+                req = urllib.request.Request(
+                    req.full_url,
+                    data=req.data,
+                    headers=dict(req.headers),
+                    method=req.get_method(),
+                )
+                continue
+            raise
+        except Exception:
+            raise
+    raise last_error or RuntimeError("All retries exhausted")
+
+
+def _resolve_model(model: str | None, backend: str) -> str:
+    """Map a model name to the appropriate backend-specific identifier."""
+    if backend == "github_models":
+        # GitHub Models uses OpenAI model names
+        # Map common Claude/generic model names to available models
+        if model is None:
+            return "gpt-4o"
+        lower = model.lower()
+        if "claude" in lower or "sonnet" in lower or "opus" in lower or "haiku" in lower:
+            # Claude isn't available on GitHub Models free tier; use gpt-4o
+            return "gpt-4o"
+        return model
+    # For claude_cli and anthropic_api, pass through
+    return model or "claude-sonnet-4-20250514"
+
+
+# ---------------------------------------------------------------------------
+# Text completion (for improve_description.py)
+# ---------------------------------------------------------------------------
+
+
+def complete_text(prompt: str, model: str | None = None, backend: str | None = None, timeout: int = 300) -> str:
+    """Send a prompt and return the text response.
+
+    Used by improve_description.py to generate improved skill descriptions.
+    """
+    if backend is None:
+        backend = detect_backend()
+    model = _resolve_model(model, backend)
+
+    if backend == "claude_cli":
+        return _complete_text_claude_cli(prompt, model, timeout)
+    elif backend == "anthropic_api":
+        return _complete_text_anthropic_api(prompt, model, timeout)
+    elif backend == "github_models":
+        return _complete_text_github_models(prompt, model, timeout)
+    else:
+        raise ValueError(f"Unknown backend: {backend}")
+
+
+def _complete_text_claude_cli(prompt: str, model: str | None, timeout: int) -> str:
+    """Original claude CLI approach."""
+    cmd = ["claude", "-p", "--output-format", "text"]
+    if model:
+        cmd.extend(["--model", model])
+
+    env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+
+    result = subprocess.run(
+        cmd,
+        input=prompt,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=timeout,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"claude -p exited {result.returncode}\nstderr: {result.stderr}")
+    return result.stdout
+
+
+def _complete_text_anthropic_api(prompt: str, model: str, timeout: int) -> str:
+    """Direct Anthropic Messages API call."""
+    api_key = os.environ["ANTHROPIC_API_KEY"]
+    body = json.dumps({
+        "model": model,
+        "max_tokens": 4096,
+        "messages": [{"role": "user", "content": prompt}],
+    })
+
+    req = urllib.request.Request(
+        "https://api.anthropic.com/v1/messages",
+        data=body.encode("utf-8"),
+        headers={
+            "Content-Type": "application/json",
+            "x-api-key": api_key,
+            "anthropic-version": "2023-06-01",
+        },
+    )
+
+    with _urlopen_with_retry(req, timeout=timeout) as resp:
+        data = json.loads(resp.read().decode("utf-8"))
+
+    # Extract text from response
+    text_parts = []
+    for block in data.get("content", []):
+        if block.get("type") == "text":
+            text_parts.append(block["text"])
+    return "\n".join(text_parts)
+
+
+def _complete_text_github_models(prompt: str, model: str, timeout: int) -> str:
+    """GitHub Models API (OpenAI-compatible)."""
+    token = _get_gh_token()
+    if not token:
+        raise RuntimeError("Failed to get gh auth token")
+
+    body = json.dumps({
+        "model": model,
+        "max_tokens": 4096,
+        "messages": [{"role": "user", "content": prompt}],
+    })
+
+    req = urllib.request.Request(
+        "https://models.inference.ai.azure.com/chat/completions",
+        data=body.encode("utf-8"),
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {token}",
+        },
+    )
+
+    with _urlopen_with_retry(req, timeout=timeout) as resp:
+        data = json.loads(resp.read().decode("utf-8"))
+
+    return data["choices"][0]["message"]["content"]
+
+
+# ---------------------------------------------------------------------------
+# Trigger evaluation (for run_eval.py)
+# ---------------------------------------------------------------------------
+
+
+TRIGGER_SYSTEM_PROMPT = """You are a helpful AI assistant with access to specialized skills.
+
+When a user sends you a task, you should decide whether to use one of your available skills.
+Skills provide specialized instructions for specific domains. You should use a skill
+when the user's task clearly matches its description.
+
+Available skills:
+{skills_list}
+
+If a task matches a skill's description, call the `use_skill` tool with the skill name.
+If the task does not match any skill, respond with a short text message explaining
+you would handle the task directly without any skill. Do NOT call the tool if
+the task is not a good match."""
+
+
+USE_SKILL_TOOL_OPENAI = {
+    "type": "function",
+    "function": {
+        "name": "use_skill",
+        "description": "Invoke a skill to handle the user's task",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "skill": {
+                    "type": "string",
+                    "description": "The name of the skill to invoke",
+                },
+            },
+            "required": ["skill"],
+        },
+    },
+}
+
+USE_SKILL_TOOL_ANTHROPIC = {
+    "name": "use_skill",
+    "description": "Invoke a skill to handle the user's task",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "skill": {
+                "type": "string",
+                "description": "The name of the skill to invoke",
+            },
+        },
+        "required": ["skill"],
+    },
+}
+
+
+def _build_skills_list(skill_name: str, skill_description: str, other_skills: list[dict] | None = None) -> str:
+    """Build the available_skills list for the system prompt.
+
+    Includes the target skill plus some realistic decoy skills to make the
+    evaluation more realistic (the model should pick the right one).
+    """
+    skills = []
+
+    # Default decoy skills that are realistic neighbors
+    default_decoys = [
+        {"name": "github-prs", "description": "Manage GitHub pull requests via GitHub CLI. Create PRs, inspect changes, list files and hunks, read comments, reply to comments, and submit reviews. Use when the user asks about PR creation, review, comments, or granular diff analysis."},
+        {"name": "github-projects", "description": "Manage GitHub Projects (Projects v2) via GitHub CLI. List projects, inspect fields, list items, add issues/PRs or draft items, and update field values. Use when the user asks about GitHub Projects boards, statuses, or moving items."},
+        {"name": "azure-board", "description": "Manage Azure DevOps work items (tasks, bugs, user stories). View items assigned to you, get details, create new work items, and change status. Use when the user asks about their tasks, board, backlog, sprints, or wants to create/update work items in Azure DevOps."},
+        {"name": "azure-diagnostics", "description": "Debug and troubleshoot production issues on Azure. Covers Container Apps and Function Apps diagnostics, log analysis with KQL, health checks, and common issue resolution."},
+    ]
+
+    decoys = other_skills if other_skills is not None else default_decoys
+
+    # Add decoys that don't clash with target skill name
+    for d in decoys:
+        if d["name"] != skill_name:
+            skills.append(f"- **{d['name']}**: {d['description']}")
+
+    # Insert the target skill at a random-ish position (middle)
+    target_entry = f"- **{skill_name}**: {skill_description}"
+    mid = len(skills) // 2
+    skills.insert(mid, target_entry)
+
+    return "\n".join(skills)
+
+
+def test_trigger(
+    query: str,
+    skill_name: str,
+    skill_description: str,
+    model: str | None = None,
+    backend: str | None = None,
+    timeout: int = 30,
+    other_skills: list[dict] | None = None,
+) -> bool:
+    """Test whether a query triggers the skill.
+
+    Returns True if the model decides to invoke the target skill.
+    """
+    if backend is None:
+        backend = detect_backend()
+    model = _resolve_model(model, backend)
+
+    if backend == "claude_cli":
+        # Original approach: delegate to run_eval's claude-based method
+        # This is handled externally by run_eval.py for backward compat
+        raise NotImplementedError("Use run_eval.run_single_query() for claude_cli backend")
+    elif backend == "anthropic_api":
+        return _test_trigger_anthropic_api(query, skill_name, skill_description, model, timeout, other_skills)
+    elif backend == "github_models":
+        return _test_trigger_github_models(query, skill_name, skill_description, model, timeout, other_skills)
+    else:
+        raise ValueError(f"Unknown backend: {backend}")
+
+
+def _test_trigger_anthropic_api(
+    query: str, skill_name: str, skill_description: str,
+    model: str, timeout: int, other_skills: list[dict] | None,
+) -> bool:
+    """Test triggering via Anthropic Messages API with tools."""
+    api_key = os.environ["ANTHROPIC_API_KEY"]
+    skills_list = _build_skills_list(skill_name, skill_description, other_skills)
+    system = TRIGGER_SYSTEM_PROMPT.format(skills_list=skills_list)
+
+    body = json.dumps({
+        "model": model,
+        "max_tokens": 256,
+        "system": system,
+        "messages": [{"role": "user", "content": query}],
+        "tools": [USE_SKILL_TOOL_ANTHROPIC],
+        "tool_choice": {"type": "auto"},
+    })
+
+    req = urllib.request.Request(
+        "https://api.anthropic.com/v1/messages",
+        data=body.encode("utf-8"),
+        headers={
+            "Content-Type": "application/json",
+            "x-api-key": api_key,
+            "anthropic-version": "2023-06-01",
+        },
+    )
+
+    try:
+        with _urlopen_with_retry(req, timeout=timeout) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except Exception as e:
+        print(f"Warning: Anthropic API call failed: {e}", file=sys.stderr)
+        return False
+
+    return _check_tool_use_anthropic(data, skill_name)
+
+
+def _test_trigger_github_models(
+    query: str, skill_name: str, skill_description: str,
+    model: str, timeout: int, other_skills: list[dict] | None,
+) -> bool:
+    """Test triggering via GitHub Models API (OpenAI-compatible) with tools."""
+    token = _get_gh_token()
+    if not token:
+        print("Warning: Failed to get gh auth token", file=sys.stderr)
+        return False
+
+    skills_list = _build_skills_list(skill_name, skill_description, other_skills)
+    system = TRIGGER_SYSTEM_PROMPT.format(skills_list=skills_list)
+
+    body = json.dumps({
+        "model": model,
+        "max_tokens": 256,
+        "messages": [
+            {"role": "system", "content": system},
+            {"role": "user", "content": query},
+        ],
+        "tools": [USE_SKILL_TOOL_OPENAI],
+        "tool_choice": "auto",
+    })
+
+    req = urllib.request.Request(
+        "https://models.inference.ai.azure.com/chat/completions",
+        data=body.encode("utf-8"),
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {token}",
+        },
+    )
+
+    try:
+        with _urlopen_with_retry(req, timeout=timeout) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except Exception as e:
+        print(f"Warning: GitHub Models API call failed: {e}", file=sys.stderr)
+        return False
+
+    return _check_tool_use_openai(data, skill_name)
+
+
+def _check_tool_use_anthropic(response: dict, skill_name: str) -> bool:
+    """Check if Anthropic response contains a tool_use for the target skill."""
+    for block in response.get("content", []):
+        if block.get("type") == "tool_use" and block.get("name") == "use_skill":
+            tool_input = block.get("input", {})
+            if skill_name in tool_input.get("skill", ""):
+                return True
+    return False
+
+
+def _check_tool_use_openai(response: dict, skill_name: str) -> bool:
+    """Check if OpenAI-compatible response contains a tool_call for the target skill."""
+    for choice in response.get("choices", []):
+        message = choice.get("message", {})
+        tool_calls = message.get("tool_calls", [])
+        for tc in tool_calls:
+            if tc.get("function", {}).get("name") == "use_skill":
+                args_str = tc["function"].get("arguments", "{}")
+                try:
+                    args = json.loads(args_str)
+                except json.JSONDecodeError:
+                    args = {}
+                if skill_name in args.get("skill", ""):
+                    return True
+    return False

--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -3,12 +3,18 @@
 
 Tests whether a skill's description causes Claude to trigger (read the skill)
 for a set of queries. Outputs results as JSON.
+
+Supports multiple backends:
+- claude CLI (original behavior, requires Claude Code)
+- Anthropic API (requires ANTHROPIC_API_KEY)
+- GitHub Models API (requires `gh auth login`)
 """
 
 import argparse
 import json
 import os
 import select
+import shutil
 import subprocess
 import sys
 import time
@@ -17,6 +23,7 @@ from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
 
 from scripts.utils import parse_skill_md
+from scripts.llm_backend import detect_backend, test_trigger
 
 
 def find_project_root() -> Path:
@@ -181,6 +188,34 @@ def run_single_query(
             command_file.unlink()
 
 
+def run_single_query_api(
+    query: str,
+    skill_name: str,
+    skill_description: str,
+    timeout: int,
+    backend: str,
+    model: str | None = None,
+) -> bool:
+    """Run a single query using the API backend (no claude CLI needed).
+
+    Uses llm_backend.test_trigger() which constructs a system prompt with
+    available_skills and a mock use_skill tool, then checks if the model
+    calls the tool for the target skill.
+    """
+    try:
+        return test_trigger(
+            query=query,
+            skill_name=skill_name,
+            skill_description=skill_description,
+            model=model,
+            backend=backend,
+            timeout=timeout,
+        )
+    except Exception as e:
+        print(f"Warning: query failed: {e}", file=sys.stderr)
+        return False
+
+
 def run_eval(
     eval_set: list[dict],
     skill_name: str,
@@ -191,23 +226,41 @@ def run_eval(
     runs_per_query: int = 1,
     trigger_threshold: float = 0.5,
     model: str | None = None,
+    backend: str | None = None,
 ) -> dict:
-    """Run the full eval set and return results."""
-    results = []
+    """Run the full eval set and return results.
+
+    Automatically selects the best available backend if not specified.
+    """
+    if backend is None:
+        backend = detect_backend()
+
+    use_api = backend != "claude_cli"
 
     with ProcessPoolExecutor(max_workers=num_workers) as executor:
         future_to_info = {}
         for item in eval_set:
             for run_idx in range(runs_per_query):
-                future = executor.submit(
-                    run_single_query,
-                    item["query"],
-                    skill_name,
-                    description,
-                    timeout,
-                    str(project_root),
-                    model,
-                )
+                if use_api:
+                    future = executor.submit(
+                        run_single_query_api,
+                        item["query"],
+                        skill_name,
+                        description,
+                        timeout,
+                        backend,
+                        model,
+                    )
+                else:
+                    future = executor.submit(
+                        run_single_query,
+                        item["query"],
+                        skill_name,
+                        description,
+                        timeout,
+                        str(project_root),
+                        model,
+                    )
                 future_to_info[future] = (item, run_idx)
 
         query_triggers: dict[str, list[bool]] = {}
@@ -224,6 +277,7 @@ def run_eval(
                 print(f"Warning: query failed: {e}", file=sys.stderr)
                 query_triggers[query].append(False)
 
+    results = []
     for query, triggers in query_triggers.items():
         item = query_items[query]
         trigger_rate = sum(triggers) / len(triggers)
@@ -265,7 +319,9 @@ def main():
     parser.add_argument("--timeout", type=int, default=30, help="Timeout per query in seconds")
     parser.add_argument("--runs-per-query", type=int, default=3, help="Number of runs per query")
     parser.add_argument("--trigger-threshold", type=float, default=0.5, help="Trigger rate threshold")
-    parser.add_argument("--model", default=None, help="Model to use for claude -p (default: user's configured model)")
+    parser.add_argument("--model", default=None, help="Model to use (default: auto-detect based on backend)")
+    parser.add_argument("--backend", default=None, choices=["claude_cli", "anthropic_api", "github_models"],
+                        help="LLM backend (default: auto-detect)")
     parser.add_argument("--verbose", action="store_true", help="Print progress to stderr")
     args = parser.parse_args()
 
@@ -280,7 +336,10 @@ def main():
     description = args.description or original_description
     project_root = find_project_root()
 
+    backend = args.backend or detect_backend()
+
     if args.verbose:
+        print(f"Backend: {backend}", file=sys.stderr)
         print(f"Evaluating: {description}", file=sys.stderr)
 
     output = run_eval(
@@ -293,6 +352,7 @@ def main():
         runs_per_query=args.runs_per_query,
         trigger_threshold=args.trigger_threshold,
         model=args.model,
+        backend=backend,
     )
 
     if args.verbose:

--- a/skills/skill-creator/scripts/run_loop.py
+++ b/skills/skill-creator/scripts/run_loop.py
@@ -19,6 +19,7 @@ from scripts.generate_report import generate_html
 from scripts.improve_description import improve_description
 from scripts.run_eval import find_project_root, run_eval
 from scripts.utils import parse_skill_md
+from scripts.llm_backend import detect_backend
 
 
 def split_eval_set(eval_set: list[dict], holdout: float, seed: int = 42) -> tuple[list[dict], list[dict]]:
@@ -58,8 +59,11 @@ def run_loop(
     verbose: bool,
     live_report_path: Path | None = None,
     log_dir: Path | None = None,
+    backend: str | None = None,
 ) -> dict:
     """Run the eval + improvement loop."""
+    if backend is None:
+        backend = detect_backend()
     project_root = find_project_root()
     name, original_description, content = parse_skill_md(skill_path)
     current_description = description_override or original_description
@@ -96,6 +100,7 @@ def run_loop(
             runs_per_query=runs_per_query,
             trigger_threshold=trigger_threshold,
             model=model,
+            backend=backend,
         )
         eval_elapsed = time.time() - t0
 
@@ -205,6 +210,7 @@ def run_loop(
             model=model,
             log_dir=log_dir,
             iteration=iteration,
+            backend=backend,
         )
         improve_elapsed = time.time() - t0
 
@@ -253,6 +259,8 @@ def main():
     parser.add_argument("--trigger-threshold", type=float, default=0.5, help="Trigger rate threshold")
     parser.add_argument("--holdout", type=float, default=0.4, help="Fraction of eval set to hold out for testing (0 to disable)")
     parser.add_argument("--model", required=True, help="Model for improvement")
+    parser.add_argument("--backend", default=None, choices=["claude_cli", "anthropic_api", "github_models"],
+                        help="LLM backend (default: auto-detect)")
     parser.add_argument("--verbose", action="store_true", help="Print progress to stderr")
     parser.add_argument("--report", default="auto", help="Generate HTML report at this path (default: 'auto' for temp file, 'none' to disable)")
     parser.add_argument("--results-dir", default=None, help="Save all outputs (results.json, report.html, log.txt) to a timestamped subdirectory here")
@@ -304,6 +312,7 @@ def main():
         verbose=args.verbose,
         live_report_path=live_report_path,
         log_dir=log_dir,
+        backend=args.backend,
     )
 
     # Save JSON output


### PR DESCRIPTION
## Summary

- Adds `llm_backend.py` abstraction supporting  multipe backends 
- Enables `run_eval.py`, `improve_description.py`, and `run_loop.py` to work **without the `claude` CLI binary** (e.g., in OpenCode or other non-Claude-Code environments)

## Motivation

The skill-creator's `run_loop.py` (description optimization) previously required the `claude` CLI binary, which isn't available in all environments.

## Changes

| File | Change |
|------|--------|
| `scripts/llm_backend.py` | **New** -- Multi-backend LLM abstraction with text completion and trigger evaluation |
| `scripts/run_eval.py` | Added `--backend` flag, `run_single_query_api()` for API-based trigger testing |
| `scripts/improve_description.py` | Replaced `_call_claude()` with `_call_llm()` using `llm_backend.complete_text()` |
| `scripts/run_loop.py` | Added `--backend` flag, threads backend through to eval and improve steps |