### PR TITLE
fix(skill-creator): fix several bugs in eval viewer and benchmark agg…

### DIFF
--- a/skills/skill-creator/eval-viewer/generate_review.py
+++ b/skills/skill-creator/eval-viewer/generate_review.py
@@ -276,7 +276,7 @@ def generate_html(
     if benchmark:
         embedded["benchmark"] = benchmark
 
-    data_json = json.dumps(embedded)
+    data_json = json.dumps(embedded).replace("</", "<\\/")
 
     return template.replace("/*__EMBEDDED_DATA__*/", f"const EMBEDDED_DATA = {data_json};")
 

--- a/skills/skill-creator/eval-viewer/viewer.html
+++ b/skills/skill-creator/eval-viewer/viewer.html
@@ -1061,8 +1061,6 @@
     }
 
     function closeDoneDialog() {
-      // Reset status back to in_progress
-      saveCurrentFeedback();
       document.getElementById("done-overlay").classList.remove("visible");
     }
 

--- a/skills/skill-creator/scripts/aggregate_benchmark.py
+++ b/skills/skill-creator/scripts/aggregate_benchmark.py
@@ -75,7 +75,7 @@ def load_run_results(benchmark_dir: Path) -> dict:
     runs_dir = benchmark_dir / "runs"
     if runs_dir.exists():
         search_dir = runs_dir
-    elif list(benchmark_dir.glob("eval-*")):
+    elif any(d.is_dir() for d in benchmark_dir.iterdir()):
         search_dir = benchmark_dir
     else:
         print(f"No eval directories found in {benchmark_dir} or {benchmark_dir / 'runs'}")
@@ -83,33 +83,46 @@ def load_run_results(benchmark_dir: Path) -> dict:
 
     results: dict[str, list] = {}
 
-    for eval_idx, eval_dir in enumerate(sorted(search_dir.glob("eval-*"))):
+    for eval_idx, eval_dir in enumerate(sorted(d for d in search_dir.iterdir() if d.is_dir())):
         metadata_path = eval_dir / "eval_metadata.json"
+        eval_name = ""
         if metadata_path.exists():
             try:
                 with open(metadata_path) as mf:
-                    eval_id = json.load(mf).get("eval_id", eval_idx)
+                    metadata = json.load(mf)
+                    eval_id = metadata.get("eval_id", eval_idx)
+                    eval_name = metadata.get("eval_name", "")
             except (json.JSONDecodeError, OSError):
                 eval_id = eval_idx
         else:
             try:
                 eval_id = int(eval_dir.name.split("-")[1])
-            except ValueError:
+            except (ValueError, IndexError):
                 eval_id = eval_idx
 
         # Discover config directories dynamically rather than hardcoding names
         for config_dir in sorted(eval_dir.iterdir()):
             if not config_dir.is_dir():
                 continue
-            # Skip non-config directories (inputs, outputs, etc.)
-            if not list(config_dir.glob("run-*")):
+
+            run_dirs = sorted(config_dir.glob("run-*"))
+            has_direct_grading = (config_dir / "grading.json").exists()
+
+            # Skip non-config directories (no run-* subdirs and no direct grading.json)
+            if not run_dirs and not has_direct_grading:
                 continue
+
             config = config_dir.name
             if config not in results:
                 results[config] = []
 
-            for run_dir in sorted(config_dir.glob("run-*")):
-                run_number = int(run_dir.name.split("-")[1])
+            # Handle flat layout (grading.json directly in config dir, no run-* nesting)
+            if not run_dirs and has_direct_grading:
+                run_dirs_to_process = [(config_dir, 1)]
+            else:
+                run_dirs_to_process = [(rd, int(rd.name.split("-")[1])) for rd in run_dirs]
+
+            for run_dir, run_number in run_dirs_to_process:
                 grading_file = run_dir / "grading.json"
 
                 if not grading_file.exists():
@@ -126,6 +139,7 @@ def load_run_results(benchmark_dir: Path) -> dict:
                 # Extract metrics
                 result = {
                     "eval_id": eval_id,
+                    "eval_name": eval_name,
                     "run_number": run_number,
                     "pass_rate": grading.get("summary", {}).get("pass_rate", 0.0),
                     "passed": grading.get("summary", {}).get("passed", 0),
@@ -237,6 +251,7 @@ def generate_benchmark(benchmark_dir: Path, skill_name: str = "", skill_path: st
         for result in results[config]:
             runs.append({
                 "eval_id": result["eval_id"],
+                "eval_name": result.get("eval_name", ""),
                 "configuration": config,
                 "run_number": result["run_number"],
                 "result": {
@@ -260,6 +275,15 @@ def generate_benchmark(benchmark_dir: Path, skill_name: str = "", skill_path: st
         for r in config
     ))
 
+    # Calculate actual runs per configuration (max run count across eval+config combos)
+    from collections import Counter
+    run_counts: Counter = Counter()
+    for config, config_results in results.items():
+        for eval_id in set(r["eval_id"] for r in config_results):
+            count = sum(1 for r in config_results if r["eval_id"] == eval_id)
+            run_counts[(eval_id, config)] = count
+    runs_per_configuration = max(run_counts.values()) if run_counts else 1
+
     benchmark = {
         "metadata": {
             "skill_name": skill_name or "<skill-name>",
@@ -268,7 +292,7 @@ def generate_benchmark(benchmark_dir: Path, skill_name: str = "", skill_path: st
             "analyzer_model": "<model-name>",
             "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
             "evals_run": eval_ids,
-            "runs_per_configuration": 3
+            "runs_per_configuration": runs_per_configuration
         },
         "runs": runs,
         "run_summary": run_summary,


### PR DESCRIPTION
…regation

- viewer.html: closing the done dialog no longer calls saveCurrentFeedback(), which was silently overwriting the just-saved "complete" status back to "in_progress", causing reviewers to appear unfinished after dismissing the confirmation overlay

- generate_review.py: escape "</" sequences in embedded JSON so file contents containing "</script>" cannot prematurely close the script tag and break the entire viewer page

- aggregate_benchmark.py: eval directory discovery now iterates all subdirectories instead of globbing "eval-*", so descriptively-named eval dirs are found correctly rather than silently producing empty benchmark output

- aggregate_benchmark.py: now handles the flat workspace layout where grading.json lives directly in the config dir (no run-* nesting), in addition to the existing nested run-* layout

- aggregate_benchmark.py: eval_name is now read from eval_metadata.json and propagated into each run entry, so the viewer can display proper section headers instead of falling back to generic "Eval N" labels

- aggregate_benchmark.py: runs_per_configuration in benchmark metadata is now computed from actual run counts instead of being hardcoded to 3