### PR TITLE
fix: remove unused imports in slack-gif-creator and skill-creator

### DIFF
--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -4,7 +4,6 @@ Quick validation script for skills - minimal version
 """
 
 import sys
-import os
 import re
 import yaml
 from pathlib import Path

--- a/skills/slack-gif-creator/core/frame_composer.py
+++ b/skills/slack-gif-creator/core/frame_composer.py
@@ -8,7 +8,6 @@ together to create animation frames.
 
 from typing import Optional
 
-import numpy as np
 from PIL import Image, ImageDraw, ImageFont
 
 

--- a/skills/slack-gif-creator/core/gif_builder.py
+++ b/skills/slack-gif-creator/core/gif_builder.py
@@ -7,7 +7,6 @@ generated frames, with automatic optimization for Slack's requirements.
 """
 
 from pathlib import Path
-from typing import Optional
 
 import imageio.v3 as imageio
 import numpy as np


### PR DESCRIPTION
**Description:**
Cleaned up several unused imports (`numpy`, `typing.Optional`, `os`) across `slack-gif-creator` and `skill-creator` to reduce clutter and resolve linter warnings (`ruff`).

Files modified:
- `skills/slack-gif-creator/core/frame_composer.py`
- `skills/slack-gif-creator/core/gif_builder.py`
- `skills/skill-creator/scripts/quick_validate.py`

*(Refactored using the open-source [0-editor](https://github.com/0-protocol/0-editor))*
