### PR TITLE
feat(skill-creator): add --eval-model option for separate eval and improvement models

### DIFF
--- a/skills/skill-creator/scripts/run_loop.py
+++ b/skills/skill-creator/scripts/run_loop.py
@@ -58,6 +58,7 @@ def run_loop(
     verbose: bool,
     live_report_path: Path | None = None,
     log_dir: Path | None = None,
+    eval_model: str | None = None,
 ) -> dict:
     """Run the eval + improvement loop."""
     project_root = find_project_root()
@@ -95,7 +96,7 @@ def run_loop(
             project_root=project_root,
             runs_per_query=runs_per_query,
             trigger_threshold=trigger_threshold,
-            model=model,
+            model=eval_model or model,
         )
         eval_elapsed = time.time() - t0
 
@@ -252,7 +253,8 @@ def main():
     parser.add_argument("--runs-per-query", type=int, default=3, help="Number of runs per query")
     parser.add_argument("--trigger-threshold", type=float, default=0.5, help="Trigger rate threshold")
     parser.add_argument("--holdout", type=float, default=0.4, help="Fraction of eval set to hold out for testing (0 to disable)")
-    parser.add_argument("--model", required=True, help="Model for improvement")
+    parser.add_argument("--model", required=True, help="Model for all stages (improvement and eval)")
+    parser.add_argument("--eval-model", default=None, help="Model for eval trigger testing (defaults to --model if not set)")
     parser.add_argument("--verbose", action="store_true", help="Print progress to stderr")
     parser.add_argument("--report", default="auto", help="Generate HTML report at this path (default: 'auto' for temp file, 'none' to disable)")
     parser.add_argument("--results-dir", default=None, help="Save all outputs (results.json, report.html, log.txt) to a timestamped subdirectory here")
@@ -304,6 +306,7 @@ def main():
         verbose=args.verbose,
         live_report_path=live_report_path,
         log_dir=log_dir,
+        eval_model=args.eval_model,
     )
 
     # Save JSON output


### PR DESCRIPTION
## Summary

Adds an optional `--eval-model` CLI argument to `run_loop.py`, allowing users to specify a different model for the eval trigger-testing phase while `--model` remains the primary model for description improvement.

## Motivation

The `run_loop.py` script has two distinct phases with very different cost/quality profiles:

| Phase | Calls | Concurrency | Priority |
|-------|-------|-------------|----------|
| **Eval** (trigger testing) | Many (num_workers × runs_per_query × eval_set_size) | High (default 10 workers) | Speed & cost |
| **Improve** (description rewrite) | 1 per iteration | None | Quality |

Currently both phases are forced to use the same `--model`. In practice, users often want a lighter/cheaper model for the high-volume eval phase and a stronger model for the single-call description improvement. For example:

```bash
# Before: forced to pick one model for both phases
python3 -m scripts.run_loop --model claude-opus-4-6 ...   # expensive for eval
python3 -m scripts.run_loop --model claude-haiku-4-5 ...  # weak for improvement

# After: best of both worlds
python3 -m scripts.run_loop \
  --model claude-opus-4-6 \           # strong model for description improvement
  --eval-model claude-haiku-4-5 \     # fast/cheap model for trigger testing
  ...
```

## Changes

4 minimal changes in `skills/skill-creator/scripts/run_loop.py`:

1. **`run_loop()` function**: Added `eval_model: str | None = None` parameter
2. **`run_eval()` call**: Changed `model=model` → `model=eval_model or model` (falls back to `--model` when not set)
3. **`improve_description()` call**: Unchanged — always uses `--model` (the primary model)
4. **CLI**: Added `--eval-model` argument; updated `--model` help text from "Model for improvement" to "Model for all stages (improvement and eval)"

## Backward Compatibility

Fully backward compatible. Without `--eval-model`, behavior is identical to the current version — both phases use `--model`.

## Testing

Tested locally with:

```bash
# Without --eval-model (backward compat): works identically to before
python3 -m scripts.run_loop --model claude-sonnet-4-6 \
  --eval-set evals/eval_set.json --skill-path . --verbose

# With --eval-model: eval uses haiku, improvement uses opus
python3 -m scripts.run_loop --model claude-opus-4-6 --eval-model claude-haiku-4-5 \
  --eval-set evals/eval_set.json --skill-path . --verbose
```

Both modes produce correct results. The `--eval-model` variant completes eval phases significantly faster while maintaining improvement quality.