### PR TITLE
Add git validation stop hook to prevent premature PR creation

### DIFF
--- a/backup/settings.json
+++ b/backup/settings.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "https://json.schemastore.org/claude-code-settings.json",
+    "hooks": {
+        "Stop": [
+            {
+                "matcher": "",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "~/.claude/stop-hook-git-check.sh"
+                    }
+                ]
+            }
+        ]
+    },
+    "permissions": {
+        "allow": ["Skill"]
+    }
+}

--- a/backup/stop-hook-git-check.sh
+++ b/backup/stop-hook-git-check.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Read the JSON input from stdin
+input=$(cat)
+
+# Check if stop hook is already active (recursion prevention)
+stop_hook_active=$(echo "$input" | jq -r '.stop_hook_active')
+if [[ "$stop_hook_active" = "true" ]]; then
+  exit 0
+fi
+
+# Check if we're in a git repository - bail if not
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  exit 0
+fi
+
+no_pr_reminder="Do not create a pull request unless the user has explicitly asked for one."
+
+# Check for uncommitted changes (both staged and unstaged)
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "There are uncommitted changes in the repository. Please commit and push these changes to the remote branch. $no_pr_reminder" >&2
+  exit 2
+fi
+
+# Check for untracked files that might be important
+untracked_files=$(git ls-files --others --exclude-standard)
+if [[ -n "$untracked_files" ]]; then
+  echo "There are untracked files in the repository. Please commit and push these changes to the remote branch. $no_pr_reminder" >&2
+  exit 2
+fi
+
+current_branch=$(git branch --show-current)
+if [[ -n "$current_branch" ]]; then
+  if git rev-parse "origin/$current_branch" >/dev/null 2>&1; then
+    # Branch exists on remote - compare against it
+    unpushed=$(git rev-list "origin/$current_branch..HEAD" --count 2>/dev/null) || unpushed=0
+    if [[ "$unpushed" -gt 0 ]]; then
+      echo "There are $unpushed unpushed commit(s) on branch '$current_branch'. Please push these changes to the remote repository. $no_pr_reminder" >&2
+      exit 2
+    fi
+  else
+    # Branch doesn't exist on remote - compare against default branch
+    unpushed=$(git rev-list "origin/HEAD..HEAD" --count 2>/dev/null) || unpushed=0
+    if [[ "$unpushed" -gt 0 ]]; then
+      echo "Branch '$current_branch' has $unpushed unpushed commit(s) and no remote branch. Please push these changes to the remote repository. $no_pr_reminder" >&2
+      exit 2
+    fi
+  fi
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
This PR adds a git repository validation hook that prevents pull request creation when there are uncommitted changes, untracked files, or unpushed commits. The hook is designed to be used as a "Stop" hook in Claude Code settings to catch common mistakes before initiating a PR workflow.

## Key Changes
- **stop-hook-git-check.sh**: New bash script that validates git repository state by checking for:
  - Uncommitted changes (both staged and unstaged)
  - Untracked files that should be committed
  - Unpushed commits on the current branch or against the default branch
  - Recursion prevention to avoid infinite loops
  - Graceful handling when not in a git repository

- **settings.json**: New Claude Code settings configuration that registers the git validation script as a Stop hook, ensuring it runs before PR-related operations

## Implementation Details
- The script reads JSON input from stdin and checks the `stop_hook_active` flag to prevent recursion
- Uses `git diff`, `git ls-files`, and `git rev-list` to comprehensively validate repository state
- Handles both cases where a remote branch exists and where it doesn't (comparing against origin/HEAD)
- Returns exit code 2 with descriptive error messages when validation fails, preventing PR creation
- Includes a reminder message to only create PRs when explicitly requested by the user

https://claude.ai/code/session_019TkrB2s4QCATL3sykRtxwD