### PR TITLE
Add /review skill — daily usage review

### DIFF
--- a/skills/review-zh/SKILL.md
+++ b/skills/review-zh/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: review
+description: |
+  生成每日 Claude Code 使用复盘 — 成本、习惯、改进建议。
+  触发词：review、复盘、今天干了啥、日报、usage report。
+  不用于：代码 review 或 PR review。
+argument-hint: "[日期: YYYY-MM-DD，默认今天] [--save 保存到文件]"
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Glob
+  - Grep
+  - WebFetch
+---
+
+# Review Skill — 每日使用复盘（中文版）
+
+## 执行步骤
+
+### 1. 确定日期
+使用传入参数，否则默认今天。格式：`YYYY-MM-DD`。
+
+### 2. Token 成本分析
+
+检测 ccusage：
+```bash
+command -v ccusage &>/dev/null && echo "has_ccusage" || echo "no_ccusage"
+```
+
+**有 ccusage**：
+```bash
+ccusage session        # 当前 session
+ccusage daily --days 7 # 7天趋势
+```
+
+**无 ccusage（JSONL fallback）**：
+```python
+import json, glob, os
+from datetime import date, timedelta
+
+def get_day_stats(day_str):
+    keys = ["input_tokens", "output_tokens", "cache_creation_input_tokens", "cache_read_input_tokens"]
+    total = {k: 0 for k in keys}
+    sessions, small = 0, 0
+    for f in glob.glob(os.path.expanduser("~/.claude/projects/*/*.jsonl")):
+        if "subagents" in f: continue
+        if date.fromtimestamp(os.path.getmtime(f)).isoformat() != day_str: continue
+        sessions += 1
+        msgs = 0
+        with open(f) as fp:
+            for line in fp:
+                try:
+                    msg = json.loads(line)
+                    if msg.get("type") == "assistant":
+                        msgs += 1
+                        for k in keys:
+                            total[k] += msg.get("message", {}).get("usage", {}).get(k, 0) or 0
+                except: pass
+        if msgs <= 5: small += 1
+    inp, out, cc, cr = total["input_tokens"], total["output_tokens"], total["cache_creation_input_tokens"], total["cache_read_input_tokens"]
+    cost = (inp*3 + out*15 + cc*3.75 + cr*0.30) / 1_000_000
+    return sessions, small, cost
+
+today = "{DATE}"
+sessions, small, cost = get_day_stats(today)
+print(f"今日: {sessions} sessions, 预估 ${cost:.2f}")
+print(f"短会话(≤5条): {small} 个")
+
+from datetime import date as d
+base = d.fromisoformat(today)
+for i in range(6, -1, -1):
+    day = (base - timedelta(days=i)).isoformat()
+    s, _, c = get_day_stats(day)
+    if s: print(f"{day}: {s} sessions, ${c:.2f}")
+```
+
+从数据中提炼 **1-2 条核心建议**。
+
+### 3. 提取 bash 命令（如有 hook）
+
+```bash
+[ -f ~/.claude/hooks/logs/bash-history.log ] && \
+  grep "^\[{DATE}" ~/.claude/hooks/logs/bash-history.log || echo "no_hook"
+```
+
+如有，统计：命令总数、最常用工具类型（git/python/ssh/curl 等）、活跃项目目录。
+
+### 4. Skill 使用情况
+
+**4a. 用户已安装 skill 列表：**
+```bash
+ls ~/.claude/skills/ | grep -v INDEX
+```
+
+**4b. 近 3 天用了哪些 skill：**
+从 bash-history 和 session JSONL 中检测 skill 调用（grep "Launching skill" 或 skill 名称出现在 history 中）：
+```bash
+# 近 3 天 bash history 中出现的 skill 名
+for i in 0 1 2; do
+  DAY=$(date -v-${i}d +%Y-%m-%d 2>/dev/null || date -d "{DATE} -${i} days" +%Y-%m-%d)
+  grep "^\[$DAY" ~/.claude/hooks/logs/bash-history.log 2>/dev/null
+done | grep -oE '/(review|clip|cost|status|publish|wrap|eileen|decide|batch-process|claude-to-im)\b' | sort -u
+```
+
+**输出**：
+- 今天用了哪些 skill
+- 近 3 天**完全没用过**的 skill → 提示用户是否要删除/清理
+
+### 5. 命令 & Skill 推荐（硬性要求，每次必须输出）
+
+**5a. 获取最新 CHANGELOG：**
+```
+WebFetch: https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md
+提示词: 提取最近 3 个版本中新增的斜杠命令（/xxx）或命令行功能。每条：命令名、一句话说明、版本号。
+```
+
+**5b. 获取官方 skill 列表：**
+```
+WebFetch: https://raw.githubusercontent.com/anthropics/claude-code/main/SKILLS.md
+提示词: 列出所有官方推荐的 skill，每条：名称、一句话说明、安装方式。
+```
+如果 SKILLS.md 不存在，用 CHANGELOG 中提到的官方 skill/plugin 信息代替。
+
+**5c. 必须推荐以下内容（硬性规定，缺一不可）：**
+
+| 类别 | 数量 | 来源 | 选择标准 |
+|------|------|------|----------|
+| 最新命令 | 1-2 个 | CHANGELOG 最近版本 | 新增的 `/命令` 或 CLI 功能 |
+| 常用但未用 | 2 个 | Claude Code 内置命令 | 用户今天没用过，但跟工作场景匹配的高频命令 |
+| 官方 Skill | 2 个 | 官方 skill 列表/CHANGELOG | 官方发布或推荐的 skill |
+
+**内置命令参考列表**（用于判断"常用但未用"）：
+- `/compact` — 压缩上下文，节省 token
+- `/resume` — 恢复之前的 session
+- `/model` — 切换模型
+- `/cost` — 查看当前花费
+- `/memory` — 管理记忆
+- `/help` — 查看帮助
+- `/config` — 修改配置
+- `/terminal` — 打开终端
+- `/vim` — vim 模式
+- `/fast` — 快速模式（同一个 Opus 模型，更快输出）
+- `/clear` — 清除上下文
+- `/login` — 登录
+- `/pr-review` — PR 评审
+- `/init` — 初始化项目 CLAUDE.md
+
+每条推荐必须说明**为什么适合这个用户**（结合当天的操作和习惯）。
+
+### 6. 生成输出
+
+输出格式（控制在 25 行以内）：
+
+```
+# 复盘 · {DATE}
+
+**今日概览**：{N} sessions · {N} 条命令 · 预估 ${X.XX}
+**7天均值**：${X.XX}/天 · 本周共 ${X.XX}
+
+**你做了什么**
+- [3条，从命令和 session 推断，要具体]
+
+**建议**
+- [1-2条成本/习惯建议，有数据支撑]
+
+**Skill 使用**
+- 今天用了：/xxx, /yyy
+- 近3天没用过：/aaa, /bbb → 考虑是否需要？
+
+**推荐**
+- 🆕 最新命令：`/xxx`（vX.X.X）— [说明 + 为什么适合你]
+- 💡 你可能需要：`/xxx` — [结合今天场景说明]、`/yyy` — [说明]
+- 📦 官方 Skill：`skill-name` — [说明]、`skill-name` — [说明]
+
+**明日一件事**：[最高优先级的一个改变]
+```
+
+### 7. 保存（可选）
+
+- 传入 `--save`：保存到 `./review-{DATE}.md`
+- 在 `*/observer/*` 目录下：自动保存到 `daily-reviews/{DATE}.md`
+- 否则仅展示
+
+---
+
+**注意**：无 bash-history hook 时，在末尾加一行：
+`💡 安装 bash-history hook 可获得更精准的命令分析`

--- a/skills/review/README.md
+++ b/skills/review/README.md
@@ -1,0 +1,102 @@
+# /review — Daily Usage Review for Claude Code
+
+**You spend $50-150/day on Claude Code but have no idea where the money goes.**
+
+This skill fixes that. Run `/review` at the end of your day and get:
+
+- How much you spent, how many sessions, what you actually did
+- Which habits are costing you money (too many short sessions, wrong model, etc.)
+- Commands and skills you should be using but aren't
+
+## The Problem
+
+Claude Code users face three blind spots:
+
+1. **Cost opacity** — No built-in way to see daily/weekly spend breakdown
+2. **Habit unawareness** — Starting 10+ sessions/day when `/compact` would save 80% of cache creation costs
+3. **Feature discovery** — Claude Code ships new commands constantly, but users stick to the 3-4 they know
+
+## What It Does
+
+```
+/review              # review today
+/review 2026-03-19   # review a specific date
+/review --save       # save to ./review-2026-03-20.md
+```
+
+Output (~20 lines):
+
+```
+# Daily Review · 2026-03-20
+
+**Overview**: 7 sessions · 90 commands · est. $26.27
+**7-day avg**: $65.88/day · week total $461.15
+
+**What you worked on**
+- Server debugging via SSH (22 calls)
+- Blog development with Hugo
+- Claude Code cost optimization — migrated MCP config, redesigned skills
+
+**Suggestions**
+- Today $26 vs weekly avg $66 — session discipline is working, keep it up
+- 31 `ls` + 20 `find` calls — use Glob/Grep tools instead, faster and cheaper
+
+**Skill usage**
+- Used today: /review, /cost, /model
+- Not used in 3 days: /publish, /decide → still need these?
+
+**Recommendations**
+- 🆕 New: `/fast` (v2.1.80) — same Opus model, faster output. Perfect for iterative work
+- 💡 Try: `/compact` — you opened 7 sessions, could've been 3 with compact
+- 💡 Try: `/resume` — pick up where you left off instead of new session
+- 📦 Skills: `frontend-design` — you touched Hugo templates today
+- 📦 Skills: `claude-api` — useful if you're building with Claude's API
+
+**One thing for tomorrow**: use `/compact` before opening a new session
+```
+
+## Key Design Decisions
+
+### Mandatory recommendations
+Every review **must** include:
+- 1-2 latest commands from the CHANGELOG
+- 2 built-in commands you didn't use but should have
+- 2 official skills relevant to your work
+
+This isn't optional. The whole point is surfacing things you don't know about.
+
+### Suggestions over data
+Users don't need token breakdowns — they need "you're wasting money because X, do Y instead." The skill shows just enough numbers to be credible, then focuses on actionable advice.
+
+### Zero config
+Works out of the box. Reads `~/.claude/projects/` for session data. Optionally reads bash-history hook logs for richer command analysis. Supports `ccusage` if installed.
+
+## Data Sources
+
+| Source | Required? | What it provides |
+|--------|-----------|------------------|
+| `~/.claude/projects/*/*.jsonl` | Yes (always exists) | Session count, token usage, cost estimate |
+| `~/.claude/hooks/logs/bash-history.log` | Optional (hook) | Command count, tool breakdown, active projects |
+| `ccusage` CLI | Optional (npm install) | Faster, more accurate cost data |
+| Claude Code CHANGELOG | Fetched live | Latest feature/command recommendations |
+
+## Install
+
+Copy `SKILL.md` to your Claude Code skills directory:
+
+```bash
+mkdir -p ~/.claude/skills/review
+curl -o ~/.claude/skills/review/SKILL.md \
+  https://raw.githubusercontent.com/anthropics/skills/main/skills/review/SKILL.md
+```
+
+Then just type `/review` in Claude Code.
+
+## Languages
+
+- **English**: this skill (`/review`)
+- **中文版**: see [review-zh/SKILL.md](../review-zh/SKILL.md) — 同样的功能，中文输出
+
+## License
+
+Apache 2.0

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: review
+description: "Generate a daily Claude Code usage review — token costs, session habits, and actionable suggestions including command/skill recommendations. Use when: user says 'review', 'daily review', 'usage report', 'what did I do today'. Do NOT use for: code review or PR review."
+---
+
+# Daily Usage Review
+
+Generate a concise daily review of Claude Code usage with cost analysis, habit insights, and personalized command/skill recommendations.
+
+## Arguments
+
+- Optional date: `YYYY-MM-DD` (defaults to today)
+- `--save`: write output to `./review-{DATE}.md`
+
+## Step 1 — Date & Environment
+
+Determine review date. Detect available data sources:
+
+```bash
+command -v ccusage &>/dev/null && echo "has_ccusage" || echo "no_ccusage"
+[ -f ~/.claude/hooks/logs/bash-history.log ] && echo "has_bash_hook" || echo "no_bash_hook"
+```
+
+## Step 2 — Token Cost Analysis
+
+**With ccusage:**
+```bash
+ccusage session && ccusage daily --days 7
+```
+
+**Without ccusage (JSONL fallback):**
+
+Parse `~/.claude/projects/*/*.jsonl` (skip `*/subagents/*`). For each file modified on the target date, sum `usage` fields from assistant messages: `input_tokens`, `output_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens`.
+
+Cost estimate (Sonnet 4.6): input $3/M, output $15/M, cache_creation $3.75/M, cache_read $0.30/M.
+
+Track: session count, short sessions (≤5 messages), and 7-day daily totals.
+
+Distill **1-2 cost suggestions** from the data (e.g., too many short sessions → use `/compact`).
+
+## Step 3 — Bash Commands (if hook available)
+
+```bash
+grep "^\[{DATE}" ~/.claude/hooks/logs/bash-history.log
+```
+
+Summarize: total count, top tool types (git/python/ssh/curl), active directories.
+
+## Step 4 — Skill Usage
+
+List installed skills:
+```bash
+ls ~/.claude/skills/ 2>/dev/null | grep -v INDEX
+```
+
+Detect which skills were invoked in the last 3 days (from bash-history or session JSONL).
+
+Report:
+- Skills used today
+- Skills **not used in 3 days** → suggest cleanup
+
+## Step 5 — Command & Skill Recommendations (MANDATORY)
+
+Every review MUST include ALL of the following:
+
+### 5a. Latest commands (1-2)
+Fetch the changelog:
+```
+WebFetch: https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md
+Prompt: Extract new slash commands or CLI features from the last 3 versions. Each: name, one-line description, version.
+```
+Pick 1-2 that match the user's workflow. Explain why.
+
+### 5b. Commonly used but unused commands (2)
+From this reference list, pick 2 that the user didn't use today but should have based on their activity:
+- `/compact` — compress context, save tokens
+- `/resume` — resume a previous session
+- `/model` — switch models mid-session
+- `/cost` — check current spend
+- `/memory` — manage persistent memories
+- `/config` — modify settings
+- `/terminal` — open terminal
+- `/vim` — vim mode
+- `/fast` — fast output mode (same model)
+- `/clear` — clear context
+- `/pr-review` — PR review
+- `/init` — initialize project CLAUDE.md
+
+Each must explain **why it fits this user's workflow**.
+
+### 5c. Official skills (2)
+Fetch official skills:
+```
+WebFetch: https://raw.githubusercontent.com/anthropics/claude-code/main/SKILLS.md
+Prompt: List all officially recommended skills with name, description, install method.
+```
+If unavailable, use skills mentioned in the CHANGELOG. Pick 2 relevant to user's work. Explain why.
+
+## Step 6 — Output
+
+Target: under 25 lines.
+
+```
+# Daily Review · {DATE}
+
+**Overview**: {N} sessions · {N} commands · est. ${X.XX}
+**7-day avg**: ${X.XX}/day · week total ${X.XX}
+
+**What you worked on**
+- [3 specific bullets from commands + sessions]
+
+**Suggestions**
+- [1-2 cost/habit suggestions with data]
+
+**Skill usage**
+- Used today: /xxx, /yyy
+- Not used in 3 days: /aaa, /bbb → still need these?
+
+**Recommendations**
+- 🆕 New: `/xxx` (vX.X.X) — [why it fits you]
+- 💡 Try: `/xxx` — [reason], `/yyy` — [reason]
+- 📦 Skills: `name` — [desc], `name` — [desc]
+
+**One thing for tomorrow**: [single highest-impact change]
+```
+
+If bash-history hook is missing, append:
+`Tip: install a bash-history hook for richer command tracking.`


### PR DESCRIPTION
## Summary

- Adds `/review` skill for daily Claude Code usage analysis
- Zero-config: reads `~/.claude/projects/` JSONL files, optionally `ccusage` and bash-history hook
- Focuses on **actionable suggestions over raw data** — tells users what to change, not just what happened
- Mandatory recommendations section: latest commands from CHANGELOG + commonly-used-but-unused commands + official skills
- Includes Chinese version (`review-zh`)

## The problem this solves

Claude Code users have no built-in way to:
1. See daily/weekly cost breakdown
2. Detect wasteful session habits (too many short sessions, wrong model choice)
3. Discover new commands and skills they should be using

## What the output looks like

```
# Daily Review · 2026-03-20

**Overview**: 7 sessions · 90 commands · est. $26.27
**7-day avg**: $65.88/day · week total $461.15

**What you worked on**
- Server debugging via SSH (22 calls)
- Blog development with Hugo
- Cost optimization — migrated MCP config, redesigned skills

**Suggestions**
- Today $26 vs weekly avg $66 — session discipline working
- 31 ls + 20 find → use Glob/Grep tools instead

**Skill usage**
- Used today: /review, /cost, /model
- Not used in 3 days: /publish → still need it?

**Recommendations**
- 🆕 New: /fast (v2.1.80) — same model, faster output
- 💡 Try: /compact — 7 sessions could've been 3
- 📦 Skills: frontend-design, claude-api

**One thing for tomorrow**: /compact before new session
```

## Files
- `skills/review/SKILL.md` — English version
- `skills/review/README.md` — Documentation with design decisions
- `skills/review-zh/SKILL.md` — Chinese version (同样功能，中文输出)

## Test plan
- [x] Tested with JSONL fallback (no ccusage)
- [x] Tested with bash-history hook
- [x] Tested CHANGELOG fetch via WebFetch
- [x] Verified output stays under 25 lines
- [x] Verified mandatory recommendations section always appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)