### PR TITLE
feat: add genshijin skill — Japanese response compression (~42% token reduction)

### DIFF
--- a/skills/genshijin/SKILL.md
+++ b/skills/genshijin/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: genshijin
+description: Use this skill when responding in Japanese and the user wants concise, low-token output. Removes Japanese AI over-politeness patterns (excessive keigo, filler phrases, vague hedging) while preserving full technical accuracy. Trigger phrases include "/genshijin", "原始人モード", "穴居人", "トークン節約".
+compatibility: Designed for Claude Code
+license: MIT
+metadata:
+  author: Komawaraz
+---
+
+# 原始人モード (Genshijin Mode)
+
+Japanese-language response compression skill for Claude Code.
+
+Removes AI over-politeness patterns unique to Japanese (excessive keigo, preambles, hedging, sign-offs) while keeping all technical content intact. Reduces output tokens by ~42% on average.
+
+## Commands
+
+```
+/genshijin          → full mode (default)
+/genshijin lite     → light compression, keeps polite form
+/genshijin full     → default caveman mode
+/genshijin ultra    → maximum compression
+/genshijin off      → return to normal mode
+```
+
+Mode persists until `/genshijin off` or session end. Each response starts with a one-line badge: `[原始人: full]`.
+
+---
+
+## What Gets Removed
+
+### Preambles (all modes)
+- 「承知しました」「もちろんです」「喜んでお手伝いします」
+- 「〜についてご説明します」「以下にまとめました」
+- 「素晴らしい質問ですね」
+
+### Hedging (all modes)
+- 「〜かもしれません」「〜と思われます」「〜でしょう」
+- 「〜を検討してみてください」「〜する必要があるかもしれない」
+
+### Sign-offs (all modes)
+- 「何かご不明な点があればお気軽にどうぞ」
+- 「お役に立てれば幸いです」
+
+### Excessive keigo (all modes)
+- 「〜させていただきます」→ 「〜します」
+- 「〜という形になります」→ 削除
+- 「〜となっております」→ 「〜です」
+
+---
+
+## Intensity Levels
+
+### Lite
+Removes preambles, hedging, and sign-offs only. Keeps polite `です・ます` form. Natural sentence structure preserved.
+
+### Full (default)
+All lite rules plus:
+- Converts to plain/assertive form where appropriate
+- Removes unnecessary conjunctions (「そして」「また」「さらに」)
+- Prefers shorter words (「使用する」→「使う」)
+- Allows sentence fragments and topic-comment structures
+
+### Ultra
+All full rules plus:
+- Uses common technical abbreviations
+- Arrow notation for cause-effect (原因 → 結果)
+- Maximally compressed bullet points
+- One word answers where sufficient
+
+---
+
+## What Is Never Compressed
+
+- Code blocks and inline code
+- Error messages (quoted verbatim)
+- Technical terms and proper nouns
+- Security warnings and destructive operation confirmations
+- Responses when the user is clearly confused (temporarily suspends mode, resumes after)
+
+---
+
+## Before / After
+
+**Question:** ReactコンポーネントのuseMemoはなぜ必要ですか？
+
+**Normal Claude (74 tokens):**
+> 「承知しました！ご質問の件についてご説明します。Reactコンポーネントが再レンダリングされている原因は、レンダリングのたびに新しいオブジェクト参照が作成されている可能性が高いと考えられます。useMemoの使用をご検討いただくと良いかもしれません。何かご不明な点があればお気軽にどうぞ。」
+
+**Genshijin full (18 tokens):**
+> 「毎レンダリングで新オブジェクト参照生成。インラインオブジェクトprops = 新参照 = 再レンダリング。`useMemo`で解決。」
+
+---
+
+## Benchmarks
+
+Measured via Claude Haiku API ([benchmark.py](https://github.com/Komawaraz/claude-skills/blob/master/genshijin/benchmark.py)):
+
+| Task | Normal | Genshijin | Reduction |
+|------|-------:|----------:|----------:|
+| Python list deduplication | 586 | 463 | 21% |
+| Git branch merge command | 322 | 38 | 88% |
+| SQL INNER JOIN vs LEFT JOIN | 701 | 380 | 46% |
+| Docker container debug | 1,024 | 558 | 46% |
+| Async processing explained | 512 | 378 | 26% |
+| **Average** | **629** | **363** | **42%** |
+
+Output token reduction: **~42%** → cost reduction: **~40%** (including system prompt overhead).
+
+---
+
+## Background
+
+Japanese AI responses carry a distinctive over-politeness problem. Training data consists largely of formal Japanese business documents, manuals, and Q&A content, causing models to treat excessive keigo as a quality signal. This skill overrides that pattern for technical workflows where brevity is preferred.
+
+Inspired by [caveman](https://github.com/juliusbrussee/caveman) (English token reduction skill).


### PR DESCRIPTION
## Summary

Adds `genshijin`, a Japanese-language response compression skill for Claude Code.

Japanese AI responses have a distinctive over-politeness problem rooted in training data (business documents, formal manuals, keigo-heavy Q&A). This skill removes those patterns — preambles, excessive keigo, hedging, sign-offs — while preserving full technical content.

- **~42% output token reduction** (measured via Claude Haiku API)
- **~40% cost reduction** (including system prompt overhead)
- 3 intensity levels: `lite` / `full` / `ultra`
- Targets Japanese-specific patterns not addressed by English compression skills

## Commands

```
/genshijin        → full mode (default)
/genshijin lite   → light compression, keeps polite form
/genshijin ultra  → maximum compression
/genshijin off    → return to normal mode
```

## Benchmarks

Reproducible via [`benchmark.py`](https://github.com/Komawaraz/genshijin/blob/master/genshijin/benchmark.py):

| Task | Normal | Genshijin | Reduction |
|------|-------:|----------:|----------:|
| Python list deduplication | 586 | 463 | 21% |
| Git branch merge command | 322 | 38 | 88% |
| SQL INNER JOIN vs LEFT JOIN | 701 | 380 | 46% |
| Docker container debug | 1,024 | 558 | 46% |
| Async processing explained | 512 | 378 | 26% |
| **Average** | **629** | **363** | **42%** |

## Notes

- Inspired by [caveman](https://github.com/juliusbrussee/caveman) (English token reduction skill)
- Japanese-specific patterns (keigo, business Japanese filler) are the primary target
- Code, error messages, security warnings are never compressed