### PR TITLE
docs(skill-creator): add Framework Independence principle

### DIFF
--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -2,7 +2,6 @@
 name: skill-creator
 description: Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, edit, or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or optimize a skill's description for better triggering accuracy.
 ---
-
 # Skill Creator
 
 A skill for creating new skills and iteratively improving them.
@@ -107,6 +106,53 @@ cloud-deploy/
     └── azure.md
 ```
 Claude reads only the relevant reference file.
+
+#### Principle of Framework Independence
+
+**A skill must never own a framework. It may only reference one.**
+
+Frameworks are independent, versioned, public assets that live in their own
+GitHub repositories. They include: scoring models, taxonomies, standards
+(SFIA, OWASP, etc.), API specs, brand registries, vocabulary maps,
+classification systems — any logic reusable across more than one skill.
+
+**Rules:**
+1. If logic could apply to more than one skill → it is a framework, not skill content
+2. Frameworks live in their own public GitHub repo — not inside any skill folder
+3. Skills reference frameworks by GitHub URL, not by file path
+4. A skill fetches a framework at runtime — it never copies framework content inline
+5. Frameworks are versioned independently via Git tags — skills pin a version or track `main`
+6. Any skill, by anyone, can reference any public framework
+7. No skill "owns" a framework — the GitHub repo owner maintains it
+
+**How to reference a framework in a skill:**
+```markdown
+> **Framework:** https://github.com/opensaasapps/frameworks/tree/main/sfia
+> Read this before proceeding. Do not copy its content into this skill.
+```
+
+Or pinned to a version:
+```markdown
+> **Framework:** https://github.com/opensaasapps/frameworks/tree/v1.0/sfia
+```
+
+**What belongs in a skill vs a framework:**
+
+| Belongs in SKILL.md | Belongs in a framework repo |
+|---|---|
+| Workflow steps | Scoring rubrics |
+| Trigger conditions | Taxonomies and classifications |
+| Input/output format | External API specs |
+| Which framework to use | Brand/vendor registries |
+| How to apply results | Standards (SFIA, OWASP, ISO) |
+| Error handling | Vocabulary and category maps |
+
+**When creating a skill that uses any classification, scoring model, or standard:**
+check if a public framework repo already exists for it. If yes, reference it
+by URL. If no, create it as a new public GitHub repo first, then reference it.
+Never inline it into the skill.
+
+---
 
 #### Principle of Lack of Surprise
 


### PR DESCRIPTION
# PR: Add Framework Independence Principle to skill-creator

**Branch:** `feat/framework-independence-principle`
**Type:** RFC / Discussion — pure addition, no existing content modified

---

## Summary

Adds one new design principle — **Framework Independence** — to the Skill
Writing Guide in `skill-creator/SKILL.md`.

> *A skill must never own a framework. It may only reference one.*

---

## The core idea

Frameworks (scoring rubrics, taxonomies, standards like SFIA, API specs,
brand registries) should live in their own **public GitHub repositories**,
not embedded inside skill files.

Skills reference frameworks by **GitHub URL**:

```markdown
> **Framework:** https://github.com/opensaasapps/frameworks/tree/main/sfia
> Fetch this before proceeding. Do not copy its content into this skill.
```

Pinned to a version:
```markdown
> **Framework:** https://github.com/opensaasapps/frameworks/tree/v1.0/sfia
```

This means:
- Frameworks are versioned independently via Git tags
- Any skill, by anyone, can reference any public framework by URL
- Update the framework repo once → all skills that reference it benefit
- No skill "owns" a framework — the GitHub repo owner maintains it
- Works across any skills infrastructure — no dependency on directory layout

---

## What this adds to skill-creator

A single new section inserted between "Domain organization" and "Principle
of Lack of Surprise" in the Skill Writing Guide. Zero deletions. Zero
modifications to existing content.

Covers:
- The principle and its rules
- The GitHub URL reference pattern with version pinning examples
- A skill vs framework decision table
- Guidance to create a framework repo first, then reference it

---

## Why GitHub URLs specifically

We considered file path references but a GitHub URL is strictly better:

- The URL is the identity — no ambiguity, no directory convention to agree on
- Works across any skills infrastructure (Anthropic, third-party, private)
- Public frameworks are discoverable and community-contributable
- Version pinning via Git tags is universal and well-understood
- No new syntax to invent or standardise

---

## Origin

Emerged from building a skill suite in a single session (`agentnxxt/agentskills`).
Initially embedded SFIA levels, brand registries, and scoring rubrics inside
individual skills. When we caught the duplication across three skills, we
extracted them into a public `opensaasapps/frameworks` repo and had each
skill reference them by URL. The skills shrank, became easier to read, and
the frameworks became independently maintainable.

Example frameworks now living independently:
- https://github.com/opensaasapps/frameworks/tree/main/sfia
- https://github.com/opensaasapps/frameworks/tree/main/known-brands
- https://github.com/opensaasapps/frameworks/tree/main/rebrand-scoring
- https://github.com/opensaasapps/frameworks/tree/main/unboxd-badges-schema

---

## No open questions

The GitHub URL pattern requires no agreement on directory structure, loading
syntax, or runtime mechanisms. A skill fetches the URL, reads the content,
applies it. That's it.

---

## Author

**Chinmay Panda** ([@fractional-pm](https://github.com/fractional-pm))

This principle emerged from a skill-building session where Chinmay identified
that skills were embedding reusable logic inline and proposed separating them
into independently maintained, publicly referenced frameworks. The GitHub URL
reference pattern (vs file paths) was also Chinmay's call — cleaner, no
conventions to agree on, works across any infrastructure.

The four frameworks extracted and published as a result:
- https://github.com/OpenSaaSApps/frameworks/tree/main/sfia
- https://github.com/OpenSaaSApps/frameworks/tree/main/known-brands
- https://github.com/OpenSaaSApps/frameworks/tree/main/rebrand-scoring
- https://github.com/OpenSaaSApps/frameworks/tree/main/unboxd-badges-schema
