### PR TITLE
Add zyka-ai-media skill: AI video, image, and voice generation

### DIFF
--- a/skills/zyka-ai-media/LICENSE.txt
+++ b/skills/zyka-ai-media/LICENSE.txt
@@ -1,0 +1,15 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/skills/zyka-ai-media/SKILL.md
+++ b/skills/zyka-ai-media/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: zyka-ai-media
+description: Generate AI videos, images, and voice using the Zyka SDK (npm package 'zyka-sdk'). Use this skill when users want to create AI-generated media — videos (Sora, Veo, Kling, WAN, Seedance), images (DALL·E, GPT Image, Flux, Nano Banana, Stable Diffusion), text-to-speech (ElevenLabs, Chatterbox, Qwen3), or talking head videos. The SDK handles local file uploads, auto-polling, and auto-download automatically.
+---
+
+# Zyka AI Media Generation
+
+Generate AI videos, images, and voice programmatically using Zyka's unified SDK. One package, 30+ AI models.
+
+## Setup
+
+Install the SDK from npm:
+```bash
+npm install zyka-sdk
+```
+
+Authentication — set your Zyka API key (get one at https://zyka.ai/settings/api-keys):
+```bash
+export ZYKA_API_KEY=zk_live_...
+```
+
+Or pass it directly:
+```js
+const { ZykaClient } = require('zyka-sdk');
+const client = new ZykaClient({ apiKey: 'zk_live_...' });
+```
+
+## Key Behaviors
+- **Local files** are auto-uploaded. Pass `'./photo.png'` instead of a URL.
+- **Auto-wait** is on by default. `await client.createVideo(...)` returns when the video is ready.
+- **Auto-download** with the `output` option: `{ output: './result.mp4' }`.
+
+---
+
+## Video Generation
+
+```js
+const result = await client.createVideo({
+  model: 'MODEL_NAME',
+  prompt: 'description of what to generate',
+});
+console.log(result.outputUrl);
+```
+
+### Available Video Models
+
+| Model | `model` value | Key params |
+|---|---|---|
+| OpenAI Sora | `sora` | `sub_model: 'sora-2'`, `seconds: '4'/'8'/'12'`, `size: '1280x720'` |
+| Google Veo | `veo` | `sub_model: 'veo-3.0-generate-001'`, `seconds: '4'-'8'`, `aspect_ratio: '16:9'/'9:16'` |
+| Kling AI | `kling` | `sub_model: 'kling-v2-master'`, `duration: '5'/'10'`, `aspect_ratio: '16:9'` |
+| ByteDance Seedance | `bytedance` | `sub_model: 'Seedance V1.5 Pro'`, `duration: '4'-'12'`, `resolution: '1080p'` |
+| Alibaba WAN | `wan` | `sub_model: 'wan-2-6-t2v'`, `duration: 5/10/15` |
+| Talking Head | `infinite_talk` | `image_url: './face.jpg'`, `audio_url: './speech.mp3'` |
+
+### Examples
+
+**Text to video:**
+```js
+await client.createVideo({
+  model: 'wan',
+  prompt: 'A cinematic sunset over mountains with golden light',
+  duration: 5
+});
+```
+
+**Image to video (animate a photo):**
+```js
+await client.createVideo({
+  model: 'kling',
+  sub_model: 'kling-v2-master',
+  prompt: 'gentle camera zoom in with wind blowing',
+  image_url: './photo.jpg',
+  duration: '5',
+  aspect_ratio: '16:9'
+});
+```
+
+**Talking head (lip sync a face with audio):**
+```js
+await client.createVideo({
+  model: 'infinite_talk',
+  image_url: './face.jpg',
+  audio_url: './speech.mp3'
+});
+```
+
+---
+
+## Image Generation
+
+```js
+const result = await client.createImage({
+  model: 'MODEL_NAME',
+  prompt: 'description',
+}, { output: './result.png' });
+```
+
+### Available Image Models
+
+| Model | `model` value | Notes |
+|---|---|---|
+| Nano Banana | `nano_banana` | Sub-models: `nano-banana-1`, `nano-banana-pro`. Great for edits. |
+| DALL·E 3 | `dall_e_3` | Quality: `'standard'`/`'hd'` |
+| GPT Image 1 | `gpt_image_1` | Supports `background: 'transparent'` |
+| GPT Image 1.5 | `gpt_image_1_5` | Latest OpenAI model |
+| Flux Schnell | `flux_1_schnell` | Fast generation |
+| Flux 2 Dev | `flux_2_dev` | High quality |
+| Kling Image | `kling` | Sub-models: `kling-v1` to `kling-image-v3` |
+| Stable Diffusion XL | `stable_diffusion_xl_base_1_0` | Classic SD |
+| SD 1.5 img2img | `stable_diffusion_v1_5_img2img` | Requires `image` input |
+| Z Image Turbo | `z_image_turbo` | Fast |
+
+### Examples
+
+**Generate from text:**
+```js
+await client.createImage({
+  model: 'gpt_image_1',
+  prompt: 'A neon-lit cyberpunk cityscape at night'
+}, { output: './city.png' });
+```
+
+**Edit an existing image:**
+```js
+await client.createImage({
+  model: 'nano_banana',
+  sub_model: 'nano-banana-pro',
+  image: './photo.png',
+  prompt: 'make the background a tropical beach'
+}, { output: './edited.png' });
+```
+
+**Transparent background:**
+```js
+await client.createImage({
+  model: 'gpt_image_1',
+  prompt: 'a cute cartoon cat mascot',
+  background: 'transparent'
+}, { output: './mascot.png' });
+```
+
+---
+
+## Text-to-Speech (TTS)
+
+```js
+const result = await client.createTTS({
+  provider: 'PROVIDER_NAME',
+  script: 'Text to speak',
+});
+```
+
+### Available TTS Providers
+
+| Provider | `provider` value | Notes |
+|---|---|---|
+| ElevenLabs | `elevenlabs` | Requires `voice_id` |
+| Qwen3 | `qwen3` | Voice design, clone, custom |
+| Chatterbox | `chatterbox` | Voice cloning + emotion control |
+| VoxCPM | `voxcpm` | Voice cloning |
+| MiniMax | `minimax` | 17 preset voices |
+
+### Examples
+
+**Generate speech:**
+```js
+await client.createTTS({
+  provider: 'elevenlabs',
+  voice_id: 'voice-id-here',
+  script: 'Welcome to Zyka, the AI media generation platform.'
+}, { output: './speech.mp3' });
+```
+
+**Clone a voice:**
+```js
+await client.createTTS({
+  provider: 'chatterbox',
+  actual_voice_url: './my-voice.mp3',
+  script: 'This sounds just like me!',
+  exaggeration: 0.5
+}, { output: './cloned.mp3' });
+```
+
+---
+
+## Guidelines
+
+- Always install `zyka-sdk` from npm before using it: `npm install zyka-sdk`
+- Always set `ZYKA_API_KEY` environment variable or pass `apiKey` in the constructor
+- Prefer passing local file paths (e.g., `'./photo.png'`) — the SDK auto-uploads them
+- Use the `output` option to automatically download results to disk
+- All generation methods auto-wait for completion by default — no polling code needed
+- When the user asks to edit an image, use `nano_banana` with `sub_model: 'nano-banana-pro'`
+- When the user asks for a video from text, default to the `wan` model
+- When the user asks for image-to-video, default to the `kling` model
+
+## API Reference
+
+| Method | Description |
+|---|---|
+| `client.createVideo(params, opts?)` | Video generation (auto-waits for completion) |
+| `client.createImage(params, opts?)` | Image generation (auto-waits for completion) |
+| `client.createTTS(params, opts?)` | Text-to-speech generation (auto-waits for completion) |
+
+**Options:** `{ waitForCompletion?: boolean, output?: string, timeoutMs?: number }`
+
+## Auth Priority
+1. `config.apiKey` → 2. `ZYKA_API_KEY` env → 3. `config.token` → 4. `ZYKA_API_TOKEN` env → 5. `~/.zyka/config.json`

--- a/skills/zyka-ai-media/SKILL.md
+++ b/skills/zyka-ai-media/SKILL.md
@@ -1,209 +1,158 @@
 ---
 name: zyka-ai-media
-description: Generate AI videos, images, and voice using the Zyka SDK (npm package 'zyka-sdk'). Use this skill when users want to create AI-generated media — videos (Sora, Veo, Kling, WAN, Seedance), images (DALL·E, GPT Image, Flux, Nano Banana, Stable Diffusion), text-to-speech (ElevenLabs, Chatterbox, Qwen3), or talking head videos. The SDK handles local file uploads, auto-polling, and auto-download automatically.
+description: Generate AI videos, images, and voice using the Zyka CLI (npm package 'zyka'). Use this skill when users want to create AI-generated media — videos (Sora, Veo, Kling, WAN, Seedance), images (DALL·E, GPT Image, Flux, Nano Banana, Stable Diffusion), text-to-speech (ElevenLabs, Chatterbox, Qwen3), or talking head videos. Run CLI commands directly — no code needed.
 ---
 
 # Zyka AI Media Generation
 
-Generate AI videos, images, and voice programmatically using Zyka's unified SDK. One package, 30+ AI models.
+Generate AI videos, images, and voice directly from the terminal using the `zyka` CLI. One command, 30+ AI models. No code writing required.
 
 ## Setup
 
-Install the SDK from npm:
+The CLI is available via npx (no install needed) or can be installed globally:
 ```bash
-npm install zyka-sdk
+npx zyka --help
+# or install globally:
+npm install -g zyka
 ```
 
-Authentication — set your Zyka API key (get one at https://zyka.ai/settings/api-keys):
+Set your API key:
 ```bash
 export ZYKA_API_KEY=zk_live_...
 ```
 
-Or pass it directly:
-```js
-const { ZykaClient } = require('zyka-sdk');
-const client = new ZykaClient({ apiKey: 'zk_live_...' });
-```
+Users can get an API key at https://zyka.ai/settings/api-keys
 
-## Key Behaviors
-- **Local files** are auto-uploaded. Pass `'./photo.png'` instead of a URL.
-- **Auto-wait** is on by default. `await client.createVideo(...)` returns when the video is ready.
-- **Auto-download** with the `output` option: `{ output: './result.mp4' }`.
+## IMPORTANT: Always use CLI commands, never write code scripts
+
+When a user asks to generate media, **run the `npx zyka generate` command directly** — do NOT write JavaScript files or scripts. The CLI handles everything: file uploads, waiting for completion, and downloading results.
 
 ---
 
-## Video Generation
+## Generate Videos
 
-```js
-const result = await client.createVideo({
-  model: 'MODEL_NAME',
-  prompt: 'description of what to generate',
-});
-console.log(result.outputUrl);
+```bash
+npx zyka generate video -m MODEL -p "prompt" [options]
 ```
 
-### Available Video Models
-
-| Model | `model` value | Key params |
+### Video Models
+| Model | `-m` value | Key options |
 |---|---|---|
-| OpenAI Sora | `sora` | `sub_model: 'sora-2'`, `seconds: '4'/'8'/'12'`, `size: '1280x720'` |
-| Google Veo | `veo` | `sub_model: 'veo-3.0-generate-001'`, `seconds: '4'-'8'`, `aspect_ratio: '16:9'/'9:16'` |
-| Kling AI | `kling` | `sub_model: 'kling-v2-master'`, `duration: '5'/'10'`, `aspect_ratio: '16:9'` |
-| ByteDance Seedance | `bytedance` | `sub_model: 'Seedance V1.5 Pro'`, `duration: '4'-'12'`, `resolution: '1080p'` |
-| Alibaba WAN | `wan` | `sub_model: 'wan-2-6-t2v'`, `duration: 5/10/15` |
-| Talking Head | `infinite_talk` | `image_url: './face.jpg'`, `audio_url: './speech.mp3'` |
+| OpenAI Sora | `sora` | `-s sora-2`, `-d 4/8/12` |
+| Google Veo | `veo` | `-s veo-3.0-generate-001`, `-d 4-8`, `-a 16:9/9:16` |
+| Kling AI | `kling` | `-s kling-v2-master`, `-d 5/10`, `-a 16:9` |
+| ByteDance Seedance | `bytedance` | `-s "Seedance V1.5 Pro"`, `-d 4-12` |
+| Alibaba WAN | `wan` | `-s wan-2-6-t2v`, `-d 5/10/15` |
+| Talking Head | `infinite_talk` | `--image ./face.jpg --audio ./speech.mp3` |
 
-### Examples
+### Video Examples
 
 **Text to video:**
-```js
-await client.createVideo({
-  model: 'wan',
-  prompt: 'A cinematic sunset over mountains with golden light',
-  duration: 5
-});
+```bash
+npx zyka generate video -m wan -p "A cinematic sunset over mountains" -d 5 -o ./sunset.mp4
 ```
 
 **Image to video (animate a photo):**
-```js
-await client.createVideo({
-  model: 'kling',
-  sub_model: 'kling-v2-master',
-  prompt: 'gentle camera zoom in with wind blowing',
-  image_url: './photo.jpg',
-  duration: '5',
-  aspect_ratio: '16:9'
-});
+```bash
+npx zyka generate video -m kling -s kling-v2-master -p "gentle zoom in with wind" --image ./photo.jpg -d 5 -a 16:9 -o ./animated.mp4
 ```
 
-**Talking head (lip sync a face with audio):**
-```js
-await client.createVideo({
-  model: 'infinite_talk',
-  image_url: './face.jpg',
-  audio_url: './speech.mp3'
-});
+**Talking head (lip sync):**
+```bash
+npx zyka generate video -m infinite_talk -p "lip sync" --image ./face.jpg --audio ./speech.mp3 -o ./talking.mp4
 ```
 
 ---
 
-## Image Generation
+## Generate Images
 
-```js
-const result = await client.createImage({
-  model: 'MODEL_NAME',
-  prompt: 'description',
-}, { output: './result.png' });
+```bash
+npx zyka generate image -m MODEL -p "prompt" [options]
 ```
 
-### Available Image Models
-
-| Model | `model` value | Notes |
+### Image Models
+| Model | `-m` value | Notes |
 |---|---|---|
-| Nano Banana | `nano_banana` | Sub-models: `nano-banana-1`, `nano-banana-pro`. Great for edits. |
-| DALL·E 3 | `dall_e_3` | Quality: `'standard'`/`'hd'` |
-| GPT Image 1 | `gpt_image_1` | Supports `background: 'transparent'` |
-| GPT Image 1.5 | `gpt_image_1_5` | Latest OpenAI model |
-| Flux Schnell | `flux_1_schnell` | Fast generation |
+| Nano Banana | `nano_banana` | `-s nano-banana-pro` for edits |
+| DALL·E 3 | `dall_e_3` | High quality |
+| GPT Image 1 | `gpt_image_1` | Supports transparency |
+| GPT Image 1.5 | `gpt_image_1_5` | Latest OpenAI |
+| Flux Schnell | `flux_1_schnell` | Fast |
 | Flux 2 Dev | `flux_2_dev` | High quality |
-| Kling Image | `kling` | Sub-models: `kling-v1` to `kling-image-v3` |
+| Kling Image | `kling` | `-s kling-image-v3` |
 | Stable Diffusion XL | `stable_diffusion_xl_base_1_0` | Classic SD |
-| SD 1.5 img2img | `stable_diffusion_v1_5_img2img` | Requires `image` input |
+| SD img2img | `stable_diffusion_v1_5_img2img` | Needs `--image` |
 | Z Image Turbo | `z_image_turbo` | Fast |
 
-### Examples
+### Image Examples
 
 **Generate from text:**
-```js
-await client.createImage({
-  model: 'gpt_image_1',
-  prompt: 'A neon-lit cyberpunk cityscape at night'
-}, { output: './city.png' });
+```bash
+npx zyka generate image -m gpt_image_1 -p "A neon cyberpunk cityscape" -o ./city.png
 ```
 
 **Edit an existing image:**
-```js
-await client.createImage({
-  model: 'nano_banana',
-  sub_model: 'nano-banana-pro',
-  image: './photo.png',
-  prompt: 'make the background a tropical beach'
-}, { output: './edited.png' });
+```bash
+npx zyka generate image -m nano_banana -s nano-banana-pro -p "make the hair straight" --image ./me.png -o ./result.png
 ```
 
-**Transparent background:**
-```js
-await client.createImage({
-  model: 'gpt_image_1',
-  prompt: 'a cute cartoon cat mascot',
-  background: 'transparent'
-}, { output: './mascot.png' });
+**Edit a photo (change style):**
+```bash
+npx zyka generate image -m nano_banana -s nano-banana-pro -p "make it look cinematic" --image ./photo.png -o ./cinematic.png
 ```
 
 ---
 
-## Text-to-Speech (TTS)
+## Generate Text-to-Speech
 
-```js
-const result = await client.createTTS({
-  provider: 'PROVIDER_NAME',
-  script: 'Text to speak',
-});
+```bash
+npx zyka generate tts --script "text" [options]
 ```
 
-### Available TTS Providers
-
-| Provider | `provider` value | Notes |
+### TTS Providers
+| Provider | `--provider` value | Notes |
 |---|---|---|
-| ElevenLabs | `elevenlabs` | Requires `voice_id` |
-| Qwen3 | `qwen3` | Voice design, clone, custom |
-| Chatterbox | `chatterbox` | Voice cloning + emotion control |
-| VoxCPM | `voxcpm` | Voice cloning |
+| ElevenLabs | `elevenlabs` | Needs `--voice-id` |
+| Qwen3 | `qwen3` | Voice design/clone |
+| Chatterbox | `chatterbox` | Clone + emotion |
 | MiniMax | `minimax` | 17 preset voices |
 
-### Examples
+### TTS Examples
 
 **Generate speech:**
-```js
-await client.createTTS({
-  provider: 'elevenlabs',
-  voice_id: 'voice-id-here',
-  script: 'Welcome to Zyka, the AI media generation platform.'
-}, { output: './speech.mp3' });
+```bash
+npx zyka generate tts --provider elevenlabs --voice-id VOICE_ID --script "Welcome to Zyka" -o ./speech.mp3
 ```
 
 **Clone a voice:**
-```js
-await client.createTTS({
-  provider: 'chatterbox',
-  actual_voice_url: './my-voice.mp3',
-  script: 'This sounds just like me!',
-  exaggeration: 0.5
-}, { output: './cloned.mp3' });
+```bash
+npx zyka generate tts --provider chatterbox --voice ./my-voice.mp3 --script "This sounds like me" -o ./cloned.mp3
 ```
 
 ---
 
 ## Guidelines
 
-- Always install `zyka-sdk` from npm before using it: `npm install zyka-sdk`
-- Always set `ZYKA_API_KEY` environment variable or pass `apiKey` in the constructor
-- Prefer passing local file paths (e.g., `'./photo.png'`) — the SDK auto-uploads them
-- Use the `output` option to automatically download results to disk
-- All generation methods auto-wait for completion by default — no polling code needed
-- When the user asks to edit an image, use `nano_banana` with `sub_model: 'nano-banana-pro'`
-- When the user asks for a video from text, default to the `wan` model
-- When the user asks for image-to-video, default to the `kling` model
+- **ALWAYS use `npx zyka generate` CLI commands** — never write JavaScript files
+- Set `ZYKA_API_KEY` env var before running commands
+- Use `-o ./filename` to save results to disk (auto-downloads)
+- Use `--image ./path` to pass local image files (auto-uploads)
+- Use `--audio ./path` to pass local audio files (auto-uploads)
+- All commands auto-wait for completion — no polling needed
+- When editing images, default to `-m nano_banana -s nano-banana-pro`
+- When generating videos from text, default to `-m wan`
+- When animating images to video, default to `-m kling`
 
-## API Reference
+## CLI Options Reference
 
-| Method | Description |
+| Flag | Description |
 |---|---|
-| `client.createVideo(params, opts?)` | Video generation (auto-waits for completion) |
-| `client.createImage(params, opts?)` | Image generation (auto-waits for completion) |
-| `client.createTTS(params, opts?)` | Text-to-speech generation (auto-waits for completion) |
-
-**Options:** `{ waitForCompletion?: boolean, output?: string, timeoutMs?: number }`
-
-## Auth Priority
-1. `config.apiKey` → 2. `ZYKA_API_KEY` env → 3. `config.token` → 4. `ZYKA_API_TOKEN` env → 5. `~/.zyka/config.json`
+| `-m, --model` | Model name (required for video/image) |
+| `-p, --prompt` | Text prompt (required) |
+| `-s, --sub-model` | Model variant |
+| `-d, --duration` | Video duration in seconds |
+| `-a, --aspect-ratio` | Aspect ratio (16:9, 9:16, 1:1) |
+| `--image` | Input image path (for editing/animating) |
+| `--audio` | Input audio path (for talking heads) |
+| `-o, --output` | Save result to this file path |
+| `--no-wait` | Don't wait for completion |


### PR DESCRIPTION
## Summary

Adds a new skill for generating AI media using the [Zyka SDK](https://www.npmjs.com/package/zyka-sdk) (`npm install zyka-sdk`).

## What this skill does

Teaches Claude to generate AI videos, images, and voice using Zyka's unified API. Users simply describe what they want — "make a sunset video", "edit my photo", "generate a voiceover" — and Claude handles the rest.

### Supported media types
- **🎬 AI Videos** — Sora, Veo, Kling, WAN, Seedance, talking heads (6 models)
- **🖼️ AI Images** — DALL·E 3, GPT Image, Flux, Nano Banana, Stable Diffusion (10+ models)
- **🎤 Text-to-Speech** — ElevenLabs, Chatterbox, Qwen3, MiniMax (5 providers)

### Key features
- Auto-uploads local files (no manual URL conversion)
- Auto-waits for completion (no polling code)
- Auto-downloads results to disk
- 30+ AI models through one unified API

## Files
- `skills/zyka-ai-media/SKILL.md` — Skill instructions with YAML frontmatter
- `skills/zyka-ai-media/LICENSE.txt` — Apache 2.0

## npm package
Published at: https://www.npmjs.com/package/zyka-sdk

## Links
- GitHub: https://github.com/kshitijdixit/zyka-sdk
- Website: https://zyka.ai