### PR TITLE
Add divination skill

### DIFF
--- a/skills/divination/LICENSE.txt
+++ b/skills/divination/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Amenti Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/divination/SKILL.md
+++ b/skills/divination/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: divination
+description: Use this skill when the user wants tarot, I Ching, an oracle-style reading, or symbolic guidance for an open-ended human question. It installs and uses the OpenDivination CLI, defaults to ordinary computer RNG, and can opt into QRNG or resonance when the user wants that explicitly.
+license: MIT. Complete terms in LICENSE.txt
+---
+
+# Divination
+
+Use the OpenDivination CLI for tarot draws, I Ching casts, entropy source inspection, and provenance-aware symbolic guidance.
+
+## Use When
+
+- The user explicitly asks for tarot, I Ching, a reading, a cast, a pull, an oracle, or divination
+- The user wants symbolic or reflective guidance rather than factual analysis
+- The user is asking an open-ended personal, relational, spiritual, creative, or life-direction question
+- The user wants a contemplative prompt, journaling seed, or creative constraint
+- The question is ambiguous enough that a symbolic reading could help surface perspective
+
+## Do Not Use When
+
+- The user wants factual verification, prediction, diagnosis, or expert advice
+- The user is asking for medical, legal, financial, safety, or other high-stakes guidance
+- The task is technical, operational, or transactional with no symbolic framing
+
+Keep divination separate from practical advice. If both are needed, present the reading first as symbolic guidance, then clearly separate any practical follow-up.
+
+## Install Once
+
+Check whether `opendivination` is already available:
+
+```bash
+opendivination version
+```
+
+If not installed, prefer `pipx`:
+
+```bash
+python3 -m pip install --user pipx
+python3 -m pipx ensurepath
+python3 -m pipx install opendivination
+```
+
+If PyPI is unavailable or the user wants the GitHub build directly:
+
+```bash
+python3 -m pipx install git+https://github.com/amenti-labs/opendivination.git
+```
+
+## First-Run Setup
+
+Run:
+
+```bash
+opendivination setup
+```
+
+Ask the user which entropy path they want:
+
+- `computer`: default computer RNG (`csprng`)
+- `remote_quantum`: remote QRNG provider such as ANU
+- `local_hardware`: local hardware source such as QCicada when available
+
+Default to `computer` unless the user explicitly wants QRNG.
+
+## Default Commands
+
+Tarot:
+
+```bash
+opendivination draw tarot --json
+```
+
+I Ching:
+
+```bash
+opendivination draw iching --method yarrow --json
+```
+
+Sources:
+
+```bash
+opendivination sources --json
+```
+
+## Technique Selection
+
+- Use tarot for broad archetypal reflection, emotional tone, relationship themes, and creative guidance
+- Use I Ching for process questions, transitions, timing, strategy, and “what is unfolding?”
+- If the user asks for a generic reading and does not care which system to use, default to tarot
+
+## Provenance Rules
+
+When the user asks about randomness, trust, or “quantum,” always include:
+
+- `provenance.source_id`
+- `provenance.is_quantum`
+
+Never imply quantum entropy when the source is `csprng`.
+
+## Resonance
+
+Resonance is optional and should only be used when the user explicitly wants embedding-based symbolic matching.
+
+Simplest local setup:
+
+```bash
+ollama pull nomic-embed-text
+opendivination draw tarot \
+  --mode resonance \
+  --embed-provider local \
+  --embed-model nomic-embed-text \
+  --json
+```
+
+Default to standard selection mode unless the user asks for resonance.
+
+## Output Handling
+
+- Prefer `--json` when the result will be consumed by an agent
+- Report the symbol cleanly first
+- Keep the symbolic interpretation separate from provenance facts
+- Do not present the reading as objective proof


### PR DESCRIPTION
## Summary
- add a new `divination` skill for tarot, I Ching, and provenance-aware oracle workflows
- keep the skill self-contained and lightweight: install the OpenDivination CLI if needed, run guided setup, then use the CLI directly
- default the instructions to ordinary computer RNG, with QRNG and resonance treated as explicit opt-ins

## Why
This fills a gap in the current example set: a symbolic-guidance skill that is still operationally concrete. The skill is useful for explicit tarot / I Ching requests, but also for open-ended reflective questions where a user wants an oracle-style frame rather than factual analysis.

I kept the instructions intentionally small and practical:
- no bundled scripts
- no special marketplace assumptions
- clear install fallback from PyPI to the public GitHub repo
- explicit guardrails around high-stakes advice and quantum/provenance claims

## Notes
OpenDivination repo: https://github.com/amenti-labs/opendivination
