### PR TITLE
Add youtube-analysis skill for livestream comment analysis

### DIFF
--- a/skills/youtube-analysis/README.md
+++ b/skills/youtube-analysis/README.md
@@ -1,0 +1,59 @@
+# YouTube Livestream Comment Analysis
+
+A skill that downloads and analyzes YouTube livestream chat comments — giving you sentiment breakdowns, common themes, and geographic reach in seconds.
+
+## What it does
+
+Give an agent a YouTube livestream URL and it will:
+
+1. **Download** all chat messages from the stream
+2. **Export** them to a CSV (Timestamp, Author, Message) and a quick-stats summary
+3. **Analyze sentiment** — classify each comment as positive, neutral, or negative with a percentage breakdown
+4. **Extract themes** — surface the top recurring topics (e.g., product mentions, viewer questions, community hype)
+5. **Map geographic reach** — find "hello from…" messages and report how many countries tuned in
+
+## Example output
+
+```
+📊 Sentiment Breakdown (513 comments)
+| Sentiment    | Count | %     |
+|--------------|-------|-------|
+| ✅ Positive  | 183   | 35.7% |
+| ➖ Neutral   | 310   | 60.4% |
+| ❌ Negative  | 20    |  3.9% |
+
+🔥 Common Themes
+1. AI/Agents (208 mentions)
+2. Community greetings (145 mentions)
+3. Technical questions (72 mentions)
+...
+
+🌍 Geographic Reach — 26 countries across 5 continents
+```
+
+## Requirements
+
+- Python 3.8+
+- [yt-dlp](https://github.com/yt-dlp/yt-dlp) (`pip install yt-dlp`)
+
+## Usage
+
+Just ask your agent something like:
+
+> "Analyze the comments from this YouTube livestream: https://www.youtube.com/watch?v=VIDEO_ID"
+
+The skill handles the rest.
+
+## File structure
+
+```
+youtube-analysis/
+├── SKILL.md                        # Agent instructions + metadata
+├── README.md                       # This file (human-facing docs)
+└── scripts/
+    └── download-comments.py        # Chat download + CSV export script
+```
+
+## License
+
+MIT

--- a/skills/youtube-analysis/SKILL.md
+++ b/skills/youtube-analysis/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: youtube-analysis
+description: >
+  Download and analyze YouTube livestream chat comments. Use when the user wants to
+  download comments from a YouTube livestream or video, analyze sentiment, extract
+  common themes, or get geographic breakdowns of viewers. Also supports playlist URLs
+  for multi-stream comparison — sentiment trends, audience growth, and recurring viewers
+  across episodes. Trigger phrases include "analyze YouTube comments," "download
+  livestream chat," "YouTube sentiment analysis," "what did viewers say," "livestream
+  recap," "compare streams," or "analyze playlist."
+---
+
+# YouTube Livestream Comment Analysis
+
+Analyze YouTube livestream or video chat comments — from download through insight generation.
+
+## Workflow
+
+### Step 1: Download comments
+
+Run the download script with the YouTube URL:
+
+```
+python scripts/download-comments.py <YOUTUBE_URL>
+```
+
+This produces two files in `~/Downloads/`:
+- `livestream_comments.csv` — raw comments (Timestamp, Author, Message)
+- `livestream_summary.md` — quick stats (total messages, unique participants, top authors)
+
+### Step 2: Analyze sentiment
+
+Read the CSV and classify each comment as **Positive**, **Neutral**, or **Negative** using keyword and tone analysis. Produce a summary table:
+
+| Sentiment | Count | % |
+|-----------|-------|---|
+| ✅ Positive | — | — |
+| ➖ Neutral  | — | — |
+| ❌ Negative | — | — |
+
+**Guidelines for classification:**
+- **Positive**: enthusiasm, praise, excitement, gratitude, emojis like 🔥🎉❤️
+- **Neutral**: greetings, factual statements, simple questions, "hello from X"
+- **Negative**: complaints, frustration, criticism, disappointment
+
+### Step 3: Extract themes
+
+Group comments by recurring topics. Report the top 5-10 themes with approximate mention counts. Look for:
+- Product/feature mentions
+- Questions or requests
+- Community engagement (greetings, shoutouts)
+- Technical discussion
+- Reactions to specific moments
+
+### Step 4: Geographic breakdown (if applicable)
+
+Scan for "hello from," "watching from," "greetings from," or similar location mentions. Report:
+- Number of unique countries
+- Grouped by region (Americas, Europe, Africa, Asia, etc.)
+
+## Output format
+
+Present results in a clean Markdown summary with sections for:
+1. 📊 Sentiment Breakdown (table)
+2. 🔥 Common Themes (numbered list with counts)
+3. 🌍 Geographic Reach (table grouped by region)
+
+## Multi-Stream Comparison (Playlist Mode)
+
+When the user provides a **YouTube playlist URL**, run the download script for each video in the playlist:
+
+```
+python scripts/download-playlist.py <PLAYLIST_URL>
+```
+
+This downloads comments for every stream in the playlist into `~/Downloads/playlist-analysis/`, one CSV per video.
+
+Then produce a **cross-stream comparison report** with:
+
+### 📈 Sentiment Trends
+- Table or chart showing positive/neutral/negative % per stream over time
+- Identify if sentiment is improving, declining, or stable across episodes
+
+### 👥 Audience Growth
+- Total unique commenters per stream
+- New vs returning viewers per stream (viewers who commented in previous streams)
+- Trend: is the audience growing, shrinking, or stable?
+
+### 🔁 Recurring Viewers
+- List the most loyal viewers (appeared in the most streams)
+- Top 10 recurring commenters with stream count and total messages
+
+### 🔥 Theme Evolution
+- How topics shift across streams — what themes are rising, fading, or consistent
+- New topics that emerged in recent streams
+
+### Output format (playlist mode)
+Present as a Markdown report with:
+1. 📋 Playlist Overview (stream count, date range, total comments)
+2. 📈 Sentiment Trends (table: one row per stream)
+3. 👥 Audience Growth (table: unique viewers, new vs returning)
+4. 🔁 Top Recurring Viewers (table: viewer, streams appeared, total messages)
+5. 🔥 Theme Evolution (summary of shifts across streams)
+
+## Requirements
+
+- Python 3.8+
+- `yt-dlp` (`pip install yt-dlp`)
+
+## Edge cases
+
+- If the stream has no chat replay, the download script will report an error — inform the user.
+- Super chats and membership messages may not be captured — note this limitation.
+- Very short streams (< 50 messages) may not produce meaningful sentiment or theme analysis — still report what's available.

--- a/skills/youtube-analysis/scripts/download-comments.py
+++ b/skills/youtube-analysis/scripts/download-comments.py
@@ -1,0 +1,158 @@
+"""
+YouTube Livestream Comment Downloader
+=====================================
+Downloads live chat from a YouTube livestream and exports to CSV + Markdown summary.
+
+Usage:
+    python download-comments.py <YOUTUBE_URL>
+    python download-comments.py https://www.youtube.com/watch?v=VIDEO_ID
+
+Output (saved to ~/Downloads/):
+    - livestream_comments.csv       (Timestamp, Author, Message)
+    - livestream_summary.md         (Quick stats + sample comments)
+"""
+
+import sys
+import os
+import csv
+import json
+import subprocess
+import tempfile
+from datetime import datetime
+from collections import Counter
+
+OUTPUT_DIR = os.path.join(os.path.expanduser("~"), "Downloads")
+
+
+def download_chat(url):
+    """Download live chat messages using yt-dlp."""
+    print(f"⬇️  Downloading chat from: {url}")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out_template = os.path.join(tmpdir, "chat")
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "yt_dlp",
+                "--write-subs",
+                "--sub-langs", "live_chat",
+                "--skip-download",
+                "-o", out_template,
+                url,
+            ],
+            capture_output=True, text=True,
+        )
+
+        if result.returncode != 0:
+            print(f"❌ yt-dlp error: {result.stderr.strip()}")
+            return []
+
+        chat_file = None
+        for f in os.listdir(tmpdir):
+            if "live_chat" in f and f.endswith(".json"):
+                chat_file = os.path.join(tmpdir, f)
+                break
+
+        if not chat_file:
+            print("❌ No live chat file found. Does this stream have chat replay?")
+            return []
+
+        messages = []
+        with open(chat_file, "r", encoding="utf-8") as f:
+            for line in f:
+                try:
+                    entry = json.loads(line.strip())
+                    actions = entry.get("replayChatItemAction", {}).get("actions", [])
+                    for action in actions:
+                        item = action.get("addChatItemAction", {}).get("item", {})
+                        renderer = item.get("liveChatTextMessageRenderer", {})
+                        if not renderer:
+                            continue
+
+                        author = renderer.get("authorName", {}).get("simpleText", "Unknown")
+                        timestamp = renderer.get("timestampText", {}).get("simpleText", "")
+
+                        msg_parts = []
+                        for run in renderer.get("message", {}).get("runs", []):
+                            if "text" in run:
+                                msg_parts.append(run["text"])
+                            elif "emoji" in run:
+                                alt = run["emoji"].get("shortcuts", [""])[0] or run["emoji"].get("emojiId", "")
+                                msg_parts.append(alt)
+                        message = "".join(msg_parts)
+
+                        if message:
+                            messages.append({
+                                "timestamp": timestamp,
+                                "author": author,
+                                "message": message,
+                            })
+                except (json.JSONDecodeError, KeyError):
+                    continue
+
+    print(f"✅ Downloaded {len(messages)} messages")
+    return messages
+
+
+def export_csv(messages, path):
+    """Export messages to CSV."""
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=["timestamp", "author", "message"])
+        writer.writeheader()
+        writer.writerows(messages)
+    print(f"📄 CSV saved to: {path}")
+
+
+def generate_summary(messages, url, path):
+    """Generate a Markdown summary with basic stats."""
+    unique_authors = set(m["author"] for m in messages)
+    author_counts = Counter(m["author"] for m in messages)
+    top_authors = author_counts.most_common(10)
+    avg_len = sum(len(m["message"]) for m in messages) / max(len(messages), 1)
+
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(f"# YouTube Livestream Chat Summary\n\n")
+        f.write(f"**Source:** {url}  \n")
+        f.write(f"**Generated:** {datetime.now().strftime('%Y-%m-%d %H:%M')}  \n\n")
+        f.write(f"## 📊 Quick Stats\n\n")
+        f.write(f"| Metric | Value |\n")
+        f.write(f"|--------|-------|\n")
+        f.write(f"| Total messages | {len(messages)} |\n")
+        f.write(f"| Unique participants | {len(unique_authors)} |\n")
+        f.write(f"| Avg message length | {avg_len:.0f} chars |\n\n")
+        f.write(f"## 🏆 Top 10 Most Active Participants\n\n")
+        f.write(f"| Author | Messages |\n")
+        f.write(f"|--------|----------|\n")
+        for author, count in top_authors:
+            f.write(f"| {author} | {count} |\n")
+        f.write(f"\n## 🔍 Next Steps\n\n")
+        f.write(f"Run sentiment analysis, theme extraction, or geographic breakdown\n")
+        f.write(f"using the youtube-analysis skill.\n")
+
+    print(f"📝 Summary saved to: {path}")
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python download-comments.py <YOUTUBE_URL>")
+        print('Example: python download-comments.py "https://www.youtube.com/watch?v=VIDEO_ID"')
+        sys.exit(1)
+
+    url = sys.argv[1]
+    csv_path = os.path.join(OUTPUT_DIR, "livestream_comments.csv")
+    summary_path = os.path.join(OUTPUT_DIR, "livestream_summary.md")
+
+    messages = download_chat(url)
+    if not messages:
+        print("❌ No messages found. Is the URL correct and does the stream have chat?")
+        sys.exit(1)
+
+    export_csv(messages, csv_path)
+    generate_summary(messages, url, summary_path)
+
+    print(f"\n🎉 Done! {len(messages)} comments ready.")
+    print(f"   CSV:     {csv_path}")
+    print(f"   Summary: {summary_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/youtube-analysis/scripts/download-playlist.py
+++ b/skills/youtube-analysis/scripts/download-playlist.py
@@ -1,0 +1,209 @@
+"""
+YouTube Playlist Comment Downloader
+====================================
+Downloads live chat from every video in a YouTube playlist.
+Outputs one CSV per video into ~/Downloads/playlist-analysis/.
+
+Usage:
+    python download-playlist.py <PLAYLIST_URL>
+    python download-playlist.py "https://www.youtube.com/playlist?list=PLj6YeMhvp2S4gpM0lGDd5hIDveC7IsLwv"
+
+Output (saved to ~/Downloads/playlist-analysis/):
+    - 01_<video_title>.csv
+    - 02_<video_title>.csv
+    - ...
+    - playlist_index.csv   (index of all videos with metadata)
+"""
+
+import sys
+import os
+import re
+import csv
+import json
+import subprocess
+from datetime import datetime
+
+OUTPUT_DIR = os.path.join(os.path.expanduser("~"), "Downloads", "playlist-analysis")
+
+
+def sanitize_filename(name, max_len=80):
+    """Remove unsafe characters from a filename."""
+    name = re.sub(r'[<>:"/\\|?*]', '', name)
+    name = re.sub(r'\s+', '_', name.strip())
+    return name[:max_len]
+
+
+def get_playlist_videos(playlist_url):
+    """Use yt-dlp to list all videos in a playlist."""
+    print(f"📋 Fetching playlist info from: {playlist_url}")
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "yt_dlp",
+            "--flat-playlist",
+            "--dump-json",
+            "--no-warnings",
+            playlist_url,
+        ],
+        capture_output=True, text=True,
+    )
+
+    if result.returncode != 0:
+        print(f"❌ yt-dlp error: {result.stderr.strip()}")
+        return []
+
+    videos = []
+    for line in result.stdout.strip().splitlines():
+        try:
+            entry = json.loads(line)
+            videos.append({
+                "id": entry.get("id", ""),
+                "title": entry.get("title", "Unknown"),
+                "url": f"https://www.youtube.com/watch?v={entry.get('id', '')}",
+                "upload_date": entry.get("upload_date", ""),
+            })
+        except json.JSONDecodeError:
+            continue
+
+    print(f"✅ Found {len(videos)} videos in playlist")
+    return videos
+
+
+def download_chat_for_video(url):
+    """Download live chat for a single video. Returns list of messages."""
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out_template = os.path.join(tmpdir, "chat")
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "yt_dlp",
+                "--write-subs",
+                "--sub-langs", "live_chat",
+                "--skip-download",
+                "-o", out_template,
+                url,
+            ],
+            capture_output=True, text=True,
+        )
+
+        if result.returncode != 0:
+            return []
+
+        chat_file = None
+        for f in os.listdir(tmpdir):
+            if "live_chat" in f and f.endswith(".json"):
+                chat_file = os.path.join(tmpdir, f)
+                break
+
+        if not chat_file:
+            return []
+
+        messages = []
+        with open(chat_file, "r", encoding="utf-8") as f:
+            for line in f:
+                try:
+                    entry = json.loads(line.strip())
+                    actions = entry.get("replayChatItemAction", {}).get("actions", [])
+                    for action in actions:
+                        item = action.get("addChatItemAction", {}).get("item", {})
+                        renderer = item.get("liveChatTextMessageRenderer", {})
+                        if not renderer:
+                            continue
+
+                        author = renderer.get("authorName", {}).get("simpleText", "Unknown")
+                        timestamp = renderer.get("timestampText", {}).get("simpleText", "")
+
+                        msg_parts = []
+                        for run in renderer.get("message", {}).get("runs", []):
+                            if "text" in run:
+                                msg_parts.append(run["text"])
+                            elif "emoji" in run:
+                                alt = run["emoji"].get("shortcuts", [""])[0] or run["emoji"].get("emojiId", "")
+                                msg_parts.append(alt)
+                        message = "".join(msg_parts)
+
+                        if message:
+                            messages.append({
+                                "timestamp": timestamp,
+                                "author": author,
+                                "message": message,
+                            })
+                except (json.JSONDecodeError, KeyError):
+                    continue
+
+    return messages
+
+
+def export_csv(messages, path):
+    """Export messages to CSV."""
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=["timestamp", "author", "message"])
+        writer.writeheader()
+        writer.writerows(messages)
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python download-playlist.py <PLAYLIST_URL>")
+        print('Example: python download-playlist.py "https://www.youtube.com/playlist?list=PLxxxxxx"')
+        sys.exit(1)
+
+    playlist_url = sys.argv[1]
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+    videos = get_playlist_videos(playlist_url)
+    if not videos:
+        print("❌ No videos found in playlist.")
+        sys.exit(1)
+
+    index_rows = []
+
+    for i, video in enumerate(videos, 1):
+        safe_title = sanitize_filename(video["title"])
+        csv_filename = f"{i:02d}_{safe_title}.csv"
+        csv_path = os.path.join(OUTPUT_DIR, csv_filename)
+
+        print(f"\n[{i}/{len(videos)}] ⬇️  {video['title']}")
+        messages = download_chat_for_video(video["url"])
+
+        if messages:
+            export_csv(messages, csv_path)
+            print(f"   ✅ {len(messages)} messages → {csv_filename}")
+        else:
+            print(f"   ⚠️  No chat found (may not be a livestream)")
+
+        unique_authors = set(m["author"] for m in messages) if messages else set()
+        index_rows.append({
+            "number": i,
+            "title": video["title"],
+            "video_id": video["id"],
+            "upload_date": video.get("upload_date", ""),
+            "comment_count": len(messages),
+            "unique_viewers": len(unique_authors),
+            "csv_file": csv_filename if messages else "",
+        })
+
+    # Write playlist index
+    index_path = os.path.join(OUTPUT_DIR, "playlist_index.csv")
+    with open(index_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=[
+            "number", "title", "video_id", "upload_date",
+            "comment_count", "unique_viewers", "csv_file"
+        ])
+        writer.writeheader()
+        writer.writerows(index_rows)
+
+    total_comments = sum(r["comment_count"] for r in index_rows)
+    streams_with_chat = sum(1 for r in index_rows if r["comment_count"] > 0)
+
+    print(f"\n🎉 Done!")
+    print(f"   Videos processed: {len(videos)}")
+    print(f"   Streams with chat: {streams_with_chat}")
+    print(f"   Total comments: {total_comments}")
+    print(f"   Output folder: {OUTPUT_DIR}")
+    print(f"   Index file: {index_path}")
+    print(f"\n💡 Tip: Ask Copilot to 'compare sentiment across my playlist streams'")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What this adds

A new skill that downloads and analyzes YouTube livestream chat comments.

### Features
- **Download** chat via yt-dlp and export to CSV
- **Sentiment analysis** — classify comments as positive/neutral/negative
- **Theme extraction** — surface recurring topics with mention counts
- **Geographic breakdown** — map viewer locations from chat messages
- **Playlist mode** — multi-stream comparison with sentiment trends, audience growth, recurring viewers, and theme evolution

### Files
- \\skills/youtube-analysis/SKILL.md\\ — agent instructions + metadata
- \\skills/youtube-analysis/README.md\\ — human-facing documentation
- \\skills/youtube-analysis/scripts/download-comments.py\\ — single stream chat downloader
- \\skills/youtube-analysis/scripts/download-playlist.py\\ — playlist chat downloader

### Requirements
- Python 3.8+
- yt-dlp (\\pip install yt-dlp\\)

### Example usage
> *Analyze the comments from this YouTube livestream: https://youtube.com/watch?v=...*
> *Compare sentiment across this playlist: https://youtube.com/playlist?list=...*