### PR TITLE
fix: claude-api skill frontmatter yaml format

### DIFF
--- a/skills/claude-api/SKILL.md
+++ b/skills/claude-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: claude-api
-description: Build, debug, and optimize Claude API / Anthropic SDK apps. Apps built with this skill should include prompt caching. TRIGGER when: code imports anthropic/@anthropic-ai/sdk; user asks to use the Claude API, Anthropic SDKs, or Managed Agents (/v1/agents, /v1/sessions, /v1/environments). DO NOT TRIGGER when: code imports `openai`/other AI SDK, general programming, or ML/data-science tasks.
+description: "Build, debug, and optimize Claude API / Anthropic SDK apps. Apps built with this skill should include prompt caching. TRIGGER when: code imports anthropic/@anthropic-ai/sdk; user asks to use the Claude API, Anthropic SDKs, or Managed Agents (/v1/agents, /v1/sessions, /v1/environments). DO NOT TRIGGER when: code imports `openai`/other AI SDK, general programming, or ML/data-science tasks."
 license: Complete terms in LICENSE.txt
 ---
 


### PR DESCRIPTION
A previous [PR](https://github.com/anthropics/skills/pull/897)￼ added skill frontmatter, but the YAML is malformed, preventing installation via `npx skills` and causing it to render incorrectly on GitHub. This fixes the issue by adding quotes around the description.

Before:
https://github.com/anthropics/skills/blob/main/skills/claude-api/SKILL.md

<img width="2642" height="874" alt="2026-04-09 at 11 52 15@2x" src="https://github.com/user-attachments/assets/a1cb5b5e-c766-4f32-9e9a-fa3ca879eb51" />

After:
https://github.com/allenzhou101/skills/blob/a/skill-yaml-rendering/skills/claude-api/SKILL.md
<img width="2752" height="1106" alt="2026-04-09 at 12 00 41@2x" src="https://github.com/user-attachments/assets/503a29ac-8aa4-4c1b-9ed3-233caa0f87d1" />

