### PR TITLE
fix(algorithmic-art): add missing Regenerate and Download PNG buttons to viewer template

### DIFF
--- a/skills/algorithmic-art/templates/viewer.html
+++ b/skills/algorithmic-art/templates/viewer.html
@@ -273,6 +273,7 @@
         .button-row {
             display: flex;
             gap: 8px;
+            margin-bottom: 8px;
         }
 
         .button-row .button {
@@ -424,8 +425,10 @@
             <div class="control-section">
                 <h3>Actions</h3>
                 <div class="button-row">
+                    <button class="button secondary" onclick="regenerateArtwork()">Regenerate</button>
                     <button class="button" onclick="resetParameters()">Reset</button>
                 </div>
+                <button class="button tertiary" onclick="downloadPNG()">Download PNG</button>
             </div>
         </div>
 
@@ -588,6 +591,14 @@
             
             updateSeedDisplay();
             initializeSystem();
+        }
+
+        function regenerateArtwork() {
+            initializeSystem();
+        }
+
+        function downloadPNG() {
+            saveCanvas('algorithmic-art-' + params.seed, 'png');
         }
 
         // Initialize UI on load


### PR DESCRIPTION
## Summary

The SKILL.md specifies three required Actions in the viewer sidebar (lines 327-335):

> **4. Actions (FIXED)** - Always include exactly as shown:
> - Regenerate button
> - Reset button
> - Download PNG button
>
> Regenerate, Reset, Download buttons must work

The `templates/viewer.html` only includes the Reset button. This PR adds the missing two.

## Changes

- **Regenerate button** (`button secondary`): calls `initializeSystem()` to re-render with the current seed and parameters
- **Download PNG button** (`button tertiary`): calls p5.js `saveCanvas()` with the seed number in the filename for traceability
- Both use existing CSS classes already defined in the template

## Test plan

- [x] Verified the three buttons render correctly in the sidebar Actions section
- [x] Regenerate re-renders without changing seed or parameters
- [x] Download PNG triggers a file download named `algorithmic-art-{seed}.png`
- [x] Reset still works as before
- [x] No changes to any other section of the template

Closes #813