### PR TITLE
Fix run_eval parallel worker matching causing ~0% recall

### DIFF
--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -50,6 +50,10 @@ def run_single_query(
     """
     unique_id = uuid.uuid4().hex[:8]
     clean_name = f"{skill_name}-skill-{unique_id}"
+    # Match any worker's temp command, not just ours. With parallel workers,
+    # Claude sees multiple identically-described commands and picks one
+    # arbitrarily — matching on the shared prefix avoids false negatives.
+    match_prefix = f"{skill_name}-skill-"
     project_commands_dir = Path(project_root) / ".claude" / "commands"
     command_file = project_commands_dir / f"{clean_name}.md"
 
@@ -144,12 +148,12 @@ def run_single_query(
                             delta = se.get("delta", {})
                             if delta.get("type") == "input_json_delta":
                                 accumulated_json += delta.get("partial_json", "")
-                                if clean_name in accumulated_json:
+                                if match_prefix in accumulated_json:
                                     return True
 
                         elif se_type in ("content_block_stop", "message_stop"):
                             if pending_tool_name:
-                                return clean_name in accumulated_json
+                                return match_prefix in accumulated_json
                             if se_type == "message_stop":
                                 return False
 
@@ -161,9 +165,9 @@ def run_single_query(
                                 continue
                             tool_name = content_item.get("name", "")
                             tool_input = content_item.get("input", {})
-                            if tool_name == "Skill" and clean_name in tool_input.get("skill", ""):
+                            if tool_name == "Skill" and match_prefix in tool_input.get("skill", ""):
                                 triggered = True
-                            elif tool_name == "Read" and clean_name in tool_input.get("file_path", ""):
+                            elif tool_name == "Read" and match_prefix in tool_input.get("file_path", ""):
                                 triggered = True
                             return triggered
 


### PR DESCRIPTION
## Summary

- Fix `run_single_query` in `skill-creator/scripts/run_eval.py` to match on skill name prefix instead of exact UUID, fixing near-zero recall when running with parallel workers

## Problem

Each parallel worker creates a uniquely-named command file (e.g. `rust-conventions-skill-a1b2c3d4.md`). With `num_workers=10` (the default), Claude sees all 10 identically-described command files and picks one arbitrarily. But each worker only checks for its own exact UUID in Claude's output — so the probability of a match is ~1/N per worker.

In practice this produces ~0% recall on `should_trigger=true` queries, making the eval results meaningless. With multiple skills running concurrently, the problem compounds further.

## Fix

Introduce `match_prefix = f"{skill_name}-skill-"` and use it in place of the exact `clean_name` for all trigger detection checks. Each command file still gets a unique name (avoiding filesystem collisions), but the trigger check now accepts any worker's file as a match.

## Validation

Tested across 5 skills (100 total queries) with the patched harness:

| Metric | Before (exact match) | After (prefix match) |
|--------|:-------------------:|:-------------------:|
| Precision | 100% | 100% |
| Recall | ~0-10% | 41-90% |
| F1 | ~0-18% | 58-95% |

Fixes #556

🤖 Generated with [Claude Code](https://claude.com/claude-code)