### PR TITLE
Add audhd-executive-function and session-handoff skills

### DIFF
--- a/skills/audhd-executive-function/SKILL.md
+++ b/skills/audhd-executive-function/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: audhd-executive-function
+description: "External executive function system for users with ADHD, ASD, or AUDHD (combined ADHD + Autism). Invoke when generating any actionable output: daily schedules, morning briefings, task lists, checklists, engagement hitlists, or any 'here is what to do' output. Trigger keywords: AUDHD, ADHD, neurodivergent, executive function, daily schedule, energy modes, task design, actionability, copy-paste tasks, no decisions, RSD, rejection sensitivity."
+metadata:
+  version: 1.0.0
+  author: Assaf Kipnis
+  license: Apache-2.0
+  tags: [audhd, adhd, asd, neurodivergent, executive-function, daily-schedule, energy-modes, actionability, task-design]
+---
+
+# AUDHD Executive Function Skill
+
+You are building an external executive function system for a user with AUDHD (combined ADHD + Autism). This skill governs how ALL daily outputs are structured, especially the daily schedule HTML.
+
+**Always read these files first:**
+1. `references/research.md` - AUDHD research and design principles
+2. `references/user-profile.md` - this specific user's behavioral profile
+
+The daily HTML is not a briefing. It is the user's entire workday, pre-loaded and ready to execute action by action. The system IS their executive function, working memory, follow-up tracker, relationship manager, and copywriter.
+
+---
+
+## THE ONE RULE
+
+**If the user cannot copy-paste it, click it, or check it off, it does not belong in the output.**
+
+Everything else flows from this.
+
+---
+
+## ACTIONABILITY RULES (ENFORCED)
+
+### A1: No Cross-References
+Never say "see section above," "copy-paste from section X," or "refer to file Y." Every checklist item contains the actual text inline with a Copy button. The user never scrolls or searches.
+
+### A2: Next Physical Action
+Every item is the literal next physical thing the user does. Not "Follow up with Sarah" but the actual email text in a copy box. If a draft can't be pre-written (needs user's eyes first), say exactly that: "Read Sarah's message first, then respond. No pre-written draft."
+
+### A3: All Pending Actions Get Drafts
+Every pending action that's due today or this week appears in the HTML with a pre-written draft message. No action item exists without its corresponding copy-paste text.
+
+### A4: Recent Meeting Follow-ups
+All meetings from the past 48 hours produce follow-up items with full draft text. Call happened yesterday = follow-up email is in today's Quick Wins.
+
+### A5: Dashboards at the Bottom
+Pipeline health, temperature scores, and analytics go in collapsed sections at the bottom. The top of the HTML is ONLY actionable items. A dashboard number without an attached action and draft is informational waste.
+
+### A6: Risk Signals Get Recovery Drafts
+Every risk signal (score dropping, contact cooling, no reply past threshold) includes the specific recovery DM/email draft. "Contact score dropping" becomes a copy-paste message.
+
+### A7: Friction-Ordered
+Items sorted by friction, lowest first. 2-minute scheduling replies before 5-minute DMs before 10-minute emails. Quick momentum wins first to build dopamine.
+
+---
+
+## STRUCTURE RULES
+
+### Section Order (matches energy curve)
+1. **Quick Wins** - copy-paste scheduling replies, comments, short DMs (2-3 min each)
+2. **Messages** - longer DMs, connection requests, follow-up emails (3-5 min each)
+3. **Posts** - social content to publish (copy into composer)
+4. **Emails** - longer follow-ups, value-adds
+5. **Deep Focus** - meeting prep, research, writing (only if energy allows)
+6. **FYI** (collapsed) - auto-closed contacts, pipeline health, effort summary
+
+### Every Item Has
+- Platform icon or badge (LinkedIn/X/Reddit/Email/Slack/etc.)
+- Person name + company
+- What to do (one sentence)
+- The actual text in a copy-paste box with Copy button
+- **For emails: a subject line in its own copy box above the body.** Never output an email draft without a subject line.
+- Link to open the target (post URL, DM compose, email compose)
+- Estimated time
+- Energy tag (Quick Win / Deep Focus / People / Admin)
+
+### Items That Cannot Be Pre-Written
+Some items need the user's judgment (e.g., reviewing a contract). For these, say exactly: "Read [X] first, then respond. No pre-written draft - needs your eyes." Never leave it vague.
+
+---
+
+## LANGUAGE RULES (ENFORCED)
+
+### Never Use
+- "overdue" (use "carried forward")
+- "missed" (use "ready when you are")
+- "failed" (use "didn't land")
+- "forgot" (use "not yet done")
+- "dropped the ball" (never)
+- "behind" (use "in progress")
+- "urgent" as pressure (state facts calmly: "Meeting with Alex is at 11:30am")
+- "you need to" (use "you could")
+- "you should have" (never)
+- "nobody responded" (use "awaiting reply")
+- "ghosted" (use "no reply yet")
+
+### Always Use
+- Effort tracking: "You sent 4 messages yesterday" not outcome tracking
+- "Carried forward from yesterday" not "this is overdue"
+- "You could..." not "you need to..."
+- Calm factual statements: "Call was yesterday. Materials not yet sent."
+
+### Progress Framing
+- "5 of 12 done" is a win. Show what WAS done, never what wasn't
+- Completed items stay visible (struck through) so user sees accomplishments
+- End-of-day: "You completed X actions, sent Y messages" - effort celebration
+
+---
+
+## DECISION ELIMINATION
+
+### The System Decides
+- Who to contact (based on priority, cooling risk, pipeline health)
+- What to say (pre-written in user's voice)
+- In what order (friction-sorted, momentum-first)
+- Through which channel (DM / email / comment / reply)
+
+### The User Executes
+- Copy text
+- Click link
+- Paste text
+- Check box
+
+### Never Present Options
+Bad: "Here are 3 comment styles. Which do you prefer?"
+Good: One comment, ready to copy. User edits if they want to.
+
+Bad: "Would you like me to draft a follow-up?"
+Good: The follow-up is already there with copy-paste text.
+
+---
+
+## WALL OF AWFUL MITIGATION
+
+### Pre-Process Emotional Labor
+- All messages pre-written (eliminates blank-page wall)
+- All outreach framed as "sharing expertise" not "asking for something"
+- Show recent wins before scary tasks: "You sent 6 messages this week. 2 got replies." Then the next outreach item
+
+### Momentum-First Ordering
+- Start with 2-3 Quick Wins (copy-paste comments, scheduling replies)
+- Build completion dopamine
+- THEN surface harder tasks (follow-ups, new outreach, deep focus)
+- Never start the day with the hardest item
+
+### Skip Without Shame
+- If user skips an item, it moves to "carried forward" without commentary
+- Every section is independently completable. Missing one module does not invalidate others
+
+---
+
+## RELATIONSHIP CONTEXT (INLINE)
+
+Every person-related task shows inline context so the user never searches their memory:
+
+```
+Jane Smith / Acme Corp
+Last: Call Tuesday. She liked the demo. Asked about integrations.
+Owed: Send pricing doc + case study. She presents to her VP Friday.
+```
+
+Then the copy-paste email text. Context + action in one place.
+
+---
+
+## CRACK DETECTION (AUTOMATIC)
+
+The system surfaces what fell through without the user remembering to check:
+
+- **Awaiting reply > 7 days:** Auto-generates follow-up draft. BUT FIRST: check sent messages to confirm the user hasn't already replied. Never draft a nudge for a conversation the user already responded to.
+- **No interaction > 14 days:** Flags with suggested re-engagement or auto-close
+- **Meeting happened but not followed up:** Call completed, materials not sent
+- **Scheduled but not confirmed:** Meeting booked but no confirmation sent
+- **Cooling contacts:** Score dropping, with specific recovery action
+
+All of these appear as normal checklist items with copy-paste text. Not as alerts. Not as warnings. Just the next action.
+
+### Temperature Dashboard Wiring (ENFORCED)
+The temperature dashboard in the FYI section must be WIRED to actions:
+- Every row shows: Name / Role / Score / Trend / **Stage** / **Next action link**
+- If the person has an action item in the HTML above, the row links to it (anchor)
+- If a contact is trending down and has NO action item above, a recovery draft MUST be auto-generated and added to the Messages or Quick Wins section. The dashboard row then links to that new action.
+- A downtrend without a linked action is a broken dashboard row. Never output one.
+- Cool contacts either get a re-engagement action or get auto-closed. No limbo rows.
+
+---
+
+## VISUAL DESIGN PRINCIPLES
+
+- Muted dark palette, high-contrast text
+- No animations, no flashing, no bright alert colors for shame
+- Red = factual time indicator only (e.g., "15 DAYS"), never shame
+- Green = actionable copy-paste box
+- Generous whitespace between sections
+- Typography hierarchy (size, weight) not color for importance
+- Single column, works on phone
+- Progress bar at top: "X of Y actions done"
+- Total time estimate: "Today: ~45 min, 14 actions"
+
+---
+
+## ANTI-PATTERNS (NEVER DO)
+
+1. **Dashboard without actions.** A score means nothing unless the draft is right there.
+2. **Pipeline counts without per-person actions.** "8 hot prospects" is analytics. Show each person with their copy-paste next action.
+3. **"See above" or "see file."** Everything inline. Always.
+4. **Options to evaluate.** The system picks. The user overrides if they want.
+5. **Questions as tasks.** "Would you like to..." is not a task. The action is.
+6. **Empty sections.** If a section has zero actions, omit it entirely.
+7. **Abstract task names.** "Follow up with Jay" is not a task. The email text is.
+8. **Stacking pressure.** Never list 3+ carried-forward items together. Spread them across energy types.
+9. **Outcome metrics.** "0 replies received" triggers RSD. Track effort only.
+10. **Sequential dependencies.** If step 3 requires step 1's output, the system carries it forward. User never holds intermediate state.
+
+---
+
+## QUALITY CHECK (ALL MUST PASS)
+
+Before outputting any daily HTML, verify:
+
+1. **Copy-paste test:** Can every single checklist item be completed by copying text and pasting it somewhere? If not, is it explicitly marked "needs your eyes"?
+2. **Link test:** Does every item have a clickable link to the target platform?
+3. **Time test:** Does every item show estimated minutes?
+4. **Context test:** Does every person-item show last interaction and what's owed?
+5. **Zero-decision test:** Can the user start working without making any choices?
+6. **No-shame test:** Zero instances of overdue/missed/failed/forgot/dropped?
+7. **Crack test:** Are all pending actions surfaced? All recent meeting follow-ups included?
+8. **Inline test:** Zero instances of "see above" or "see section" or "copy from X"?
+9. **Order test:** Are items sorted friction-first (fastest first)?
+10. **Independence test:** Can each section be completed independently? Does skipping one break others?

--- a/skills/audhd-executive-function/references/research.md
+++ b/skills/audhd-executive-function/references/research.md
@@ -1,0 +1,100 @@
+# AUDHD Executive Function Research
+
+> Synthesized from academic research, ADHD coaching frameworks, and AuDHD-specific productivity literature.
+> Sources: Barkley (scaffolding), Mahan (Wall of Awful), Dodson (interest-based nervous system), PMC, Nature, CHADD, ADDitude, Cleveland Clinic, ADDA, and 30+ additional sources.
+
+## Core AUDHD Executive Function Deficits
+
+### 1. Working Memory
+The AUDHD brain cannot reliably hold "what's next." If a task, person, or commitment is not visible on screen right now, it does not exist. Both ADHD and ASD compromise working memory independently. Combined, the deficit compounds.
+
+### 2. Task Initiation Paralysis (Wall of Awful)
+Brendan Mahan's framework: emotional barrier built from accumulated failure bricks (disappointment, rejection, shame). AUDHD walls are larger because ASD pattern-matching remembers failures more intensely. Not laziness. Self-protection.
+
+Three approaches:
+- **Door in the wall:** Change emotional state first (quick win, movement)
+- **Climb the wall:** Name the emotion, accept it, take smallest step
+- **Shrink the wall:** Reframe with self-compassion (track effort not outcomes)
+
+### 3. Task Switching Costs
+Context switching is neurologically expensive for ADHD. ASD amplifies it because autistic brains build deep mental models and resist breaking them. Switching requires 20% buffer time minimum.
+
+### 4. Decision Fatigue
+ADHD brains deplete dopamine faster during decision-making. Working memory limitations make comparing options simultaneously very costly. Too many choices = freeze.
+
+### 5. Time Blindness
+Neural mechanisms for time perception are impaired. Future events don't feel real until the last minute. Relative time ("this week") is meaningless. Absolute time ("by 2:00 PM") works.
+
+### 6. Object Permanence for Tasks
+Working memory deficit, not cognitive. If a task scrolls off screen, if a person's name isn't visible, if a follow-up is in a different tool, it ceases to exist.
+
+### 7. RSD (Rejection Sensitive Dysphoria)
+Intense emotional pain from rejection or perceived rejection. Most common coping: refusing to try at all. Not motivation failure. Self-protection from anticipated pain. Outreach, follow-ups, and asks are high-RSD tasks.
+
+## How AUDHD Differs from ADHD-Only
+
+### ASD Pattern-Matching + ADHD Chaos
+ASD builds systems. ADHD generates novelty. Productive tension: system-building provides architecture, ADHD provides creative energy.
+
+**Design implication:** Rigid structures populated with dynamic content. Layout never changes. Information changes daily.
+
+### Systems Need (ASD) vs. Rigidity Resistance (ADHD)
+Core AUDHD paradox. Craves predictable routines AND rebels against monotony. Rigid routines break the moment a step is missed, then all-or-nothing pattern collapses the entire routine.
+
+**Design implication:** "Flexible rails" - consistent sequence that tolerates skipped steps. Missing one module must not invalidate others.
+
+### Hyperfocus Tunneling (Mutual Amplification)
+Both conditions amplify hyperfocus. Can override biological needs. Requires gentle time-based interrupts.
+
+### Sensory/Cognitive Overwhelm
+Lower threshold for overload. Visual calm is mandatory. High information density, low visual noise.
+
+### All-or-Nothing Execution
+One missed step = total system collapse. ASD rigidity + ADHD emotional dysregulation.
+
+**Design implication:** Every section independently completable. Progress as "3 of 7 done" not "incomplete."
+
+### Masking Fatigue
+Professional interactions (calls, meetings, networking) cost social energy. Recovery time needed after People tasks. Never schedule back-to-back.
+
+## External Executive Function Design Principles
+
+Based on Barkley's scaffolding framework: the system IS the executive function.
+
+### Zero Decisions to Start
+System tells you exactly what to do next. Not a list of options. One task. Right now. Pre-loaded.
+
+### Single Surface
+No switching tools, tabs, or pages. One HTML page. Dashboard IS the workspace.
+
+### Copy-Paste Ready
+Every message pre-written, final-draft quality. Eliminate the compose step entirely.
+
+### Energy-Aware Batching
+Four modes: Quick Win, Deep Focus, People, Admin. Never interleave types. Include transition buffers between mode switches.
+
+### Progress Visibility
+Dopamine from completion is a neurological accommodation. Visual progress bar. Completed items stay visible. End-of-day effort summary. Never show what was NOT done.
+
+### No Shame/Guilt Language
+Never: overdue, missed, failed, forgot, dropped, behind, urgent. Use: carried forward, ready when you are, awaiting reply, you could.
+
+### Automatic Crack-Detection
+Surface what fell through without requiring the human to remember. Auto-generated follow-up drafts for items past threshold.
+
+### Relationship Memory
+Every person-related task shows inline context: last interaction, what was discussed, what's owed. Never require searching memory or another tool.
+
+## Practical Patterns
+
+### Momentum-First (Not Eat-the-Frog)
+Start with 2-3 Quick Wins. Build completion dopamine. Then surface harder tasks while dopamine is flowing.
+
+### Wall of Awful Mitigation
+Pre-write all messages. Frame as sharing value. Show recent wins before scary tasks. Offer alternatives that still move things forward.
+
+### Transition Rituals
+Brief interstitial between energy modes. Pre-load context for next task. Suggest physical buffer (stand up, water).
+
+### Body Doubling
+Dashboard is always present. Knows what you committed to. Shows what you're working on. Witnesses without judging.

--- a/skills/audhd-executive-function/references/user-profile.md
+++ b/skills/audhd-executive-function/references/user-profile.md
@@ -1,0 +1,25 @@
+# User Behavioral Profile
+
+> Populated during setup if AUDHD mode is enabled. This helps the system calibrate to YOUR specific patterns.
+
+## AUDHD Presentation
+- **Primary:** (ADHD-PI, ADHD-C, ADHD-PH, ASD, AUDHD)
+- **Medication:** (if relevant to energy patterns)
+- **Peak hours:** (when executive function is strongest)
+- **Crash patterns:** (when you reliably lose steam)
+
+## Known Triggers
+- **Task initiation blockers:** (what makes you freeze?)
+- **RSD triggers:** (what makes outreach/follow-up feel impossible?)
+- **Hyperfocus patterns:** (what do you get lost in?)
+- **Sensory considerations:** (visual preferences, noise, etc.)
+
+## What Works For You
+- (e.g., "I need to see the whole day laid out before I can start")
+- (e.g., "Short tasks first, then I build momentum")
+- (e.g., "I can't do People tasks before noon")
+
+## What Doesn't Work
+- (e.g., "Long text blocks paralyze me")
+- (e.g., "Too many options = freeze")
+- (e.g., "Shame-based motivation shuts me down completely")

--- a/skills/session-handoff/SKILL.md
+++ b/skills/session-handoff/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: session-handoff
+description: "Generates a structured handoff note at the end of a Claude Code session so the next session can resume without reconstructing context from scratch. Invoke when the user says done, stopping, wrapping up, done for now, that's it, context is running low, or when session continuity is needed. Creates a persistent handoff file covering what happened, what's in progress, decisions made, files modified, blockers, and the single recommended next action."
+metadata:
+  version: 1.0.0
+  author: Assaf Kipnis
+  license: Apache-2.0
+---
+
+# Session Handoff Skill (`/q-handoff`)
+
+> Formal session-end message for the next session. Ensures continuity across context window resets.
+
+## Purpose
+
+When a session is about to end (context running low, user says "done for now", or natural stopping point), generate a handoff note that the NEXT session can read to pick up exactly where this one left off.
+
+## When to trigger
+- User says "done", "stopping", "that's it for now", "wrapping up"
+- Context window is >80% consumed
+- After `/q-wrap` completes
+- Before any expected context compaction
+
+## Handoff note structure
+
+Save to your project's handoff file (e.g., `memory/last-handoff.md`, overwritten each time):
+
+```markdown
+# Session Handoff - [date] [time]
+
+## What happened this session
+- [Bullet list of key actions taken, decisions made, files changed]
+
+## In-progress work
+- [Anything started but not finished]
+- [Current state of any multi-step task]
+
+## Decisions made
+- [Any positioning, strategy, or process decisions with origin tags]
+
+## Files modified
+- [List of files changed this session, one per line]
+
+## Blocked / needs attention
+- [Anything that couldn't be completed and why]
+
+## Suggested next action
+- [The single most important thing to do when the next session starts]
+```
+
+## Rules
+- Keep it under 30 lines. The next session reads this on startup to restore context.
+- Be specific. "Updated talk-tracks.md" not "made some changes."
+- Include file paths so the next session can verify.
+- If nothing is in-progress, say so. Clean handoffs are good.
+- The handoff note is for CLAUDE, not for the founder. Write it as system context.


### PR DESCRIPTION
## Summary

Two founder-focused skills for Claude Code:

- **audhd-executive-function** -- Builds an external executive function system for ADHD/AUDHD users. Governs how daily outputs are structured: energy-sorted sections, copy-paste-ready actions, shame-free language, decision elimination. Useful for anyone who needs Claude to produce actionable output instead of dashboards and summaries.

- **session-handoff** -- Generates a structured handoff note at session end so the next session resumes exactly where the current one left off. 30-line limit, written for Claude not the user. Works in any project.

## Checklist

- [x] `name` in frontmatter matches directory name
- [x] `description` includes what it does AND trigger keywords
- [x] `license` field set (Apache-2.0)
- [x] SKILL.md under 500 lines (219 and 47 respectively)
- [x] Reference files in `references/` for on-demand loading
- [x] No hardcoded paths, credentials, or org-specific references
- [x] Self-contained -- works in any Claude Code project

## Who this is for

- Neurodivergent developers/founders who need shame-free, action-first task design
- Anyone who wants session continuity across Claude Code conversations

## More skills

These are part of the [kipi-skills](https://github.com/assafkip/kipi-skills) marketplace (8 skills total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)