### PR TITLE
docs: add cross-validated-search partner skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,4 @@ The markdown content below contains the instructions, examples, and guidelines t
 Skills are a great way to teach Claude how to get better at using specific pieces of software. As we see awesome example skills from partners, we may highlight some of them here:
 
 - **Notion** - [Notion Skills for Claude](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0)
+- **Cross-Validated Search** - [Cross-Validated Search](https://github.com/wd041216-bit/cross-validated-search), an evidence-aware search and claim verification skill surface for Claude-compatible workflows.


### PR DESCRIPTION
## Summary
- add Cross-Validated Search to the Partner Skills section
- highlight the repo as an evidence-aware search and claim verification skill surface for Claude-compatible workflows

## Why
Cross-Validated Search already ships a Claude Code skill surface and is useful as a concrete example of a source-backed web research and verification workflow.

## Validation
- verified the linked repository includes a Claude Code skill surface at `.claude/skills/cross-validated-search/SKILL.md`
- confirmed the project exposes `search-web`, `browse-page`, `verify-claim`, and `evidence-report` workflows