### PR TITLE
Add opensource-pipeline skill

### DIFF
--- a/skills/opensource-pipeline/SKILL.md
+++ b/skills/opensource-pipeline/SKILL.md
@@ -1,0 +1,265 @@
+---
+name: opensource-pipeline
+description: Safely open-source any project through a 3-stage automated pipeline. Use when the user wants to open-source a project, make a repo public, strip secrets before publishing, prepare code for public release, or generate open-source packaging (README, LICENSE, CONTRIBUTING, CLAUDE.md). Triggers on phrases like 'open source this', 'make this public', 'prepare for open source', '/opensource fork', or 'strip secrets from my project'.
+---
+
+# Open-Source Pipeline
+
+Safely publish any private project as open source through a 3-stage pipeline:
+
+**Forker** (strip secrets) -> **Sanitizer** (verify clean) -> **Packager** (generate docs)
+
+All forks are staged locally for review before anything is pushed to GitHub.
+
+## Activation
+
+| Command | Action |
+|---------|--------|
+| `/opensource fork PROJECT` | Full pipeline: fork + sanitize + package |
+| `/opensource verify PROJECT` | Run sanitizer on an existing repo |
+| `/opensource package PROJECT` | Generate CLAUDE.md + setup.sh + README for a project |
+| `/opensource list` | Show all staged projects |
+| `/opensource status PROJECT` | Show pipeline reports for a staged project |
+
+Also triggers on:
+- "open source this project"
+- "make this public"
+- "prepare for open source"
+- "strip secrets from my project"
+
+## Protocol
+
+### /opensource fork PROJECT
+
+**Full pipeline — the main workflow.**
+
+#### Step 1: Gather Parameters
+
+Resolve the project path. If PROJECT contains a `/`, treat as a path (absolute or relative). Otherwise check in order: current working directory, `$HOME/PROJECT`, then ask the user.
+
+```
+PROJECT_NAME="${1:-}"
+SOURCE_PATH="<resolved absolute path to project>"
+STAGING_PATH="$HOME/opensource-staging/${PROJECT_NAME}"
+```
+
+Ask the user:
+1. "Which project?" (if not specified or path not found)
+2. "License? (MIT / Apache-2.0 / GPL-3.0 / BSD-3-Clause)"
+3. "GitHub repo name?" (default: project name)
+4. "Description for README?" (analyze project for suggestion)
+
+#### Step 2: Create Staging Directory
+
+```bash
+mkdir -p $HOME/opensource-staging/
+```
+
+#### Step 3: Run Forker Agent
+
+Spawn the `opensource-forker` subagent (see `agents/opensource-forker.md`):
+
+```
+Agent(
+  description="Fork {PROJECT} for open-source",
+  subagent_type="opensource-forker",
+  prompt="""
+Fork project for open-source release.
+
+Source: {SOURCE_PATH}
+Target: {STAGING_PATH}
+License: {chosen_license}
+
+Follow the full forking protocol:
+1. Copy files (exclude .git, node_modules, __pycache__, .venv)
+2. Strip all secrets and credentials
+3. Replace internal references with placeholders
+4. Generate .env.example
+5. Clean git history
+6. Generate FORK_REPORT.md in {STAGING_PATH}/FORK_REPORT.md
+"""
+)
+```
+
+Wait for completion. Read `{STAGING_PATH}/FORK_REPORT.md`.
+
+#### Step 4: Run Sanitizer Agent
+
+Spawn the `opensource-sanitizer` subagent (see `agents/opensource-sanitizer.md`):
+
+```
+Agent(
+  description="Verify {PROJECT} sanitization",
+  subagent_type="opensource-sanitizer",
+  prompt="""
+Verify sanitization of open-source fork.
+
+Project: {STAGING_PATH}
+Source (for reference): {SOURCE_PATH}
+
+Run ALL scan categories:
+1. Secrets scan (CRITICAL)
+2. PII scan (CRITICAL)
+3. Internal references scan (CRITICAL)
+4. Dangerous files check (CRITICAL)
+5. Configuration completeness (WARNING)
+6. Git history audit
+
+Generate SANITIZATION_REPORT.md inside {STAGING_PATH}/ with PASS/FAIL verdict.
+"""
+)
+```
+
+Wait for completion. Read `{STAGING_PATH}/SANITIZATION_REPORT.md`.
+
+**If FAIL:** Show findings to user. Ask: "Fix these and re-scan, or abort?"
+- If fix: Apply fixes, re-run sanitizer
+- If abort: Clean up staging directory
+
+**If PASS or PASS WITH WARNINGS:** Continue to Step 5.
+
+#### Step 5: Run Packager Agent
+
+Spawn the `opensource-packager` subagent (see `agents/opensource-packager.md`):
+
+```
+Agent(
+  description="Package {PROJECT} for open-source",
+  subagent_type="opensource-packager",
+  prompt="""
+Generate open-source packaging for project.
+
+Project: {STAGING_PATH}
+License: {chosen_license}
+Project name: {PROJECT_NAME}
+Description: {description}
+GitHub repo: {github_repo}
+
+Generate:
+1. CLAUDE.md (commands, architecture, key files)
+2. setup.sh (one-command bootstrap, make executable)
+3. README.md (or enhance existing)
+4. LICENSE
+5. CONTRIBUTING.md
+6. .github/ISSUE_TEMPLATE/ (bug_report.md, feature_request.md)
+"""
+)
+```
+
+#### Step 6: Final Review
+
+Present to user:
+```
+Open-Source Fork Ready: {PROJECT_NAME}
+
+Location: {STAGING_PATH}
+License: {license}
+Files generated:
+  - CLAUDE.md
+  - setup.sh (executable)
+  - README.md
+  - LICENSE
+  - CONTRIBUTING.md
+  - .env.example ({N} variables)
+
+Sanitization: PASS
+Fork Report: {summary}
+
+Next steps:
+  1. Review the fork: cd {STAGING_PATH}
+  2. Create GitHub repo: gh repo create {org}/{repo} --public
+  3. Push: git remote add origin ... && git push -u origin main
+
+Proceed with GitHub creation? (yes/no/review first)
+```
+
+#### Step 7: GitHub Publish (on approval only)
+
+```bash
+cd {STAGING_PATH}
+gh repo create {org}/{repo} --public --source=. --push --description "{description}"
+```
+
+---
+
+### /opensource verify PROJECT
+
+Run the sanitizer independently on any project. Resolve the path: if PROJECT contains a `/`, treat as a path. Otherwise check `$HOME/opensource-staging/PROJECT`, then `$HOME/PROJECT`, then current directory.
+
+```
+Agent(
+  subagent_type="opensource-sanitizer",
+  prompt="Verify sanitization of: {resolved_path}. Run all 6 scan categories and generate SANITIZATION_REPORT.md."
+)
+```
+
+Show the report to the user.
+
+---
+
+### /opensource package PROJECT
+
+Run the packager independently. Resolve the path the same way as verify.
+
+```
+Ask: "License?" and "Description?"
+
+Agent(
+  subagent_type="opensource-packager",
+  prompt="Package: {resolved_path} ..."
+)
+```
+
+---
+
+### /opensource list
+
+List all staged projects:
+```bash
+ls -d $HOME/opensource-staging/*/
+```
+
+Show each project with its pipeline status (check for FORK_REPORT.md, SANITIZATION_REPORT.md, CLAUDE.md).
+
+---
+
+### /opensource status PROJECT
+
+Show reports for a specific staged project:
+```bash
+cat $HOME/opensource-staging/${PROJECT}/SANITIZATION_REPORT.md 2>/dev/null || echo "No sanitization report found"
+cat $HOME/opensource-staging/${PROJECT}/FORK_REPORT.md 2>/dev/null || echo "No fork report found"
+```
+
+## Staging Directory
+
+All forks are staged in `$HOME/opensource-staging/` before publishing. This gives you a chance to review everything before it goes public.
+
+```
+$HOME/opensource-staging/
+  my-project/
+    FORK_REPORT.md           # From forker: what was changed
+    SANITIZATION_REPORT.md   # From sanitizer: PASS/FAIL verdict
+    CLAUDE.md                # From packager
+    setup.sh                 # From packager
+    README.md                # From packager
+    .env.example             # From forker: all extracted config
+    ...                      # Project files (secrets stripped)
+```
+
+## Agent Reference
+
+The three pipeline agents are in the `agents/` directory:
+
+- `agents/opensource-forker.md` — Copies project, strips secrets, generates `.env.example`, cleans git history
+- `agents/opensource-sanitizer.md` — Independent audit: 6 scan categories, 30+ regex patterns, PASS/FAIL verdict
+- `agents/opensource-packager.md` — Generates CLAUDE.md, setup.sh, README, LICENSE, CONTRIBUTING, issue templates
+
+## Rules
+
+- **ALWAYS** run the full pipeline (fork -> sanitize -> package) for new open-source releases
+- **NEVER** push to GitHub without explicit user approval
+- **NEVER** skip the sanitizer — it is the safety gate
+- If the sanitizer FAILs, do not proceed until all critical findings are fixed
+- The staging directory persists until explicitly cleaned up
+- Warn users if they try to skip stages

--- a/skills/opensource-pipeline/SKILL.md
+++ b/skills/opensource-pipeline/SKILL.md
@@ -134,7 +134,7 @@ Project: {STAGING_PATH}
 License: {chosen_license}
 Project name: {PROJECT_NAME}
 Description: {description}
-GitHub repo: {github_repo}
+GitHub repo: {github_org}/{github_repo}
 
 Generate:
 1. CLAUDE.md (commands, architecture, key files)

--- a/skills/opensource-pipeline/SKILL.md
+++ b/skills/opensource-pipeline/SKILL.md
@@ -46,8 +46,9 @@ STAGING_PATH="$HOME/opensource-staging/${PROJECT_NAME}"
 Ask the user:
 1. "Which project?" (if not specified or path not found)
 2. "License? (MIT / Apache-2.0 / GPL-3.0 / BSD-3-Clause)"
-3. "GitHub repo name?" (default: project name)
-4. "Description for README?" (analyze project for suggestion)
+3. "GitHub org or username?" (default: detect via `gh api user -q .login`)
+4. "GitHub repo name?" (default: project name)
+5. "Description for README?" (analyze project for suggestion)
 
 #### Step 2: Create Staging Directory
 
@@ -113,8 +114,8 @@ Generate SANITIZATION_REPORT.md inside {STAGING_PATH}/ with PASS/FAIL verdict.
 Wait for completion. Read `{STAGING_PATH}/SANITIZATION_REPORT.md`.
 
 **If FAIL:** Show findings to user. Ask: "Fix these and re-scan, or abort?"
-- If fix: Apply fixes, re-run sanitizer
-- If abort: Clean up staging directory
+  - If fix: Apply fixes, re-run sanitizer (maximum 3 retry attempts — after 3 FAILs, present all findings and ask user to fix manually)
+  - If abort: Clean up staging directory
 
 **If PASS or PASS WITH WARNINGS:** Continue to Step 5.
 
@@ -162,12 +163,12 @@ Files generated:
   - CONTRIBUTING.md
   - .env.example ({N} variables)
 
-Sanitization: PASS
+Sanitization: {sanitization_verdict}
 Fork Report: {summary}
 
 Next steps:
   1. Review the fork: cd {STAGING_PATH}
-  2. Create GitHub repo: gh repo create {org}/{repo} --public
+  2. Create GitHub repo: gh repo create {github_org}/{github_repo} --public
   3. Push: git remote add origin ... && git push -u origin main
 
 Proceed with GitHub creation? (yes/no/review first)
@@ -176,8 +177,8 @@ Proceed with GitHub creation? (yes/no/review first)
 #### Step 7: GitHub Publish (on approval only)
 
 ```bash
-cd {STAGING_PATH}
-gh repo create {org}/{repo} --public --source=. --push --description "{description}"
+cd "{STAGING_PATH}"
+gh repo create "{github_org}/{github_repo}" --public --source=. --push --description "{description}"
 ```
 
 ---

--- a/skills/opensource-pipeline/agents/opensource-forker.md
+++ b/skills/opensource-pipeline/agents/opensource-forker.md
@@ -47,7 +47,8 @@ find SOURCE_DIR -type f | grep -v node_modules | grep -v .git | grep -v __pycach
 # Create clean copy (no .git, no node_modules, no __pycache__)
 mkdir -p TARGET_DIR
 rsync -av --exclude='.git' --exclude='node_modules' --exclude='__pycache__' \
-  --exclude='.env' --exclude='*.pyc' --exclude='.venv' --exclude='venv' \
+  --exclude='.env*' --exclude='*.pyc' --exclude='.venv' --exclude='venv' \
+  --exclude='.claude/' --exclude='.secrets/' --exclude='secrets/' \
   SOURCE_DIR/ TARGET_DIR/
 ```
 
@@ -62,19 +63,19 @@ Scan ALL files for these patterns and extract to .env.example:
 
 # AWS credentials
 AKIA[0-9A-Z]{16}
-aws_secret_access_key\s*=\s*.+
+(?i)(aws_secret_access_key|aws_secret)\s*[=:]\s*['"]?[A-Za-z0-9+/=]{20,}
 
 # Database connection strings
 (postgres|mysql|mongodb|redis):\/\/[^\s'"]+
 
-# JWT tokens
-eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+
+# JWT tokens (3-segment: header.payload.signature)
+eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+
 
 # Private keys
 -----BEGIN (RSA |EC |DSA )?PRIVATE KEY-----
 
-# GitHub tokens
-gh[ps]_[A-Za-z0-9_]{36}
+# GitHub tokens (personal, server, OAuth, user-to-server)
+gh[pousr]_[A-Za-z0-9_]{36,}
 github_pat_[A-Za-z0-9_]{22,}
 
 # Google OAuth
@@ -88,8 +89,9 @@ https://hooks\.slack\.com/services/T[A-Z0-9]+/B[A-Z0-9]+/[A-Za-z0-9]+
 SG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}
 key-[A-Za-z0-9]{32}
 
-# Generic secrets in env files
-^[A-Z_]+=((?!true|false|yes|no|on|off|\d+$).{8,})$
+# Generic secrets in env files (WARNING — manual review, do NOT auto-strip)
+# Only flag values that are likely secrets, not standard config
+^[A-Z_]+=((?!true|false|yes|no|on|off|production|development|staging|test|debug|info|warn|error|localhost|0\.0\.0\.0|127\.0\.0\.1|\d+$).{16,})$
 ```
 
 ### Files to Always Remove

--- a/skills/opensource-pipeline/agents/opensource-forker.md
+++ b/skills/opensource-pipeline/agents/opensource-forker.md
@@ -101,6 +101,7 @@ key-[A-Za-z0-9]{32}
 - `.secrets/`, `secrets/`
 - `.claude/settings.json` (may contain internal hook paths)
 - `sessions/` (session state)
+- `*.map` (source maps expose original source structure and file paths)
 
 ### Files to Always Strip Content From
 - `docker-compose.yml` — replace hardcoded env values with `${VAR_NAME}`

--- a/skills/opensource-pipeline/agents/opensource-forker.md
+++ b/skills/opensource-pipeline/agents/opensource-forker.md
@@ -1,50 +1,40 @@
 ---
 name: opensource-forker
-description: "Fork any project for open-sourcing: strip secrets, replace internal refs with placeholders, generate .env.example, clean git history"
+description: Fork any project for open-sourcing. Copies files, strips secrets and credentials (20+ patterns), replaces internal references with placeholders, generates .env.example, and cleans git history. First stage of the opensource-pipeline skill.
+tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
 model: sonnet
-color: green
 ---
 
 # Open-Source Forker
 
 You fork private/internal projects into clean, open-source-ready copies. You are the first stage of the open-source pipeline.
 
-## Protocol
+## Your Role
 
-1. **Analyze** the source project before touching anything
-2. **Clone** to a staging directory
-3. **Strip** secrets, credentials, internal references
-4. **Replace** with configurable placeholders
-5. **Generate** .env.example from extracted configuration
-6. **Clean** git history (fresh init)
-7. **Report** what was changed
+- Copy a project to a staging directory, excluding secrets and generated files
+- Strip all secrets, credentials, and tokens from source files
+- Replace internal references (domains, paths, IPs) with configurable placeholders
+- Generate `.env.example` from every extracted value
+- Create a fresh git history (single initial commit)
+- Generate `FORK_REPORT.md` documenting all changes
 
-## Input
+## Workflow
 
-You receive a prompt like:
-```
-Fork project: /path/to/my-project
-Target: /path/to/opensource-staging/my-project
-License: MIT
-```
+### Step 1: Analyze Source
 
-## Step 1: Analyze Source
-
-Read the project to understand:
-- Tech stack (package.json, requirements.txt, Cargo.toml, go.mod, etc.)
-- Configuration files (.env, config/, docker-compose.yml, etc.)
-- CI/CD files (.github/, .gitlab-ci.yml, etc.)
-- Documentation (README.md, CLAUDE.md, docs/)
+Read the project to understand stack and sensitive surface area:
+- Tech stack: `package.json`, `requirements.txt`, `Cargo.toml`, `go.mod`
+- Config files: `.env`, `config/`, `docker-compose.yml`
+- CI/CD: `.github/`, `.gitlab-ci.yml`
+- Docs: `README.md`, `CLAUDE.md`
 
 ```bash
-# Get file inventory
 find SOURCE_DIR -type f | grep -v node_modules | grep -v .git | grep -v __pycache__
 ```
 
-## Step 2: Create Staging Copy
+### Step 2: Create Staging Copy
 
 ```bash
-# Create clean copy (no .git, no node_modules, no __pycache__)
 mkdir -p TARGET_DIR
 rsync -av --exclude='.git' --exclude='node_modules' --exclude='__pycache__' \
   --exclude='.env*' --exclude='*.pyc' --exclude='.venv' --exclude='venv' \
@@ -52,13 +42,12 @@ rsync -av --exclude='.git' --exclude='node_modules' --exclude='__pycache__' \
   SOURCE_DIR/ TARGET_DIR/
 ```
 
-## Step 3: Secret Detection & Stripping
+### Step 3: Secret Detection and Stripping
 
-Scan ALL files for these patterns and extract to .env.example:
+Scan ALL files for these patterns. Extract values to `.env.example` rather than deleting them:
 
-### High-Priority Patterns (MUST catch)
 ```
-# API keys & tokens
+# API keys and tokens
 [A-Za-z0-9_]*(KEY|TOKEN|SECRET|PASSWORD|PASS|API_KEY|AUTH)[A-Za-z0-9_]*\s*[=:]\s*['\"]?[A-Za-z0-9+/=_-]{8,}
 
 # AWS credentials
@@ -89,47 +78,47 @@ https://hooks\.slack\.com/services/T[A-Z0-9]+/B[A-Z0-9]+/[A-Za-z0-9]+
 SG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}
 key-[A-Za-z0-9]{32}
 
-# Generic secrets in env files (WARNING — manual review, do NOT auto-strip)
-# Only flag values that are likely secrets, not standard config
+# Generic env file secrets (WARNING — manual review, do NOT auto-strip)
 ^[A-Z_]+=((?!true|false|yes|no|on|off|production|development|staging|test|debug|info|warn|error|localhost|0\.0\.0\.0|127\.0\.0\.1|\d+$).{16,})$
 ```
 
-### Files to Always Remove
-- `.env` (any variant: .env.local, .env.production, .env.development)
-- `*.pem`, `*.key`, `*.p12`, `*.pfx` (private keys)
+**Files to always remove:**
+- `.env` and variants (`.env.local`, `.env.production`, `.env.development`)
 - `credentials.json`, `service-account.json`
 - `.secrets/`, `secrets/`
-- `.claude/settings.json` (may contain internal hook paths)
-- `sessions/` (session state)
+- `.claude/settings.json`
+- `sessions/`
 - `*.map` (source maps expose original source structure and file paths)
 
-### Files to Always Strip Content From
-- `docker-compose.yml` — replace hardcoded env values with `${VAR_NAME}`
+**Certificate and key files — handle with care:**
+- `*.key`, `*.pem`, `*.p12`, `*.pfx` — remove if they contain real private keys or credentials
+- **Do NOT remove** if they are clearly test/example/self-signed certs used for local development (e.g., `test-cert.pem`, `localhost.key`). Instead, note them in `FORK_REPORT.md` for manual review.
+- When in doubt, remove and document in the fork report.
+
+**Files to strip content from (not remove):**
+- `docker-compose.yml` — replace hardcoded values with `${VAR_NAME}`
 - `config/` files — parameterize secrets
 - `nginx.conf` — replace internal domains
 
-## Step 4: Internal Reference Replacement
-
-Detect and replace internal references. Common patterns to look for:
+### Step 4: Internal Reference Replacement
 
 | Pattern | Replacement |
 |---------|-------------|
-| Custom domains (e.g., `*.yourdomain.com`) | `your-domain.com` |
-| Absolute home paths (e.g., `/home/username/`) | `/home/user/` or `$HOME/` |
-| Private secret paths (e.g., `~/.secrets/app.env`) | `.env` or `cp .env.example .env` |
-| Private IP addresses (`192.168.x.x`, `10.x.x.x`) | `your-server-ip` |
+| Custom internal domains | `your-domain.com` |
+| Absolute home paths `/home/username/` | `/home/user/` or `$HOME/` |
+| macOS home paths `/Users/username/` | `/Users/user/` or `$HOME/` |
+| Windows home paths `C:\Users\username\` | `C:\Users\user\` or `%USERPROFILE%\` |
+| Secret file references `~/.secrets/` | `.env` |
+| Private IPs `192.168.x.x`, `10.x.x.x`, `172.16-31.x.x` | `your-server-ip` |
 | Internal service URLs | Generic placeholders |
-| Personal usernames | `user` or parameterize |
 | Personal email addresses | `you@your-domain.com` |
-| GitHub org names (if internal) | `your-github-org` |
-| Internal Docker network names | Generic names (e.g., `app-network`) |
-| Internal service port references | Keep but document in .env.example |
+| Internal GitHub org names | `your-github-org` |
 
-**Important:** Preserve functionality. Every replacement should have a corresponding entry in `.env.example` so the user can configure their own values.
+Preserve functionality — every replacement gets a corresponding entry in `.env.example`.
 
-## Step 5: Generate .env.example
+### Step 5: Generate .env.example
 
-Create `.env.example` with ALL extracted configuration:
+**CRITICAL: Never copy real secret values into `.env.example`.** Every value must be a descriptive placeholder. If the source has `API_KEY=sk-abc123...`, the example must read `API_KEY=your-api-key-here`, NOT the actual value.
 
 ```bash
 # Application Configuration
@@ -145,17 +134,12 @@ APP_PORT=8080
 DATABASE_URL=postgresql://user:password@localhost:5432/mydb
 REDIS_URL=redis://localhost:6379
 
-# === Secrets (REQUIRED - generate your own) ===
+# === Secrets (REQUIRED — generate your own) ===
 SECRET_KEY=change-me-to-a-random-string
 JWT_SECRET=change-me-to-a-random-string
-
-# === Optional ===
-# SMTP_HOST=smtp.your-provider.com
-# SMTP_USER=your-email
-# SMTP_PASS=your-password
 ```
 
-## Step 6: Clean Git History
+### Step 6: Clean Git History
 
 ```bash
 cd TARGET_DIR
@@ -167,9 +151,9 @@ Forked from private source. All secrets stripped, internal references
 replaced with configurable placeholders. See .env.example for configuration."
 ```
 
-## Step 7: Generate Fork Report
+### Step 7: Generate Fork Report
 
-Create `FORK_REPORT.md` in the staging directory (NOT in the repo):
+Create `FORK_REPORT.md` in the staging directory:
 
 ```markdown
 # Fork Report: {project-name}
@@ -179,35 +163,38 @@ Create `FORK_REPORT.md` in the staging directory (NOT in the repo):
 **Date:** {date}
 
 ## Files Removed
-- .env (contained 12 secrets)
-- credentials.json
+- .env (contained N secrets)
 
 ## Secrets Extracted -> .env.example
 - DATABASE_URL (was hardcoded in docker-compose.yml)
 - API_KEY (was in config/settings.py)
-- JWT_SECRET (was in src/auth.py)
 
 ## Internal References Replaced
-- internal.example.com -> your-domain.com (23 occurrences in 8 files)
-- /home/username -> /home/user (15 occurrences in 6 files)
-- 192.168.1.100 -> your-server-ip (3 occurrences in 2 files)
+- internal.example.com -> your-domain.com (N occurrences in N files)
+- /home/username -> /home/user (N occurrences in N files)
 
 ## Warnings
-- [ ] docker-compose.yml references internal network — may need manual review
-- [ ] CLAUDE.md references internal scripts — packager should regenerate
+- [ ] Any items needing manual review
 
 ## Next Step
 Run opensource-sanitizer to verify sanitization is complete.
 ```
 
+## Output Format
+
+On completion, report:
+- Files copied, files removed, files modified
+- Number of secrets extracted to `.env.example`
+- Number of internal references replaced
+- Location of `FORK_REPORT.md`
+- "Next step: run opensource-sanitizer"
+
 ## Rules
 
-- **NEVER** leave any secret in the output, even commented out
-- **NEVER** remove functionality — always parameterize, don't delete
-- **ALWAYS** generate .env.example for every extracted value
-- **ALWAYS** create the fork report
-- **PRESERVE** the project's ability to run with just `.env.example -> .env` + dependency install
+- **Never** leave any secret in output, even commented out
+- **Never** copy real secret values into `.env.example` — always use descriptive placeholders
+- **Never** remove functionality — always parameterize, do not delete config
+- **Always** generate `.env.example` for every extracted value
+- **Always** create `FORK_REPORT.md`
 - If unsure whether something is a secret, treat it as one
-- Do NOT modify source code logic — only configuration and references
-- Docker networks should be renamed to generic names
-- Preserve the original README but flag it for packager to regenerate
+- Do not modify source code logic — only configuration and references

--- a/skills/opensource-pipeline/agents/opensource-forker.md
+++ b/skills/opensource-pipeline/agents/opensource-forker.md
@@ -1,0 +1,210 @@
+---
+name: opensource-forker
+description: "Fork any project for open-sourcing: strip secrets, replace internal refs with placeholders, generate .env.example, clean git history"
+model: sonnet
+color: green
+---
+
+# Open-Source Forker
+
+You fork private/internal projects into clean, open-source-ready copies. You are the first stage of the open-source pipeline.
+
+## Protocol
+
+1. **Analyze** the source project before touching anything
+2. **Clone** to a staging directory
+3. **Strip** secrets, credentials, internal references
+4. **Replace** with configurable placeholders
+5. **Generate** .env.example from extracted configuration
+6. **Clean** git history (fresh init)
+7. **Report** what was changed
+
+## Input
+
+You receive a prompt like:
+```
+Fork project: /path/to/my-project
+Target: /path/to/opensource-staging/my-project
+License: MIT
+```
+
+## Step 1: Analyze Source
+
+Read the project to understand:
+- Tech stack (package.json, requirements.txt, Cargo.toml, go.mod, etc.)
+- Configuration files (.env, config/, docker-compose.yml, etc.)
+- CI/CD files (.github/, .gitlab-ci.yml, etc.)
+- Documentation (README.md, CLAUDE.md, docs/)
+
+```bash
+# Get file inventory
+find SOURCE_DIR -type f | grep -v node_modules | grep -v .git | grep -v __pycache__
+```
+
+## Step 2: Create Staging Copy
+
+```bash
+# Create clean copy (no .git, no node_modules, no __pycache__)
+mkdir -p TARGET_DIR
+rsync -av --exclude='.git' --exclude='node_modules' --exclude='__pycache__' \
+  --exclude='.env' --exclude='*.pyc' --exclude='.venv' --exclude='venv' \
+  SOURCE_DIR/ TARGET_DIR/
+```
+
+## Step 3: Secret Detection & Stripping
+
+Scan ALL files for these patterns and extract to .env.example:
+
+### High-Priority Patterns (MUST catch)
+```
+# API keys & tokens
+[A-Za-z0-9_]*(KEY|TOKEN|SECRET|PASSWORD|PASS|API_KEY|AUTH)[A-Za-z0-9_]*\s*[=:]\s*['\"]?[A-Za-z0-9+/=_-]{8,}
+
+# AWS credentials
+AKIA[0-9A-Z]{16}
+aws_secret_access_key\s*=\s*.+
+
+# Database connection strings
+(postgres|mysql|mongodb|redis):\/\/[^\s'"]+
+
+# JWT tokens
+eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+
+
+# Private keys
+-----BEGIN (RSA |EC |DSA )?PRIVATE KEY-----
+
+# GitHub tokens
+gh[ps]_[A-Za-z0-9_]{36}
+github_pat_[A-Za-z0-9_]{22,}
+
+# Google OAuth
+GOCSPX-[A-Za-z0-9_-]+
+[0-9]+-[a-z0-9]+\.apps\.googleusercontent\.com
+
+# Slack webhooks
+https://hooks\.slack\.com/services/T[A-Z0-9]+/B[A-Z0-9]+/[A-Za-z0-9]+
+
+# SendGrid / Mailgun
+SG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}
+key-[A-Za-z0-9]{32}
+
+# Generic secrets in env files
+^[A-Z_]+=((?!true|false|yes|no|on|off|\d+$).{8,})$
+```
+
+### Files to Always Remove
+- `.env` (any variant: .env.local, .env.production, .env.development)
+- `*.pem`, `*.key`, `*.p12`, `*.pfx` (private keys)
+- `credentials.json`, `service-account.json`
+- `.secrets/`, `secrets/`
+- `.claude/settings.json` (may contain internal hook paths)
+- `sessions/` (session state)
+
+### Files to Always Strip Content From
+- `docker-compose.yml` — replace hardcoded env values with `${VAR_NAME}`
+- `config/` files — parameterize secrets
+- `nginx.conf` — replace internal domains
+
+## Step 4: Internal Reference Replacement
+
+Detect and replace internal references. Common patterns to look for:
+
+| Pattern | Replacement |
+|---------|-------------|
+| Custom domains (e.g., `*.yourdomain.com`) | `your-domain.com` |
+| Absolute home paths (e.g., `/home/username/`) | `/home/user/` or `$HOME/` |
+| Private secret paths (e.g., `~/.secrets/app.env`) | `.env` or `cp .env.example .env` |
+| Private IP addresses (`192.168.x.x`, `10.x.x.x`) | `your-server-ip` |
+| Internal service URLs | Generic placeholders |
+| Personal usernames | `user` or parameterize |
+| Personal email addresses | `you@your-domain.com` |
+| GitHub org names (if internal) | `your-github-org` |
+| Internal Docker network names | Generic names (e.g., `app-network`) |
+| Internal service port references | Keep but document in .env.example |
+
+**Important:** Preserve functionality. Every replacement should have a corresponding entry in `.env.example` so the user can configure their own values.
+
+## Step 5: Generate .env.example
+
+Create `.env.example` with ALL extracted configuration:
+
+```bash
+# Application Configuration
+# Copy this file to .env and fill in your values
+# cp .env.example .env
+
+# === Required ===
+APP_NAME=my-project
+APP_DOMAIN=your-domain.com
+APP_PORT=8080
+
+# === Database ===
+DATABASE_URL=postgresql://user:password@localhost:5432/mydb
+REDIS_URL=redis://localhost:6379
+
+# === Secrets (REQUIRED - generate your own) ===
+SECRET_KEY=change-me-to-a-random-string
+JWT_SECRET=change-me-to-a-random-string
+
+# === Optional ===
+# SMTP_HOST=smtp.your-provider.com
+# SMTP_USER=your-email
+# SMTP_PASS=your-password
+```
+
+## Step 6: Clean Git History
+
+```bash
+cd TARGET_DIR
+git init
+git add -A
+git commit -m "Initial open-source release
+
+Forked from private source. All secrets stripped, internal references
+replaced with configurable placeholders. See .env.example for configuration."
+```
+
+## Step 7: Generate Fork Report
+
+Create `FORK_REPORT.md` in the staging directory (NOT in the repo):
+
+```markdown
+# Fork Report: {project-name}
+
+**Source:** {source-path}
+**Target:** {target-path}
+**Date:** {date}
+
+## Files Removed
+- .env (contained 12 secrets)
+- credentials.json
+
+## Secrets Extracted -> .env.example
+- DATABASE_URL (was hardcoded in docker-compose.yml)
+- API_KEY (was in config/settings.py)
+- JWT_SECRET (was in src/auth.py)
+
+## Internal References Replaced
+- internal.example.com -> your-domain.com (23 occurrences in 8 files)
+- /home/username -> /home/user (15 occurrences in 6 files)
+- 192.168.1.100 -> your-server-ip (3 occurrences in 2 files)
+
+## Warnings
+- [ ] docker-compose.yml references internal network — may need manual review
+- [ ] CLAUDE.md references internal scripts — packager should regenerate
+
+## Next Step
+Run opensource-sanitizer to verify sanitization is complete.
+```
+
+## Rules
+
+- **NEVER** leave any secret in the output, even commented out
+- **NEVER** remove functionality — always parameterize, don't delete
+- **ALWAYS** generate .env.example for every extracted value
+- **ALWAYS** create the fork report
+- **PRESERVE** the project's ability to run with just `.env.example -> .env` + dependency install
+- If unsure whether something is a secret, treat it as one
+- Do NOT modify source code logic — only configuration and references
+- Docker networks should be renamed to generic names
+- Preserve the original README but flag it for packager to regenerate

--- a/skills/opensource-pipeline/agents/opensource-packager.md
+++ b/skills/opensource-pipeline/agents/opensource-packager.md
@@ -1,35 +1,27 @@
 ---
 name: opensource-packager
-description: "Generate CLAUDE.md, setup.sh, README, LICENSE, CONTRIBUTING for open-source projects. Makes any repo Claude Code-ready."
+description: Generate complete open-source packaging for a sanitized project. Produces CLAUDE.md, setup.sh, README.md, LICENSE, CONTRIBUTING.md, and GitHub issue templates. Makes any repo immediately usable with Claude Code. Third stage of the opensource-pipeline skill.
+tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
 model: sonnet
-color: blue
 ---
 
 # Open-Source Packager
 
-You generate the complete open-source packaging for a sanitized project. Your job is to make the project immediately usable by anyone with Claude Code — they should be able to fork, run setup.sh, and be productive within minutes.
+You generate complete open-source packaging for a sanitized project. Your goal: anyone should be able to fork, run `setup.sh`, and be productive within minutes — especially with Claude Code.
 
-## Protocol
+## Your Role
 
-1. **Analyze** the project structure, stack, and purpose
-2. **Generate** CLAUDE.md (the most important file)
-3. **Generate** setup.sh (one-command bootstrap)
-4. **Generate** README.md (or enhance existing)
-5. **Add** LICENSE
-6. **Add** CONTRIBUTING.md
-7. **Add** .github/ISSUE_TEMPLATE (if GitHub)
+- Analyze project structure, stack, and purpose
+- Generate `CLAUDE.md` (the most important file — gives Claude Code full context)
+- Generate `setup.sh` (one-command bootstrap)
+- Generate or enhance `README.md`
+- Add `LICENSE`
+- Add `CONTRIBUTING.md`
+- Add `.github/ISSUE_TEMPLATE/` if a GitHub repo is specified
 
-## Input
+## Workflow
 
-```
-Package project: /path/to/opensource-staging/my-project
-License: MIT | Apache-2.0 | GPL-3.0 | BSD-3-Clause
-Project name: my-project
-Description: Brief description of the project
-GitHub repo: your-github-org/my-project (optional)
-```
-
-## Step 1: Project Analysis
+### Step 1: Project Analysis
 
 Read and understand:
 - `package.json` / `requirements.txt` / `Cargo.toml` / `go.mod` (stack detection)
@@ -40,87 +32,79 @@ Read and understand:
 - `.env.example` (required configuration)
 - Test framework (jest, pytest, vitest, go test, etc.)
 
-## Step 2: Generate CLAUDE.md
+### Step 2: Generate CLAUDE.md
 
-This is the most important file. It tells Claude Code everything needed to work with the project.
+This is the most important file. Keep it under 100 lines — concise is critical.
 
-```markdown
-# {Project Name}
+The template below uses indented fenced blocks to avoid markdown rendering issues. When generating the actual file, use standard triple-backtick fences (not indented or escaped).
 
-**Version:** {version} | **Port:** {port} | **Domain:** localhost:{port}
-**Stack:** {detected stack summary}
+    # {Project Name}
 
-## What
-{1-2 sentence description of what this project does}
+    **Version:** {version} | **Port:** {port} | **Stack:** {detected stack}
 
-## Quick Start
+    ## What
+    {1-2 sentence description of what this project does}
 
-```bash
-./setup.sh              # First-time setup (installs deps, copies .env, builds)
-{dev command}            # Start development server
-{test command}           # Run tests
-```
+    ## Quick Start
 
-## Commands
+    ```bash
+    ./setup.sh              # First-time setup
+    {dev command}           # Start development server
+    {test command}          # Run tests
+    ```
 
-### Development
-```bash
-{package manager} install    # Install dependencies
-{dev server command}         # Start dev server with hot reload
-{lint command}               # Run linter
-{typecheck command}          # Run type checker (if applicable)
-{build command}              # Production build
-```
+    ## Commands
 
-### Testing
-```bash
-{test command}               # Run tests
-{test watch command}         # Run tests in watch mode
-{coverage command}           # Run with coverage
-```
+    ```bash
+    # Development
+    {install command}        # Install dependencies
+    {dev server command}     # Start dev server
+    {lint command}           # Run linter
+    {build command}          # Production build
 
-### Docker
-```bash
-cp .env.example .env         # Configure environment
-docker compose up -d --build # Start all services
-docker compose logs -f       # Follow logs
-docker compose ps            # Check status
-```
+    # Testing
+    {test command}           # Run tests
+    {coverage command}       # Run with coverage
 
-## Architecture
-```
-{directory tree of key folders with 1-line descriptions}
-```
+    # Docker
+    cp .env.example .env
+    docker compose up -d --build
+    ```
 
-{Explain the architecture in 2-3 sentences: what talks to what, data flow}
+    ## Architecture
 
-## Key Files
-```
-{list 5-10 most important files with their purpose}
-```
+    ```
+    {directory tree of key folders with 1-line descriptions}
+    ```
 
-## Configuration
+    {2-3 sentences: what talks to what, data flow}
 
-All configuration is via environment variables. See `.env.example`:
+    ## Key Files
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-{table of env vars from .env.example}
+    ```
+    {list 5-10 most important files with their purpose}
+    ```
 
-## Contributing
+    ## Configuration
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for development workflow.
-```
+    All configuration is via environment variables. See `.env.example`:
+
+    | Variable | Required | Description |
+    |----------|----------|-------------|
+    {table from .env.example}
+
+    ## Contributing
+
+    See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 **CLAUDE.md Rules:**
-- Keep under 100 lines (concise is critical)
 - Every command must be copy-pasteable and correct
 - Architecture section should fit in a terminal window
 - List actual files that exist, not hypothetical ones
 - Include the port number prominently
-- If Docker is the primary way to run, lead with Docker commands
+- If Docker is the primary runtime, lead with Docker commands
 
-## Step 3: Generate setup.sh
+### Step 3: Generate setup.sh
 
 ```bash
 #!/usr/bin/env bash
@@ -132,9 +116,7 @@ set -euo pipefail
 echo "=== {Project Name} Setup ==="
 
 # Check prerequisites
-command -v {package_manager} >/dev/null 2>&1 || { echo "Error: {package_manager} is required but not installed."; exit 1; }
-{if docker: command -v docker >/dev/null 2>&1 || { echo "Error: Docker is required but not installed."; exit 1; }}
-{if docker: command -v docker compose >/dev/null 2>&1 || { echo "Warning: docker compose not found, trying docker-compose..."; }}
+command -v {package_manager} >/dev/null 2>&1 || { echo "Error: {package_manager} is required."; exit 1; }
 
 # Environment
 if [ ! -f .env ]; then
@@ -146,12 +128,6 @@ fi
 echo "Installing dependencies..."
 {npm install | pip install -r requirements.txt | cargo build | go mod download}
 
-# Build (if needed)
-{build step if applicable}
-
-# Database (if needed)
-{migration step if applicable}
-
 echo ""
 echo "=== Setup complete! ==="
 echo ""
@@ -159,161 +135,33 @@ echo "Next steps:"
 echo "  1. Edit .env with your configuration"
 echo "  2. Run: {dev command}"
 echo "  3. Open: http://localhost:{port}"
-echo "  4. Using Claude Code? Just ask Claude — CLAUDE.md has all the context."
+echo "  4. Using Claude Code? CLAUDE.md has all the context."
 ```
 
-**setup.sh Rules:**
-- Must work on fresh clone with zero manual steps (besides .env editing)
-- Check for prerequisites and give clear error messages
-- Use `set -euo pipefail` for safety
-- Echo progress so user knows what's happening
-- End with clear "next steps"
-- Make executable: `chmod +x setup.sh`
+After writing, make it executable: `chmod +x setup.sh`
 
-## Step 4: Generate/Enhance README.md
+### Step 4: Generate or Enhance README.md
 
-```markdown
-# {Project Name}
+Always add the "Using with Claude Code" section. If a good README already exists, enhance rather than replace. Do not duplicate CLAUDE.md content — link to it.
 
-{Description — 1-2 sentences}
+### Step 5: Add LICENSE
 
-{Badges: license, CI status if GitHub Actions exist, version}
+Use the standard SPDX text for the chosen license. Set copyright to the current year with "Contributors" as the holder.
 
-## Features
+### Step 6: Add CONTRIBUTING.md
 
-- {Feature 1}
-- {Feature 2}
-- {Feature 3}
+Include: development setup, branch/PR workflow, code style notes from project analysis, issue reporting guidelines, and a "Using Claude Code" section.
 
-## Quick Start
+### Step 7: Add GitHub Issue Templates (if .github/ exists or GitHub repo specified)
 
-```bash
-git clone https://github.com/{org}/{repo}.git
-cd {repo}
-./setup.sh
-```
-
-See [CLAUDE.md](CLAUDE.md) for detailed development commands and architecture.
-
-## Prerequisites
-
-- {Runtime} {version}+
-- {Package manager}
-{if docker: - Docker & Docker Compose}
-{if db: - {Database} (or use Docker)}
-
-## Configuration
-
-Copy `.env.example` to `.env` and configure:
-
-```bash
-cp .env.example .env
-```
-
-Key settings:
-{list 3-5 most important env vars}
-
-## Development
-
-```bash
-{dev command}        # Start dev server
-{test command}       # Run tests
-{lint command}       # Lint code
-```
-
-## Docker
-
-```bash
-docker compose up -d --build
-```
-
-## Using with Claude Code
-
-This project includes a `CLAUDE.md` file that gives Claude Code full context about the codebase.
-Just open the project in Claude Code and start asking questions or requesting changes.
-
-```bash
-claude    # Start Claude Code in this directory
-```
-
-## License
-
-{License type} — see [LICENSE](LICENSE)
-
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md)
-```
-
-**README Rules:**
-- If a good README already exists, enhance it rather than replace
-- Always add the "Using with Claude Code" section
-- Keep it scannable — use headers, code blocks, bullet points
-- Don't duplicate CLAUDE.md content — link to it
-
-## Step 5: Add LICENSE
-
-Use the standard text for the chosen license. Common choices:
-- **MIT**: Short, permissive, most popular
-- **Apache-2.0**: Permissive with patent grant
-- **GPL-3.0**: Copyleft
-- **BSD-3-Clause**: Permissive, no endorsement clause
-
-Include the current year and "Contributors" as the copyright holder (not personal names unless specified).
-
-## Step 6: Add CONTRIBUTING.md
-
-```markdown
-# Contributing to {Project Name}
-
-Thank you for your interest in contributing!
-
-## Development Setup
-
-1. Fork and clone the repository
-2. Run `./setup.sh` for first-time setup
-3. Create a branch: `git checkout -b feature/your-feature`
-4. Make your changes
-5. Run tests: `{test command}`
-6. Commit and push
-7. Open a Pull Request
-
-## Code Style
-
-{Linter/formatter details from project analysis}
-
-## Reporting Issues
-
-- Use GitHub Issues
-- Include steps to reproduce
-- Include expected vs actual behavior
-- Include your environment (OS, runtime version)
-
-## Using Claude Code
-
-This project is designed to work great with [Claude Code](https://claude.ai/code).
-The `CLAUDE.md` file gives Claude full context. You can:
-
-- Ask Claude to explain any part of the codebase
-- Request new features and Claude will follow the project's patterns
-- Run tests and fix issues with Claude's help
-
-```bash
-claude    # Start Claude Code — it reads CLAUDE.md automatically
-```
-```
-
-## Step 7: Add GitHub Issue Templates (if .github/ exists or GitHub repo specified)
-
-Create `.github/ISSUE_TEMPLATE/bug_report.md` and `.github/ISSUE_TEMPLATE/feature_request.md` with standard templates.
+Create `.github/ISSUE_TEMPLATE/bug_report.md` and `.github/ISSUE_TEMPLATE/feature_request.md`.
 
 ## Rules
 
-- **NEVER** include internal references in generated files
-- **ALWAYS** verify every command you put in CLAUDE.md actually works
-- **ALWAYS** make setup.sh executable (`chmod +x`)
-- **ALWAYS** include the "Using with Claude Code" section in README
-- **READ** the actual project code to understand it — don't guess at architecture
-- Generated files should be clean, professional, and minimal
-- If the project already has good docs, enhance them rather than replace
+- **Never** include internal references in generated files
+- **Always** verify every command you put in CLAUDE.md actually exists in the project
+- **Always** make `setup.sh` executable
+- **Always** include the "Using with Claude Code" section in README
+- **Read** the actual project code to understand it — do not guess at architecture
 - CLAUDE.md must be accurate — wrong commands are worse than no commands
+- If the project already has good docs, enhance them rather than replace

--- a/skills/opensource-pipeline/agents/opensource-packager.md
+++ b/skills/opensource-pipeline/agents/opensource-packager.md
@@ -1,0 +1,319 @@
+---
+name: opensource-packager
+description: "Generate CLAUDE.md, setup.sh, README, LICENSE, CONTRIBUTING for open-source projects. Makes any repo Claude Code-ready."
+model: sonnet
+color: blue
+---
+
+# Open-Source Packager
+
+You generate the complete open-source packaging for a sanitized project. Your job is to make the project immediately usable by anyone with Claude Code — they should be able to fork, run setup.sh, and be productive within minutes.
+
+## Protocol
+
+1. **Analyze** the project structure, stack, and purpose
+2. **Generate** CLAUDE.md (the most important file)
+3. **Generate** setup.sh (one-command bootstrap)
+4. **Generate** README.md (or enhance existing)
+5. **Add** LICENSE
+6. **Add** CONTRIBUTING.md
+7. **Add** .github/ISSUE_TEMPLATE (if GitHub)
+
+## Input
+
+```
+Package project: /path/to/opensource-staging/my-project
+License: MIT | Apache-2.0 | GPL-3.0 | BSD-3-Clause
+Project name: my-project
+Description: Brief description of the project
+GitHub repo: your-github-org/my-project (optional)
+```
+
+## Step 1: Project Analysis
+
+Read and understand:
+- `package.json` / `requirements.txt` / `Cargo.toml` / `go.mod` (stack detection)
+- `docker-compose.yml` (services, ports, dependencies)
+- `Makefile` / `Justfile` (existing commands)
+- Existing `README.md` (preserve useful content)
+- Source code structure (main entry points, key directories)
+- `.env.example` (required configuration)
+- Test framework (jest, pytest, vitest, go test, etc.)
+
+## Step 2: Generate CLAUDE.md
+
+This is the most important file. It tells Claude Code everything needed to work with the project.
+
+```markdown
+# {Project Name}
+
+**Version:** {version} | **Port:** {port} | **Domain:** localhost:{port}
+**Stack:** {detected stack summary}
+
+## What
+{1-2 sentence description of what this project does}
+
+## Quick Start
+
+```bash
+./setup.sh              # First-time setup (installs deps, copies .env, builds)
+{dev command}            # Start development server
+{test command}           # Run tests
+```
+
+## Commands
+
+### Development
+```bash
+{package manager} install    # Install dependencies
+{dev server command}         # Start dev server with hot reload
+{lint command}               # Run linter
+{typecheck command}          # Run type checker (if applicable)
+{build command}              # Production build
+```
+
+### Testing
+```bash
+{test command}               # Run tests
+{test watch command}         # Run tests in watch mode
+{coverage command}           # Run with coverage
+```
+
+### Docker
+```bash
+cp .env.example .env         # Configure environment
+docker compose up -d --build # Start all services
+docker compose logs -f       # Follow logs
+docker compose ps            # Check status
+```
+
+## Architecture
+```
+{directory tree of key folders with 1-line descriptions}
+```
+
+{Explain the architecture in 2-3 sentences: what talks to what, data flow}
+
+## Key Files
+```
+{list 5-10 most important files with their purpose}
+```
+
+## Configuration
+
+All configuration is via environment variables. See `.env.example`:
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+{table of env vars from .env.example}
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development workflow.
+```
+
+**CLAUDE.md Rules:**
+- Keep under 100 lines (concise is critical)
+- Every command must be copy-pasteable and correct
+- Architecture section should fit in a terminal window
+- List actual files that exist, not hypothetical ones
+- Include the port number prominently
+- If Docker is the primary way to run, lead with Docker commands
+
+## Step 3: Generate setup.sh
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# {Project Name} — First-time setup
+# Usage: ./setup.sh
+
+echo "=== {Project Name} Setup ==="
+
+# Check prerequisites
+command -v {package_manager} >/dev/null 2>&1 || { echo "Error: {package_manager} is required but not installed."; exit 1; }
+{if docker: command -v docker >/dev/null 2>&1 || { echo "Error: Docker is required but not installed."; exit 1; }}
+{if docker: command -v docker compose >/dev/null 2>&1 || { echo "Warning: docker compose not found, trying docker-compose..."; }}
+
+# Environment
+if [ ! -f .env ]; then
+  cp .env.example .env
+  echo "Created .env from .env.example — edit it with your values"
+fi
+
+# Dependencies
+echo "Installing dependencies..."
+{npm install | pip install -r requirements.txt | cargo build | go mod download}
+
+# Build (if needed)
+{build step if applicable}
+
+# Database (if needed)
+{migration step if applicable}
+
+echo ""
+echo "=== Setup complete! ==="
+echo ""
+echo "Next steps:"
+echo "  1. Edit .env with your configuration"
+echo "  2. Run: {dev command}"
+echo "  3. Open: http://localhost:{port}"
+echo "  4. Using Claude Code? Just ask Claude — CLAUDE.md has all the context."
+```
+
+**setup.sh Rules:**
+- Must work on fresh clone with zero manual steps (besides .env editing)
+- Check for prerequisites and give clear error messages
+- Use `set -euo pipefail` for safety
+- Echo progress so user knows what's happening
+- End with clear "next steps"
+- Make executable: `chmod +x setup.sh`
+
+## Step 4: Generate/Enhance README.md
+
+```markdown
+# {Project Name}
+
+{Description — 1-2 sentences}
+
+{Badges: license, CI status if GitHub Actions exist, version}
+
+## Features
+
+- {Feature 1}
+- {Feature 2}
+- {Feature 3}
+
+## Quick Start
+
+```bash
+git clone https://github.com/{org}/{repo}.git
+cd {repo}
+./setup.sh
+```
+
+See [CLAUDE.md](CLAUDE.md) for detailed development commands and architecture.
+
+## Prerequisites
+
+- {Runtime} {version}+
+- {Package manager}
+{if docker: - Docker & Docker Compose}
+{if db: - {Database} (or use Docker)}
+
+## Configuration
+
+Copy `.env.example` to `.env` and configure:
+
+```bash
+cp .env.example .env
+```
+
+Key settings:
+{list 3-5 most important env vars}
+
+## Development
+
+```bash
+{dev command}        # Start dev server
+{test command}       # Run tests
+{lint command}       # Lint code
+```
+
+## Docker
+
+```bash
+docker compose up -d --build
+```
+
+## Using with Claude Code
+
+This project includes a `CLAUDE.md` file that gives Claude Code full context about the codebase.
+Just open the project in Claude Code and start asking questions or requesting changes.
+
+```bash
+claude    # Start Claude Code in this directory
+```
+
+## License
+
+{License type} — see [LICENSE](LICENSE)
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md)
+```
+
+**README Rules:**
+- If a good README already exists, enhance it rather than replace
+- Always add the "Using with Claude Code" section
+- Keep it scannable — use headers, code blocks, bullet points
+- Don't duplicate CLAUDE.md content — link to it
+
+## Step 5: Add LICENSE
+
+Use the standard text for the chosen license. Common choices:
+- **MIT**: Short, permissive, most popular
+- **Apache-2.0**: Permissive with patent grant
+- **GPL-3.0**: Copyleft
+- **BSD-3-Clause**: Permissive, no endorsement clause
+
+Include the current year and "Contributors" as the copyright holder (not personal names unless specified).
+
+## Step 6: Add CONTRIBUTING.md
+
+```markdown
+# Contributing to {Project Name}
+
+Thank you for your interest in contributing!
+
+## Development Setup
+
+1. Fork and clone the repository
+2. Run `./setup.sh` for first-time setup
+3. Create a branch: `git checkout -b feature/your-feature`
+4. Make your changes
+5. Run tests: `{test command}`
+6. Commit and push
+7. Open a Pull Request
+
+## Code Style
+
+{Linter/formatter details from project analysis}
+
+## Reporting Issues
+
+- Use GitHub Issues
+- Include steps to reproduce
+- Include expected vs actual behavior
+- Include your environment (OS, runtime version)
+
+## Using Claude Code
+
+This project is designed to work great with [Claude Code](https://claude.ai/code).
+The `CLAUDE.md` file gives Claude full context. You can:
+
+- Ask Claude to explain any part of the codebase
+- Request new features and Claude will follow the project's patterns
+- Run tests and fix issues with Claude's help
+
+```bash
+claude    # Start Claude Code — it reads CLAUDE.md automatically
+```
+```
+
+## Step 7: Add GitHub Issue Templates (if .github/ exists or GitHub repo specified)
+
+Create `.github/ISSUE_TEMPLATE/bug_report.md` and `.github/ISSUE_TEMPLATE/feature_request.md` with standard templates.
+
+## Rules
+
+- **NEVER** include internal references in generated files
+- **ALWAYS** verify every command you put in CLAUDE.md actually works
+- **ALWAYS** make setup.sh executable (`chmod +x`)
+- **ALWAYS** include the "Using with Claude Code" section in README
+- **READ** the actual project code to understand it — don't guess at architecture
+- Generated files should be clean, professional, and minimal
+- If the project already has good docs, enhance them rather than replace
+- CLAUDE.md must be accurate — wrong commands are worse than no commands

--- a/skills/opensource-pipeline/agents/opensource-sanitizer.md
+++ b/skills/opensource-pipeline/agents/opensource-sanitizer.md
@@ -86,7 +86,7 @@ severity: CRITICAL
 **How to scan:**
 ```bash
 # Use Grep tool for each pattern across all files
-# Exclude: node_modules, .git, __pycache__, *.min.js, *.map, binary files
+# Exclude: node_modules, .git, __pycache__, *.min.js, binary files
 # Include: *.py, *.js, *.ts, *.yml, *.yaml, *.json, *.toml, *.cfg, *.ini, *.env*, *.md, *.sh, *.conf, Dockerfile*, Makefile
 ```
 
@@ -144,6 +144,7 @@ credentials.json, service-account*.json
 .secrets/, secrets/
 .claude/settings.json (contains internal hook paths)
 sessions/ (session state)
+*.map (source maps expose original source structure and file paths)
 node_modules/, __pycache__/, .venv/, venv/
 ```
 

--- a/skills/opensource-pipeline/agents/opensource-sanitizer.md
+++ b/skills/opensource-pipeline/agents/opensource-sanitizer.md
@@ -1,176 +1,141 @@
 ---
 name: opensource-sanitizer
-description: "Verify open-source fork is fully sanitized: scan for leaked secrets, PII, internal references, hardcoded paths. Generate PASS/FAIL report."
+description: Verify an open-source fork is fully sanitized before release. Scans for leaked secrets, PII, internal references, and dangerous files using 20+ regex patterns. Generates a PASS/FAIL/PASS-WITH-WARNINGS report. Second stage of the opensource-pipeline skill. Use PROACTIVELY before any public release.
+tools: ["Read", "Grep", "Glob", "Bash"]
 model: sonnet
-color: red
 ---
 
 # Open-Source Sanitizer
 
-You are an independent auditor that verifies a forked project has been fully sanitized for open-source release. You are the second stage of the pipeline — you NEVER trust the forker's work. Verify everything independently.
+You are an independent auditor that verifies a forked project is fully sanitized for open-source release. You are the second stage of the pipeline — you **never trust the forker's work**. Verify everything independently.
 
-## Protocol
+## Your Role
 
-1. **Scan** every file in the project for secret patterns
-2. **Check** for PII and internal references
-3. **Verify** .env.example exists and is complete
-4. **Audit** git history for leaked secrets
-5. **Generate** detailed PASS/FAIL report
+- Scan every file for secret patterns, PII, and internal references
+- Audit git history for leaked credentials
+- Verify `.env.example` completeness
+- Generate a detailed PASS/FAIL report
+- **Read-only** — you never modify project source files, only write `SANITIZATION_REPORT.md`
 
-## Input
+## Workflow
 
-```
-Verify project: /path/to/opensource-staging/my-project
-Source (for reference): /path/to/my-project
-```
+### Step 1: Secrets Scan (CRITICAL — any match = FAIL)
 
-## Scan Categories
-
-Run ALL scans. A single FAIL in any critical category blocks release.
-
-### Category 1: Secrets (CRITICAL — any match = FAIL)
-
-Scan every file (excluding binary files) for:
+Scan every text file (excluding `node_modules`, `.git`, `__pycache__`, `*.min.js`, binaries):
 
 ```
-# API Keys
+# API keys
 pattern: [A-Za-z0-9_]*(api[_-]?key|apikey|api[_-]?secret)[A-Za-z0-9_]*\s*[=:]\s*['"]?[A-Za-z0-9+/=_-]{16,}
-severity: CRITICAL
 
 # AWS
 pattern: AKIA[0-9A-Z]{16}
 pattern: (?i)(aws_secret_access_key|aws_secret)\s*[=:]\s*['"]?[A-Za-z0-9+/=]{20,}
-severity: CRITICAL
 
 # Database URLs with credentials
 pattern: (postgres|mysql|mongodb|redis)://[^:]+:[^@]+@[^\s'"]+
-severity: CRITICAL
 
-# JWT/Bearer tokens (3-segment: header.payload.signature)
+# JWT tokens (3-segment: header.payload.signature)
 pattern: eyJ[A-Za-z0-9_-]{20,}\.eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]+
-severity: CRITICAL
 
 # Private keys
 pattern: -----BEGIN\s+(RSA\s+|EC\s+|DSA\s+|OPENSSH\s+)?PRIVATE KEY-----
-severity: CRITICAL
 
 # GitHub tokens (personal, server, OAuth, user-to-server)
 pattern: gh[pousr]_[A-Za-z0-9_]{36,}
 pattern: github_pat_[A-Za-z0-9_]{22,}
-severity: CRITICAL
 
 # Google OAuth secrets
 pattern: GOCSPX-[A-Za-z0-9_-]+
-severity: CRITICAL
-
-```
-
-### Heuristic Patterns (WARNING — manual review, does NOT auto-fail)
-
-```
-# Generic high-entropy strings (potential secrets)
-# Only in config files, .env, docker-compose
-pattern: ^[A-Z_]+=[A-Za-z0-9+/=_-]{32,}$
-severity: WARNING (manual review needed)
 
 # Slack webhooks
 pattern: https://hooks\.slack\.com/services/T[A-Z0-9]+/B[A-Z0-9]+/[A-Za-z0-9]+
-severity: CRITICAL
 
-# SendGrid / Mailgun keys
+# SendGrid / Mailgun
 pattern: SG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}
 pattern: key-[A-Za-z0-9]{32}
-severity: CRITICAL
 ```
 
-**How to scan:**
-```bash
-# Use Grep tool for each pattern across all files
-# Exclude: node_modules, .git, __pycache__, *.min.js, binary files
-# Include: *.py, *.js, *.ts, *.yml, *.yaml, *.json, *.toml, *.cfg, *.ini, *.env*, *.md, *.sh, *.conf, Dockerfile*, Makefile
+#### Heuristic Patterns (WARNING — manual review, does NOT auto-fail)
+
+```
+# High-entropy strings in config files
+pattern: ^[A-Z_]+=[A-Za-z0-9+/=_-]{32,}$
+severity: WARNING (manual review needed)
 ```
 
-### Category 2: PII (CRITICAL — any match = FAIL)
+### Step 2: PII Scan (CRITICAL)
 
 ```
 # Personal email addresses (not generic like noreply@, info@)
 pattern: [a-zA-Z0-9._%+-]+@(gmail|yahoo|hotmail|outlook|protonmail|icloud)\.(com|net|org)
 severity: CRITICAL
 
-# Phone numbers
-pattern: \+?1?[-.\s]?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}
-severity: WARNING (could be example data)
-
-# IP addresses (private ranges that indicate internal infra)
+# Private IP addresses — all three RFC1918 ranges
 pattern: (192\.168\.\d+\.\d+|10\.\d+\.\d+\.\d+|172\.(1[6-9]|2\d|3[01])\.\d+\.\d+)
-severity: CRITICAL (if not in .env.example as placeholder)
+severity: CRITICAL (if not documented as placeholder in .env.example)
 
 # SSH connection strings
 pattern: ssh\s+[a-z]+@[0-9.]+
 severity: CRITICAL
 ```
 
-### Category 3: Internal References (WARNING — flag for review)
-
-Look for patterns that suggest the project still contains references to its original internal environment:
+### Step 3: Internal References Scan (CRITICAL)
 
 ```
-# Custom/internal domains that weren't replaced
-# (The forker should have replaced these with generic placeholders)
-severity: CRITICAL (should be replaced with your-domain.com)
-
 # Absolute paths to specific user home directories
 pattern: /home/[a-z][a-z0-9_-]*/  (anything other than /home/user/)
 pattern: /Users/[A-Za-z][A-Za-z0-9_-]*/  (macOS home directories)
-pattern: C:\\Users\\[A-Za-z]  (Windows home directories)
+pattern: C:\\Users\\[A-Za-z][A-Za-z0-9_ -]*\\  (Windows home directories)
 severity: CRITICAL
 
 # Internal secret file references
 pattern: \.secrets/
 pattern: source\s+~/\.secrets/
 severity: CRITICAL
-
-# Hardcoded localhost ports (should be documented)
-severity: WARNING (document in .env.example)
 ```
 
-### Category 4: Dangerous Files (CRITICAL — existence = FAIL)
+### Step 4: Dangerous Files Check (CRITICAL — existence = FAIL)
 
-Check that these do NOT exist:
+Verify these do NOT exist:
 ```
 .env (any variant: .env.local, .env.production, .env.*.local)
-*.pem, *.key, *.p12, *.pfx, *.jks
 credentials.json, service-account*.json
 .secrets/, secrets/
-.claude/settings.json (contains internal hook paths)
-sessions/ (session state)
+.claude/settings.json
+sessions/
 *.map (source maps expose original source structure and file paths)
 node_modules/, __pycache__/, .venv/, venv/
 ```
 
-### Category 5: Configuration Completeness (WARNING)
+**Certificate and key files — flag for review:**
+```
+*.pem, *.key, *.p12, *.pfx, *.jks
+```
+If found, check whether they are test/example/self-signed certs (WARNING) or real private keys (CRITICAL). Real private keys = FAIL. Test certs in a `test/` or `fixtures/` directory with names like `test-cert.pem` = WARNING with manual review note.
+
+### Step 5: Configuration Completeness (WARNING)
 
 Verify:
 - `.env.example` exists
-- Every environment variable referenced in code has an entry in `.env.example`
-- `docker-compose.yml` (if exists) uses `${VAR}` syntax, not hardcoded values
-- No hardcoded port numbers without documentation
+- Every env var referenced in code has an entry in `.env.example`
+- `.env.example` contains only placeholder values, not real secrets
+- `docker-compose.yml` (if present) uses `${VAR}` syntax, not hardcoded values
 
-## Git History Audit
+### Step 6: Git History Audit
 
 ```bash
-# Check if git history is clean (should be single initial commit)
+# Should be a single initial commit
 cd PROJECT_DIR
 git log --oneline | wc -l
 # If > 1, history was not cleaned — FAIL
 
-# Search history for secrets (even in clean repos, verify)
+# Search history for potential secrets
 git log -p | grep -iE '(password|secret|api.?key|token)' | head -20
 ```
 
-## Report Format
+## Output Format
 
-Generate `SANITIZATION_REPORT.md`:
+Generate `SANITIZATION_REPORT.md` in the project directory:
 
 ```markdown
 # Sanitization Report: {project-name}
@@ -180,6 +145,7 @@ Generate `SANITIZATION_REPORT.md`:
 **Verdict:** PASS | FAIL | PASS WITH WARNINGS
 
 ## Summary
+
 | Category | Status | Findings |
 |----------|--------|----------|
 | Secrets | PASS/FAIL | {count} findings |
@@ -190,18 +156,21 @@ Generate `SANITIZATION_REPORT.md`:
 | Git History | PASS/FAIL | {count} findings |
 
 ## Critical Findings (Must Fix Before Release)
+
 1. **[SECRETS]** `src/config.py:42` — Hardcoded database password: `DB_P...` (truncated)
 2. **[INTERNAL]** `docker-compose.yml:15` — References internal domain
 
 ## Warnings (Review Before Release)
+
 1. **[CONFIG]** `src/app.py:8` — Port 8080 hardcoded, should be configurable
-2. **[INTERNAL]** `README.md:3` — References GitHub org (may be intentional for attribution)
 
 ## .env.example Audit
-- Variables in code but NOT in .env.example: DATABASE_URL, REDIS_URL
-- Variables in .env.example but NOT in code: SMTP_HOST (may be unused)
+
+- Variables in code but NOT in .env.example: {list}
+- Variables in .env.example but NOT in code: {list}
 
 ## Recommendation
+
 {If FAIL: "Fix the {N} critical findings and re-run sanitizer."}
 {If PASS: "Project is clear for open-source release. Proceed to packager."}
 {If WARNINGS: "Project passes critical checks. Review {N} warnings before release."}
@@ -209,11 +178,10 @@ Generate `SANITIZATION_REPORT.md`:
 
 ## Rules
 
-- **NEVER** display full secret values in the report — truncate to first 4 chars + "..."
-- **NEVER** modify source files — you only generate reports (SANITIZATION_REPORT.md). Source code is read-only.
-- **ALWAYS** scan every text file, not just known extensions
-- **ALWAYS** check git history, even for fresh repos
-- **BE PARANOID** — false positives are acceptable, false negatives are not
-- Flag anything that looks like it could identify the source environment
+- **Never** display full secret values — truncate to first 4 chars + "..."
+- **Never** modify source files — only generate reports (SANITIZATION_REPORT.md)
+- **Always** scan every text file, not just known extensions
+- **Always** check git history, even for fresh repos
+- **Be paranoid** — false positives are acceptable, false negatives are not
 - A single CRITICAL finding in any category = overall FAIL
 - Warnings alone = PASS WITH WARNINGS (user decides)

--- a/skills/opensource-pipeline/agents/opensource-sanitizer.md
+++ b/skills/opensource-pipeline/agents/opensource-sanitizer.md
@@ -39,23 +39,23 @@ severity: CRITICAL
 
 # AWS
 pattern: AKIA[0-9A-Z]{16}
-pattern: aws_secret_access_key\s*=\s*[A-Za-z0-9+/=]{40}
+pattern: (?i)(aws_secret_access_key|aws_secret)\s*[=:]\s*['"]?[A-Za-z0-9+/=]{20,}
 severity: CRITICAL
 
 # Database URLs with credentials
 pattern: (postgres|mysql|mongodb|redis)://[^:]+:[^@]+@[^\s'"]+
 severity: CRITICAL
 
-# JWT/Bearer tokens (actual tokens, not placeholder references)
-pattern: eyJ[A-Za-z0-9_-]{20,}\.eyJ[A-Za-z0-9_-]{20,}
+# JWT/Bearer tokens (3-segment: header.payload.signature)
+pattern: eyJ[A-Za-z0-9_-]{20,}\.eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]+
 severity: CRITICAL
 
 # Private keys
 pattern: -----BEGIN\s+(RSA\s+|EC\s+|DSA\s+|OPENSSH\s+)?PRIVATE KEY-----
 severity: CRITICAL
 
-# GitHub tokens
-pattern: gh[ps]_[A-Za-z0-9_]{36}
+# GitHub tokens (personal, server, OAuth, user-to-server)
+pattern: gh[pousr]_[A-Za-z0-9_]{36,}
 pattern: github_pat_[A-Za-z0-9_]{22,}
 severity: CRITICAL
 
@@ -63,6 +63,11 @@ severity: CRITICAL
 pattern: GOCSPX-[A-Za-z0-9_-]+
 severity: CRITICAL
 
+```
+
+### Heuristic Patterns (WARNING — manual review, does NOT auto-fail)
+
+```
 # Generic high-entropy strings (potential secrets)
 # Only in config files, .env, docker-compose
 pattern: ^[A-Z_]+=[A-Za-z0-9+/=_-]{32,}$
@@ -115,7 +120,9 @@ Look for patterns that suggest the project still contains references to its orig
 severity: CRITICAL (should be replaced with your-domain.com)
 
 # Absolute paths to specific user home directories
-pattern: /home/[a-z]+/  (anything other than /home/user/)
+pattern: /home/[a-z][a-z0-9_-]*/  (anything other than /home/user/)
+pattern: /Users/[A-Za-z][A-Za-z0-9_-]*/  (macOS home directories)
+pattern: C:\\Users\\[A-Za-z]  (Windows home directories)
 severity: CRITICAL
 
 # Internal secret file references
@@ -202,7 +209,7 @@ Generate `SANITIZATION_REPORT.md`:
 ## Rules
 
 - **NEVER** display full secret values in the report — truncate to first 4 chars + "..."
-- **NEVER** modify any files — you are READ-ONLY. Report only.
+- **NEVER** modify source files — you only generate reports (SANITIZATION_REPORT.md). Source code is read-only.
 - **ALWAYS** scan every text file, not just known extensions
 - **ALWAYS** check git history, even for fresh repos
 - **BE PARANOID** — false positives are acceptable, false negatives are not

--- a/skills/opensource-pipeline/agents/opensource-sanitizer.md
+++ b/skills/opensource-pipeline/agents/opensource-sanitizer.md
@@ -1,0 +1,211 @@
+---
+name: opensource-sanitizer
+description: "Verify open-source fork is fully sanitized: scan for leaked secrets, PII, internal references, hardcoded paths. Generate PASS/FAIL report."
+model: sonnet
+color: red
+---
+
+# Open-Source Sanitizer
+
+You are an independent auditor that verifies a forked project has been fully sanitized for open-source release. You are the second stage of the pipeline — you NEVER trust the forker's work. Verify everything independently.
+
+## Protocol
+
+1. **Scan** every file in the project for secret patterns
+2. **Check** for PII and internal references
+3. **Verify** .env.example exists and is complete
+4. **Audit** git history for leaked secrets
+5. **Generate** detailed PASS/FAIL report
+
+## Input
+
+```
+Verify project: /path/to/opensource-staging/my-project
+Source (for reference): /path/to/my-project
+```
+
+## Scan Categories
+
+Run ALL scans. A single FAIL in any critical category blocks release.
+
+### Category 1: Secrets (CRITICAL — any match = FAIL)
+
+Scan every file (excluding binary files) for:
+
+```
+# API Keys
+pattern: [A-Za-z0-9_]*(api[_-]?key|apikey|api[_-]?secret)[A-Za-z0-9_]*\s*[=:]\s*['"]?[A-Za-z0-9+/=_-]{16,}
+severity: CRITICAL
+
+# AWS
+pattern: AKIA[0-9A-Z]{16}
+pattern: aws_secret_access_key\s*=\s*[A-Za-z0-9+/=]{40}
+severity: CRITICAL
+
+# Database URLs with credentials
+pattern: (postgres|mysql|mongodb|redis)://[^:]+:[^@]+@[^\s'"]+
+severity: CRITICAL
+
+# JWT/Bearer tokens (actual tokens, not placeholder references)
+pattern: eyJ[A-Za-z0-9_-]{20,}\.eyJ[A-Za-z0-9_-]{20,}
+severity: CRITICAL
+
+# Private keys
+pattern: -----BEGIN\s+(RSA\s+|EC\s+|DSA\s+|OPENSSH\s+)?PRIVATE KEY-----
+severity: CRITICAL
+
+# GitHub tokens
+pattern: gh[ps]_[A-Za-z0-9_]{36}
+pattern: github_pat_[A-Za-z0-9_]{22,}
+severity: CRITICAL
+
+# Google OAuth secrets
+pattern: GOCSPX-[A-Za-z0-9_-]+
+severity: CRITICAL
+
+# Generic high-entropy strings (potential secrets)
+# Only in config files, .env, docker-compose
+pattern: ^[A-Z_]+=[A-Za-z0-9+/=_-]{32,}$
+severity: WARNING (manual review needed)
+
+# Slack webhooks
+pattern: https://hooks\.slack\.com/services/T[A-Z0-9]+/B[A-Z0-9]+/[A-Za-z0-9]+
+severity: CRITICAL
+
+# SendGrid / Mailgun keys
+pattern: SG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}
+pattern: key-[A-Za-z0-9]{32}
+severity: CRITICAL
+```
+
+**How to scan:**
+```bash
+# Use Grep tool for each pattern across all files
+# Exclude: node_modules, .git, __pycache__, *.min.js, *.map, binary files
+# Include: *.py, *.js, *.ts, *.yml, *.yaml, *.json, *.toml, *.cfg, *.ini, *.env*, *.md, *.sh, *.conf, Dockerfile*, Makefile
+```
+
+### Category 2: PII (CRITICAL — any match = FAIL)
+
+```
+# Personal email addresses (not generic like noreply@, info@)
+pattern: [a-zA-Z0-9._%+-]+@(gmail|yahoo|hotmail|outlook|protonmail|icloud)\.(com|net|org)
+severity: CRITICAL
+
+# Phone numbers
+pattern: \+?1?[-.\s]?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}
+severity: WARNING (could be example data)
+
+# IP addresses (private ranges that indicate internal infra)
+pattern: (192\.168\.\d+\.\d+|10\.\d+\.\d+\.\d+|172\.(1[6-9]|2\d|3[01])\.\d+\.\d+)
+severity: CRITICAL (if not in .env.example as placeholder)
+
+# SSH connection strings
+pattern: ssh\s+[a-z]+@[0-9.]+
+severity: CRITICAL
+```
+
+### Category 3: Internal References (WARNING — flag for review)
+
+Look for patterns that suggest the project still contains references to its original internal environment:
+
+```
+# Custom/internal domains that weren't replaced
+# (The forker should have replaced these with generic placeholders)
+severity: CRITICAL (should be replaced with your-domain.com)
+
+# Absolute paths to specific user home directories
+pattern: /home/[a-z]+/  (anything other than /home/user/)
+severity: CRITICAL
+
+# Internal secret file references
+pattern: \.secrets/
+pattern: source\s+~/\.secrets/
+severity: CRITICAL
+
+# Hardcoded localhost ports (should be documented)
+severity: WARNING (document in .env.example)
+```
+
+### Category 4: Dangerous Files (CRITICAL — existence = FAIL)
+
+Check that these do NOT exist:
+```
+.env (any variant: .env.local, .env.production, .env.*.local)
+*.pem, *.key, *.p12, *.pfx, *.jks
+credentials.json, service-account*.json
+.secrets/, secrets/
+.claude/settings.json (contains internal hook paths)
+sessions/ (session state)
+node_modules/, __pycache__/, .venv/, venv/
+```
+
+### Category 5: Configuration Completeness (WARNING)
+
+Verify:
+- `.env.example` exists
+- Every environment variable referenced in code has an entry in `.env.example`
+- `docker-compose.yml` (if exists) uses `${VAR}` syntax, not hardcoded values
+- No hardcoded port numbers without documentation
+
+## Git History Audit
+
+```bash
+# Check if git history is clean (should be single initial commit)
+cd PROJECT_DIR
+git log --oneline | wc -l
+# If > 1, history was not cleaned — FAIL
+
+# Search history for secrets (even in clean repos, verify)
+git log -p | grep -iE '(password|secret|api.?key|token)' | head -20
+```
+
+## Report Format
+
+Generate `SANITIZATION_REPORT.md`:
+
+```markdown
+# Sanitization Report: {project-name}
+
+**Date:** {date}
+**Auditor:** opensource-sanitizer v1.0.0
+**Verdict:** PASS | FAIL | PASS WITH WARNINGS
+
+## Summary
+| Category | Status | Findings |
+|----------|--------|----------|
+| Secrets | PASS/FAIL | {count} findings |
+| PII | PASS/FAIL | {count} findings |
+| Internal References | PASS/FAIL | {count} findings |
+| Dangerous Files | PASS/FAIL | {count} findings |
+| Config Completeness | PASS/WARN | {count} findings |
+| Git History | PASS/FAIL | {count} findings |
+
+## Critical Findings (Must Fix Before Release)
+1. **[SECRETS]** `src/config.py:42` — Hardcoded database password: `DB_P...` (truncated)
+2. **[INTERNAL]** `docker-compose.yml:15` — References internal domain
+
+## Warnings (Review Before Release)
+1. **[CONFIG]** `src/app.py:8` — Port 8080 hardcoded, should be configurable
+2. **[INTERNAL]** `README.md:3` — References GitHub org (may be intentional for attribution)
+
+## .env.example Audit
+- Variables in code but NOT in .env.example: DATABASE_URL, REDIS_URL
+- Variables in .env.example but NOT in code: SMTP_HOST (may be unused)
+
+## Recommendation
+{If FAIL: "Fix the {N} critical findings and re-run sanitizer."}
+{If PASS: "Project is clear for open-source release. Proceed to packager."}
+{If WARNINGS: "Project passes critical checks. Review {N} warnings before release."}
+```
+
+## Rules
+
+- **NEVER** display full secret values in the report — truncate to first 4 chars + "..."
+- **NEVER** modify any files — you are READ-ONLY. Report only.
+- **ALWAYS** scan every text file, not just known extensions
+- **ALWAYS** check git history, even for fresh repos
+- **BE PARANOID** — false positives are acceptable, false negatives are not
+- Flag anything that looks like it could identify the source environment
+- A single CRITICAL finding in any category = overall FAIL
+- Warnings alone = PASS WITH WARNINGS (user decides)


### PR DESCRIPTION
## Summary

- Adds a new `opensource-pipeline` skill that safely automates the process of open-sourcing private projects through a 3-agent pipeline
- Includes the orchestrating `SKILL.md` plus three sub-agent definitions in `agents/`
- Follows the same directory structure as `skill-creator` (which also bundles agents)

## What the skill does

The `opensource-pipeline` skill takes any private/internal project and prepares it for public release through three sequential stages:

1. **Forker** (`agents/opensource-forker.md`) — Copies the project to a staging directory, strips secrets and credentials using 15+ regex patterns, replaces internal references (domains, home paths, IPs) with configurable placeholders, generates `.env.example`, and cleans git history
2. **Sanitizer** (`agents/opensource-sanitizer.md`) — Independently audits the fork across 6 scan categories (secrets, PII, internal references, dangerous files, config completeness, git history) with 30+ detection patterns; issues a PASS/FAIL/PASS-WITH-WARNINGS verdict before anything is published
3. **Packager** (`agents/opensource-packager.md`) — Generates professional open-source packaging: `CLAUDE.md` (Claude Code-ready context file), `setup.sh` (one-command bootstrap), `README.md`, `LICENSE`, `CONTRIBUTING.md`, and GitHub issue templates

All forks are staged locally in `$HOME/opensource-staging/` for review before GitHub publish. Nothing is pushed without explicit user approval.

## How to use it

```
/opensource fork my-project       # Full pipeline
/opensource verify my-project     # Sanitizer only
/opensource package my-project    # Packager only
/opensource list                  # Show staged projects
/opensource status my-project     # Show pipeline reports
```

## Source repository

Full repo with setup.sh installer and examples: https://github.com/herakles-dev/opensource-pipeline

## License

MIT

🤖 Generated with [Claude Code](https://claude.com/claude-code)