### PR TITLE
Add notification skill

### DIFF
--- a/skills/notification/LICENSE.txt
+++ b/skills/notification/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/notification/SKILL.md
+++ b/skills/notification/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: notification
+description: Send push notifications. MUST use when the user asks to send, test, or configure notifications, or mentions "notify me", "ping me", "alert me", "let me know", or /notification.
+---
+
+# Notification
+
+Send messages to mobile / desktop devices. Use this skill for **any** notification-related request.
+
+## Triggers
+
+Activate when the user:
+- Uses `/notification` or asks to send/test a notification
+- Says "notify me", "ping me", "alert me", "let me know", "send a push notification"
+- Asks about notification setup, configuration, or troubleshooting
+- Requests to be alerted when a task completes
+
+## Workflow
+
+1. **If there is a task**, complete it first — this skill adds a notification at the end.
+2. **Send the notification** using the command below. Do not skip this step even if the task failed. If the user only asked to send/test a notification (no preceding task), go directly to this step.
+
+### Compose fields
+
+| Field | Description |
+|---|---|
+| `--title` | The task or notification name in the user's own words (e.g. "Run test suite", "Test notification") |
+| `--message` | Concise outcome summary (max 200 chars). On failure, state what failed and why. |
+| `--urgent` | Add this flag when the user says "urgent", "important", "high priority", or "asap". Omit otherwise. |
+| `--successed` | Add this flag when the task succeeded. Omit on failure. |
+
+### Send command
+
+```bash
+node "<skill-directory>/scripts/send.mjs" \
+  --title "<title>" \
+  --message "<message>" \
+  [--urgent] \
+  [--successed]
+```
+
+## Failure handling
+
+- **Script fails** (non-zero exit): Tell the user the notification could not be sent, but still deliver the task result.
+- **Task fails**: Send the notification **without** `--successed` so the user knows to check back. A failure notification is as valuable as a success one — the user may be AFK.
+- **Missing env vars**: The script prints setup instructions on error — relay them to the user.

--- a/skills/notification/scripts/send.mjs
+++ b/skills/notification/scripts/send.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+
+// Usage: node send.mjs --title "..." --message "..." [--urgent] [--successed]
+// Provider is auto-detected from environment variables (NTFY_URL or BARK_URL).
+
+const args = process.argv.slice(2);
+
+function getArg(name) {
+  const idx = args.indexOf(`--${name}`);
+  return idx !== -1 && idx + 1 < args.length ? args[idx + 1] : undefined;
+}
+
+function hasFlag(name) {
+  return args.includes(`--${name}`);
+}
+
+// Collect all configured providers
+const providers = [];
+if (process.env.NTFY_URL) providers.push("ntfy");
+if (process.env.BARK_URL) providers.push("bark");
+
+if (providers.length === 0) {
+  console.error(`Error: No notification service configured. Set at least one environment variable:
+
+  ntfy (cross-platform):
+    export NTFY_URL="https://ntfy.sh/your-topic"
+    export NTFY_TOKEN="tk_xxx"          # optional, for private servers
+
+  Bark (iOS):
+    export BARK_URL="https://api.day.app/your_device_key"
+
+Set these in your shell profile, .env, or Claude Code settings (env field in settings.json).`);
+  process.exit(1);
+}
+
+const title = getArg("title") || "";
+const message = getArg("message") || "";
+const urgent = hasFlag("urgent");
+const successed = hasFlag("successed");
+const priority = urgent ? "5" : "3";
+const tags = successed ? "white_check_mark" : "x";
+
+if (!message) {
+  console.error("Error: --message is required");
+  process.exit(1);
+}
+
+async function sendNtfy() {
+  // Split NTFY_URL into root URL and topic
+  // e.g. "https://ntfy.sh/my-topic" -> root="https://ntfy.sh", topic="my-topic"
+  const parsed = new URL(process.env.NTFY_URL);
+  const topic = parsed.pathname.slice(1);
+  parsed.pathname = "/";
+
+  const headers = { "Content-Type": "application/json; charset=utf-8" };
+  if (process.env.NTFY_TOKEN) {
+    headers["Authorization"] = `Bearer ${process.env.NTFY_TOKEN}`;
+  }
+
+  const body = JSON.stringify({
+    topic,
+    title,
+    message,
+    priority: Number(priority),
+    tags: [tags],
+  });
+
+  const res = await fetch(parsed.toString(), { method: "POST", headers, body });
+  console.log(res.status);
+  if (!res.ok) {
+    console.error(await res.text());
+    process.exit(1);
+  }
+}
+
+async function sendBark() {
+  const body = JSON.stringify({
+    title,
+    body: message,
+    group: "claude-code",
+    level: priority === "5" ? "timeSensitive" : "active",
+    icon: "https://claude.ai/favicon.ico",
+  });
+
+  const res = await fetch(process.env.BARK_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+    body,
+  });
+  console.log(res.status);
+  if (!res.ok) {
+    console.error(await res.text());
+    process.exit(1);
+  }
+}
+
+// Send to all configured providers
+const results = await Promise.allSettled(
+  providers.map((p) => (p === "ntfy" ? sendNtfy() : sendBark()))
+);
+
+const failures = results.filter((r) => r.status === "rejected");
+if (failures.length > 0) {
+  for (const f of failures) console.error(f.reason);
+  process.exit(1);
+}


### PR DESCRIPTION
---

## Add notification skill

### Summary

Add a new `notification` skill that enables Claude Code to send push notifications to users' mobile and desktop devices upon task completion or on demand.

### Motivation

Users often run long-running tasks (test suites, builds, deployments) and step away from their terminal. This skill allows Claude Code to proactively notify users when work is done — or when something fails — so they don't have to keep checking back.

### What's included

| File | Description |
|------|-------------|
| `skills/notification/SKILL.md` | Skill definition with triggers, workflow, and failure handling |
| `skills/notification/scripts/send.mjs` | Notification dispatch script (Node.js) |
| `skills/notification/LICENSE.txt` | Apache 2.0 license |

### Features

- **Multi-provider support**: Auto-detects configured providers from environment variables
  - [ntfy](https://ntfy.sh) — cross-platform (iOS, Android, desktop, web)
  - [Bark](https://github.com/Finb/Bark) — iOS native push notifications
- **Fan-out delivery**: Sends to all configured providers simultaneously via `Promise.allSettled`
- **Priority levels**: Supports normal and urgent (time-sensitive) notifications
- **Success/failure indicators**: Visual status tags (✅ / ❌) in notification payload
- **Zero dependencies**: Uses only Node.js built-in `fetch` — no `npm install` required

### Trigger phrases

The skill activates when users say:
- `/notification`, "notify me", "ping me", "alert me", "let me know"
- Or explicitly ask to send/test/configure notifications

### Configuration

Users set environment variables in their shell profile or Claude Code `settings.json`:

```bash
# ntfy (cross-platform)
export NTFY_URL="https://ntfy.sh/your-topic"
export NTFY_TOKEN="tk_xxx"          # optional, for private servers

# Bark (iOS)
export BARK_URL="https://api.day.app/your_device_key"
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)