### PR TITLE
fix: close validation image input file

### DIFF
--- a/skills/pdf/scripts/create_validation_image.py
+++ b/skills/pdf/scripts/create_validation_image.py
@@ -10,20 +10,20 @@ def create_validation_image(page_number, fields_json_path, input_path, output_pa
     with open(fields_json_path, 'r') as f:
         data = json.load(f)
 
-        img = Image.open(input_path)
-        draw = ImageDraw.Draw(img)
-        num_boxes = 0
-        
-        for field in data["form_fields"]:
-            if field["page_number"] == page_number:
-                entry_box = field['entry_bounding_box']
-                label_box = field['label_bounding_box']
-                draw.rectangle(entry_box, outline='red', width=2)
-                draw.rectangle(label_box, outline='blue', width=2)
-                num_boxes += 2
-        
-        img.save(output_path)
-        print(f"Created validation image at {output_path} with {num_boxes} bounding boxes")
+        with Image.open(input_path) as img:
+            draw = ImageDraw.Draw(img)
+            num_boxes = 0
+
+            for field in data["form_fields"]:
+                if field["page_number"] == page_number:
+                    entry_box = field['entry_bounding_box']
+                    label_box = field['label_bounding_box']
+                    draw.rectangle(entry_box, outline='red', width=2)
+                    draw.rectangle(label_box, outline='blue', width=2)
+                    num_boxes += 2
+
+            img.save(output_path)
+            print(f"Created validation image at {output_path} with {num_boxes} bounding boxes")
 
 
 if __name__ == "__main__":

--- a/skills/pdf/scripts/test_create_validation_image.py
+++ b/skills/pdf/scripts/test_create_validation_image.py
@@ -1,0 +1,72 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import create_validation_image
+
+
+class FakeImage:
+    def __init__(self):
+        self.closed = False
+        self.saved_to = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.close()
+
+    def close(self):
+        self.closed = True
+
+    def save(self, output_path):
+        self.saved_to = output_path
+
+
+class CreateValidationImageTests(unittest.TestCase):
+    def test_create_validation_image_closes_input_image(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            fields_json_path = tmp_path / "fields.json"
+            output_path = tmp_path / "output.png"
+            fields_json_path.write_text(
+                json.dumps(
+                    {
+                        "form_fields": [
+                            {
+                                "page_number": 2,
+                                "entry_bounding_box": [1, 2, 3, 4],
+                                "label_bounding_box": [5, 6, 7, 8],
+                            },
+                            {
+                                "page_number": 3,
+                                "entry_bounding_box": [9, 10, 11, 12],
+                                "label_bounding_box": [13, 14, 15, 16],
+                            },
+                        ]
+                    }
+                )
+            )
+
+            fake_image = FakeImage()
+            fake_draw = MagicMock()
+
+            with patch.object(create_validation_image.Image, "open", return_value=fake_image) as image_open:
+                with patch.object(create_validation_image.ImageDraw, "Draw", return_value=fake_draw):
+                    create_validation_image.create_validation_image(
+                        2,
+                        str(fields_json_path),
+                        "input.png",
+                        str(output_path),
+                    )
+
+            image_open.assert_called_once_with("input.png")
+            self.assertTrue(fake_image.closed)
+            self.assertEqual(fake_image.saved_to, str(output_path))
+            self.assertEqual(fake_draw.rectangle.call_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- close the Pillow image opened in `create_validation_image.py` with a context manager
- keep the change scoped to the confirmed issue from the earlier resource-leak scan

## Verification

- `python3 -m py_compile skills/pdf/scripts/create_validation_image.py`
