### PR TITLE
feat(skills): add 0-editor skill for agent-native fuzzy file editing

### DIFF
--- a/skills/0-editor/README.md
+++ b/skills/0-editor/README.md
@@ -1,0 +1,12 @@
+# 0-editor
+
+A robust, native file editing skill for agents that uses fuzzy AST/line matching instead of exact string replacement. Use this skill whenever you need to edit source code files to avoid whitespace and indentation matching errors.
+
+## Why 0-editor?
+
+Standard agentic `edit` tools often rely on exact string matching. This means any hallucinated space, tab, or newline by the LLM will cause the edit to fail. 
+`0-editor` aligns edits semantically by allowing agents to pass chunks of code, intelligently ignoring indentation and whitespace drifts.
+
+## Included files
+
+- `SKILL.md`: The system prompt to attach to your agent or load into your context window when working with code bases.

--- a/skills/0-editor/SKILL.md
+++ b/skills/0-editor/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: 0-editor
+description: A robust, native file editing skill for OpenClaw that uses fuzzy AST/line matching instead of exact string replacement. Use this skill whenever you need to edit source code files to avoid whitespace and indentation matching errors.
+---
+
+# 0-editor: Agent-Native File Editing
+
+Do NOT use the built-in `edit` tool for modifying blocks of code. The native `edit` tool requires exact string matches, meaning any hallucinated space, tab, or newline will cause your edit to fail.
+
+Instead, use `0-editor` which aligns your edits semantically.
+
+## Usage Instructions
+
+When you need to modify a file:
+
+1. Write the code you want to replace into a temporary file:
+   `write /tmp/old.txt`
+2. Write the new code into another temporary file:
+   `write /tmp/new.txt`
+3. Run the `0-editor` CLI via the `exec` tool:
+   `exec 0-editor <target_file> /tmp/old.txt /tmp/new.txt`
+
+## Example Tool Call
+
+```json
+// 1. Write the old block
+{"call": "default_api:write", "args": {"file_path": "/tmp/old.txt", "content": "function add(a, b) {\n  return a + b;\n}"}}
+
+// 2. Write the new block
+{"call": "default_api:write", "args": {"file_path": "/tmp/new.txt", "content": "function add(a, b, c=0) {\n  return a + b + c;\n}"}}
+
+// 3. Execute 0-editor
+{"call": "default_api:exec", "args": {"command": "0-editor /workspace/math.js /tmp/old.txt /tmp/new.txt"}}
+```
+
+`0-editor` will intelligently ignore indentation and whitespace drifts, locate the old block in `math.js`, and replace it with your new block perfectly.


### PR DESCRIPTION
### Description
This PR adds the `0-editor` skill to the registry. 

**The Problem:** Autonomous agents frequently fail when using native `edit` or string-replace tools because LLMs inevitably hallucinate whitespace, indentation, or newlines. This causes exact-match patch failures, leading to massive context window thrashing, endless retry loops, and token burn.

**The Solution:** `0-editor` provides a standardized workflow for agents to bypass exact string matching by using an AST/fuzzy-matching CLI tool (which ignores whitespace drifts). This skill defines the prompt and operational guidelines for agents to perform resilient, multi-line codebase edits.

*(Generated via Sun Force)*