### PR TITLE
docs: document optional frontmatter fields (license, metadata, allowed-tools) in skill-creator and template

### DIFF
--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -66,7 +66,12 @@ Based on the user interview, fill in these components:
 - **name**: Skill identifier
 - **description**: When to trigger, what it does. This is the primary triggering mechanism - include both what the skill does AND specific contexts for when to use it. All "when to use" info goes here, not in the body. Note: currently Claude has a tendency to "undertrigger" skills -- to not use them when they'd be useful. To combat this, please make the skill descriptions a little bit "pushy". So for instance, instead of "How to build a simple fast dashboard to display internal Anthropic data.", you might write "How to build a simple fast dashboard to display internal Anthropic data. Make sure to use this skill whenever the user mentions dashboards, data visualization, internal metrics, or wants to display any kind of company data, even if they don't explicitly ask for a 'dashboard.'"
 - **compatibility**: Required tools, dependencies (optional, rarely needed)
+- **license**: License name or reference to a bundled LICENSE file (optional)
+- **metadata**: Arbitrary key-value mapping for author, version, etc. (optional)
+- **allowed-tools**: Space-delimited list of pre-approved tools the skill may use (optional, experimental). Example: `Bash(git:*) Bash(jq:*) Read`. Use this when a skill should only have access to specific tools — for instance, a read-only analysis skill that shouldn't modify files.
 - **the rest of the skill :)**
+
+The full list of allowed frontmatter fields per the [Agent Skills spec](https://agentskills.io/specification) is: `name`, `description`, `license`, `compatibility`, `metadata`, and `allowed-tools`. Only `name` and `description` are required.
 
 ### Skill Writing Guide
 

--- a/template/SKILL.md
+++ b/template/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: template-skill
-description: Replace with description of the skill and when Claude should use it.
+description: Replace with description of the skill and when to use it.
+# license: Apache-2.0
+# compatibility: Requires Python 3.10+
+# allowed-tools: Bash(git:*) Read
+# metadata:
+#   author: your-org
+#   version: "1.0"
 ---
 
 # Insert instructions below


### PR DESCRIPTION
## Summary

The skill-creator SKILL.md and the template only documented `name` and `description` as frontmatter fields. However, the [Agent Skills spec](https://agentskills.io/specification) and the repo's own `quick_validate.py` already support additional optional fields that were undocumented:

| Field | Status | Description |
|-------|--------|-------------|
| `name` | Required | Already documented |
| `description` | Required | Already documented |
| `compatibility` | Optional | Already documented |
| `license` | Optional | **NEW** - License name or reference to bundled LICENSE file |
| `metadata` | Optional | **NEW** - Arbitrary key-value mapping (author, version, etc.) |
| `allowed-tools` | Optional (experimental) | **NEW** - Space-delimited tool restriction list |

## Changes

### `skills/skill-creator/SKILL.md`
- Added `license`, `metadata`, and `allowed-tools` to the "Write the SKILL.md" section with descriptions and usage guidance
- Added a reference to the official Agent Skills spec for the complete field list

### `template/SKILL.md`
- Added all optional frontmatter fields as YAML comments so skill creators discover them when starting from the template

## Motivation

Users creating skills via the skill-creator weren't aware these fields exist. The `allowed-tools` field is particularly useful — it lets skill authors restrict which tools a skill can use (e.g., read-only analysis skills). The validation script (`quick_validate.py`) already accepts all these fields, so this is purely a documentation gap.

## Note on `model` field

The screenshot from Claude Code's `.agent.md` format shows a `model:` field. This is **not** part of the Agent Skills spec — it's specific to Claude Code agent files (`.agent.md`), not skills (`SKILL.md`). It was intentionally not added here.