### PR TITLE
Add personality-profile: multi-framework personality assessment

### DIFF
--- a/skills/personality-profile/LICENSE.txt
+++ b/skills/personality-profile/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Zhou Yuan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/personality-profile/SKILL.md
+++ b/skills/personality-profile/SKILL.md
@@ -1,0 +1,449 @@
+---
+name: personality-profile
+description: Conduct an interactive personality assessment that produces results across 5 major frameworks (Enneagram, MBTI, Big Five, DISC, Attachment Style) from a single conversational session. Use when the user wants to understand their personality, asks 'what type am I', mentions personality tests, MBTI, Enneagram, Big Five, or wants self-discovery insights. Also use when designing personality features for apps. Supports modes - full, express, deep, life-story, single-framework, and for-app.
+license: Complete terms in LICENSE.txt
+---
+
+# Unified Personality Profile
+
+One conversation, five frameworks. A single adaptive session maps your personality across Enneagram, MBTI, Big Five (OCEAN), DISC, and Attachment Style — not through a sterile questionnaire, but through a real conversation about how you live.
+
+The magic: each response you give feeds multiple frameworks simultaneously through a shared scoring matrix. Big Five anchors the math; Enneagram and Attachment capture what the numbers can't — your core fears, desires, and relational patterns.
+
+---
+
+## Modes
+
+| Mode | Trigger | Questions | Duration | Best For |
+|------|---------|-----------|----------|----------|
+| **Full** | `/personality-profile` or `/personality-profile full` | ~40 | 15 min | Complete profile, high confidence |
+| **Express** | `/personality-profile express` | ~15 | 5 min | Quick directional snapshot |
+| **Deep** | `/personality-profile deep` | 40 + follow-ups | 20-25 min | Maximum depth, narrative interview |
+| **Single** | `/personality-profile enneagram` (or mbti, big-five, disc, attachment) | 8-12 | 5-8 min | Framework-specific deep dive |
+| **Life Story** | `/personality-profile life-story` | 0 (uses prior results) | 5-10 min | Speculative biographical narrative from childhood to elder years |
+| **For-App** | `/personality-profile for-app` | — | — | Implementable data structure for developers |
+
+---
+
+## Phase 1: Setup
+
+Set expectations warmly — this matters more than you think. People who understand what's coming give more honest answers.
+
+**Say something like:**
+
+> I'm going to walk you through a personality assessment — but not the kind where you pick A/B/C/D for 40 minutes. It's more like a structured conversation about how you actually think, feel, make decisions, and relate to people.
+>
+> By the end, you'll get results across five major personality frameworks — Enneagram, MBTI, Big Five, DISC, and Attachment Style — all from this single session.
+>
+> There are no right or wrong answers. Go with your gut, not what you think you "should" say.
+>
+> Before we start — have you taken any personality assessments before? MBTI, Enneagram, Big Five, or anything else? If so, what were your results? I'll compare our findings against them.
+
+If the user provides prior results, note them for the report. In Phase 4, include a "Comparison with Prior Results" subsection that explains what's consistent, what changed, and why any differences make sense.
+
+**Mode-specific adjustments:**
+- **Express**: "This is the quick version — about 15 questions, 5 minutes. You'll get directional results across all five frameworks, but with lower confidence than the full version."
+- **Deep**: "This is the deep version. I'll ask the standard questions plus follow-up probes when I notice something interesting. Expect 20-25 minutes — the payoff is a much richer portrait."
+- **Single framework**: "We'll focus specifically on [framework] — I'll ask 8-12 targeted questions to get a high-confidence result for that one framework."
+
+---
+
+## Phase 2: Adaptive Interview
+
+### Interview Style: Conversational, Not Clinical
+
+Present questions as natural scenarios. After each batch of 5, briefly reflect back what you're noticing — this builds trust and makes people feel heard, which makes them more honest.
+
+**Two question formats available:**
+
+**Format A — Scenario Choice (default for Full and Express):**
+Present a scenario with 4 options. Label options with descriptions, not just letters. Always allow "none of these" or "between X and Y."
+
+**Format B — Open-Ended Probe (default for Deep mode, optional in Full):**
+Ask an open question, listen to the response, then map it to scoring dimensions internally. Follow up with one clarifying probe if the response is ambiguous.
+
+Example open-ended: "When you walk into a party where you only know one person, what's your internal experience? Walk me through it."
+
+The scoring vectors are identical regardless of format — see `references/question-bank.md` for the mapping. Open-ended responses require you to judge which scoring vector the response most closely matches.
+
+### Batch Structure (Full Mode)
+
+| Batch | Questions | Primary Targets | Cross-Maps To |
+|-------|-----------|-----------------|---------------|
+| 1 | 1-5 | Energy + Social orientation | Big Five E, MBTI E/I, DISC I/S |
+| 2 | 6-10 | Information processing + Curiosity | Big Five O, MBTI S/N |
+| 3 | 11-15 | Decision-making + Values | Big Five A, MBTI T/F, Enneagram triad |
+| 4 | 16-20 | Structure + Organization | Big Five C, MBTI J/P, DISC D/C |
+| 5 | 21-25 | Stress response + Core fears | Big Five N, Enneagram type, Attachment |
+| 6 | 26-30 | Relationship patterns + Trust | Attachment style, Enneagram wing |
+| 7 | 31-35 | Motivation + Achievement | Enneagram core desire, DISC primary |
+| 8 | 36-40 | **Adaptive** — disambiguate closest calls | Fill gaps in under-determined dimensions |
+
+**Between-batch reflection** (say after each batch):
+- Batch 1-2: "I'm starting to see how you orient to the world..."
+- Batch 3-4: "Your decision-making style is coming into focus..."
+- Batch 5-6: "Now I'm getting into the deeper layers — what drives you and how you connect..."
+- Batch 7: "Almost there — let me check a few things..."
+
+### Batch 8: Adaptive Disambiguation
+
+This is where the skill earns its keep. After Batch 7, examine all scores and generate 5 questions that target the closest calls:
+
+**Disambiguation triggers and question types:**
+
+| Condition | Generate |
+|-----------|----------|
+| Enneagram top two types within 2 points | Fear-differentiating scenario (see `references/question-bank.md` §Adaptive Templates) |
+| MBTI any dichotomy score within 10 of threshold (50) | Values-in-conflict scenario for that dichotomy |
+| Attachment anxiety AND avoidance both near threshold (3-5) | Intimacy-distance scenario |
+| Big Five any dimension 40-60 (ambiguous zone) | Behavioral-preference scenario for that dimension |
+| Enneagram wing unclear (adjacent types equal) | Motivation-flavor scenario |
+
+If nothing is ambiguous (rare), use the 5 integration questions from `references/question-bank.md` §Batch 8 Defaults.
+
+### Express Mode Batch Structure
+
+Use the 15-item express set from `references/question-bank.md` §Express. Present in 3 batches of 5. Each question is triple-loaded (targets 2-3 frameworks simultaneously).
+
+After scoring, downgrade all confidence levels by one tier and add: "Express mode — directional only. Run `/personality-profile full` for higher confidence."
+
+---
+
+## Phase 3: Scoring
+
+Compute all five frameworks simultaneously. Each user response feeds multiple frameworks through the shared scoring matrix defined in `references/question-bank.md`.
+
+### Scoring Architecture
+
+```
+User Response (to each question)
+    │
+    ▼
+[Extract scoring vector: E, O, A, C, N, Enn, Att]
+    │
+    ├──▶ Big Five (continuous 0-100 per dimension)
+    │       │
+    │       ├──▶ MBTI (threshold at 50 per dichotomy)
+    │       │       E≥50→E, O≥50→N, A≥50→F, C≥50→J
+    │       │
+    │       └──▶ DISC (computed from E + A dimensions)
+    │               D = E + (100-A), I = E + A
+    │               S = (100-E) + A, C = (100-E) + (100-A)
+    │
+    ├──▶ Enneagram (independent type signal counting)
+    │       Count all Enn:T[n] signals → rank 9 types
+    │       Wing = higher-scoring adjacent type
+    │
+    └──▶ Attachment (independent anxiety/avoidance 2×2)
+            Count Att:Anx, Att:Avo, Att:Sec, Att:Fear signals
+            → classify into 4 quadrants
+```
+
+**Critical**: Big Five scores FIRST because MBTI and DISC derive from it. Enneagram and Attachment score independently — they measure motivation and relational patterns that behavioral traits alone can't capture.
+
+Full scoring algorithms, normalization formulas, interpretation bands, and confidence thresholds are in `references/frameworks.md`.
+
+### Cross-Framework Consistency Check
+
+After scoring, run a consistency check using the correlation table in `references/frameworks.md` §Big Five ↔ Enneagram Correlations. If a result strongly contradicts the expected pattern (e.g., Type 8 with very high Agreeableness), don't suppress it — flag it as a noteworthy tension and explore it in the Cross-Framework Insights section.
+
+---
+
+## Phase 4: Report Generation
+
+Output the profile using this structure. The narrative sections are what make this valuable — anyone can output a table of labels. The goal is for the person to feel *seen*.
+
+```markdown
+# Your Personality Profile
+
+## At a Glance
+
+| Framework | Result | Confidence |
+|-----------|--------|------------|
+| Enneagram | Type [X]w[Y] — "[Name]" | [High/Medium/Low] |
+| MBTI | [XXXX] — "[Name]" | [High/Medium/Low] |
+| Big Five | O:[score] C:[score] E:[score] A:[score] N:[score] | — |
+| DISC | [Primary]/[Secondary] | [High/Medium/Low] |
+| Attachment | [Style] | [High/Medium/Low] |
+
+## The Story of You
+
+[2-3 paragraphs. This is the crown jewel — a coherent narrative that weaves
+all five frameworks into a portrait of how this person thinks, feels, decides,
+and relates. Written in second person ("You tend to...").
+
+Follow this arc:
+1. Opening hook — lead with the most distinctive cross-framework pattern
+2. Inner world — connect Enneagram core motivation + Big Five O/N + Attachment
+3. Outer world — connect MBTI cognitive functions + DISC style + Big Five E/A
+4. Integration — where inner and outer reinforce each other, where they create tension
+5. Growth edge — one specific, actionable insight from converging stress patterns
+
+Do NOT list traits. Weave a story. Example thread:
+"You process the world through a lens of possibility (High O, Ne-dominant) — but
+unlike the stereotypical ENFP who scatters in all directions, your Type 3 core
+keeps you focused on outcomes that matter. The result is someone who generates
+ten ideas but instinctively filters for the one that will land..."]
+
+## Framework Details
+
+### Enneagram: Type [X]w[Y] — [Name]
+- **Core motivation**: [what drives you]
+- **Core fear**: [what you avoid]
+- **Growth direction**: → Type [Y] (integrate toward [description])
+- **Stress pattern**: → Type [Z] (under pressure: [description])
+- **Wing influence**: Your [Y] wing adds [description]
+- **Triad**: [Gut/Heart/Head] — your center of intelligence
+
+### MBTI: [XXXX] — [Name]
+- **Cognitive function stack**: [Dom] → [Aux] → [Tert] → [Inf]
+- **What this means in practice**: [2-3 sentences — concrete, not abstract]
+- **Borderline calls**: [any dimension within 10 of threshold — name both possibilities]
+
+### Big Five (OCEAN)
+
+**Openness**: [score]%
+[██████████░░░░░░░░░░] [Very High/High/Average/Low/Very Low]
+[1 sentence interpretation specific to this person]
+
+**Conscientiousness**: [score]%
+[████████░░░░░░░░░░░░] [label]
+[1 sentence interpretation]
+
+**Extraversion**: [score]%
+[bar] [label]
+[1 sentence interpretation]
+
+**Agreeableness**: [score]%
+[bar] [label]
+[1 sentence interpretation]
+
+**Neuroticism**: [score]%
+[bar] [label]
+[1 sentence interpretation]
+
+### DISC: [Primary]/[Secondary]
+- **Communication preference**: [how you prefer to communicate]
+- **Under stress**: [behavioral shift]
+- **Works best with**: [complementary styles]
+- **Co-primary note**: [only if two styles within 10 points — describe blend]
+
+### Attachment Style: [Style Name]
+- **Pattern**: [description of relational tendencies]
+- **In relationships**: [how this manifests concretely]
+- **Growth edge**: [specific, actionable awareness]
+
+## Cross-Framework Insights
+
+[Connect the dots across frameworks. Look for triple signals (same pattern
+appearing in 3+ frameworks) and noteworthy contradictions.
+
+Triple signal example: "Your high Openness (Big Five) + Intuitive preference
+(MBTI) + Type 4 (Enneagram) = creativity isn't just a trait, it's a core need."
+
+Contradiction example: "Your high Agreeableness (Big Five) seems to conflict
+with your Type 8 (Enneagram) — but this actually means you fight FOR people,
+not against them. Your protective instinct serves connection, not dominance."
+
+See `references/frameworks.md` §Cross-Framework Synthesis Rules for the full
+pattern table.]
+
+## What This Means for You
+
+[1-2 paragraphs of practical, actionable takeaways. Not generic advice.
+Address: one strength to lean into, one blind spot to watch, one growth
+practice that specifically matches this person's profile convergence.]
+
+## Caveats
+
+- This is an LLM-guided assessment, not a clinically validated instrument
+- Confidence levels reflect internal consistency, not psychometric validity
+- Personality is contextual — you show different patterns at work vs. home
+- Use these results as a mirror for reflection, not a box to live in
+```
+
+### Confidence Scoring Rules
+
+| Framework | High | Medium | Low |
+|-----------|------|--------|-----|
+| Big Five | 6+ contributing questions per dim | 4-5 per dim | <4 per dim |
+| MBTI | All dichotomies >20 from threshold | 1-2 within 10-20 | Any within 10 |
+| Enneagram | Top type 20%+ above #2 | 10-20% above #2 | <10% above #2 |
+| DISC | Primary 15+ above secondary | 8-15 above | <8 above |
+| Attachment | Both dims well past threshold | One near threshold | Both near threshold |
+
+When confidence is Low, always present the alternative:
+> "Enneagram: Type 5w6 — Confidence: Low. Equally consistent with Type 1w9. Key differentiator: Does your inner critic focus on 'I need to know more' (T5) or 'I need to do better' (T1)?"
+
+---
+
+## Deep Mode
+
+Deep mode uses all 40 standard questions PLUS open-ended follow-up probes. After each batch, instead of just reflecting, ask one open-ended follow-up targeting the most interesting signal you've detected:
+
+- Batch 1-2 follow-up: "You mentioned [specific detail]. Tell me more about that — what's the internal experience like?"
+- Batch 3-4 follow-up: "When [scenario from their response], what's the voice in your head saying?"
+- Batch 5-6 follow-up: "Think of the last time you felt truly safe in a relationship. What made it feel that way?"
+- Batch 7 follow-up: "What's the thing you're most afraid people will find out about you?"
+
+Map follow-up responses to scoring vectors using your judgment. These responses carry 1.5× weight because they're more authentic than forced-choice answers.
+
+The report for Deep mode adds a **"Patterns I Noticed"** section before Caveats — specific observations from the open-ended responses that illuminate the scores.
+
+---
+
+## Single Framework Mode
+
+Focus on one framework with maximum depth. Use only the questions tagged for that framework in `references/question-bank.md`, plus 2-3 custom probes.
+
+**Enneagram deep dive** (most requested):
+- Use Batch 5 + Batch 7 questions (core fears + motivation)
+- Add: stress behavior scenario, growth behavior scenario, wing differentiation
+- Report includes: type, wing, stress/growth arrows, triad, instinctual variant hints
+- Cross-reference Big Five correlations for consistency check
+
+**MBTI deep dive**:
+- Use Batch 1 (E/I) + Batch 2 (S/N) + Batch 3 (T/F) + Batch 4 (J/P)
+- Add: cognitive function scenarios for top 2 type candidates
+- Report includes: 4-letter type, full function stack, type dynamics, cognitive development
+
+---
+
+## Life Story Mode
+
+Generate a speculative biographical narrative — from childhood to elder years — based on a completed personality profile. This mode requires prior results from a Full, Deep, or Single assessment (or user-provided framework results).
+
+**Trigger**: `/personality-profile life-story` after completing an assessment, or when the user says "give me my life story", "what was I like as a child", or similar.
+
+### Input Requirements
+
+A complete profile (all 5 frameworks) OR at minimum Enneagram type + wing + one of (MBTI or Big Five). The more frameworks available, the richer the narrative.
+
+### Six Life Stages
+
+| Stage | Age Range | Primary Frameworks Used | Core Question |
+|-------|-----------|------------------------|---------------|
+| **The Seed** | 0-12 | Attachment origin + Enneagram core fear formation + Big Five O/C early patterns | How did the core wound form? |
+| **The Awakening** | 13-18 | MBTI dominant function emergence + Enneagram defense mechanisms + E/N stress patterns | How did identity crystallize? |
+| **The Forge** | 19-30 | DISC work style + Enneagram motivation + Te/Fe auxiliary development + Attachment in relationships | How did survival strategy become career strategy? |
+| **The Ascent** | 31-45 | Enneagram stress/growth arrows in action + MBTI tertiary function awakening + Big Five N evolution | What triggered the first real identity question? |
+| **The Metamorphosis** | 46-60 | MBTI inferior function confrontation + Enneagram integration direction + Attachment evolution possibility | What did freedom/authenticity actually require? |
+| **The Integration** | 60+ | All frameworks converging + Enneagram health levels + Earned Secure trajectory | What gets left behind? |
+
+### Narrative Principles
+
+1. **Second person, literary voice** — "You were the child who..." not "Type 5 children tend to..."
+2. **Concrete scenes, not abstractions** — Describe specific moments (staying late at the library, solving a problem no one else could, the night you realized you hadn't talked to anyone in three days)
+3. **Weave frameworks invisibly** — The reader should feel understood, not categorized. Zero framework jargon in the narrative — no "O:83", no "Ni-Te", no "Dismissive-Avoidant". Name frameworks only when the insight is sharper for it, and even then prefer plain language
+4. **Honor contradictions** — Where frameworks predict different things, that's where the richest story lives (e.g., high C + Freedom pursuit = structure-serves-freedom paradox)
+5. **Include turning points** — Each stage should have at least one inflection point unique to this type combination
+6. **The misidentification arc** — If the user was previously typed differently (e.g., T1 when actually T5), weave this into the story as a discovery moment
+7. **Future stages are speculative** — Clearly frame unwritten chapters as "your data predicts" not "this will happen"
+8. **Cultural sensitivity** — Don't assume Western life milestones. Use the user's biographical hints (if shared during assessment) to anchor the narrative
+
+### Writing Quality Standard (The 4 Laws)
+
+These principles separate a Life Story that makes someone cry from one that makes them nod politely. They were discovered through iterative user testing — V1 (academic) failed, V2 (clean narrative) was "okay", V3 (with all 4 laws) broke through. The moat of Life Story as a product feature is **literary quality**, not psychological accuracy.
+
+1. **Surprise / 意外感** — The reader cannot be allowed to nod through the entire story. Every stage needs at least one "wait, what?" moment — a line that reframes something they thought they understood about themselves. Examples: "你瞧不起大多数人。不是恶意。是你真的觉得他们在浪费时间。" / "壳裂了不是英雄觉醒，是你终于累了。" The surprise should come from saying what's TRUE but what they've never heard anyone say out loud.
+
+2. **Dirty details / 脏细节** — No elegant suffering. Replace "经济困难" with "月底数硬币买泡面". Replace "late night debugging" with "凌晨两点对着报错信息发呆，咖啡凉了也不知道". Replace "you invested in self-improvement" with "买了课发现是垃圾但不敢退款因为那是你一周的饭钱". The specificity of the detail is what makes the reader think "this is about ME, not about a personality type."
+
+3. **Lived experience over summary / 经历 > 总结** — WRONG: "你偶尔会被情感击中。" RIGHT: "看到照片胸口发紧——你咽回去，假装在看手机。" The body knows before the mind does. Write the body sensation, the micro-behavior, the thing the reader does when no one is watching. Every emotional insight must be expressed as a scene the reader can SEE, not a conclusion they are told.
+
+4. **Dark side / 暗面** — Every type has shadow material that conventional assessments euphemize away. Write it. Intellectual superiority as a defense mechanism ("你的聪明一直在保护你——也一直在推开人"). Using absence to hurt people in relationships ("你的伤害方式是安静的：你不在。"). Fear masquerading as principle for a decade ("你用恐惧驱动了自己十年，还以为那是原则"). The dark side is where the reader feels most deeply seen — because no one else has ever named it for them.
+
+**Calibration**: If the story reads like something a therapist would nod approvingly at, it's too safe. If it reads like something that would make the reader pause, put down their phone, and stare at the ceiling — that's the target.
+
+### Cross-Framework Developmental Psychology
+
+Each framework has known developmental patterns to draw from:
+
+**Enneagram**: Core fear forms in childhood (0-7), defense strategy solidifies in adolescence, stress/growth arrows activate in adulthood, integration is the lifelong project.
+
+**MBTI Cognitive Functions**: Dominant develops first (childhood-adolescence), auxiliary in young adulthood (20s-30s), tertiary emerges at midlife (35-50), inferior function confrontation in later life (50+). Each function development creates a specific life chapter.
+
+**Big Five Age Trends** (empirical): Neuroticism tends to decrease with age; Agreeableness and Conscientiousness tend to increase through midlife; Openness is relatively stable; Extraversion shows modest decline. Use these trends to project future chapters.
+
+**Attachment**: Can shift across lifespan — Earned Secure is achievable through consistent relationship work. Dismissive-Avoidant with high Secure baseline has shortest path. Fearful-Avoidant has longest but most transformative arc.
+
+### Output Format
+
+```markdown
+# The Story of Your Life
+
+*Based on [type summary] — speculative narrative, not biography*
+
+## I. 种子 · The Seed (0—12)
+[400-600 words — core wound formation, early patterns, family dynamics inference]
+
+## II. 觉醒 · The Awakening (13—18)
+[400-600 words — identity crystallization, first stress patterns, misidentification seed]
+
+## III. 锻造 · The Forge (19—30)
+[400-600 words — survival strategy → career strategy, relationship patterns emerge]
+
+## IV. 攀登 · The Ascent (31—45)
+[400-600 words — success/mastery, identity questioning begins, growth direction activates]
+
+## V. 蜕变 · The Metamorphosis (46—60)
+[400-600 words — authenticity crisis, inferior function, reinvention]
+
+## VI. 圆融 · The Integration (60+)
+[200-400 words — speculative, future-facing, the resolution of the core fear]
+
+---
+*Speculative narrative based on personality data. Not biography.*
+```
+
+**No Cross-Framework Weave Index** — V1 testing showed that appending a framework-mapping table breaks the emotional spell of the narrative. The story must end as a story, not as an analysis. Framework attribution lives in the test result file, not in the Life Story output.
+
+### Personalization Signals
+
+Draw on anything the user shared during assessment or mentioned in conversation:
+- Prior test results and misidentification history
+- Career trajectory hints
+- Relationship status or patterns mentioned
+- Cultural background cues
+- Specific answers that revealed biographical details (e.g., "I tend to leave parties early" → social energy management scene)
+
+### Anti-Patterns for Life Story
+
+- **Don't write a textbook** — "Type 5s in childhood typically..." is clinical death. Write a STORY.
+- **Don't make every stage positive** — Include the struggles, the loneliness, the defense mechanisms that cost something
+- **Don't project certainty on future stages** — "Your data suggests" not "You will"
+- **Don't ignore the user's actual biographical hints** — If they mentioned being a "穷学生" who became an executive, USE that
+- **Don't make it generic** — Every sentence should be impossible to write without THIS person's specific cross-framework data
+- **Don't use parenthetical framework annotations** — "(O:83)" or "(Ni-Te stack)" in the narrative body breaks immersion instantly. Framework mapping belongs in test results, not in the story
+- **Don't summarize emotions** — "你偶尔会被情感击中" is a report. "看到照片胸口发紧——咽回去，假装在看手机" is a story. Always choose the latter
+- **Don't be uniformly warm** — If every stage arc is "struggled → grew → became stronger", the story is a lie. Some stages should end with unresolved tension, bad habits that persisted, or insights that came too late
+- **Don't append analysis tables** — No Cross-Framework Weave Index, no scoring breakdown. The story must end as a story. The analytical reader already has the test results file
+
+---
+
+## For-App Mode
+
+When the user is building a personality assessment feature (not taking a test):
+
+1. Output the question bank as a JSON data structure with scoring vectors
+2. Include the scoring algorithm as executable pseudocode
+3. Include cross-framework mapping functions
+4. Reference EnneaMe's architecture: `src/data/quickDetectionQuestionsV2.ts` for question format, `src/services/personalityEngine.ts` for signal routing, `api/src/services/bayesianEngine.ts` for Bayesian aggregation
+
+---
+
+## Anti-Patterns
+
+- **Don't be clinical.** This is a conversation, not a medical exam. Warm, curious language throughout.
+- **Don't over-qualify.** One caveat section at the end. Don't hedge every statement.
+- **Don't flatten to labels.** "You're an INTJ" is worthless. "You lead with internal pattern-recognition (Ni), which means you often 'just know' things before you can explain how" — that's valuable.
+- **Don't ignore contradictions.** High Agreeableness + Type 8 is fascinating. Explore it.
+- **Don't rush.** Each batch is a mini-conversation. Acknowledge what you're hearing.
+- **Don't project.** Score what the person actually said, not what their "type" would say. If their answers don't fit a clean type, say so — that's honest, not a failure.
+
+---
+
+## References
+
+- `references/question-bank.md` — Full 40-question bank with scoring vectors, express set, adaptive templates
+- `references/frameworks.md` — Scoring algorithms, cross-mapping tables, type descriptions, synthesis rules, confidence calibration

--- a/skills/personality-profile/references/frameworks.md
+++ b/skills/personality-profile/references/frameworks.md
@@ -1,0 +1,326 @@
+# Framework Reference
+
+Detailed descriptions, scoring algorithms, and cross-mapping tables for all five frameworks.
+
+---
+
+## 1. Big Five (OCEAN) — Bridge Framework
+
+The most empirically validated personality model. Score this first; MBTI and DISC derive from it.
+
+### Dimensions
+
+| Dimension | Low Pole | High Pole | What it Measures |
+|-----------|----------|-----------|-----------------|
+| **O**penness | Conventional, practical | Curious, imaginative | Receptivity to new ideas, aesthetics, variety |
+| **C**onscientiousness | Flexible, spontaneous | Organized, disciplined | Self-regulation, planning, goal pursuit |
+| **E**xtraversion | Reserved, solitary | Energetic, sociable | Social energy, positive affect, assertiveness |
+| **A**greeableness | Competitive, skeptical | Cooperative, trusting | Interpersonal warmth, compliance, empathy |
+| **N**euroticism | Calm, resilient | Sensitive, reactive | Emotional instability, anxiety, mood swings |
+
+### Scoring Algorithm
+
+Each question option shifts a dimension by its weight (see `question-bank.md`). After all questions:
+
+```
+raw_score[dim] = sum(all weights for that dimension)
+```
+
+Normalize to 0-100 scale:
+
+```
+# Full mode: 40 questions, max possible shift per dim ≈ ±40
+normalized[dim] = clamp((raw_score[dim] + 40) / 80 * 100, 0, 100)
+
+# Express mode: 15 questions, max possible shift ≈ ±15
+normalized[dim] = clamp((raw_score[dim] + 15) / 30 * 100, 0, 100)
+```
+
+### Interpretation Bands
+
+| Range | Label | Description |
+|-------|-------|-------------|
+| 0-25 | Very Low | Well below average — notable trait |
+| 26-40 | Low | Below average |
+| 41-60 | Average | Typical range |
+| 61-75 | High | Above average |
+| 76-100 | Very High | Well above average — notable trait |
+
+---
+
+## 2. MBTI — Derived from Big Five
+
+### Mapping Rules
+
+| Big Five Dimension | MBTI Dichotomy | Threshold |
+|-------------------|----------------|-----------|
+| Extraversion | E (≥50) / I (<50) | 50 |
+| Openness | N (≥50) / S (<50) | 50 |
+| Agreeableness | F (≥50) / T (<50) | 50 |
+| Conscientiousness | J (≥50) / P (<50) | 50 |
+
+### Confidence Signal
+
+Distance from threshold indicates confidence:
+- `|score - 50| > 20` → High confidence on that dichotomy
+- `|score - 50| ∈ [10, 20]` → Medium confidence
+- `|score - 50| < 10` → Low confidence — explicitly note both possibilities
+
+### Cognitive Functions
+
+Derive the dominant/auxiliary stack from the 4-letter type:
+
+| Type | Dominant | Auxiliary | Tertiary | Inferior |
+|------|----------|----------|----------|----------|
+| INTJ | Ni | Te | Fi | Se |
+| INTP | Ti | Ne | Si | Fe |
+| ENTJ | Te | Ni | Se | Fi |
+| ENTP | Ne | Ti | Fe | Si |
+| INFJ | Ni | Fe | Ti | Se |
+| INFP | Fi | Ne | Si | Te |
+| ENFJ | Fe | Ni | Se | Ti |
+| ENFP | Ne | Fi | Te | Si |
+| ISTJ | Si | Te | Fi | Ne |
+| ISFJ | Si | Fe | Ti | Ne |
+| ESTJ | Te | Si | Ne | Fi |
+| ESFJ | Fe | Si | Ne | Ti |
+| ISTP | Ti | Se | Ni | Fe |
+| ISFP | Fi | Se | Ni | Te |
+| ESTP | Se | Ti | Fe | Ni |
+| ESFP | Se | Fi | Te | Ni |
+
+### Type Nicknames
+
+| Type | Nickname |
+|------|----------|
+| INTJ | The Architect |
+| INTP | The Logician |
+| ENTJ | The Commander |
+| ENTP | The Debater |
+| INFJ | The Advocate |
+| INFP | The Mediator |
+| ENFJ | The Protagonist |
+| ENFP | The Campaigner |
+| ISTJ | The Logistician |
+| ISFJ | The Defender |
+| ESTJ | The Executive |
+| ESFJ | The Consul |
+| ISTP | The Virtuoso |
+| ISFP | The Adventurer |
+| ESTP | The Entrepreneur |
+| ESFP | The Entertainer |
+
+---
+
+## 3. Enneagram — Independent Scoring
+
+The Enneagram cannot be fully derived from Big Five — it measures core motivations and fears, not behavioral traits.
+
+### Type Descriptions
+
+| Type | Name | Core Fear | Core Desire | Stress → | Growth → |
+|------|------|-----------|-------------|----------|----------|
+| 1 | The Reformer | Being corrupt, defective | Integrity, being good | → 4 (moody, self-pity) | → 7 (spontaneous, joyful) |
+| 2 | The Helper | Being unloved, unwanted | Being loved, needed | → 8 (controlling, aggressive) | → 4 (self-aware, authentic) |
+| 3 | The Achiever | Being worthless, without value | Being valuable, admired | → 9 (disengaged, apathetic) | → 6 (loyal, committed) |
+| 4 | The Individualist | Being ordinary, without identity | Being unique, authentic | → 2 (clingy, people-pleasing) | → 1 (principled, objective) |
+| 5 | The Investigator | Being helpless, incompetent | Being capable, competent | → 7 (scattered, escapist) | → 8 (decisive, confident) |
+| 6 | The Loyalist | Being without support, guidance | Having security, support | → 3 (image-focused, competitive) | → 9 (relaxed, trusting) |
+| 7 | The Enthusiast | Being trapped, in pain | Being satisfied, fulfilled | → 1 (critical, rigid) | → 5 (focused, insightful) |
+| 8 | The Challenger | Being controlled, harmed | Self-protection, autonomy | → 5 (withdrawn, secretive) | → 2 (caring, open-hearted) |
+| 9 | The Peacemaker | Loss, fragmentation, separation | Inner stability, peace | → 6 (anxious, reactive) | → 3 (focused, assertive) |
+
+### Scoring Algorithm
+
+Count all Enneagram signals across questions:
+
+```
+type_score[T] = sum(weight for every option selected that has Enn:T[n] signal)
+```
+
+Weight: Each signal from a selected option counts as 1 point. Rank all 9 types by score.
+
+**Wing determination**: The wing is whichever adjacent type (±1, wrapping 9↔1) scores higher.
+
+```
+# Example: Primary = Type 5
+wing = max(type_score[4], type_score[6])  → if T4 > T6, wing = 5w4
+```
+
+**Stress/Growth arrows** (from Batch 5 Q25 + core fear questions): If user's stress behavior matches the stress direction of a type, that's a confirming signal.
+
+### Triads
+
+| Triad | Types | Center |
+|-------|-------|--------|
+| Gut (Body) | 8, 9, 1 | Instinct / Anger |
+| Heart (Feeling) | 2, 3, 4 | Emotion / Shame |
+| Head (Thinking) | 5, 6, 7 | Thinking / Fear |
+
+### Big Five ↔ Enneagram Correlations (Reference Only)
+
+These are empirical tendencies, not derivation rules. Use for consistency checks:
+
+| Enneagram Type | Typical Big Five Pattern |
+|---------------|------------------------|
+| Type 1 | High C, Low N (or high N manifesting as self-criticism) |
+| Type 2 | High A, High E |
+| Type 3 | High C, High E, Low A |
+| Type 4 | High O, High N, Low C |
+| Type 5 | High O, Low E, Low A |
+| Type 6 | High N, Average C |
+| Type 7 | High O, High E, Low C, Low N |
+| Type 8 | Low A, High E, Low N |
+| Type 9 | High A, Low N, Low C |
+
+If a user's Enneagram type strongly contradicts their Big Five profile (e.g., Type 8 with very high Agreeableness), this is noteworthy — explore it in the Cross-Framework Insights section rather than dismissing it.
+
+---
+
+## 4. DISC — Derived from Big Five
+
+### Mapping Rules
+
+DISC uses two primary Big Five dimensions:
+
+```
+Dominance (D):     High E + Low A → assertive, results-oriented
+Influence (I):     High E + High A → enthusiastic, persuasive
+Steadiness (S):    Low E + High A → patient, supportive
+Conscientiousness (C): Low E + Low A → analytical, precise
+```
+
+### Scoring Algorithm
+
+```
+D_score = E_normalized + (100 - A_normalized)
+I_score = E_normalized + A_normalized
+S_score = (100 - E_normalized) + A_normalized
+C_score = (100 - E_normalized) + (100 - A_normalized)
+```
+
+Primary style = highest score. Secondary = second highest.
+
+When two styles are within 10 points, report both as co-primary.
+
+### Style Descriptions
+
+| Style | Profile | Communication | Under Stress | Complements |
+|-------|---------|---------------|-------------|-------------|
+| **D**ominance | Direct, decisive, competitive | Brief, bottom-line oriented | Impatient, insensitive | S (patience), C (caution) |
+| **I**nfluence | Enthusiastic, optimistic, social | Animated, relationship-focused | Disorganized, overpromises | C (detail), D (focus) |
+| **S**teadiness | Patient, reliable, team-oriented | Warm, listening-oriented | Resistant to change, passive | D (urgency), I (adaptability) |
+| **C**onscientiousness | Analytical, systematic, careful | Data-driven, precise | Overanalyzes, indecisive | I (speed), S (empathy) |
+
+---
+
+## 5. Attachment Style — Independent Scoring
+
+Based on the anxiety/avoidance two-dimensional model (Bartholomew & Horowitz, 1991).
+
+### Two Dimensions
+
+**Attachment Anxiety**: Fear of abandonment, need for reassurance, sensitivity to rejection signals.
+
+**Attachment Avoidance**: Discomfort with closeness, preference for emotional self-sufficiency, suppression of attachment needs.
+
+### Scoring Algorithm
+
+Count signals from Batch 6 + stress/relationship questions:
+
+```
+anxiety_score = count(Att:Anx signals) + count(Att:Fear signals)
+avoidance_score = count(Att:Avo signals) + count(Att:Fear signals)
+secure_score = count(Att:Sec signals)
+```
+
+Threshold (full mode, ~12 attachment-relevant questions):
+- `anxiety_high` = anxiety_score > 4
+- `avoidance_high` = avoidance_score > 4
+
+### 2×2 Classification
+
+| | Low Avoidance | High Avoidance |
+|---|---|---|
+| **Low Anxiety** | **Secure** — comfortable with intimacy and independence | **Dismissive-Avoidant** — self-reliant, downplays attachment needs |
+| **High Anxiety** | **Anxious-Preoccupied** — craves closeness, fears rejection | **Fearful-Avoidant** — wants closeness but fears vulnerability |
+
+### Style Descriptions
+
+| Style | In Relationships | Growth Edge |
+|-------|-----------------|-------------|
+| **Secure** | Trusting, communicative, comfortable with both closeness and autonomy | Already healthy baseline — growth through deepening empathy |
+| **Anxious-Preoccupied** | Seeks reassurance, hypervigilant to partner's mood, self-worth tied to relationship | Building internal security, tolerating ambiguity |
+| **Dismissive-Avoidant** | Values independence above all, slow to open up, minimizes emotions | Allowing vulnerability, recognizing need for others |
+| **Fearful-Avoidant** | Push-pull pattern, wants intimacy but expects hurt | Building trust gradually, recognizing protective patterns |
+
+---
+
+## Cross-Framework Synthesis Rules
+
+When generating the "Cross-Framework Insights" report section, look for these convergence patterns:
+
+### Triple Signals (High Confidence Insights)
+
+| Pattern | Interpretation |
+|---------|---------------|
+| High O + N preference + Type 4/5 | Creativity/knowledge is a core need, not just a preference |
+| High A + F preference + Type 2/9 | Harmony-seeking is deep — across behavior, values, and motivation |
+| Low A + T preference + Type 8 | Independence and directness are central to identity |
+| High C + J preference + Type 1 | Standards and order aren't just habits — they're driven by fear of corruption |
+| High E + Type 7 + Secure attachment | Genuine enthusiasm and trust — resilient extroversion |
+
+### Contradictions Worth Exploring
+
+| Pattern | What it Might Mean |
+|---------|-------------------|
+| High A + Type 8 | Protective gentleness — fights for others, not against them |
+| Low N + Anxious attachment | Emotional stability in general, but activated in close relationships |
+| High C + Type 7 | Structured adventurer — loves novelty but plans for it |
+| Type 3 + Secure attachment | Achievement drive not rooted in insecurity — healthy ambition |
+| High O + ISTJ | Curious within systems — innovates inside established frameworks |
+
+### Narrative Synthesis Guidelines
+
+The "Story of You" section should weave, not list. Follow this structure:
+
+1. **Opening hook**: Lead with the most distinctive cross-framework pattern
+2. **Inner world**: Connect Enneagram core motivation + Big Five O/N + Attachment
+3. **Outer world**: Connect MBTI cognitive functions + DISC style + Big Five E/A
+4. **Integration**: How the inner and outer connect — where they reinforce, where they create tension
+5. **Growth edge**: One specific, actionable insight from the convergence of stress patterns
+
+Example narrative thread:
+> "You process the world through a lens of possibility (High O, Ne-dominant) — but unlike the stereotypical ENFP who scatters in all directions, your Type 3 core keeps you focused on outcomes that matter. The result is someone who generates ten ideas but instinctively filters for the one that will land..."
+
+---
+
+## Confidence Calibration
+
+### Per-Framework Rules
+
+| Framework | High Confidence | Medium | Low |
+|-----------|----------------|--------|-----|
+| Big Five | Each dimension has 6+ contributing questions | 4-5 contributing questions | <4 contributing questions |
+| MBTI | All dichotomies >20 from threshold | 1-2 dichotomies within 10-20 | Any dichotomy within 10 |
+| Enneagram | Top type scores 20%+ above #2 | Top type 10-20% above #2 | Top type <10% above #2 |
+| DISC | Primary style 15+ above secondary | Primary 8-15 above secondary | Primary <8 above secondary |
+| Attachment | Clear quadrant (both dims well past threshold) | One dim near threshold | Both dims near threshold |
+
+### Express Mode Adjustment
+
+In express mode (15 questions), downgrade all confidence levels by one tier:
+- What would be "High" becomes "Medium"
+- What would be "Medium" becomes "Low"
+- Add note: "Express assessment — directional only"
+
+### Reporting Low Confidence
+
+When confidence is Low, always present alternatives:
+
+```
+Enneagram: Type 5w6 — "The Investigator" | Confidence: Low
+  → Equally consistent with Type 1w9. Key differentiator: Does your
+    inner critic focus on "I need to know more" (T5) or "I need to
+    do better" (T1)?
+```

--- a/skills/personality-profile/references/question-bank.md
+++ b/skills/personality-profile/references/question-bank.md
@@ -1,0 +1,421 @@
+# Question Bank
+
+40 scenario-based questions. Each targets 2-3 frameworks simultaneously via the scoring matrix below.
+
+## Scoring Key
+
+Each option has a weight vector: `[E, O, A, C, N, Enn, Att]`
+- **E/O/A/C/N**: Big Five dimension shift (-2 to +2)
+- **Enn**: Enneagram type signal (e.g., `T1`, `T4w5`)
+- **Att**: Attachment signal (`Sec`, `Anx`, `Avo`, `Fear`)
+
+Weight magnitude: `2` = strong signal, `1` = moderate, `0` = neutral.
+
+---
+
+## Batch 1: Energy + Social Orientation
+
+**Targets**: Big Five E, MBTI E/I, DISC I/S
+
+### Q1
+You arrive at a party where you know almost no one. After 30 minutes, you're most likely:
+
+- **(A)** In the middle of a group, swapping stories with strangers `[E+2, O+1, A+1, C0, N0, Enn:T7, Att:Sec]`
+- **(B)** Having a deep one-on-one conversation in a quiet corner `[E-1, O+1, A+1, C0, N0, Enn:T4, Att:Sec]`
+- **(C)** Observing the room dynamics, deciding who's worth approaching `[E-1, O+1, A0, C+1, N0, Enn:T5, Att:Avo]`
+- **(D)** Already making plans to leave — you've hit your social limit `[E-2, O0, A0, C0, N+1, Enn:T9, Att:Avo]`
+
+### Q2
+Your ideal weekend morning:
+
+- **(A)** Brunch with friends — the more the merrier `[E+2, O0, A+1, C0, N-1, Enn:T7, Att:Sec]`
+- **(B)** A solo hike or bike ride — moving energy, no agenda `[E0, O+1, A0, C0, N-1, Enn:T8, Att:Avo]`
+- **(C)** Coffee and a book at home — pure recharge time `[E-2, O+1, A0, C0, N0, Enn:T5, Att:Avo]`
+- **(D)** Helping a friend move or running errands for family `[E0, O0, A+2, C+1, N0, Enn:T2, Att:Anx]`
+
+### Q3
+In a meeting, your energy tends to come from:
+
+- **(A)** Bouncing ideas off others in real time `[E+2, O+1, A0, C0, N0, Enn:T7, Att:Sec]`
+- **(B)** Thinking through the problem alone first, then sharing your conclusions `[E-1, O+1, A0, C+1, N0, Enn:T5, Att:Avo]`
+- **(C)** Reading the room and keeping harmony `[E0, O0, A+2, C0, N0, Enn:T9, Att:Anx]`
+- **(D)** Driving toward decisions — meetings should end with actions `[E+1, O0, A-1, C+2, N0, Enn:T3, Att:Sec]`
+
+### Q4
+When you need to recharge after a stressful week:
+
+- **(A)** Call your closest friends — talking it through helps `[E+1, O0, A+1, C0, N0, Enn:T2, Att:Anx]`
+- **(B)** Complete silence, alone, door closed `[E-2, O0, A0, C0, N+1, Enn:T5, Att:Avo]`
+- **(C)** Physical activity — run, gym, anything to burn it off `[E0, O0, A0, C+1, N-1, Enn:T8, Att:Sec]`
+- **(D)** A creative outlet — journaling, music, cooking something new `[E-1, O+2, A0, C0, N0, Enn:T4, Att:Sec]`
+
+### Q5
+People who know you well would say:
+
+- **(A)** "They light up the room" `[E+2, O+1, A+1, C0, N-1, Enn:T7, Att:Sec]`
+- **(B)** "They're always there when you need them" `[E0, O0, A+2, C+1, N0, Enn:T2, Att:Anx]`
+- **(C)** "They think deeply about everything" `[E-1, O+2, A0, C0, N0, Enn:T5, Att:Avo]`
+- **(D)** "They get things done, no drama" `[E0, O0, A0, C+2, N-1, Enn:T1, Att:Sec]`
+
+---
+
+## Batch 2: Information Processing + Curiosity
+
+**Targets**: Big Five O, MBTI S/N
+
+### Q6
+When learning something new, you prefer:
+
+- **(A)** The big picture first — frameworks and theories excite you `[E0, O+2, A0, C0, N0, Enn:T5, Att:Sec]`
+- **(B)** Hands-on practice — learn by doing, not reading `[E0, O-1, A0, C+1, N0, Enn:T8, Att:Sec]`
+- **(C)** Step-by-step instructions — don't skip ahead `[E0, O-1, A0, C+2, N0, Enn:T6, Att:Anx]`
+- **(D)** Making unexpected connections — "this reminds me of…" `[E0, O+2, A0, C-1, N0, Enn:T7, Att:Sec]`
+
+### Q7
+You're browsing a bookstore. What catches your eye first?
+
+- **(A)** Philosophy, psychology, or speculative fiction `[E0, O+2, A0, C0, N0, Enn:T4, Att:Sec]`
+- **(B)** Business, biography, or self-improvement `[E0, O0, A0, C+1, N0, Enn:T3, Att:Sec]`
+- **(C)** Practical guides — cooking, finance, fitness `[E0, O-1, A0, C+2, N0, Enn:T1, Att:Sec]`
+- **(D)** Whatever the staff recommends — you trust curation `[E0, O+1, A+1, C0, N0, Enn:T9, Att:Anx]`
+
+### Q8
+In conversations, you're most engaged when:
+
+- **(A)** Exploring "what if" scenarios and abstract possibilities `[E0, O+2, A0, C0, N0, Enn:T5, Att:Sec]`
+- **(B)** Exchanging real experiences and practical advice `[E0, O-1, A+1, C+1, N0, Enn:T6, Att:Sec]`
+- **(C)** Going deep into someone's emotional world `[E0, O+1, A+2, C0, N0, Enn:T4, Att:Anx]`
+- **(D)** Debating ideas where you disagree `[E+1, O+1, A-1, C0, N0, Enn:T8, Att:Sec]`
+
+### Q9
+When facing a problem at work, your first instinct is:
+
+- **(A)** Look for patterns — this is like that other problem we solved `[E0, O+1, A0, C+1, N0, Enn:T5, Att:Sec]`
+- **(B)** Ask an expert or search for a proven method `[E0, O-1, A+1, C+1, N0, Enn:T6, Att:Anx]`
+- **(C)** Challenge the premise — is this even the right problem? `[E0, O+2, A-1, C0, N0, Enn:T8, Att:Sec]`
+- **(D)** Try something immediately and iterate based on results `[E+1, O+1, A0, C-1, N0, Enn:T7, Att:Sec]`
+
+### Q10
+Your notes/workspace tend to be:
+
+- **(A)** Chaotic but meaningful — you know where everything is `[E0, O+2, A0, C-2, N0, Enn:T7, Att:Sec]`
+- **(B)** Color-coded, structured, everything in its place `[E0, O0, A0, C+2, N0, Enn:T1, Att:Sec]`
+- **(C)** Minimal — you keep most things in your head `[E0, O+1, A0, C0, N0, Enn:T5, Att:Avo]`
+- **(D)** Practical clusters — grouped by project, not by system `[E0, O0, A0, C+1, N0, Enn:T3, Att:Sec]`
+
+---
+
+## Batch 3: Decision-Making + Values
+
+**Targets**: Big Five A, MBTI T/F, Enneagram triad
+
+### Q11
+A friend asks for honest feedback on their startup idea, and you think it has serious flaws. You:
+
+- **(A)** Tell them directly, point by point — honesty is respect `[E0, O0, A-2, C+1, N0, Enn:T8, Att:Sec]`
+- **(B)** Acknowledge what's good first, then gently raise concerns `[E0, O0, A+2, C0, N0, Enn:T2, Att:Anx]`
+- **(C)** Ask probing questions and let them discover the flaws themselves `[E0, O+1, A0, C+1, N0, Enn:T5, Att:Avo]`
+- **(D)** Support their enthusiasm — they'll figure it out along the way `[E0, O0, A+1, C-1, N0, Enn:T9, Att:Anx]`
+
+### Q12
+In a team conflict, you instinctively:
+
+- **(A)** Find the fairest solution — what's right is right `[E0, O0, A0, C+1, N0, Enn:T1, Att:Sec]`
+- **(B)** Mediate — make sure everyone feels heard `[E0, O0, A+2, C0, N+1, Enn:T9, Att:Anx]`
+- **(C)** Analyze the root cause — emotions aside, what actually happened? `[E0, O+1, A-1, C+1, N0, Enn:T5, Att:Avo]`
+- **(D)** Take charge — someone needs to decide and move on `[E+1, O0, A-1, C+1, N0, Enn:T8, Att:Sec]`
+
+### Q13
+When making a major life decision (career change, move, relationship), you rely most on:
+
+- **(A)** Gut feeling — you know when something feels right `[E0, O+1, A+1, C-1, N0, Enn:T4, Att:Sec]`
+- **(B)** Pros/cons analysis — logic should guide, not emotion `[E0, O0, A-1, C+2, N0, Enn:T5, Att:Avo]`
+- **(C)** Consulting people you trust — their perspective matters `[E0, O0, A+2, C0, N0, Enn:T6, Att:Anx]`
+- **(D)** Your core values — does this align with who I want to be? `[E0, O+1, A+1, C0, N0, Enn:T1, Att:Sec]`
+
+### Q14
+What bothers you most in a colleague?
+
+- **(A)** Incompetence — not meeting basic standards `[E0, O0, A-1, C+2, N+1, Enn:T1, Att:Sec]`
+- **(B)** Coldness — treating people like resources `[E0, O0, A+2, C0, N+1, Enn:T2, Att:Anx]`
+- **(C)** Dishonesty — saying one thing, doing another `[E0, O0, A0, C+1, N+1, Enn:T6, Att:Anx]`
+- **(D)** Laziness — coasting while others carry the weight `[E0, O0, A-1, C+1, N+1, Enn:T3, Att:Sec]`
+
+### Q15
+Your sense of right and wrong is most shaped by:
+
+- **(A)** Universal principles — fairness, justice, consistency `[E0, O0, A0, C+1, N0, Enn:T1, Att:Sec]`
+- **(B)** Empathy — how does this affect the people involved? `[E0, O0, A+2, C0, N0, Enn:T2, Att:Anx]`
+- **(C)** Pragmatism — what produces the best outcome? `[E0, O0, A-1, C+1, N0, Enn:T3, Att:Sec]`
+- **(D)** Personal authenticity — am I being true to myself? `[E0, O+1, A0, C0, N0, Enn:T4, Att:Sec]`
+
+---
+
+## Batch 4: Structure + Organization
+
+**Targets**: Big Five C, MBTI J/P, DISC D/C
+
+### Q16
+Your approach to deadlines:
+
+- **(A)** Plan backwards from the deadline, build in buffer time `[E0, O0, A0, C+2, N-1, Enn:T1, Att:Sec]`
+- **(B)** Start early out of anxiety — you can't relax until it's done `[E0, O0, A0, C+1, N+2, Enn:T6, Att:Anx]`
+- **(C)** Deadline pressure is when your best work happens `[E0, O+1, A0, C-2, N0, Enn:T7, Att:Sec]`
+- **(D)** You focus on quality regardless — if it needs more time, it needs more time `[E0, O+1, A0, C+1, N0, Enn:T4, Att:Sec]`
+
+### Q17
+When you start a new project:
+
+- **(A)** Create a detailed plan with milestones before writing a line `[E0, O0, A0, C+2, N0, Enn:T1, Att:Sec]`
+- **(B)** Jump in and figure it out as you go — planning kills momentum `[E+1, O+1, A0, C-2, N0, Enn:T7, Att:Sec]`
+- **(C)** Research extensively first — understand the full landscape `[E0, O+2, A0, C+1, N0, Enn:T5, Att:Sec]`
+- **(D)** Find a template or proven method and adapt it `[E0, O-1, A0, C+1, N0, Enn:T6, Att:Anx]`
+
+### Q18
+Your email inbox is most likely:
+
+- **(A)** Inbox zero, labels, filters — fully managed `[E0, O0, A0, C+2, N-1, Enn:T1, Att:Sec]`
+- **(B)** Read everything, reply to most, accept the pile `[E0, O0, A+1, C0, N0, Enn:T2, Att:Anx]`
+- **(C)** 5,000+ unread — you use search, not folders `[E0, O+1, A0, C-2, N0, Enn:T7, Att:Sec]`
+- **(D)** Managed in bursts — ignore for days, then blitz through `[E0, O0, A0, C-1, N0, Enn:T8, Att:Sec]`
+
+### Q19
+How do you feel about rules and systems?
+
+- **(A)** They exist for a reason — follow them unless there's a strong case not to `[E0, O-1, A0, C+2, N0, Enn:T1, Att:Sec]`
+- **(B)** Useful as defaults, but you'll bend them when needed `[E0, O+1, A0, C0, N0, Enn:T3, Att:Sec]`
+- **(C)** Mostly unnecessary — competent people don't need rules `[E0, O+1, A-1, C-1, N0, Enn:T8, Att:Sec]`
+- **(D)** You follow them to avoid conflict, even if you disagree `[E0, O0, A+1, C+1, N+1, Enn:T9, Att:Anx]`
+
+### Q20
+When plans change unexpectedly:
+
+- **(A)** Exciting — new possibilities! `[E+1, O+2, A0, C-2, N-1, Enn:T7, Att:Sec]`
+- **(B)** Stressful — you had it figured out, now what? `[E0, O0, A0, C+1, N+2, Enn:T6, Att:Anx]`
+- **(C)** Annoying but manageable — adapt and move on `[E0, O0, A0, C+1, N0, Enn:T3, Att:Sec]`
+- **(D)** Fine — you didn't have a strong plan anyway `[E0, O+1, A0, C-1, N0, Enn:T9, Att:Sec]`
+
+---
+
+## Batch 5: Stress Response + Core Fears
+
+**Targets**: Big Five N, Enneagram type, Attachment
+
+### Q21
+When you feel overwhelmed, what comes first?
+
+- **(A)** Self-criticism — "I should be handling this better" `[E0, O0, A0, C+1, N+2, Enn:T1, Att:Anx]`
+- **(B)** Withdrawal — you pull inward and go quiet `[E-2, O0, A0, C0, N+1, Enn:T5, Att:Avo]`
+- **(C)** Worry spiral — imagining worst-case scenarios `[E0, O0, A0, C0, N+2, Enn:T6, Att:Anx]`
+- **(D)** Distraction — you fill the time with anything else `[E+1, O0, A0, C-1, N0, Enn:T7, Att:Avo]`
+
+### Q22
+Your deepest fear is closest to:
+
+- **(A)** Being corrupt or morally flawed `[E0, O0, A0, C+1, N+1, Enn:T1, Att:Sec]`
+- **(B)** Being unloved or unwanted `[E0, O0, A+1, C0, N+1, Enn:T2, Att:Anx]`
+- **(C)** Being worthless or without achievements `[E0, O0, A0, C+1, N+1, Enn:T3, Att:Sec]`
+- **(D)** Being ordinary — without identity or significance `[E0, O+2, A0, C0, N+1, Enn:T4, Att:Sec]`
+
+### Q23
+Continuing from Q22, or is your deepest fear closer to:
+
+- **(A)** Being helpless, incompetent, or unable to cope `[E0, O+1, A0, C0, N+1, Enn:T5, Att:Avo]`
+- **(B)** Being without support or guidance — left on your own `[E0, O0, A+1, C0, N+2, Enn:T6, Att:Anx]`
+- **(C)** Being trapped in pain or deprivation `[E+1, O+1, A0, C-1, N+1, Enn:T7, Att:Avo]`
+- **(D)** Being controlled or harmed by others `[E0, O0, A-2, C0, N+1, Enn:T8, Att:Sec]`
+
+### Q24
+When a close friend cancels plans at the last minute:
+
+- **(A)** Secretly relieved — you could use the alone time `[E-1, O0, A0, C0, N-1, Enn:T5, Att:Avo]`
+- **(B)** Hurt, even if you don't show it — it feels personal `[E0, O0, A+1, C0, N+2, Enn:T2, Att:Anx]`
+- **(C)** Fine — you immediately pivot to a new plan `[E+1, O+1, A0, C0, N-1, Enn:T7, Att:Sec]`
+- **(D)** Annoyed at the disrespect for your time `[E0, O0, A-1, C+1, N+1, Enn:T1, Att:Sec]`
+
+### Q25
+Under extreme stress, people have told you that you:
+
+- **(A)** Become controlling or rigid `[E0, O-1, A-1, C+2, N+2, Enn:T1→T4, Att:Anx]`
+- **(B)** Become clingy or people-pleasing `[E+1, O0, A+2, C0, N+2, Enn:T2→T8, Att:Anx]`
+- **(C)** Become withdrawn and emotionally shut down `[E-2, O0, A-1, C0, N+1, Enn:T5→T7, Att:Avo]`
+- **(D)** Become reckless or self-destructive `[E+1, O+1, A-1, C-2, N+1, Enn:T7→T1, Att:Fear]`
+
+---
+
+## Batch 6: Relationship Patterns + Trust
+
+**Targets**: Attachment style, Enneagram wing
+
+### Q26
+In your closest relationship, you tend to:
+
+- **(A)** Feel secure — you trust them and give space freely `[E0, O0, A+1, C0, N-2, Enn:T9, Att:Sec]`
+- **(B)** Need reassurance — you sometimes worry they'll leave `[E0, O0, A+1, C0, N+2, Enn:T2, Att:Anx]`
+- **(C)** Value independence — too much closeness feels suffocating `[E0, O0, A-1, C0, N0, Enn:T5, Att:Avo]`
+- **(D)** Oscillate — want closeness but fear vulnerability `[E0, O0, A0, C0, N+2, Enn:T6, Att:Fear]`
+
+### Q27
+When someone you care about is upset, you instinctively:
+
+- **(A)** Fix the problem — emotions are signals to act on `[E0, O0, A0, C+1, N0, Enn:T1, Att:Sec]`
+- **(B)** Hold space — just be present, don't try to fix `[E0, O0, A+2, C0, N0, Enn:T9, Att:Sec]`
+- **(C)** Drop everything to help — their pain becomes yours `[E0, O0, A+2, C0, N+1, Enn:T2, Att:Anx]`
+- **(D)** Feel uncomfortable — you want to help but aren't sure how `[E-1, O0, A0, C0, N+1, Enn:T5, Att:Avo]`
+
+### Q28
+Trust in new relationships comes from:
+
+- **(A)** Consistency — show up reliably and I'll trust you `[E0, O0, A0, C+1, N0, Enn:T6, Att:Anx]`
+- **(B)** Vulnerability — if you open up first, I'll follow `[E0, O+1, A+1, C0, N0, Enn:T4, Att:Anx]`
+- **(C)** Competence — earn my respect through actions `[E0, O0, A-1, C+1, N0, Enn:T8, Att:Sec]`
+- **(D)** It comes naturally — I generally trust people until proven wrong `[E0, O0, A+1, C0, N-1, Enn:T7, Att:Sec]`
+
+### Q29
+Your conflict resolution style:
+
+- **(A)** Address it directly and immediately `[E+1, O0, A-1, C+1, N0, Enn:T8, Att:Sec]`
+- **(B)** Avoid until it's absolutely necessary `[E-1, O0, A+1, C0, N+1, Enn:T9, Att:Avo]`
+- **(C)** Over-prepare your case, then present calmly `[E0, O0, A0, C+2, N+1, Enn:T6, Att:Anx]`
+- **(D)** Process internally for a long time, then speak from the heart `[E0, O+1, A+1, C0, N+1, Enn:T4, Att:Anx]`
+
+### Q30
+The relationship dynamic you fall into most often:
+
+- **(A)** Caretaker — you anticipate others' needs before they ask `[E0, O0, A+2, C0, N+1, Enn:T2, Att:Anx]`
+- **(B)** Advisor — people come to you for honest perspective `[E0, O+1, A0, C+1, N0, Enn:T5, Att:Avo]`
+- **(C)** Connector — you bring people together `[E+1, O+1, A+1, C0, N-1, Enn:T7, Att:Sec]`
+- **(D)** Protector — you shield people from unfairness `[E0, O0, A0, C+1, N0, Enn:T8, Att:Sec]`
+
+---
+
+## Batch 7: Motivation + Achievement
+
+**Targets**: Enneagram core desire, DISC primary
+
+### Q31
+What drives you most at work?
+
+- **(A)** Doing things right — quality and integrity matter `[E0, O0, A0, C+2, N0, Enn:T1, Att:Sec]`
+- **(B)** Being valued — knowing your contribution matters `[E0, O0, A+1, C0, N0, Enn:T2, Att:Anx]`
+- **(C)** Winning — measurable success and recognition `[E+1, O0, A-1, C+1, N0, Enn:T3, Att:Sec]`
+- **(D)** Meaning — creating something uniquely yours `[E0, O+2, A0, C0, N0, Enn:T4, Att:Sec]`
+
+### Q32
+Continuing — what drives you most?
+
+- **(A)** Mastery — understanding things at the deepest level `[E0, O+2, A0, C+1, N0, Enn:T5, Att:Avo]`
+- **(B)** Security — building a stable foundation `[E0, O0, A0, C+1, N+1, Enn:T6, Att:Anx]`
+- **(C)** Freedom — options, experiences, no limitations `[E+1, O+2, A0, C-1, N0, Enn:T7, Att:Sec]`
+- **(D)** Impact — making things happen, having influence `[E+1, O0, A-2, C+1, N0, Enn:T8, Att:Sec]`
+
+### Q33
+When you accomplish something significant, you feel:
+
+- **(A)** Already focused on what's next — rest is for later `[E0, O0, A0, C+1, N0, Enn:T3, Att:Sec]`
+- **(B)** Genuinely satisfied — you can savor this `[E0, O0, A0, C0, N-1, Enn:T9, Att:Sec]`
+- **(C)** Need to share it — the reaction matters `[E+1, O0, A+1, C0, N0, Enn:T2, Att:Anx]`
+- **(D)** It's never quite enough — you see the flaws `[E0, O0, A0, C+1, N+1, Enn:T1, Att:Sec]`
+
+### Q34
+Your relationship with authority:
+
+- **(A)** Respect earned authority, challenge arbitrary rules `[E0, O+1, A-1, C+1, N0, Enn:T8, Att:Sec]`
+- **(B)** Generally comply — rocking the boat isn't worth it `[E0, O0, A+1, C+1, N0, Enn:T9, Att:Anx]`
+- **(C)** Question everything — you need to understand the "why" `[E0, O+1, A0, C0, N0, Enn:T6, Att:Anx]`
+- **(D)** You want to BE the authority — lead by example `[E+1, O0, A-1, C+1, N0, Enn:T3, Att:Sec]`
+
+### Q35
+How do you define success?
+
+- **(A)** Living with integrity — being a good person `[E0, O0, A+1, C+1, N0, Enn:T1, Att:Sec]`
+- **(B)** Deep expertise — being genuinely excellent at something `[E0, O+2, A0, C+1, N0, Enn:T5, Att:Avo]`
+- **(C)** Independence — doing what you want, when you want `[E0, O+1, A-1, C0, N0, Enn:T7, Att:Sec]`
+- **(D)** Meaningful connections — the relationships you build `[E0, O0, A+2, C0, N0, Enn:T2, Att:Anx]`
+
+---
+
+## Batch 8: Integration + Adaptive Questions
+
+**Targets**: Fill gaps in under-determined dimensions
+
+> **This batch is adaptive.** The 5 questions below are defaults. After scoring Batches 1-7, replace any default with a disambiguation question targeting the closest call.
+
+### Q36 (default — Type 3 vs Type 7 disambiguation)
+When you're at your best, you're most proud of:
+
+- **(A)** Your ability to achieve goals others can't `[E0, O0, A0, C+1, N0, Enn:T3, Att:Sec]`
+- **(B)** Your ability to find joy in any situation `[E+1, O+1, A+1, C0, N-1, Enn:T7, Att:Sec]`
+- **(C)** Your ability to make others feel safe and understood `[E0, O0, A+2, C0, N0, Enn:T2, Att:Anx]`
+- **(D)** Your ability to see the truth others miss `[E0, O+2, A0, C0, N0, Enn:T5, Att:Avo]`
+
+### Q37 (default — Type 1 vs Type 6 disambiguation)
+When you notice something isn't right:
+
+- **(A)** You feel compelled to fix it — it bothers you until it's correct `[E0, O0, A0, C+2, N+1, Enn:T1, Att:Sec]`
+- **(B)** You flag the risk — better safe than sorry `[E0, O0, A0, C+1, N+1, Enn:T6, Att:Anx]`
+- **(C)** You note it but let it go — not everything needs fixing `[E0, O0, A+1, C0, N-1, Enn:T9, Att:Sec]`
+- **(D)** You challenge whoever's responsible — accountability matters `[E+1, O0, A-1, C+1, N0, Enn:T8, Att:Sec]`
+
+### Q38 (default — Type 4 vs Type 9 disambiguation)
+In a group where everyone agrees, you:
+
+- **(A)** Feel relieved — harmony is comfortable `[E0, O0, A+1, C0, N-1, Enn:T9, Att:Sec]`
+- **(B)** Feel suspicious — groupthink is dangerous `[E0, O+1, A-1, C0, N+1, Enn:T6, Att:Anx]`
+- **(C)** Feel restless — you instinctively want to voice the dissenting view `[E0, O+2, A-1, C0, N0, Enn:T4, Att:Sec]`
+- **(D)** Feel fine — you focus on execution, not consensus `[E0, O0, A0, C+1, N0, Enn:T3, Att:Sec]`
+
+### Q39 (default — Attachment anxiety vs avoidance clarifier)
+After a meaningful conversation with someone you've just met:
+
+- **(A)** You replay it warmly but don't feel urgency to follow up `[E0, O0, A0, C0, N0, Att:Sec]`
+- **(B)** You text them within hours — you want to keep the connection alive `[E+1, O0, A+1, C0, N+1, Att:Anx]`
+- **(C)** You enjoyed it but pull back — you don't want to seem too eager `[E-1, O0, A0, C0, N0, Att:Avo]`
+- **(D)** You want to reach out but overthink it — what if they don't reciprocate? `[E0, O0, A0, C0, N+2, Att:Fear]`
+
+### Q40 (default — E/I boundary clarifier)
+At the end of a great social event, you:
+
+- **(A)** Want to keep the night going — "where to next?" `[E+2, O+1, A+1, C-1, N-1, Enn:T7, Att:Sec]`
+- **(B)** Felt energized during the event, but now you need solo time `[E0, O0, A0, C0, N0, Enn:T5, Att:Sec]`
+- **(C)** Already exhausted — you hit your wall 2 hours ago `[E-2, O0, A0, C0, N0, Enn:T5, Att:Avo]`
+- **(D)** Happy you came, but you'll decline the next one to balance `[E-1, O0, A0, C+1, N0, Enn:T6, Att:Sec]`
+
+---
+
+## Express Set (15 Questions)
+
+For `/personality-profile express` mode, use these 15 triple-loaded questions:
+
+**Q1, Q3, Q5** (Batch 1) — Energy + Social
+**Q6, Q9** (Batch 2) — Information + Problem-solving
+**Q11, Q13, Q15** (Batch 3) — Decisions + Values
+**Q16, Q19** (Batch 4) — Structure + Rules
+**Q22, Q23** (Batch 5) — Core fears (split pair)
+**Q26** (Batch 6) — Attachment pattern
+**Q31** (Batch 7) — Work motivation
+**Q39** (Batch 8) — Relationship follow-up
+
+Express mode trades Batch 8 adaptiveness for speed. Report should note lower confidence.
+
+---
+
+## Disambiguation Question Templates
+
+When Batch 8 needs adaptive questions, use these templates:
+
+### Enneagram Type Pairs
+- **T1 vs T6**: "When you notice a flaw, is your first impulse to fix it (T1) or to assess the risk it poses (T6)?"
+- **T2 vs T9**: "Do you actively help others to feel needed (T2) or to keep the peace (T9)?"
+- **T3 vs T7**: "Do you chase achievement for status (T3) or for the rush of new experiences (T7)?"
+- **T4 vs T5**: "When you feel different from others, do you feel special (T4) or detached (T5)?"
+- **T8 vs T3**: "Do you pursue power for autonomy (T8) or for recognition (T3)?"
+
+### MBTI Borderline Dimensions
+- **T/F at 50**: Present a trolley-problem variant — save 5 strangers or 1 loved one
+- **J/P at 50**: "Your flight leaves in 3 hours. Are you already packed (J) or do you pack in 20 minutes right before (P)?"
+- **S/N at 50**: "When reading a novel, do you track plot details carefully (S) or skip ahead to see where it's going (N)?"
+
+### Attachment Clarifiers
+- **Anx vs Avo**: "After an argument, do you want to talk it through immediately (Anx) or need space first (Avo)?"
+- **Sec vs Fear**: "Do you generally feel safe in close relationships (Sec) or do you feel both drawn to and wary of intimacy (Fear)?"

--- a/skills/psychometrics/LICENSE.txt
+++ b/skills/psychometrics/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Zhou Yuan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/psychometrics/SKILL.md
+++ b/skills/psychometrics/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: psychometrics
+description: Psychometric review checklist for validating personality assessment systems against academic standards. Use when reviewing construct validity, reliability, cross-framework mapping, confidence calibration, or ethical boundaries of personality assessment engines and signal dictionaries.
+license: Complete terms in LICENSE.txt
+---
+
+# /psychometrics — 心理测量学审查
+
+> 用于审查 EnneaMe 多维人格评估系统的心理测量学合规性。
+
+## 使用方式
+
+```
+/psychometrics [审查对象]
+```
+
+示例：
+- `/psychometrics big-five-signal-dictionary` — 审查 Big Five 信号字典的构念效度
+- `/psychometrics bayesian-engine` — 审查贝叶斯推断引擎的测量信度
+- `/psychometrics enneagram-bigfive-mapping` — 审查跨框架先验映射的学术基础
+
+## 审查维度
+
+### 1. 构念效度（Construct Validity）
+- 我们提取的信号是否真正测量了目标构念？
+- 信号定义是否与原始量表（NEO-PI-R、MBTI Form M）的维度定义一致？
+- facet 级别的定义是否足够精确，避免维度交叉污染？
+
+### 2. 信度（Reliability）
+- 测试-重测信度：同一用户在不同对话中是否得到一致结果？
+- 内部一致性：同一维度的多个信号之间是否相关？
+- LLM 信号提取的评估者间信度（inter-rater reliability）：不同 LLM 是否提取相同信号？
+
+### 3. 框架间映射合理性
+- Enneagram → Big Five 先验映射是否有文献支撑？
+- 引用的研究样本量是否足够（N > 200）？
+- 映射关系是统计相关还是因果关系？（只应做相关推断）
+
+### 4. 置信度校准
+- 贝叶斯后验的置信度是否与实际准确度校准？
+- 多少信号点后才应展示结果？
+- 是否需要设置最低 confidence 阈值？
+
+### 5. 伦理与边界
+- 产品是否明确声明"这不是临床诊断工具"？
+- 是否避免了对用户的标签化伤害？
+- 用户是否可以对推断结果提出异议/修正？
+
+## 关键学术参考
+
+| 框架 | 核心量表 | 关键文献 |
+|------|---------|---------|
+| Big Five | NEO-PI-R (Costa & McCrae 1992) | McCrae et al. 2005 (跨文化验证) |
+| MBTI | Form M (Myers & Briggs) | Pittenger 1993 (批评性综述) |
+| Enneagram | RHETI v2.5 (Riso & Hudson) | Wagner & Walker 1983 |
+| VIA | VIA-IS (Peterson & Seligman 2004) | Park et al. 2006 |
+
+## 审查产出物
+
+产出 `psychometrics-review-{subject}.md` 文件，包含：
+1. 各维度的合规/不合规评估（pass / warning / fail）
+2. 具体问题描述和修正建议
+3. 需要补充的文献引用
+4. 信号字典/引擎设计的修改建议
+
+## 审查标准
+
+| 等级 | 含义 |
+|------|------|
+| Pass | 符合心理测量学标准，可直接使用 |
+| Warning | 有潜在问题，建议修正后使用 |
+| Fail | 严重违反测量学原则，必须修正 |


### PR DESCRIPTION
## Summary

Adds two new skills for personality assessment:

- **personality-profile**: Interactive multi-framework personality assessment (Enneagram, MBTI, Big Five, DISC, Attachment Style) in a single conversation session. Supports 6 modes: Full, Express, Deep, Single-framework, Life Story narrative, and For-App developer integration.
- **psychometrics**: Psychometric review checklist for validating personality assessment systems against academic standards (construct validity, reliability, ethics).

## Key Features

- 40-question bank with shared scoring matrix — each question feeds 2-3 frameworks simultaneously
- Adaptive disambiguation (Batch 8) targets the closest calls
- Confidence calibration (High/Medium/Low) with transparent thresholds
- Life Story mode generates literary biographical narratives
- For-App mode outputs structured JSON for developer integration
- Academic grounding: Costa & McCrae 1992, Riso & Hudson, Bartholomew & Horowitz 1991

## Related

- GitHub: https://github.com/sunnyzhouy/personality-skills
- npm: personality-profile-skill