### PR TITLE
Add use-native-llm-apis skill

### DIFF
--- a/skills/use-native-llm-apis/LICENSE.txt
+++ b/skills/use-native-llm-apis/LICENSE.txt
@@ -1,0 +1,30 @@
+© 2025 Anthropic, PBC. All rights reserved.
+
+LICENSE: Use of these materials (including all code, prompts, assets, files,
+and other components of this Skill) is governed by your agreement with
+Anthropic regarding use of Anthropic's services. If no separate agreement
+exists, use is governed by Anthropic's Consumer Terms of Service or
+Commercial Terms of Service, as applicable:
+https://www.anthropic.com/legal/consumer-terms
+https://www.anthropic.com/legal/commercial-terms
+Your applicable agreement is referred to as the "Agreement." "Services" are
+as defined in the Agreement.
+
+ADDITIONAL RESTRICTIONS: Notwithstanding anything in the Agreement to the
+contrary, users may not:
+
+- Extract these materials from the Services or retain copies of these
+  materials outside the Services
+- Reproduce or copy these materials, except for temporary copies created
+  automatically during authorized use of the Services
+- Create derivative works based on these materials
+- Distribute, sublicense, or transfer these materials to any third party
+- Make, offer to sell, sell, or import any inventions embodied in these
+  materials
+- Reverse engineer, decompile, or disassemble these materials
+
+The receipt, viewing, or possession of these materials does not convey or
+imply any license or right beyond those expressly granted above.
+
+Anthropic retains all right, title, and interest in these materials,
+including all copyrights, patents, and other intellectual property rights.

--- a/skills/use-native-llm-apis/SKILL.md
+++ b/skills/use-native-llm-apis/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: use-native-llm-apis
+description: Use when implementing, integrating, migrating, or debugging provider-native LLM APIs in code, especially auth, request shapes, streaming, tool calling, structured output, or provider switching.
+---
+
+# Use Native LLM APIs
+
+Use this skill for provider-native API implementation work, not pricing research, prompt writing, or generic AI product planning.
+
+This skill covers a broad provider registry, but the provider files are not all equally deep. Some are gold references, some are usable notes, and some are partial. Historical or reserved depth labels such as `skeleton` may still appear in maintenance docs, but the live snapshot in [references/research/coverage-status.md](references/research/coverage-status.md) is the source of truth.
+
+## Trigger Boundary
+
+Trigger when both are true:
+
+1. the request names a provider or clearly implies a provider-native API
+2. the request asks for implementation work in code
+
+Typical implementation work:
+
+- integrate / connect / call
+- migrate / switch
+- debug 400 / 401 / 422
+- add streaming
+- add tool calling
+- add structured JSON output
+- 接入 / 对接 / 调用 / 迁移 / 切换 / 排查
+
+Do not trigger for:
+
+- pricing or model comparison
+- prompt engineering
+- chatbot or RAG planning without concrete provider API work
+
+## Start Protocol
+
+Always use this order:
+
+1. open [references/start-here.md](references/start-here.md)
+2. choose exactly one task recipe
+3. resolve the provider path through [references/providers/index.md](references/providers/index.md)
+4. open the exact provider file
+5. open one comparison file only if the task requires it
+6. check [references/routing-checklist.md](references/routing-checklist.md)
+7. then write or patch code
+
+Do not jump directly from `SKILL.md` to a guessed provider file.
+
+## Missing-Info Rule
+
+Ask at most one clarification question before routing:
+
+- provider missing -> ask which provider API they want
+- provider present but task ambiguous -> ask one task question
+- provider and task both missing -> do not trigger yet
+
+Examples:
+
+- "给项目加 AI 对话" -> do not trigger yet
+- "Hook up Claude" -> ask what task they need
+- "Convert OpenAI to Gemini" -> route immediately as migration
+
+## Guardrails
+
+- Keep the work provider-native unless the user explicitly wants an abstraction layer.
+- Resolve provider paths through `references/providers/index.md`, not from memory.
+- Treat partial provider files as starting notes, not authoritative end-to-end references.
+- Treat `skeleton` as a reserved or historical depth label unless the live coverage snapshot says otherwise.
+- Prefer raw HTTP examples over abstraction-heavy wrappers.
+- Prefer official docs over memory when bundled references are insufficient.
+- Do not assume OpenAI-compatible means fully behavior-compatible.
+
+For trigger examples and few-shot routing, see [references/recipes/prompt-patterns.md](references/recipes/prompt-patterns.md).


### PR DESCRIPTION
## Summary

This PR adds the `use-native-llm-apis` skill - a provider-native LLM API integration reference for coding assistants.

## What it does

Helps developers implement, integrate, migrate, or debug provider-native LLM APIs, including:
- Native API integration (auth, request shapes, endpoints)
- Provider migration (OpenAI → Gemini/Anthropic/DeepSeek)
- Adding streaming, tool calling, structured output
- Debugging 400/401/422/429/5xx errors

## Coverage

38+ providers across 4 categories:
- **Native LLM Providers**: OpenAI, Anthropic, Gemini, DeepSeek, Zhipu, Bailian, Kimi, Doubao, MiniMax, StepFun, Xiaomi MiMo
- **Cloud Platforms**: Azure OpenAI, AWS Bedrock, NVIDIA NIM, ModelScope, GitHub Copilot SDK
- **Gateways**: OpenRouter, SiliconFlow, AiHubMix, Novita AI, NewAPI
- **Relays/Proxies**: PackyCode, Cubence, CrazyRouter, Compshare, CTok.ai, Right Code, X-Code API, Ai Go Code, AICodeMirror, DMXAPI

## Files added

- `skills/use-native-llm-apis/SKILL.md` - Skill definition with triggers and routing
- `skills/use-native-llm-apis/LICENSE.txt` - License file

## Checklist

- [x] Skill follows the SKILL.md format with YAML frontmatter
- [x] Includes clear trigger boundaries and start protocol
- [x] LICENSE file included
- [x] Tested locally

---
**Note**: This skill complements the existing `claude-api` skill by focusing on _provider-native_ APIs rather than Claude-specific implementations.