### PR TITLE
Add ordeal skill — automated chaos testing for Python

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -38,7 +38,8 @@
         "./skills/slack-gif-creator",
         "./skills/theme-factory",
         "./skills/web-artifacts-builder",
-        "./skills/webapp-testing"
+        "./skills/webapp-testing",
+        "./skills/ordeal"
       ]
     }
     ,

--- a/skills/ordeal/LICENSE.txt
+++ b/skills/ordeal/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/ordeal/SKILL.md
+++ b/skills/ordeal/SKILL.md
@@ -25,6 +25,24 @@ for key in sorted(c):
 
 `ordeal --help` shows all CLI commands.
 
+## Reading ordeal's output
+
+ordeal's output is self-describing. When it finds something actionable, it tells you what to fix:
+
+- **Surviving mutants** include `.remediation` — the specific test to write
+- **Coverage gaps** include `.reachability_suggestions()` — branches not reached
+- **`generate_test_stubs()`** returns ready-to-use Python test code
+- **JSON to stdout** is structured for programmatic consumption; human reports go to stderr
+
+## Vocabulary
+
+- **Mutation score** — ratio of mutants killed by tests (0.0–1.0). A surviving mutant is a code change your tests didn't catch.
+- **Fault injection** — simulate failures (timeouts, disk errors, network resets) during tests. Active under `--chaos`.
+- **Property** — something ordeal discovered is true about a function (e.g., "output is bounded 0–1", "commutative", "deterministic").
+- **Seed corpus** — failing inputs in `.ordeal/seeds/`, replayed automatically on every `pytest` run.
+- **Fault ablation** — after a bug, replay without each fault to find which ones were necessary.
+- **Chaos mode** (`--chaos`) — activates fault injection, buggify(), and property tracking.
+
 ## Guardrails
 
 - If a test exposes a bug, fix the source — never weaken the test

--- a/skills/ordeal/SKILL.md
+++ b/skills/ordeal/SKILL.md
@@ -1,48 +1,18 @@
 ---
 name: ordeal
-description: Test Python code with ordeal — discover properties, inject faults, mutate, explore state space
+description: Automated chaos testing for Python — discovers properties, injects faults, mutates code, explores state space. TRIGGER when: code imports `ordeal`, user asks to test/audit/fuzz Python code, or check test quality.
 user_invocable: true
 ---
 
-# ordeal — automated chaos testing for Python
+# ordeal
 
-You have access to `ordeal`, an automated testing toolkit. Use it when the user asks you to test, audit, or improve test coverage for Python code.
+Automated chaos testing for Python. Discovers properties, injects faults, runs mutation testing, explores reachable states.
 
-## When to use ordeal
+Install: `pip install ordeal`
 
-- User says "test this", "is this well-tested?", "find bugs", "what could go wrong?"
-- User wants to know if a refactor changed behavior
-- User wants chaos/fault-injection testing
-- A module has no tests or weak tests
+## Discovery
 
-## Quick decision tree
-
-1. **No tests exist yet** → run `ordeal init <package>` (discovers properties, generates tests, validates with mutations)
-2. **Tests exist, check quality** → run `ordeal audit <module>`
-3. **Test a specific function** → use `mutate()` in Python or `ordeal mutate <target>`
-4. **Deep exploration** → run `ordeal explore`
-5. **Discover what a function does** → run `ordeal mine <target>`
-6. **Compare two implementations** → use `diff(old_fn, new_fn)` in Python
-
-## Commands
-
-```
-ordeal init <package>              # zero-to-tests: mine → generate → mutate-validate → explore
-ordeal init --dry-run              # preview without writing
-ordeal audit <module>              # mutation score + property coverage + test gaps
-ordeal mutate <target>             # mutation testing (function or module)
-ordeal mutate <target> -p thorough # all 14 mutation operators
-ordeal mutate <target> --generate-stubs tests/gaps.py  # write tests for surviving mutants
-ordeal mine <target>               # discover properties of a function
-ordeal explore                     # coverage-guided state-space exploration (reads ordeal.toml)
-ordeal replay <trace.json>         # replay a failure trace
-ordeal replay --shrink --ablate <trace.json>  # shrink + find which faults matter
-ordeal benchmark                   # USL scaling analysis
-```
-
-## Living reference
-
-`catalog()` returns every fault, invariant, strategy, and capability at runtime — always up-to-date even when this skill isn't. When in doubt, call it.
+`catalog()` returns every capability at runtime — faults, invariants, strategies, mutations, and more. Always up-to-date.
 
 ```python
 from ordeal import catalog
@@ -53,59 +23,9 @@ for key in sorted(c):
         print(f"  {item['qualname']}  -- {item['doc']}")
 ```
 
-## Python API (when you need more control)
+`ordeal --help` shows all CLI commands.
 
-```python
-from ordeal import mutate
+## Guardrails
 
-# Mutation testing — are tests strong enough?
-result = mutate("myapp.scoring.compute")
-print(result.summary())              # gaps with cause + fix
-stubs = result.generate_test_stubs() # ready-to-use test code
-result.kill_attribution()            # which tests kill which mutants
-
-# Discover properties
-from ordeal import mine
-props = mine("myapp.scoring.compute")  # returns discovered invariants
-
-# Chaos testing — what if calls fail?
-from ordeal import chaos_for
-chaos_for("myapp.scoring")  # auto-discovers faults + invariants
-
-# Differential testing — did a refactor change behavior?
-from ordeal import diff
-diff(old_fn, new_fn)
-
-# Module-wide exploration
-from ordeal.state import explore
-state = explore("myapp")  # mine + scan + mutate + chaos in one pass
-```
-
-## Reading results
-
-- `mutate()` returns a `MutationResult` with `.score` (0.0–1.0), `.survived` (list of gaps), `.summary()`, `.generate_test_stubs()`
-- `ordeal init` prints JSON to stdout (for you) and a quality report to stderr (for the human)
-- `ordeal audit` prints a structured report with mutation score, property coverage, and specific test gaps
-- `ordeal explore` saves traces to `.ordeal/traces/` and seeds to `.ordeal/seeds/`
-
-## Interpreting gaps
-
-When mutants survive, each one has:
-- `.operator` — what was changed (e.g., "negate_condition", "boundary_off_by_one")
-- `.source_line` — where in the source
-- `.remediation` — what test to write
-
-Generate stubs with `result.generate_test_stubs()` — they include real param names, typed examples, and invariant suggestions.
-
-## Key patterns
-
-- **Seeds auto-replay**: failing inputs save to `.ordeal/seeds/` and replay on every `pytest` run
-- **Fault ablation**: after finding a bug, `ablate_faults(trace)` tells you which faults were necessary
-- **`--chaos` flag**: enables fault injection during pytest; `--chaos-seed 42` for reproducibility
-- **Config via `ordeal.toml`**: explore, mutate, and audit all read from it
-
-## What NOT to do
-
-- Don't weaken a test to make it pass — if a test exposes a bug, fix the source
-- Don't skip `ordeal init` and hand-write everything — let ordeal discover properties first, then refine
-- Don't run `mutate()` on code that imports heavy frameworks (numpy/torch) without `--mutant-timeout`
+- If a test exposes a bug, fix the source — never weaken the test
+- Heavy frameworks (numpy/torch): use `--mutant-timeout` with `mutate()`

--- a/skills/ordeal/SKILL.md
+++ b/skills/ordeal/SKILL.md
@@ -23,7 +23,7 @@ for key in sorted(c):
         print(f"  {item['qualname']}  -- {item['doc']}")
 ```
 
-`ordeal --help` shows all CLI commands.
+`ordeal --help` shows all CLI commands. Full docs at https://docs.byordeal.com/
 
 ## Reading ordeal's output
 

--- a/skills/ordeal/SKILL.md
+++ b/skills/ordeal/SKILL.md
@@ -1,14 +1,12 @@
 ---
 name: ordeal
-description: Automated chaos testing for Python — discover properties, inject faults, mutate code, explore state space. TRIGGER when: code imports `ordeal`, user asks to test/audit/fuzz Python code, find bugs, or check test quality.
-license: Complete terms in LICENSE.txt
+description: Test Python code with ordeal — discover properties, inject faults, mutate, explore state space
+user_invocable: true
 ---
 
 # ordeal — automated chaos testing for Python
 
-You have access to `ordeal`, an automated testing toolkit for Python. It discovers properties, injects faults, runs mutation testing, and explores reachable states. Use it when the user asks you to test, audit, or improve test coverage for Python code.
-
-Install: `pip install ordeal` (or `uv add ordeal`)
+You have access to `ordeal`, an automated testing toolkit. Use it when the user asks you to test, audit, or improve test coverage for Python code.
 
 ## When to use ordeal
 
@@ -29,7 +27,7 @@ Install: `pip install ordeal` (or `uv add ordeal`)
 ## Commands
 
 ```
-ordeal init <package>              # zero-to-tests: mine -> generate -> mutate-validate -> explore
+ordeal init <package>              # zero-to-tests: mine → generate → mutate-validate → explore
 ordeal init --dry-run              # preview without writing
 ordeal audit <module>              # mutation score + property coverage + test gaps
 ordeal mutate <target>             # mutation testing (function or module)
@@ -42,13 +40,23 @@ ordeal replay --shrink --ablate <trace.json>  # shrink + find which faults matte
 ordeal benchmark                   # USL scaling analysis
 ```
 
+## Living reference
+
+`catalog()` returns every fault, invariant, strategy, and capability at runtime — always up-to-date even when this skill isn't. When in doubt, call it.
+
+```python
+from ordeal import catalog
+c = catalog()
+for key in sorted(c):
+    print(f"\n{key}:")
+    for item in c[key]:
+        print(f"  {item['qualname']}  -- {item['doc']}")
+```
+
 ## Python API (when you need more control)
 
 ```python
-from ordeal import mutate, catalog
-
-# See everything ordeal can do
-catalog()
+from ordeal import mutate
 
 # Mutation testing — are tests strong enough?
 result = mutate("myapp.scoring.compute")
@@ -75,7 +83,7 @@ state = explore("myapp")  # mine + scan + mutate + chaos in one pass
 
 ## Reading results
 
-- `mutate()` returns a `MutationResult` with `.score` (0.0-1.0), `.survived` (list of gaps), `.summary()`, `.generate_test_stubs()`
+- `mutate()` returns a `MutationResult` with `.score` (0.0–1.0), `.survived` (list of gaps), `.summary()`, `.generate_test_stubs()`
 - `ordeal init` prints JSON to stdout (for you) and a quality report to stderr (for the human)
 - `ordeal audit` prints a structured report with mutation score, property coverage, and specific test gaps
 - `ordeal explore` saves traces to `.ordeal/traces/` and seeds to `.ordeal/seeds/`

--- a/skills/ordeal/SKILL.md
+++ b/skills/ordeal/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: ordeal
+description: Automated chaos testing for Python — discover properties, inject faults, mutate code, explore state space. TRIGGER when: code imports `ordeal`, user asks to test/audit/fuzz Python code, find bugs, or check test quality.
+license: Complete terms in LICENSE.txt
+---
+
+# ordeal — automated chaos testing for Python
+
+You have access to `ordeal`, an automated testing toolkit for Python. It discovers properties, injects faults, runs mutation testing, and explores reachable states. Use it when the user asks you to test, audit, or improve test coverage for Python code.
+
+Install: `pip install ordeal` (or `uv add ordeal`)
+
+## When to use ordeal
+
+- User says "test this", "is this well-tested?", "find bugs", "what could go wrong?"
+- User wants to know if a refactor changed behavior
+- User wants chaos/fault-injection testing
+- A module has no tests or weak tests
+
+## Quick decision tree
+
+1. **No tests exist yet** → run `ordeal init <package>` (discovers properties, generates tests, validates with mutations)
+2. **Tests exist, check quality** → run `ordeal audit <module>`
+3. **Test a specific function** → use `mutate()` in Python or `ordeal mutate <target>`
+4. **Deep exploration** → run `ordeal explore`
+5. **Discover what a function does** → run `ordeal mine <target>`
+6. **Compare two implementations** → use `diff(old_fn, new_fn)` in Python
+
+## Commands
+
+```
+ordeal init <package>              # zero-to-tests: mine -> generate -> mutate-validate -> explore
+ordeal init --dry-run              # preview without writing
+ordeal audit <module>              # mutation score + property coverage + test gaps
+ordeal mutate <target>             # mutation testing (function or module)
+ordeal mutate <target> -p thorough # all 14 mutation operators
+ordeal mutate <target> --generate-stubs tests/gaps.py  # write tests for surviving mutants
+ordeal mine <target>               # discover properties of a function
+ordeal explore                     # coverage-guided state-space exploration (reads ordeal.toml)
+ordeal replay <trace.json>         # replay a failure trace
+ordeal replay --shrink --ablate <trace.json>  # shrink + find which faults matter
+ordeal benchmark                   # USL scaling analysis
+```
+
+## Python API (when you need more control)
+
+```python
+from ordeal import mutate, catalog
+
+# See everything ordeal can do
+catalog()
+
+# Mutation testing — are tests strong enough?
+result = mutate("myapp.scoring.compute")
+print(result.summary())              # gaps with cause + fix
+stubs = result.generate_test_stubs() # ready-to-use test code
+result.kill_attribution()            # which tests kill which mutants
+
+# Discover properties
+from ordeal import mine
+props = mine("myapp.scoring.compute")  # returns discovered invariants
+
+# Chaos testing — what if calls fail?
+from ordeal import chaos_for
+chaos_for("myapp.scoring")  # auto-discovers faults + invariants
+
+# Differential testing — did a refactor change behavior?
+from ordeal import diff
+diff(old_fn, new_fn)
+
+# Module-wide exploration
+from ordeal.state import explore
+state = explore("myapp")  # mine + scan + mutate + chaos in one pass
+```
+
+## Reading results
+
+- `mutate()` returns a `MutationResult` with `.score` (0.0-1.0), `.survived` (list of gaps), `.summary()`, `.generate_test_stubs()`
+- `ordeal init` prints JSON to stdout (for you) and a quality report to stderr (for the human)
+- `ordeal audit` prints a structured report with mutation score, property coverage, and specific test gaps
+- `ordeal explore` saves traces to `.ordeal/traces/` and seeds to `.ordeal/seeds/`
+
+## Interpreting gaps
+
+When mutants survive, each one has:
+- `.operator` — what was changed (e.g., "negate_condition", "boundary_off_by_one")
+- `.source_line` — where in the source
+- `.remediation` — what test to write
+
+Generate stubs with `result.generate_test_stubs()` — they include real param names, typed examples, and invariant suggestions.
+
+## Key patterns
+
+- **Seeds auto-replay**: failing inputs save to `.ordeal/seeds/` and replay on every `pytest` run
+- **Fault ablation**: after finding a bug, `ablate_faults(trace)` tells you which faults were necessary
+- **`--chaos` flag**: enables fault injection during pytest; `--chaos-seed 42` for reproducibility
+- **Config via `ordeal.toml`**: explore, mutate, and audit all read from it
+
+## What NOT to do
+
+- Don't weaken a test to make it pass — if a test exposes a bug, fix the source
+- Don't skip `ordeal init` and hand-write everything — let ordeal discover properties first, then refine
+- Don't run `mutate()` on code that imports heavy frameworks (numpy/torch) without `--mutant-timeout`


### PR DESCRIPTION
## Summary

- Adds `skills/ordeal/` with SKILL.md teaching AI agents how to use [ordeal](https://github.com/teilomillet/ordeal) for Python testing
- Registers the skill in `marketplace.json` under example-skills

## What is ordeal?

ordeal is an automated chaos testing toolkit for Python. It discovers properties, injects faults, runs mutation testing, and explores reachable states. Key capabilities:

- `ordeal init` — zero-to-validated-tests in one command (mine properties, generate tests, validate with mutations)
- `ordeal mutate` — mutation testing with gap analysis and test stub generation
- `ordeal explore` — coverage-guided state-space exploration (AFL-style)
- `ordeal audit` — mutation score + property coverage + test gap reporting
- Fault injection, chaos testing, differential testing, metamorphic testing

## What the skill teaches agents

- Decision tree: which ordeal tool to use for a given task
- CLI commands and Python API with examples
- How to read and interpret results (mutation gaps, coverage reports)
- Key patterns (seed replay, fault ablation, config)

## Test plan

- [ ] Verify SKILL.md frontmatter follows repo conventions (name, description, license)
- [ ] Verify marketplace.json is valid JSON
- [ ] Verify skill activates when user asks to test Python code

🤖 Generated with [Claude Code](https://claude.com/claude-code)