### PR TITLE
Add mobile-design skill for React Native + Expo

### DIFF
--- a/skills/mobile-design/LICENSE.txt
+++ b/skills/mobile-design/LICENSE.txt
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/skills/mobile-design/SKILL.md
+++ b/skills/mobile-design/SKILL.md
@@ -1,0 +1,409 @@
+---
+name: mobile-design
+description: Design and build production-grade React Native + Expo mobile screens, components, and navigation flows. Use when the user asks to create, redesign, or audit a mobile UI - screens, components, navigation, animations, or design systems. Produces working NativeWind/StyleSheet code with accessibility, dark mode, and all UI states handled.
+license: Complete terms in LICENSE.txt
+---
+
+This skill guides the design and implementation of production-grade React Native + Expo mobile interfaces. It produces working, accessible code that handles all UI states - not mockups or pseudocode.
+
+The user provides a mobile UI task: a screen to build, a component to design, a navigation flow to map, or an existing screen to audit or improve.
+
+## Design Thinking
+
+Before writing code, commit to a clear design direction:
+
+- **Platform**: iOS-first, Android-first, or cross-platform? (Affects shadows, fonts, navigation patterns)
+- **Context**: What is the user doing on this screen? What did they just come from, where do they go next?
+- **Hierarchy**: What is the single most important thing on screen? Design everything else to support it.
+- **Touch model**: Which elements are interactive? Are tap targets >= 44x44pt?
+- **States**: What does empty, loading, error, and fully-populated look like?
+
+**CRITICAL**: Mobile screens have limited space. Ruthless prioritization beats feature-completeness. One clear action per screen beats five equal-weight actions.
+
+## Styling Approach
+
+Use **NativeWind** (Tailwind for React Native) for all styles unless the component requires animation (use `StyleSheet` only for Reanimated animated styles):
+
+```tsx
+// Preferred - NativeWind
+<View className="flex-1 bg-background p-4">
+  <Text className="text-xl font-semibold text-foreground">Title</Text>
+</View>
+
+// Only for Reanimated animated values
+const animatedStyle = useAnimatedStyle(() => ({
+  transform: [{ scale: scale.value }],
+}));
+```
+
+### Spacing Scale
+
+```
+p-2 / gap-2 = 8px    (tight groupings)
+p-3 / gap-3 = 12px   (related items)
+p-4 / gap-4 = 16px   (standard padding)
+p-6 / gap-6 = 24px   (section separation)
+p-8 / gap-8 = 32px   (large breathing room)
+```
+
+### Border Radius
+
+```
+rounded-lg    -> inputs, small cards
+rounded-xl    -> cards, list items, modals
+rounded-2xl   -> large containers, bottom sheets
+rounded-full  -> avatars, pills, icon buttons, FABs
+```
+
+### Typography
+
+```
+text-2xl font-bold      -> screen/page titles
+text-xl  font-semibold  -> section headers
+text-base font-medium   -> primary labels, body
+text-sm                 -> secondary info, descriptions
+text-xs                 -> timestamps, metadata, captions
+```
+
+## Screen Design
+
+Structure every screen around four layers:
+
+1. **Header** - Navigation context + title + optional action (back, close, menu)
+2. **Content** - Primary content area (scrollable or fixed)
+3. **Actions** - Primary CTA(s), bottom-anchored for thumb reach
+4. **States** - Empty, loading, error variants of the content layer
+
+### Layout Patterns
+
+| Pattern | When to Use | Key Components |
+|---------|-------------|---------------|
+| List/Feed | Scrollable items, posts, history | `FlatList` + pull-to-refresh |
+| Form | Data collection, settings | `ScrollView` + `KeyboardAvoidingView` |
+| Modal/Sheet | Focused actions, confirmations | `Modal` or bottom sheet with drag handle |
+| Dashboard | Multiple data types at a glance | `ScrollView` + card grid |
+| Pager | Parallel sections (tabs) | `PagerView` or Tab navigator |
+| Camera/Immersive | Media capture, full-bleed views | Absolute overlays on `CameraView` |
+| Onboarding | Multi-step flows | Pager + progress indicator + skip |
+
+### Screen Template
+
+```tsx
+import { View, Text, FlatList, ActivityIndicator, Pressable } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+interface ScreenProps {
+  // define props
+}
+
+export function ExampleScreen({}: ScreenProps) {
+  const { data, isLoading, error, refetch } = useData();
+
+  if (isLoading) return <LoadingState />;
+  if (error) return <ErrorState message={error.message} onRetry={refetch} />;
+  if (!data?.length) return <EmptyState />;
+
+  return (
+    <SafeAreaView className="flex-1 bg-background" edges={['top']}>
+      {/* Header */}
+      <View className="px-4 pb-3 flex-row items-center justify-between">
+        <Text className="text-2xl font-bold text-foreground">Title</Text>
+      </View>
+
+      {/* Content */}
+      <FlatList
+        data={data}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => <ItemCard item={item} />}
+        contentContainerClassName="px-4 gap-3 pb-8"
+        showsVerticalScrollIndicator={false}
+      />
+
+      {/* Primary action */}
+      <View className="px-4 pb-6 pt-3 border-t border-border">
+        <Pressable
+          onPress={handleAction}
+          accessibilityRole="button"
+          accessibilityLabel="Primary action"
+          className="bg-primary rounded-xl py-4 items-center"
+        >
+          <Text className="text-white text-base font-semibold">Action</Text>
+        </Pressable>
+      </View>
+    </SafeAreaView>
+  );
+}
+```
+
+## Component Design
+
+Every component must define:
+- **Props interface** - typed inputs and event callbacks
+- **Variants** - default, active/selected, disabled, loading
+- **Accessibility** - `accessibilityRole`, `accessibilityLabel`, `accessibilityState`
+
+### Component Template
+
+```tsx
+import { Pressable, Text, View } from 'react-native';
+
+interface CardProps {
+  title: string;
+  subtitle?: string;
+  onPress?: () => void;
+  variant?: 'default' | 'active' | 'disabled';
+  isLoading?: boolean;
+}
+
+export function Card({
+  title,
+  subtitle,
+  onPress,
+  variant = 'default',
+  isLoading = false,
+}: CardProps) {
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={variant === 'disabled' || isLoading}
+      accessibilityRole="button"
+      accessibilityLabel={title}
+      accessibilityState={{ disabled: variant === 'disabled' }}
+      className={[
+        'rounded-xl p-4 bg-card border border-border',
+        variant === 'active' && 'border-primary bg-primary/10',
+        variant === 'disabled' && 'opacity-50',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <Text className="text-base font-medium text-foreground">{title}</Text>
+      {subtitle && (
+        <Text className="text-sm text-muted-foreground mt-1">{subtitle}</Text>
+      )}
+    </Pressable>
+  );
+}
+```
+
+## UI States
+
+Design all three states at the same time as the happy path - never defer them.
+
+### Empty State
+
+```tsx
+function EmptyState({
+  icon,
+  title,
+  subtitle,
+  actionLabel,
+  onAction,
+}: {
+  icon: string;
+  title: string;
+  subtitle: string;
+  actionLabel?: string;
+  onAction?: () => void;
+}) {
+  return (
+    <View className="flex-1 items-center justify-center gap-3 px-8">
+      <Text className="text-5xl">{icon}</Text>
+      <Text className="text-xl font-semibold text-foreground text-center">{title}</Text>
+      <Text className="text-sm text-muted-foreground text-center leading-relaxed">{subtitle}</Text>
+      {actionLabel && (
+        <Pressable
+          onPress={onAction}
+          accessibilityRole="button"
+          className="mt-2 bg-primary rounded-xl px-6 py-3"
+        >
+          <Text className="text-white font-semibold">{actionLabel}</Text>
+        </Pressable>
+      )}
+    </View>
+  );
+}
+```
+
+### Loading State (Skeleton)
+
+```tsx
+function SkeletonCard() {
+  return (
+    <View className="rounded-xl bg-card border border-border p-4 gap-3">
+      <View className="h-4 bg-muted rounded-full w-3/4" />
+      <View className="h-3 bg-muted rounded-full w-1/2" />
+    </View>
+  );
+}
+
+function LoadingState() {
+  return (
+    <View className="flex-1 items-center justify-center gap-3">
+      <ActivityIndicator size="large" />
+      <Text className="text-sm text-muted-foreground">Loading...</Text>
+    </View>
+  );
+}
+```
+
+### Error State
+
+```tsx
+function ErrorState({
+  message,
+  onRetry,
+}: {
+  message: string;
+  onRetry: () => void;
+}) {
+  return (
+    <View className="flex-1 items-center justify-center gap-3 px-8">
+      <Text className="text-4xl">[!]</Text>
+      <Text className="text-xl font-semibold text-foreground text-center">
+        Something went wrong
+      </Text>
+      <Text className="text-sm text-muted-foreground text-center">{message}</Text>
+      <Pressable
+        onPress={onRetry}
+        accessibilityRole="button"
+        className="bg-primary rounded-xl px-6 py-3"
+      >
+        <Text className="text-white font-semibold">Try Again</Text>
+      </Pressable>
+    </View>
+  );
+}
+```
+
+## Navigation Design (Expo Router)
+
+Map every flow before writing code:
+
+1. **Route names** - match the `app/` directory structure
+2. **Navigation type**: push (drill-down), replace (no back), modal (overlay), dismiss
+3. **Params** - typed with `useLocalSearchParams<{ id: string }>()`
+4. **Guards** - back/dismiss warnings for unsaved changes
+
+```tsx
+// Navigate with typed params
+router.push({ pathname: '/item/[id]', params: { id: item.id } });
+
+// Modal presentation (set in _layout.tsx)
+<Stack.Screen name="create" options={{ presentation: 'modal' }} />
+
+// Read params
+const { id } = useLocalSearchParams<{ id: string }>();
+
+// Replace (no back stack entry)
+router.replace('/home');
+```
+
+## Animations (react-native-reanimated)
+
+Use shared values - never `useState` - for animated styles. Keep gestures on the UI thread.
+
+```tsx
+// Fade in on mount
+const opacity = useSharedValue(0);
+useEffect(() => { opacity.value = withTiming(1, { duration: 300 }); }, []);
+const fadeStyle = useAnimatedStyle(() => ({ opacity: opacity.value }));
+
+// Spring scale on press (satisfying tap feedback)
+const scale = useSharedValue(1);
+const pressStyle = useAnimatedStyle(() => ({ transform: [{ scale: scale.value }] }));
+const handlers = useAnimatedGestureHandler({
+  onStart: () => { scale.value = withSpring(0.96); },
+  onEnd: () => { scale.value = withSpring(1); },
+});
+
+// Slide-up sheet
+const translateY = useSharedValue(400);
+useEffect(() => { translateY.value = withSpring(0, { damping: 20 }); }, []);
+const sheetStyle = useAnimatedStyle(() => ({
+  transform: [{ translateY: translateY.value }],
+}));
+```
+
+## Accessibility
+
+Every interactive element must have:
+- `accessibilityRole`: `button`, `link`, `image`, `header`, `text`, `checkbox`, `radio`
+- `accessibilityLabel`: meaningful description (not just the visible text if context is needed)
+- `accessibilityState`: `{ disabled, selected, checked, busy }`
+- Minimum **44x44pt** tap target - use `className="min-h-[44px] min-w-[44px]"` to enforce
+
+```tsx
+<Pressable
+  accessibilityRole="button"
+  accessibilityLabel="Delete photo"
+  accessibilityState={{ disabled: isDeleting }}
+  className="min-h-[44px] min-w-[44px] items-center justify-center"
+>
+  <TrashIcon />
+</Pressable>
+```
+
+## Dark Mode
+
+Design for dark mode from the start. Use semantic color tokens (`foreground`, `background`, `muted`, `card`, `border`, `primary`) - never hardcode hex values. If using a custom theme system, map it to CSS variables and toggle via a root class.
+
+```tsx
+// Good - token-based, works in both modes
+<View className="bg-background">
+  <Text className="text-foreground">Hello</Text>
+  <Text className="text-muted-foreground">Subtitle</Text>
+</View>
+
+// Bad - breaks in dark mode
+<View style={{ backgroundColor: '#ffffff' }}>
+  <Text style={{ color: '#000000' }}>Hello</Text>
+</View>
+```
+
+## Performance Guidelines
+
+- Use `FlatList` or `FlashList` for any list > 10 items - never `ScrollView` + `map()`
+- Never nest a `ScrollView` inside a `FlatList` (or vice versa) - causes gesture conflicts and jank
+- `useCallback` on `renderItem` and `keyExtractor` to prevent unnecessary re-renders
+- `removeClippedSubviews` on long lists
+- Prefer `Pressable` over `TouchableOpacity` for new code
+
+```tsx
+// Good
+<FlatList
+  data={items}
+  keyExtractor={useCallback((item) => item.id, [])}
+  renderItem={useCallback(({ item }) => <ItemCard item={item} />, [])}
+  removeClippedSubviews
+/>
+
+// Bad - unmounts/remounts everything on scroll
+<ScrollView>
+  {items.map((item) => <ItemCard key={item.id} item={item} />)}
+</ScrollView>
+```
+
+## Output Format
+
+- Always output **working, complete code** - no pseudocode, no ellipsis placeholders
+- Include **all three states** (empty, loading, error) in every screen
+- Show **before / after** when auditing existing code
+- Annotate non-obvious decisions with `// why` comments
+- Flag performance risks inline as `// WARN performance:`
+- Flag accessibility gaps as `// WARN a11y:`
+- Use `// TODO:` only for items that genuinely require external data to resolve
+
+## Proactive Checks
+
+When reviewing or building any mobile UI:
+
+- **Hardcoded color** (`#`, `rgb(`, `hsl(`) -> replace with semantic token
+- **Tap target < 44pt** -> add `min-h-[44px] min-w-[44px]`
+- **Missing empty state** -> add before shipping
+- **Missing loading state** -> add skeleton or spinner for async data
+- **ScrollView wrapping a list** -> replace with `FlatList`
+- **FlatList inside ScrollView** -> restructure layout
+- **No `accessibilityRole` on Pressable** -> add it
+- **Inline StyleSheet for non-animated styles** -> convert to NativeWind
+- **`useState` driving an animation** -> replace with `useSharedValue`

--- a/skills/mobile-design/evals/evals.json
+++ b/skills/mobile-design/evals/evals.json
@@ -1,0 +1,76 @@
+{
+  "skill_name": "mobile-design",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Design a user profile screen for a React Native + Expo app. It should show the user's avatar, name, bio, a stats row (posts, followers, following), and a list of their recent posts. Use NativeWind for styling.",
+      "expected_output": "A complete, working React Native screen component using NativeWind classes. Should include: SafeAreaView root, avatar image with rounded-full, stats row with three columns, FlatList for posts. Must handle loading, empty, and error states. All interactive elements have accessibilityRole and accessibilityLabel. No hardcoded colors.",
+      "expectations": [
+        "Uses FlatList (not ScrollView + map) for the posts list",
+        "Includes a loading state (skeleton or ActivityIndicator)",
+        "Includes an empty state when the user has no posts",
+        "All Pressable/TouchableOpacity elements have accessibilityRole and accessibilityLabel",
+        "No hardcoded hex colors — uses semantic tokens or NativeWind classes",
+        "Avatar uses rounded-full class",
+        "SafeAreaView wraps the root",
+        "Component exports a named function"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Build a reusable NotificationBadge component for React Native + Expo. It should show a count on top of an icon, support a dot-only variant (no number), and disappear when count is zero. Use NativeWind.",
+      "expected_output": "A typed React Native component with props for count, variant ('count' | 'dot'), and optional children. Handles zero/undefined count by hiding the badge. Uses absolute positioning to overlay on the icon. Accessible with proper labels.",
+      "expectations": [
+        "Defines a TypeScript props interface",
+        "Badge is hidden when count is 0 or undefined",
+        "Supports both 'count' and 'dot' variants",
+        "Uses absolute positioning for the badge overlay",
+        "Badge has accessibilityLabel describing the count",
+        "Uses NativeWind classes for styling (no StyleSheet for non-animated styles)",
+        "Count truncates at 99+ for large numbers"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Design the navigation flow for a checkout feature in a React Native + Expo app using Expo Router. The flow has three steps: cart review, address entry, and payment. Show the route structure, screen transitions, param passing, and how to handle the back button on the payment screen.",
+      "expected_output": "A complete navigation design including: Expo Router file paths for all three screens, typed params for each route, appropriate presentation mode, back-stack behavior, and a guard on the payment screen warning the user before navigating away. Includes code snippets for each screen's navigation calls.",
+      "expectations": [
+        "Provides Expo Router file paths following the app/ directory convention",
+        "Shows typed useLocalSearchParams usage for passing data between screens",
+        "Payment screen has a back/dismiss guard (warns on unsaved state)",
+        "Uses router.push for forward navigation and router.back() or router.dismiss() for back",
+        "Explains when to use router.replace vs router.push",
+        "Includes a Stack.Screen options snippet for at least one screen"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Audit this React Native screen for issues:\n\n```tsx\nexport default function FeedScreen() {\n  const [items, setItems] = React.useState([]);\n  const [loading, setLoading] = React.useState(false);\n\n  return (\n    <ScrollView style={{ flex: 1, backgroundColor: '#ffffff' }}>\n      {loading && <ActivityIndicator />}\n      {items.map(item => (\n        <TouchableOpacity\n          key={item.id}\n          style={{ padding: 12, borderBottomWidth: 1, borderColor: '#e5e5e5' }}\n          onPress={() => navigation.navigate('Detail', { id: item.id })}\n        >\n          <Text style={{ fontSize: 16, color: '#111111' }}>{item.title}</Text>\n          <Text style={{ fontSize: 13, color: '#888888' }}>{item.subtitle}</Text>\n        </TouchableOpacity>\n      ))}\n    </ScrollView>\n  );\n}\n```",
+      "expected_output": "A detailed audit identifying all issues and a corrected version of the screen. Issues should include: ScrollView + map anti-pattern, hardcoded colors, missing empty state, missing error state, missing accessibilityRole/accessibilityLabel.",
+      "expectations": [
+        "Identifies ScrollView + map as a performance anti-pattern and recommends FlatList",
+        "Flags all hardcoded hex colors and recommends semantic tokens",
+        "Identifies missing empty state",
+        "Identifies missing error state",
+        "Flags TouchableOpacity missing accessibilityRole and accessibilityLabel",
+        "Provides a corrected version of the screen",
+        "Corrected version uses FlatList with keyExtractor",
+        "Corrected version includes empty, loading, and error states"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Design a spring animation for a like button in React Native. When tapped, it should scale up to 1.3x then spring back to 1.0, play a haptic, and toggle a filled/outline heart icon. Use react-native-reanimated.",
+      "expected_output": "A complete LikeButton component using react-native-reanimated with useSharedValue and useAnimatedStyle. The animation uses withSpring for the bounce effect. Haptic feedback is triggered on press. The icon toggles between filled and outline states.",
+      "expectations": [
+        "Uses useSharedValue and useAnimatedStyle from react-native-reanimated",
+        "Uses withSpring for the scale animation (not withTiming)",
+        "Scale goes above 1.0 (e.g. 1.3) before returning to 1.0",
+        "Haptic feedback is included (e.g. Haptics.impactAsync or Haptics.selectionAsync)",
+        "Icon state toggle uses useState (separate from animation state)",
+        "No StyleSheet used for the animated style — uses useAnimatedStyle",
+        "Component has accessibilityRole='button' and accessibilityLabel that reflects current state"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds a new `mobile-design` skill for designing and building production-grade React Native + Expo mobile interfaces
- Complements the existing `frontend-design` skill (which covers web) with mobile-specific patterns
- Uses NativeWind (Tailwind for React Native) for styling guidance

## What the skill covers

- **Screen design** - layout patterns, SafeAreaView, FlatList usage, content hierarchy
- **Component design** - typed props, variants (default/active/disabled/loading), accessibility
- **UI states** - empty, loading (skeleton), and error state templates
- **Navigation** - Expo Router file-based routing, typed params, modal vs push vs replace
- **Animations** - react-native-reanimated patterns (fade, spring, slide-up sheet)
- **Accessibility** - 44pt tap targets, accessibilityRole/Label/State on all interactive elements
- **Dark mode** - semantic token usage, never hardcoded colors
- **Performance** - FlatList vs ScrollView guidance, useCallback on renderItem
- **Proactive checks** - flags hardcoded colors, missing states, small tap targets, anti-patterns

## Evals

5 evals covering: profile screen design, reusable component design, navigation flow mapping, screen audit, and animation design.

## Validation

Passes `quick_validate.py` - valid frontmatter, kebab-case name, description under 1024 chars, no disallowed frontmatter properties.

_Generated with [Claude Code](https://claude.ai/claude-code)_