### PR TITLE
Add demo-video and code-tour skills

### DIFF
--- a/skills/code-tour/SKILL.md
+++ b/skills/code-tour/SKILL.md
@@ -1,0 +1,466 @@
+---
+name: code-tour
+description: >
+  Create CodeTour .tour files -- persona-targeted, step-by-step walkthroughs
+  that link to real files and line numbers. Supports 20 developer personas,
+  all CodeTour step types, and tour-level fields (ref, isPrimary, nextTour).
+  Works with any repository in any language.
+trigger: |
+  When the user asks to create a tour, code tour, onboarding tour, PR review tour,
+  architecture tour, RCA tour, bug tour, vibe check, contributor guide, or any
+  structured walkthrough through code. Phrases: "create a tour", "make a code tour",
+  "generate a tour", "onboarding tour", "tour for this PR", "tour for this bug",
+  "RCA tour", "architecture tour", "explain how X works", "vibe check",
+  "PR review tour", "contributor guide", "help someone ramp up".
+---
+
+# Code Tour Skill
+
+You are creating a **CodeTour** -- a persona-targeted, step-by-step walkthrough of a codebase
+that links directly to files and line numbers. CodeTour files live in `.tours/` and work with
+the [VS Code CodeTour extension](https://github.com/microsoft/codetour).
+
+> For additional tooling (validation scripts, schema, examples): [github.com/vaddisrinivas/code-tour](https://github.com/vaddisrinivas/code-tour)
+
+A great tour is not just annotated files. It is a **narrative** -- a story told to a specific
+person about what matters, why it matters, and what to do next. Your goal is to write the tour
+that the right person would wish existed when they first opened this repo.
+
+**CRITICAL: Only create `.tour` JSON files in `.tours/`. Never create, modify, or scaffold any other files.**
+
+## When to Use
+
+Activate when the user asks for any kind of guided code walkthrough:
+- Onboarding tours for new team members
+- PR review tours that tell the "change story"
+- Architecture overviews for tech leads
+- Bug/RCA investigation trails
+- Feature explainers (UI -> API -> backend -> storage)
+- Quick "vibe check" tours (5-8 steps, fast path only)
+- Security review tours mapping trust boundaries
+- Contributor guides for open source repos
+
+## How It Works
+
+1. **Discover the repo** -- explore the codebase structure, read key files, map entry points
+2. **Infer the intent** -- determine persona, depth, and focus from the user's request
+3. **Read actual files** -- verify every file path and line number before writing them into the tour
+4. **Write the tour** -- save to `.tours/<persona>-<focus>.tour` with proper narrative arc
+5. **Validate** -- confirm every path exists, every line number is in bounds, narrative flows
+
+No external tools required -- the skill works entirely through file reading and JSON writing.
+
+## Examples
+
+**"Create an onboarding tour for new joiners"**
+- Use `new-joiner` persona, standard depth (9-13 steps)
+- Start with a directory step on `src/`, cover setup, business context, service boundaries
+- Define team terms, explain the key modules, close with suggested next tours
+
+**"Tour for PR #456"**
+- Use `pr-reviewer` persona, set `ref` to the PR branch
+- Open with a `uri` step linking to the PR, cover changed files with "why" context
+- Add steps for unchanged-but-critical dependency files, close with reviewer checklist
+
+**"Quick vibe check of this repo"**
+- Use `vibecoder` persona, quick depth (5-8 steps max)
+- Entry point, main loop, core modules -- "start here / core loop / ignore for now"
+- Cut ruthlessly, no deep dives
+
+---
+
+## Step 1: Discover the repo
+
+Before asking the user anything, explore the codebase:
+
+- List the root directory, read the README, and check key config files
+  (package.json, pyproject.toml, go.mod, Cargo.toml, composer.json, etc.)
+- Identify the language(s), framework(s), and what the project does
+- Map the folder structure 1-2 levels deep
+- Find entry points: main files, index files, app bootstrapping
+- **Note which files actually exist** -- every path you write in the tour must be real
+
+If the repo is sparse or empty, say so and work with what exists.
+
+### Entry points by language/framework
+
+Don't read everything -- start here, then follow imports.
+
+| Stack | Entry points to read first |
+|-------|---------------------------|
+| **Node.js / TS** | `index.js/ts`, `server.js`, `app.js`, `src/main.ts`, `package.json` (scripts) |
+| **Python** | `main.py`, `app.py`, `__main__.py`, `manage.py` (Django), `app/__init__.py` (Flask/FastAPI) |
+| **Go** | `main.go`, `cmd/<name>/main.go`, `internal/` |
+| **Rust** | `src/main.rs`, `src/lib.rs`, `Cargo.toml` |
+| **Java / Kotlin** | `*Application.java`, `src/main/java/.../Main.java`, `build.gradle` |
+| **Ruby** | `config/application.rb`, `config/routes.rb`, `app/controllers/application_controller.rb` |
+| **PHP** | `index.php`, `public/index.php`, `bootstrap/app.php` (Laravel) |
+
+### Repo type variants -- adjust focus accordingly
+
+| Repo type | What to emphasize | Typical anchor files |
+|-----------|-------------------|----------------------|
+| **Service / API** | Request lifecycle, auth, error contracts | router, middleware, handler, schema |
+| **Library / SDK** | Public API surface, extension points, versioning | index/exports, types, changelog |
+| **CLI tool** | Command parsing, config loading, output formatting | main, commands/, config |
+| **Monorepo** | Package boundaries, shared contracts, build graph | root package.json/pnpm-workspace, shared/, packages/ |
+| **Frontend app** | Component hierarchy, state management, routing | pages/, store/, router, api/ |
+
+### Large repo strategy
+
+For repos with 100+ files: don't try to read everything.
+
+1. Read entry points and the README first
+2. Build a mental model of the top 5-7 modules
+3. For the requested persona, identify the **2-3 modules that matter most** and read those deeply
+4. For modules you're not covering, mention them in the intro step as "out of scope for this tour"
+5. Use `directory` steps for areas you mapped but didn't read -- they orient without requiring full knowledge
+
+A focused 10-step tour of the right files beats a scattered 25-step tour of everything.
+
+---
+
+## Step 2: Read the intent -- infer everything you can, ask only what you can't
+
+**One message from the user should be enough.** Read their request and infer persona,
+depth, and focus before asking anything.
+
+### Intent map
+
+| User says | Persona | Depth | Action |
+|-----------|---------|-------|--------|
+| "tour for this PR" / "PR review" / "#123" | pr-reviewer | standard | Add `uri` step for the PR; use `ref` for the branch |
+| "why did X break" / "RCA" / "incident" | rca-investigator | standard | Trace the failure causality chain |
+| "debug X" / "bug tour" / "find the bug" | bug-fixer | standard | Entry -> fault points -> tests |
+| "onboarding" / "new joiner" / "ramp up" | new-joiner | standard | Directories, setup, business context |
+| "quick tour" / "vibe check" / "just the gist" | vibecoder | quick | 5-8 steps, fast path only |
+| "explain how X works" / "feature tour" | feature-explainer | standard | UI -> API -> backend -> storage |
+| "architecture" / "tech lead" / "system design" | architect | deep | Boundaries, decisions, tradeoffs |
+| "security" / "auth review" / "trust boundaries" | security-reviewer | standard | Auth flow, validation, sensitive sinks |
+| "refactor" / "safe to extract?" | refactorer | standard | Seams, hidden deps, extraction order |
+| "contributor" / "open source onboarding" | external-contributor | quick | Safe areas, conventions, landmines |
+
+**Infer silently:** persona, depth, focus area, whether to add `uri`/`ref`, `isPrimary`.
+
+**Ask only if you genuinely can't infer:**
+- "bug tour" but no bug described -> ask for the bug description
+- "feature tour" but no feature named -> ask which feature
+
+### PR tour recipe
+
+When the user says "tour for this PR" or pastes a GitHub PR URL:
+
+1. Set `"ref"` to the PR's branch name
+2. Open with a `uri` step pointing to the PR itself
+3. Cover **changed files first** -- what changed and why
+4. Add steps for **files not in the diff** that reviewers must understand
+5. Flag invariants the change must preserve
+6. Close with a reviewer checklist
+
+---
+
+## Step 3: Read the actual files -- no exceptions
+
+**Every file path and line number in the tour must be verified by reading the file.**
+A tour pointing to the wrong file or a non-existent line is worse than no tour.
+
+For every planned step:
+1. Read the file
+2. Find the exact line of the code you want to highlight
+3. Understand it well enough to explain it to the target persona
+
+If a user-requested file doesn't exist, say so -- don't silently substitute another.
+
+---
+
+## Step 4: Write the tour
+
+Save to `.tours/<persona>-<focus>.tour`.
+
+### Tour root
+
+```json
+{
+  "$schema": "https://aka.ms/codetour-schema",
+  "title": "Descriptive Title -- Persona / Goal",
+  "description": "One sentence: who this is for and what they'll understand after.",
+  "ref": "main",
+  "isPrimary": false,
+  "nextTour": "Title of follow-up tour",
+  "steps": []
+}
+```
+
+Omit any field that doesn't apply to this tour.
+
+---
+
+### Step types -- the full toolkit
+
+**Content step** -- narrative only, no file. Use for intro and closing. Max 2 per tour.
+```json
+{ "title": "Welcome", "description": "markdown..." }
+```
+
+**Directory step** -- orient to a module. "What lives here."
+```json
+{ "directory": "src/services", "title": "Service Layer", "description": "..." }
+```
+
+**File + line step** -- the workhorse. One specific meaningful line.
+```json
+{ "file": "src/auth/middleware.ts", "line": 42, "title": "Auth Gate", "description": "..." }
+```
+
+> **Path rule -- always relative to repo root.** Never use an absolute path and never use a leading `./`.
+
+**Selection step** -- a block of logic. Use when one line isn't enough.
+```json
+{
+  "file": "src/core/pipeline.py",
+  "selection": { "start": { "line": 15, "character": 0 }, "end": { "line": 34, "character": 0 } },
+  "title": "The Request Pipeline",
+  "description": "..."
+}
+```
+
+**Pattern step** -- match by regex instead of line number. Use when line numbers shift frequently.
+```json
+{ "file": "src/app.ts", "pattern": "export default class Application", "title": "...", "description": "..." }
+```
+
+**URI step** -- link to an external resource: a PR, issue, RFC, ADR, architecture diagram.
+```json
+{
+  "uri": "https://github.com/org/repo/pull/456",
+  "title": "The PR That Introduced This Pattern",
+  "description": "..."
+}
+```
+
+**View step** -- auto-focus a VS Code panel (terminal, problems, scm, explorer).
+```json
+{ "file": "src/server.ts", "line": 1, "view": "terminal", "title": "...", "description": "..." }
+```
+
+**Commands step** -- execute VS Code commands when the reader arrives.
+```json
+{
+  "file": "src/server.ts", "line": 1,
+  "title": "Run It",
+  "description": "Hit the play button.",
+  "commands": ["workbench.action.terminal.focus"]
+}
+```
+
+### When to use each step type
+
+| Situation | Step type |
+|-----------|-----------|
+| Tour intro or closing | content |
+| "Here's what lives in this folder" | directory |
+| One line tells the whole story | file + line |
+| A function/class body is the point | selection |
+| Line numbers shift, file is volatile | pattern |
+| PR / issue / doc gives the "why" | uri |
+| Reader should open terminal or explorer | view or commands |
+
+---
+
+### Step count calibration
+
+| Depth | Total steps | Core path steps | Notes |
+|-------|-------------|-----------------|-------|
+| Quick | 5-8 | 3-5 | Vibecoder, fast explorer -- cut ruthlessly |
+| Standard | 9-13 | 6-9 | Most personas -- breadth + enough detail |
+| Deep | 14-18 | 10-13 | Architect, RCA -- every tradeoff surfaced |
+
+Scale with repo size too:
+
+| Repo size | Recommended standard depth |
+|-----------|---------------------------|
+| Tiny (< 20 files) | 5-8 steps |
+| Small (20-80 files) | 8-11 steps |
+| Medium (80-300 files) | 10-13 steps |
+| Large (300+ files) | 12-15 steps (scoped to relevant subsystem) |
+
+---
+
+### Writing excellent descriptions -- the SMIG formula
+
+Every description should answer four questions in order:
+
+**S -- Situation**: What is the reader looking at? One sentence grounding them in context.
+**M -- Mechanism**: How does this code work? What pattern, rule, or design is in play?
+**I -- Implication**: Why does this matter for *this persona's goal specifically*?
+**G -- Gotcha**: What would a smart person get wrong here? What's non-obvious or surprising?
+
+### Persona vocabulary cheat sheet
+
+| Persona | Their vocabulary | Avoid |
+|---------|-----------------|-------|
+| New joiner | "this means", "you'll need to", "the team calls this" | acronyms, assumed context |
+| Bug fixer | "failure path", "where this breaks", "repro steps" | architecture history |
+| Security reviewer | "trust boundary", "untrusted input", "privilege escalation" | vague "be careful" |
+| PR reviewer | "invariant", "this must stay true", "the change story" | unrelated context |
+| Architect | "seam", "coupling", "extension point", "decision" | step-by-step walkthroughs |
+| Vibecoder | "the main loop", "ignore for now", "start here" | deep explanations |
+
+---
+
+## Narrative arc -- every tour, every persona
+
+1. **Orientation** -- **must be a `file` or `directory` step, never content-only.**
+   A content-only first step renders as a blank page in VS Code CodeTour.
+
+2. **High-level map** (1-3 directory or uri steps) -- major modules and how they relate.
+
+3. **Core path** (file/line, selection, pattern, uri steps) -- the specific code that matters.
+
+4. **Closing** (content) -- what the reader now understands, what they can do next,
+   2-3 suggested follow-up tours.
+
+### What makes a closing step excellent
+
+Don't summarize -- the reader just read it. Instead tell them:
+- What they're now capable of doing
+- What danger zones to avoid
+- Which tour to read next and why
+
+---
+
+## The 20 personas
+
+| Persona | Goal | Must cover | Avoid |
+|---------|------|------------|-------|
+| **Vibecoder** | Get the vibe fast | Entry point, request flow, main modules. Max 8 steps. | Deep dives, history, edge cases |
+| **New joiner** | Structured ramp-up | Directories, setup, business context, service boundaries. | Advanced internals before basics |
+| **Reboarding engineer** | Catch up on changes | What's new vs. what they remember. | Re-explaining known things |
+| **Bug fixer** | Root cause fast | Trigger -> fault points -> tests. Repro hints. | Architecture tours |
+| **RCA investigator** | Why did it fail | Causality chain. State transitions, side effects, race conditions. | Happy path |
+| **Feature explainer** | One feature end-to-end | UI -> API -> backend -> storage. | Unrelated features |
+| **Concept learner** | Understand a pattern | Concept -> implementation -> why -> tradeoffs. | Code without framing |
+| **PR reviewer** | Review correctly | Change story, invariants, risky areas. URI step for PR. | Unrelated context |
+| **Maintainer** | Long-term health | Architectural intent, extension points, invariants. | One-time setup |
+| **Refactorer** | Safe restructuring | Seams, hidden deps, safe extraction order. | Feature explanations |
+| **Performance optimizer** | Find bottlenecks | Hot paths, N+1, I/O, caches. | Cold paths, setup code |
+| **Security reviewer** | Trust boundaries | Auth flow, input validation, secret handling. | Unrelated business logic |
+| **Test writer** | Add good tests | Behavior contracts, mocking seams, coverage gaps. | Implementation detail |
+| **API consumer** | Call the system correctly | Public surface, auth, error semantics. | Internal implementation |
+| **Platform engineer** | Operational understanding | Boot sequence, config, infra deps, graceful shutdown. | Business logic |
+| **Data engineer** | Data lineage | Event emission, schemas, source-to-sink path. | UI / request flow |
+| **AI agent operator** | Deterministic navigation | Stable anchors, allowed edit zones, validation steps. | Ambiguous structure |
+| **Product-minded engineer** | Business rules in code | Domain language, feature toggles, "why this weird code?" | Pure infrastructure |
+| **External contributor** | Contribute safely | Safe areas, code style, architecture landmines. | Deep internals |
+| **Tech lead / architect** | Shape and rationale | Boundaries, tradeoffs, risk hotspots, future evolution. | Line-by-line walkthroughs |
+
+---
+
+## Designing a tour series
+
+When a codebase is complex enough that one tour can't cover it, design a series.
+The `nextTour` field chains them: when the reader finishes one tour, VS Code offers
+to launch the next automatically.
+
+**Plan the series before writing any tour.** A good series has:
+- A clear escalation path (broad -> narrow, orientation -> deep-dive)
+- No duplicate steps between tours
+- Each tour standalone enough to be useful on its own
+
+**Common series patterns:**
+
+*Onboarding series:*
+1. "Orientation" -> repo structure, how to run it (isPrimary: true)
+2. "Core Request Flow" -> entry to response, middleware chain
+3. "Data Layer" -> models, migrations, query patterns
+
+*Architecture series:*
+1. "Module Boundaries" -> what lives where and why
+2. "Extension Points" -> where to add new features
+3. "Danger Zones" -> what must never be changed carelessly
+
+Set `nextTour` in each tour to the `title` of the next one (must match exactly).
+
+---
+
+## What CodeTour cannot do
+
+| Request | Reality |
+|---|---|
+| **Auto-advance after X seconds** | Not supported. Navigation is always manual. |
+| **Embed video or GIF** | Not supported. Descriptions are Markdown text only. |
+| **Run shell commands** | Not supported. `commands` only executes VS Code commands. |
+| **Branch / conditional next step** | Not supported. Tours are linear. |
+| **Show step without opening a file** | Partially -- content-only steps work, but step 1 must have a `file` or `directory` anchor. |
+
+---
+
+## Anti-patterns -- what ruins a tour
+
+| Anti-pattern | What it looks like | The fix |
+|---|---|---|
+| **File listing** | Visiting files in sequence with "this file contains..." | Tell a story -- each step should depend on the previous one |
+| **Generic descriptions** | "This is the main entry point." | Name the specific pattern or gotcha unique to this codebase |
+| **Line number guessing** | Writing `"line": 42` without reading the file | Never write a line number you didn't verify |
+| **Ignoring the persona** | Security reviewer getting a folder structure tour | Cut every step that doesn't serve their goal |
+| **Too many steps** | A 20-step "vibecoder" tour | Actually cut steps, don't just label it "quick" |
+| **Hallucinated files** | Steps pointing to files that don't exist | If it doesn't exist, skip the step |
+| **Recap closing** | "In this tour we covered X, Y, and Z." | Tell the reader what they can now *do* and where to go next |
+
+---
+
+## Quality checklist -- verify before writing the file
+
+- [ ] Every `file` path is **relative to the repo root** (no leading `/` or `./`)
+- [ ] Every `file` path read and confirmed to exist
+- [ ] Every `line` number verified by reading the file (not guessed)
+- [ ] Every `directory` confirmed to exist
+- [ ] Every `pattern` regex would match a real line in the file
+- [ ] Every `uri` is a complete, real URL (https://...)
+- [ ] `ref` is a real branch/tag/commit if set
+- [ ] `nextTour` exactly matches the `title` of another `.tour` file if set
+- [ ] Only `.tour` JSON files created -- no source code touched
+- [ ] First step has a `file` or `directory` anchor (not content-only)
+- [ ] Tour ends with a closing step that tells the reader what they can *do* next
+- [ ] Every description answers SMIG -- Situation, Mechanism, Implication, Gotcha
+- [ ] Persona's priorities drive step selection
+- [ ] Step count matches requested depth and repo size
+- [ ] At most 2 content-only steps (intro + closing)
+
+---
+
+## Step 5: Validate the tour
+
+After writing the tour, verify manually:
+1. Confirm step 1 has a `file` or `directory` field
+2. Confirm every `file` path exists by reading it (relative to repo root, no leading `./`)
+3. Confirm every `line` is within the file's line count
+4. Confirm every `directory` exists
+5. Read the step titles in sequence -- do they tell a coherent story?
+6. Confirm `nextTour` matches another tour's `title` exactly
+
+---
+
+## Step 6: Summarize
+
+After writing the tour, tell the user:
+- File path (`.tours/<name>.tour`)
+- One-paragraph summary of what the tour covers and who it's for
+- The `vscode.dev` URL if the repo is public (so they can share it immediately):
+  `https://vscode.dev/github.com/<owner>/<repo>`
+- 2-3 suggested follow-up tours
+- Any user-requested files that didn't exist (be explicit)
+
+---
+
+## File naming
+
+`<persona>-<focus>.tour` -- kebab-case:
+```
+onboarding-new-joiner.tour
+bug-fixer-payment-flow.tour
+architect-overview.tour
+vibecoder-quickstart.tour
+pr-review-auth-refactor.tour
+security-auth-boundaries.tour
+```

--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -1,0 +1,442 @@
+---
+name: demo-video
+description: >
+  Create polished demo videos from screenshots and scene descriptions.
+  Think like a video producer — story arc, pacing, emotion, visual hierarchy.
+  Orchestrates playwright, ffmpeg, and edge-tts MCPs directly.
+trigger: |
+  When the user asks to create a demo video, product walkthrough, feature showcase,
+  animated presentation, marketing video, product teaser, GIF, launch video,
+  onboarding video, or any visual content from screenshots, UI captures, or descriptions.
+  Phrases: "make a video", "create a demo", "product video", "demo video",
+  "animated walkthrough", "feature showcase", "record a demo", "make a GIF",
+  "launch video", "product teaser", "show how it works", "promo video".
+---
+
+# Demo Video Skill
+
+You are a video producer. Not a slideshow maker. Every frame has a job. Every second earns the next.
+
+> For the full plugin with MCP servers, templates, and automated pipeline: [github.com/vaddisrinivas/framecraft](https://github.com/vaddisrinivas/framecraft)
+
+## When to Use
+
+Activate when the user asks you to create any kind of demo video, product walkthrough, animated presentation, or visual showcase. This includes:
+- Product demos and feature showcases
+- Marketing videos and product teasers
+- Animated walkthroughs and onboarding videos
+- GIFs for README files or landing pages
+- Launch videos and promo content
+
+## How It Works
+
+You orchestrate three MCP tools to produce a video:
+
+1. **Write HTML scenes** -- design each frame as a 1920x1080 HTML page with animations
+2. **Render to PNG** -- use playwright to screenshot each HTML scene
+3. **Generate voiceover** -- use edge-tts to create narration audio per scene
+4. **Composite video** -- use ffmpeg to stitch frames, audio, and transitions into MP4
+
+| MCP | Tools | Purpose |
+|-----|-------|---------|
+| **playwright** | `browser_navigate`, `browser_screenshot` | Render HTML scenes to PNG frames |
+| **ffmpeg** | `ffmpeg_convert`, `ffmpeg_merge`, `ffmpeg_extract_frames` | Composite, transitions, audio mix |
+| **edge-tts** | TTS tools | Neural voiceover (free, no API key) |
+
+### Rendering flow
+
+Write HTML scene files to disk, then:
+1. Use playwright to navigate to each HTML file and take a 1920x1080 screenshot
+2. Use edge-tts to generate an MP3 for each scene's narration text
+3. Use ffmpeg to combine each screenshot + audio into a scene clip (with duration matching audio + 1.5s buffer)
+4. Use ffmpeg to concatenate all scene clips with crossfade transitions into the final video
+
+## Examples
+
+**"Make a 30-second demo video for my CLI tool"**
+- Apply The Classic Demo structure: hook, problem, magic moment, proof, invite
+- Write 5-6 HTML scenes with dark theme, Inter font, spring animations
+- Generate narration with `andrew` voice, composite with ffmpeg
+
+**"Create a GIF for my GitHub README"**
+- Apply The 15-Second Teaser structure: hook, demo, logo, tagline
+- Render at 640x360, 12fps, no audio, keep under 5MB
+- Export as GIF using ffmpeg palette optimization
+
+**"Product launch video for Twitter"**
+- Apply The Problem-Solution structure: before, after, how, CTA
+- First 3 seconds must hook -- bold text, high contrast
+- 1920x1080, 15-60 seconds, subtitles required for muted autoplay
+
+---
+
+## Your Mindset
+
+Before touching any tool, think like this:
+
+1. **What's the one thing the viewer should feel?** "Wow, I need this" -- not "huh, interesting features."
+2. **What's the story?** Every good demo is: problem -> magic moment -> proof -> invite.
+3. **What's the pace?** Fast enough to keep attention. Slow enough to land each point. Never boring.
+
+You are NOT making a documentation video. You are making something someone watches and immediately shares.
+
+---
+
+## Story Structures
+
+Pick the structure that fits. Don't default to "feature list."
+
+### The Classic Demo (30-60s)
+```
+1. HOOK         -- 3s  -- One provocative line or visual. Grab attention.
+2. PROBLEM      -- 5s  -- Show the pain. Make it visceral.
+3. MAGIC MOMENT -- 5s  -- The product in action. The "holy shit" moment.
+4. PROOF        -- 15s -- 2-3 features, each with visual evidence.
+5. SOCIAL PROOF -- 4s  -- Numbers, logos, quotes (optional).
+6. INVITE       -- 4s  -- CTA. URL. "Try it now."
+```
+
+### The Problem-Solution (20-40s)
+```
+1. BEFORE  -- 6s  -- Show the world without your product. Ugly, painful.
+2. AFTER   -- 6s  -- Same world, with your product. Beautiful, effortless.
+3. HOW     -- 10s -- Quick feature highlights.
+4. GET IT  -- 4s  -- CTA.
+```
+
+### The Feature Deep-Dive (45-90s)
+```
+1. CONTEXT   -- 4s  -- What the product is (one sentence).
+2. FEATURE 1 -- 8s  -- Screenshot + zoom + callout + narration.
+3. FEATURE 2 -- 8s  -- Different visual approach (browser mockup? animation?).
+4. FEATURE 3 -- 8s  -- Third visual style for variety.
+5. FEATURE 4 -- 8s  -- The "one more thing" -- most impressive feature last.
+6. SUMMARY   -- 4s  -- Recap badges.
+7. CTA       -- 4s  -- URL + invite.
+```
+
+### The 15-Second Teaser
+```
+1. HOOK    -- 2s  -- Bold text, no narration.
+2. DEMO    -- 8s  -- Fast cuts showing the product. Music-driven.
+3. LOGO    -- 3s  -- Product name + URL.
+4. TAGLINE -- 2s  -- One line that sticks.
+```
+
+---
+
+## Scene Design System
+
+### Visual Hierarchy Per Scene
+
+Every scene has exactly ONE primary focus. If you can't point at it, it's wrong.
+
+```
+Title scenes:    Focus = the product name
+Problem scenes:  Focus = the pain (red, chaotic, cramped)
+Solution scenes: Focus = the result (green, spacious, organized)
+Feature scenes:  Focus = the screenshot region being highlighted
+End scenes:      Focus = the URL / CTA button
+```
+
+### Color Language
+
+Colors are not decoration. They communicate.
+
+| Color | Meaning | Use for |
+|-------|---------|---------|
+| `#c5d5ff` | Trust, product identity | Titles, logo |
+| `#7c6af5` | Premium, accent | Subtitles, badges, links |
+| `#4ade80` | Success, positive | "After" states, checkmarks, good metrics |
+| `#f28b82` | Problem, danger, attention | "Before" states, error counts, warnings |
+| `#fbbf24` | Energy, highlight | Callouts, important numbers |
+| `#7a8099` | Neutral, secondary | Body text, descriptions |
+| `#0d0e12` | Background | Always. Dark mode only. |
+
+### Animation Timing Science
+
+The human eye needs **300ms** to register a new element. Faster = subliminal. Slower = boring.
+
+```
+Element entrance:     0.5-0.8s  (cubic-bezier(0.16, 1, 0.3, 1) for spring feel)
+Between elements:     0.2-0.4s  gap (stagger)
+Screenshot appear:    0.8-1.0s  (slightly slower -- it's the hero)
+Zoom into region:     1.0-1.5s  (smooth, never jarring)
+Scene transition:     0.3-0.5s  crossfade
+Hold after last anim: 1.0-2.0s  (let it breathe before next scene)
+```
+
+**The rhythm**: enter -> breathe -> enter -> breathe -> transition. Never enter -> enter -> enter.
+
+### Typography Rules
+
+```
+Title:     48-72px, weight 800, gradient or white
+Subtitle:  24-32px, weight 400, muted color
+Bullets:   18-22px, weight 600, accent color, pill-shaped background
+Callouts:  14-16px, weight 600, colored border + dot
+Body:      Never. If you need body text, you're doing it wrong.
+```
+
+**Font**: Inter. Always. Load from Google Fonts in every HTML scene.
+
+---
+
+## Writing Narration Like a Pro
+
+### The Rules
+
+1. **One idea per scene.** If you need "and" you need two scenes.
+2. **Lead with the verb.** "Organize your tabs" not "Tab organization is provided."
+3. **Cut every word you can.** Read it aloud. If you pause, add a comma. If you rush, cut words.
+4. **No jargon.** "Your tabs organize themselves" not "AI-powered ML-based tab categorization."
+5. **Use contrast.** "24 tabs. One click. 5 groups." Numbers land harder than adjectives.
+6. **End scenes with a period, not a question.** Statements are confident. Questions are weak.
+
+### Narration Patterns That Work
+
+| Pattern | Example | When to use |
+|---------|---------|-------------|
+| **Contrast** | "24 tabs. Zero organization." | Problem scenes |
+| **Magic** | "One click, and your tabs organize themselves." | Solution reveal |
+| **Proof** | "Corrections count triple. Rejections remembered 30 days." | Feature scenes |
+| **Numbers** | "8 providers. 3 completely free." | Credibility scenes |
+| **Invitation** | "Open source. Free. Try it now." | End card |
+| **Rhetorical** | "Sound familiar?" | After problem (use sparingly) |
+
+### Pacing Guide
+
+| Scene duration | Max narration words | Narration fills |
+|---------------|--------------------|-|
+| 3-4s | 8-12 words | ~70% of scene (leave breathing room) |
+| 5-6s | 15-22 words | ~75% |
+| 7-8s | 22-30 words | ~80% |
+| 9-10s | 28-35 words | ~80% (never fill 100%) |
+
+### Voice Direction
+
+| Voice | Personality | Best for |
+|-------|------------|----------|
+| `andrew` | Warm, confident, conversational | Product demos, launches |
+| `jenny` | Clear, upbeat, approachable | Tutorials, onboarding |
+| `davis` | Deep, authoritative, serious | Enterprise, security products |
+| `brian` | Professional, measured | B2B, technical demos |
+| `emma` | Friendly, enthusiastic | Consumer products, social |
+| `ryan` | British, polished | Premium/luxury positioning |
+
+**Switch voices between scenes** for variety in longer videos. Use one voice for narration and another for "quotes" or feature callouts.
+
+---
+
+## HTML Scene Craft
+
+### The Golden Layout
+
+Every scene follows this structure:
+
+```html
+<body>                          <!-- Full 1920x1080 canvas -->
+  <h1 class="title">...</h1>   <!-- Top 15% -- headline -->
+  <div class="hero">...</div>  <!-- Middle 65% -- screenshot/mockup/animation -->
+  <div class="footer">...</div> <!-- Bottom 20% -- bullets/badges/callouts -->
+</body>
+```
+
+**Never center everything vertically.** The eye enters top-left, scans in an F-pattern. Title up top, hero in the middle, proof at the bottom.
+
+### Background Recipe
+
+Always use this. Never flat black.
+
+```css
+background: #0d0e12;
+background-image:
+  radial-gradient(ellipse at 20% 30%, rgba(124,106,245,0.15) 0%, transparent 50%),
+  radial-gradient(ellipse at 80% 70%, rgba(79,139,255,0.10) 0%, transparent 50%);
+```
+
+Subtle purple-blue glow. Feels premium without being distracting.
+
+### Screenshot Presentation
+
+Never show a raw screenshot. Always:
+
+```css
+.screenshot {
+  border-radius: 12px;
+  box-shadow: 0 20px 60px rgba(0,0,0,0.5), 0 0 0 1px rgba(255,255,255,0.08);
+}
+```
+
+The shadow sells "this is floating on a surface." The 1px border prevents edge bleed.
+
+### The Spring Easing
+
+Use this for every entrance animation. It feels alive.
+
+```css
+cubic-bezier(0.16, 1, 0.3, 1)
+```
+
+**Never use `ease` or `linear`.** They feel robotic. The spring curve overshoots slightly then settles.
+
+---
+
+## Browser Mockup Scenes
+
+For product demos that show a web UI in action.
+
+### Building a Convincing Browser
+
+```
+Traffic lights:  12px dots, colors #ff5f57 #ffbd2e #28c940
+Title bar:       #202124, 40px height
+Tab bar:         #292b2f, flex layout
+URL bar:         #35363a, rounded 20px, with lock icon
+Content area:    #1a1a2e or embed a real screenshot
+```
+
+### Tab Group Animation Pattern
+
+Groups appear one-by-one with staggered timing:
+
+```css
+.group:nth-child(1) { animation: group-in 0.6s cubic-bezier(0.16,1,0.3,1) 0.5s forwards; }
+.group:nth-child(2) { animation: group-in 0.6s cubic-bezier(0.16,1,0.3,1) 0.9s forwards; }
+.group:nth-child(3) { animation: group-in 0.6s cubic-bezier(0.16,1,0.3,1) 1.3s forwards; }
+```
+
+Each group needs:
+- A **solid-colored label chip** (the group name)
+- A **colored bottom bar** (3px, spans the group width)
+- **Tinted background** on the tab area
+- **Favicons** as small colored squares (14px) -- brand colors sell realism
+
+### "Before vs After" Technique
+
+Scene N: Messy tabs (all grey, cramped, chaotic, red "24" counter)
+Scene N+1: Same browser, but tabs now grouped with colors (green checkmark, group badges)
+
+The contrast is the whole point. Make the "before" genuinely ugly.
+
+---
+
+## Callout & Zoom Technique
+
+### Callouts
+
+Position annotation labels that point at specific UI elements:
+
+```json
+"callouts": [
+  {"text": "Correction Tracking", "x": 35, "y": 42, "color": "#4ade80", "delay": 1.5},
+  {"text": "30-day memory", "x": 35, "y": 55, "color": "#f28b82", "delay": 2.0}
+]
+```
+
+Rules:
+- Max 3 callouts per scene (more = noise)
+- Stagger by 0.5s each
+- Use different colors per callout
+- Position so they don't overlap the content they're pointing at
+
+### Zoom
+
+Start with the full screenshot, then smoothly zoom into the interesting part:
+
+```json
+"zoom": {"x": 35, "y": 45, "scale": 2.0, "delay": 1.5, "duration": 1.2}
+```
+
+Rules:
+- Only zoom AFTER the viewer has seen the full context (1.5s delay minimum)
+- Scale 1.5-2.0x (more = disorienting)
+- Duration 1.0-1.5s (faster = jarring, slower = boring)
+- The zoom target should be the thing the narration is talking about
+
+---
+
+## Scene Config Reference
+
+```json
+{
+  "scenes": [
+    {
+      "title": "Heading text",
+      "subtitle": "Secondary text",
+      "narration": "Voiceover text",
+      "voice": "andrew",
+      "screenshot": "/absolute/path/to/image.png",
+      "bullets": ["Point 1", "Point 2"],
+      "callouts": [{"text": "Label", "x": 40, "y": 55, "color": "#4ade80", "delay": 1.5}],
+      "zoom": {"x": 40, "y": 55, "scale": 1.8, "delay": 2.0, "duration": 1.0},
+      "duration": 0,
+      "animation": "fade | slide-up | scale | none",
+      "screenshot_animation": "scale | fade | slide-up | none",
+      "custom_html": "/path/to/custom.html",
+      "bg_color": "#0d0e12",
+      "title_color": "#c5d5ff",
+      "accent_color": "#7c6af5",
+      "title_size": 48
+    }
+  ],
+  "output": "/path/to/output.mp4",
+  "width": 1920,
+  "height": 1080,
+  "fps": 24,
+  "voice": "andrew",
+  "transition": "crossfade | cut",
+  "transition_duration": 0.4,
+  "background_music": "/path/to/music.mp3",
+  "music_volume": 0.15,
+  "subtitle_format": "srt | vtt"
+}
+```
+
+`duration: 0` = auto-detect from TTS length + 1.5s buffer. Always prefer this.
+
+---
+
+## Quality Checklist
+
+Before delivering, verify:
+
+### Technical
+- [ ] Video has audio stream (`ffprobe` shows both v and a)
+- [ ] Audio duration matches video duration (within 1s)
+- [ ] Resolution is 1920x1080 (or what was configured)
+- [ ] No black frames between scenes
+- [ ] File size: 1-5MB for 30s, 3-10MB for 60s
+
+### Creative
+- [ ] First 3 seconds grab attention (no slow fade from black)
+- [ ] Every scene has exactly one focus point
+- [ ] Narration matches what's on screen (no talking about Feature B while showing Feature A)
+- [ ] Color-coding is consistent (same feature = same color throughout)
+- [ ] End card has a clear URL and CTA
+- [ ] Total duration feels right (30s for teaser, 45-60s for demo, 90s max for deep dive)
+
+### The "Would I Share This?" Test
+Watch the video. If you wouldn't share it, it's not done. Common failures:
+- Too slow (fix: cut scene durations by 20%)
+- Too much text on screen (fix: move info to narration, simplify visuals)
+- Narration is generic (fix: rewrite with specific numbers and concrete verbs)
+- Looks like a slideshow (fix: add custom_html scenes with animations)
+
+---
+
+## Platform-Specific Exports
+
+| Platform | Format | Resolution | Duration | Notes |
+|----------|--------|-----------|----------|-------|
+| GitHub README | GIF | 640x360 | 15-30s | Loop, no audio, keep under 5MB |
+| Twitter/X | MP4 | 1920x1080 | 15-60s | First 3s must hook |
+| LinkedIn | MP4 | 1920x1080 | 30-90s | Subtitles required (autoplay is muted) |
+| Product Hunt | MP4 | 1920x1080 | 30-60s | Show the product working, not talking heads |
+| Chrome Web Store | MP4 | 1280x800 | 30-45s | Must show the extension in action |
+| Landing page | GIF or MP4 | 1280x720 | 10-20s | Auto-loop, no audio, hero section |
+
+Generate GIF from MP4:
+```bash
+ffmpeg -i demo.mp4 -vf "fps=12,scale=640:360:flags=lanczos,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse" demo.gif
+```


### PR DESCRIPTION
## Summary

Two self-contained skills for Claude Code:

- **demo-video** (`skills/demo-video/SKILL.md`) -- Teaches the LLM to produce polished demo videos by orchestrating playwright, ffmpeg, and edge-tts MCPs directly. Covers story structures, scene design system, narration patterns, voice direction, HTML scene craft, and a quality checklist. Full plugin with MCP servers and templates: [github.com/vaddisrinivas/framecraft](https://github.com/vaddisrinivas/framecraft)

- **code-tour** (`skills/code-tour/SKILL.md`) -- Teaches the LLM to generate CodeTour `.tour` files with persona-targeted, step-by-step code walkthroughs. Supports 20 developer personas, all CodeTour step types (file/line, selection, pattern, uri, commands, view), tour series design, and the SMIG description formula. Additional tooling: [github.com/vaddisrinivas/code-tour](https://github.com/vaddisrinivas/code-tour)

Both skills are fully self-contained -- no references to local files, install paths, or external scripts. The LLM reads the SKILL.md and has everything it needs.