### PR TITLE
fix: Improve cross-platform PDF form rendering and CJK font handling

### DIFF
--- a/skills/pdf/SKILL.md
+++ b/skills/pdf/SKILL.md
@@ -10,6 +10,58 @@ license: Proprietary. LICENSE.txt has complete terms
 
 This guide covers essential PDF processing operations using Python libraries and command-line tools. For advanced features, JavaScript libraries, and detailed examples, see REFERENCE.md. If you need to fill out a PDF form, read FORMS.md and follow its instructions.
 
+## Critical Portable Output Requirements
+
+Apply these rules whenever the user asks for a generated PDF deliverable:
+
+1. Save the final deliverable as `output.pdf` unless the user explicitly asks for a different filename.
+2. Never rely on machine-local custom fonts (for example fonts available on one Mac only). Cross-platform readers on Windows/Android may substitute or break layout.
+3. For non-ASCII text (Chinese, Japanese, Korean, symbols), use an embeddable TrueType-outline font and embed it in the PDF. Prefer `.ttf`; only use `.otf` when it is known to work with `reportlab`.
+4. Do not put critical content only in viewer-dependent annotation layers when portability matters. Prefer writing text into page content.
+5. Before returning the file, do a quick sanity check for portability risks (missing glyphs, obvious overflow, broken line wraps).
+
+## Preferred PDF Authoring Path
+
+Keep generation simple and deterministic:
+
+1. Use `reportlab` for PDF writing and `pypdf` for merge/edit steps.
+2. Do not switch to `fpdf2` just to work around font issues in this skill flow.
+3. Do not rely on ad-hoc `fonttools` TTC-to-TTF conversion during task execution.
+4. In the AstrBot sandbox (`astrbotdevs/shipyard-neo-ship:latest` running in a macOS Docker environment), do not treat local TTC collections as the default path. Many macOS TTC fonts use PostScript outlines that `reportlab` rejects.
+5. Prefer one stable downloaded or bundled `.ttf` fallback font. If no embeddable font is available and the document only needs Chinese text, `UnicodeCIDFont("STSong-Light")` is an acceptable non-embedded fallback.
+
+## Local CJK Font Discovery Policy
+
+For Linux/sandbox environments, discovering local fonts via `fc-list` is optional. Treat it as a probe, not a guarantee.
+
+```python
+import subprocess
+
+result = subprocess.run(
+    ["fc-list", ":lang=zh", "-f", "%{file}\\n"],
+    capture_output=True,
+    text=True,
+    timeout=4,
+    check=False,
+)
+```
+
+Rules:
+
+1. Use `timeout` and `check=False` to avoid hanging or hard failure.
+2. Treat `fc-list` results as candidates, not guaranteed usable fonts.
+3. Prefer `.ttf` candidates first. Only try `.otf` if `reportlab` can actually load it.
+4. Do not auto-assume `.ttc` is usable in the AstrBot sandbox. An `invalid character '—'` error is a string-quoting bug; `postscript outlines are not supported` is a font-compatibility bug.
+5. If no compatible local font exists, download one fallback font into the working directory and reuse it. If download is impossible and the content is Chinese-only, fall back to `STSong-Light` and mention that it is not embedded.
+
+## Final Response Requirements
+
+When you create or modify a PDF file, your final response must include:
+
+1. A direct downloadable file result (attachment/file output when the platform supports it).
+2. The exact output path for fallback download, including the final `output.pdf` location.
+3. A short note if custom fonts were embedded (or if fallback fonts were used).
+
 ## Quick Start
 
 ```python
@@ -165,6 +217,56 @@ story.append(Paragraph("Content for page 2", styles['Normal']))
 # Build PDF
 doc.build(story)
 ```
+
+#### Python String Safety (Avoid SyntaxError)
+
+Unicode punctuation is usually not the real problem. Errors such as `invalid character '—' (U+2014)` often happen because the string was terminated early by an apostrophe or mismatched quote.
+
+```python
+import json
+from pathlib import Path
+
+# Preferred: load report text from UTF-8 data instead of hand-writing long literals.
+report_data = json.loads(Path("report-data.json").read_text(encoding="utf-8"))
+for line in report_data["lines"]:
+    story.append(Paragraph(line, body_style))
+```
+
+If inline text is unavoidable, use triple double-quoted literals for content that may contain apostrophes:
+
+```python
+title = """Tom's Birthday Plan"""
+story.append(Paragraph(title, title_style))
+```
+
+#### Cross-Platform Font Embedding (Required for Non-ASCII Text)
+
+```python
+from reportlab.pdfbase import pdfmetrics
+from reportlab.pdfbase.cidfonts import UnicodeCIDFont
+from reportlab.pdfbase.ttfonts import TTFont
+from reportlab.pdfgen import canvas
+
+# Preferred: use a compatible TrueType-outline font file and embed it.
+pdfmetrics.registerFont(TTFont("PortableUnicode", "./fonts/NotoSansSC-Regular.ttf"))
+
+c = canvas.Canvas("output.pdf")
+c.setFont("PortableUnicode", 12)
+c.drawString(72, 760, "Cross-platform text example")
+c.save()
+```
+
+If the sandbox only exposes unsupported TTC fonts and the document only needs Chinese text, use ReportLab's CID fallback instead of forcing TTC:
+
+```python
+pdfmetrics.registerFont(UnicodeCIDFont("STSong-Light"))
+c = canvas.Canvas("output.pdf")
+c.setFont("STSong-Light", 12)
+c.drawString(72, 760, "中文示例")
+c.save()
+```
+
+Do not recommend `/System/Library/Fonts/PingFang.ttc` or similar macOS TTC files as the primary solution in the AstrBot sandbox. They frequently fail with `postscript outlines are not supported`.
 
 #### Subscripts and Superscripts
 

--- a/skills/pdf/forms.md
+++ b/skills/pdf/forms.md
@@ -158,6 +158,17 @@ Create fields.json using `pdf_width` and `pdf_height` (signals PDF coordinates):
 }
 ```
 
+`entry_text` supports optional styling keys:
+- `font`: preferred PDF font name (default: `Helvetica`)
+- `font_size`: numeric text size
+- `font_color`: hex RGB like `000000` or `#1F2937`
+- `font_path`: path to a compatible `.ttf` font, or a known-good `.otf` file. Explicit `.ttc#0` input is supported as a last resort but is not recommended in the AstrBot sandbox.
+- `font_index`: optional integer subfont index, only needed when you intentionally pass a `.ttc` font source
+
+For CJK or other non-ASCII text, provide `font_path` whenever possible so glyphs are embedded and render consistently across macOS, Windows, and Android.
+Prefer one stable downloaded or bundled `.ttf` font. Do not depend on runtime TTC-to-TTF conversion or on sandbox-local macOS TTC fonts.
+If you explicitly pass a TTC source and it fails, treat that as an incompatible font selection and switch to a compatible `.ttf` instead of retrying random TTC indexes.
+
 **Important**: Use `pdf_width`/`pdf_height` and coordinates directly from form_structure.json.
 
 ### A.4: Validate Bounding Boxes
@@ -242,6 +253,8 @@ Create fields.json using `image_width` and `image_height` (signals image coordin
 }
 ```
 
+The same `entry_text` font options (`font`, `font_size`, `font_color`, `font_path`, `font_index`) apply here.
+
 **Important**: Use `image_width`/`image_height` and the refined pixel coordinates from the zoom analysis.
 
 ### B.5: Validate Bounding Boxes
@@ -280,7 +293,7 @@ Fix any reported errors in fields.json before proceeding.
 
 ## Step 3: Fill the Form
 
-The fill script auto-detects the coordinate system and handles conversion:
+The fill script auto-detects the coordinate system and handles conversion. It renders text into PDF page content for better viewer compatibility:
 `python scripts/fill_pdf_form_with_annotations.py <input.pdf> fields.json <output.pdf>`
 
 ## Step 4: Verify Output

--- a/skills/pdf/scripts/fill_pdf_form_with_annotations.py
+++ b/skills/pdf/scripts/fill_pdf_form_with_annotations.py
@@ -1,9 +1,75 @@
 import json
 import sys
+import importlib
+import subprocess
+from shutil import which
+from io import BytesIO
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
 
 from pypdf import PdfReader, PdfWriter
-from pypdf.annotations import FreeText
 
+
+
+STANDARD_PDF_FONTS = {
+    "Courier",
+    "Courier-Bold",
+    "Courier-Oblique",
+    "Courier-BoldOblique",
+    "Helvetica",
+    "Helvetica-Bold",
+    "Helvetica-Oblique",
+    "Helvetica-BoldOblique",
+    "Times-Roman",
+    "Times-Bold",
+    "Times-Italic",
+    "Times-BoldItalic",
+}
+
+_CUSTOM_FONT_CACHE: Dict[str, str] = {}
+_CID_FONT_READY = False
+_RLPDFMETRICS = None
+_RLCIDFONT = None
+_RLTTFONT = None
+_RLCANVAS = None
+_LOCAL_CJK_FONT_SOURCE_CACHE: Optional[str] = None
+_LOCAL_CJK_FONT_DISCOVERY_DONE = False
+
+AUTO_DISCOVERY_FONT_EXTENSIONS = {".ttf", ".otf"}
+CJK_FONT_HINTS = (
+    "noto",
+    "sourcehan",
+    "source-han",
+    "source han",
+    "wqy",
+    "wenquanyi",
+    "sarasa",
+    "lxgw",
+    "pingfang",
+    "heiti",
+    "hiragino",
+    "simhei",
+    "simsun",
+    "msyh",
+)
+
+
+def _load_reportlab() -> None:
+    global _RLPDFMETRICS, _RLCIDFONT, _RLTTFONT, _RLCANVAS
+    if _RLPDFMETRICS is not None and _RLCANVAS is not None:
+        return
+
+    try:
+        _RLPDFMETRICS = importlib.import_module("reportlab.pdfbase.pdfmetrics")
+        cidfonts = importlib.import_module("reportlab.pdfbase.cidfonts")
+        ttfonts = importlib.import_module("reportlab.pdfbase.ttfonts")
+        _RLCANVAS = importlib.import_module("reportlab.pdfgen.canvas")
+        _RLCIDFONT = cidfonts.UnicodeCIDFont
+        _RLTTFONT = ttfonts.TTFont
+    except Exception as exc:
+        raise RuntimeError(
+            "This script requires reportlab. Install it with: pip install reportlab"
+        ) from exc
 
 
 
@@ -30,70 +96,373 @@ def transform_from_pdf_coords(bbox, pdf_height):
     return left, pypdf_bottom, right, pypdf_top
 
 
+def _ensure_cid_font() -> None:
+    global _CID_FONT_READY
+    _load_reportlab()
+    if _CID_FONT_READY:
+        return
+    try:
+        _RLPDFMETRICS.getFont("STSong-Light")
+        _CID_FONT_READY = True
+        return
+    except KeyError:
+        pass
+
+    try:
+        _RLPDFMETRICS.registerFont(_RLCIDFONT("STSong-Light"))
+        _CID_FONT_READY = True
+    except Exception:
+        _CID_FONT_READY = False
+
+
+def _has_non_ascii(text: str) -> bool:
+    return any(ord(ch) > 127 for ch in text)
+
+
+def _is_auto_discovery_font(path_str: str) -> bool:
+    return Path(path_str).suffix.lower() in AUTO_DISCOVERY_FONT_EXTENSIONS
+
+
+def _run_fc_list_zh() -> List[str]:
+    if which("fc-list") is None:
+        return []
+
+    try:
+        result = subprocess.run(
+            ["fc-list", ":lang=zh", "-f", "%{file}\n"],
+            capture_output=True,
+            text=True,
+            timeout=4,
+            check=False,
+        )
+    except Exception:
+        return []
+
+    if result.returncode != 0:
+        return []
+
+    font_paths: List[str] = []
+    seen = set()
+    for line in result.stdout.splitlines():
+        candidate = line.strip()
+        if not candidate or candidate in seen:
+            continue
+        if not _is_auto_discovery_font(candidate):
+            continue
+        if not Path(candidate).exists():
+            continue
+        seen.add(candidate)
+        font_paths.append(candidate)
+    return font_paths
+
+
+def _fallback_local_font_candidates() -> List[str]:
+    common_candidates = [
+        "/usr/share/fonts/opentype/noto/NotoSansCJKSC-Regular.otf",
+        "/usr/share/fonts/truetype/noto/NotoSansSC-Regular.ttf",
+        "/Library/Fonts/Arial Unicode.ttf",
+        "C:/Windows/Fonts/simhei.ttf",
+    ]
+
+    existing = []
+    for candidate in common_candidates:
+        if Path(candidate).exists():
+            existing.append(candidate)
+    return existing
+
+
+def _font_priority_key(path_str: str) -> Tuple[int, int]:
+    lower_name = Path(path_str).name.lower()
+    has_hint = any(hint in lower_name for hint in CJK_FONT_HINTS)
+    ext = Path(path_str).suffix.lower()
+    ext_rank = {".ttf": 0, ".otf": 1, ".ttc": 2}.get(ext, 3)
+    hint_rank = 0 if has_hint else 1
+    return hint_rank, ext_rank
+
+
+def _iter_local_cjk_font_sources() -> List[str]:
+    candidates = _run_fc_list_zh() + _fallback_local_font_candidates()
+
+    deduped: List[str] = []
+    seen = set()
+    for path_str in candidates:
+        if path_str in seen:
+            continue
+        seen.add(path_str)
+        deduped.append(path_str)
+
+    deduped.sort(key=_font_priority_key)
+
+    return deduped
+
+
+def _discover_local_cjk_font_source() -> Optional[str]:
+    global _LOCAL_CJK_FONT_SOURCE_CACHE, _LOCAL_CJK_FONT_DISCOVERY_DONE
+    if _LOCAL_CJK_FONT_SOURCE_CACHE:
+        return _LOCAL_CJK_FONT_SOURCE_CACHE
+    if _LOCAL_CJK_FONT_DISCOVERY_DONE:
+        return None
+
+    probe_text = "中文字体探测"
+    for source in _iter_local_cjk_font_sources():
+        try:
+            font_name = _register_custom_font(source)
+            # Ensure this font can actually measure CJK text.
+            _RLPDFMETRICS.stringWidth(probe_text, font_name, 12)
+            _LOCAL_CJK_FONT_SOURCE_CACHE = source
+            _LOCAL_CJK_FONT_DISCOVERY_DONE = True
+            return source
+        except Exception:
+            continue
+
+    _LOCAL_CJK_FONT_DISCOVERY_DONE = True
+    return None
+
+
+def _parse_font_source(font_path: str, font_index: Optional[int]) -> Tuple[str, int]:
+    source = str(font_path).strip()
+    parsed_index = 0
+
+    if "#" in source:
+        base, maybe_index = source.rsplit("#", 1)
+        if maybe_index.isdigit():
+            source = base
+            parsed_index = int(maybe_index)
+
+    if source.lower().endswith(".ttc") and "," in source:
+        base, maybe_index = source.rsplit(",", 1)
+        if maybe_index.isdigit():
+            source = base
+            parsed_index = int(maybe_index)
+
+    if font_index is not None:
+        parsed_index = int(font_index)
+
+    return source, parsed_index
+
+
+def _register_custom_font(font_path: str, font_index: Optional[int] = None) -> str:
+    _load_reportlab()
+    normalized_path, normalized_index = _parse_font_source(font_path, font_index)
+    resolved_path = Path(normalized_path).expanduser()
+    if not resolved_path.exists():
+        raise FileNotFoundError(f"Font file not found: {resolved_path}")
+
+    resolved = str(resolved_path.resolve())
+    cache_key = f"{resolved}#{normalized_index}"
+
+    cached = _CUSTOM_FONT_CACHE.get(cache_key)
+    if cached:
+        return cached
+
+    font_name = f"CustomFont_{abs(hash(cache_key))}"
+    try:
+        _RLPDFMETRICS.getFont(font_name)
+    except KeyError:
+        try:
+            if resolved.lower().endswith(".ttc"):
+                _RLPDFMETRICS.registerFont(_RLTTFONT(font_name, resolved, subfontIndex=normalized_index))
+            else:
+                _RLPDFMETRICS.registerFont(_RLTTFONT(font_name, resolved))
+        except Exception as exc:
+            if resolved.lower().endswith(".ttc"):
+                raise RuntimeError(
+                    "Failed to load TTC font. In the AstrBot sandbox, macOS TTC fonts often use PostScript outlines unsupported by reportlab. Prefer a compatible .ttf font or the Chinese-only STSong-Light fallback."
+                ) from exc
+            raise
+
+    _CUSTOM_FONT_CACHE[cache_key] = font_name
+    return font_name
+
+
+def _resolve_font(entry_text: dict, text: str) -> str:
+    _load_reportlab()
+    font_path = entry_text.get("font_path")
+    font_index = entry_text.get("font_index")
+    if font_path:
+        return _register_custom_font(font_path, font_index)
+
+    requested = entry_text.get("font", "Helvetica")
+    if requested in STANDARD_PDF_FONTS:
+        return requested
+    try:
+        _RLPDFMETRICS.getFont(requested)
+        return requested
+    except KeyError:
+        pass
+
+    if _has_non_ascii(text):
+        discovered_source = _discover_local_cjk_font_source()
+        if discovered_source:
+            try:
+                return _register_custom_font(discovered_source)
+            except Exception:
+                pass
+
+        _ensure_cid_font()
+        if _CID_FONT_READY:
+            return "STSong-Light"
+
+        raise RuntimeError(
+            "No usable font found for non-ASCII text. Provide entry_text.font_path to a compatible .ttf font, or limit the document to Chinese text and use a CID fallback."
+        )
+
+    return "Helvetica"
+
+
+def _parse_hex_color(color_value: str) -> Tuple[float, float, float]:
+    normalized = str(color_value).strip().lstrip("#")
+    if len(normalized) != 6:
+        return 0.0, 0.0, 0.0
+    try:
+        red = int(normalized[0:2], 16) / 255.0
+        green = int(normalized[2:4], 16) / 255.0
+        blue = int(normalized[4:6], 16) / 255.0
+    except ValueError:
+        return 0.0, 0.0, 0.0
+    return red, green, blue
+
+
+def _wrap_text(text: str, font_name: str, font_size: float, max_width: float) -> List[str]:
+    _load_reportlab()
+    if max_width <= 1:
+        return [text]
+
+    wrapped_lines: List[str] = []
+    source_lines = text.splitlines() or [""]
+    for src in source_lines:
+        if not src:
+            wrapped_lines.append("")
+            continue
+        current = ""
+        for ch in src:
+            candidate = current + ch
+            if current and _RLPDFMETRICS.stringWidth(candidate, font_name, font_size) > max_width:
+                wrapped_lines.append(current)
+                current = ch
+            else:
+                current = candidate
+        if current:
+            wrapped_lines.append(current)
+
+    return wrapped_lines or [""]
+
+
+def _draw_text_in_box(page_canvas: Any, rect: Tuple[float, float, float, float], entry_text: dict) -> None:
+    text = str(entry_text.get("text", ""))
+    if not text:
+        return
+
+    left, bottom, right, top = rect
+    box_width = max(1.0, float(right) - float(left))
+    box_height = max(1.0, float(top) - float(bottom))
+
+    font_size = float(entry_text.get("font_size", 12))
+    font_name = _resolve_font(entry_text, text)
+    red, green, blue = _parse_hex_color(entry_text.get("font_color", "000000"))
+
+    padding = 1.0
+    max_text_width = max(1.0, box_width - (padding * 2))
+    lines = _wrap_text(text, font_name, font_size, max_text_width)
+    line_height = font_size * 1.2
+    max_lines = max(1, int((box_height - (padding * 2)) / line_height))
+    visible_lines = lines[:max_lines]
+
+    page_canvas.setFillColorRGB(red, green, blue)
+    page_canvas.setFont(font_name, font_size)
+
+    y = float(top) - padding - font_size
+    min_y = float(bottom) + padding
+    for line in visible_lines:
+        if y < min_y:
+            break
+        page_canvas.drawString(float(left) + padding, y, line)
+        y -= line_height
+
+
+def _transform_entry_box(field: dict, page_info: dict, pdf_width: float, pdf_height: float):
+    if "pdf_width" in page_info:
+        return transform_from_pdf_coords(
+            field["entry_bounding_box"],
+            float(pdf_height),
+        )
+
+    image_width = page_info["image_width"]
+    image_height = page_info["image_height"]
+    return transform_from_image_coords(
+        field["entry_bounding_box"],
+        image_width,
+        image_height,
+        float(pdf_width),
+        float(pdf_height),
+    )
+
+
+def _build_overlay_pdf(reader: PdfReader, fields_data: dict) -> Tuple[PdfReader, int]:
+    _load_reportlab()
+    page_info_by_number = {p["page_number"]: p for p in fields_data.get("pages", [])}
+    draw_items_by_page: Dict[int, List[Tuple[Tuple[float, float, float, float], dict]]] = {}
+
+    for field in fields_data.get("form_fields", []):
+        page_num = field.get("page_number")
+        if not page_num or page_num < 1 or page_num > len(reader.pages):
+            continue
+        if "entry_text" not in field or "text" not in field["entry_text"]:
+            continue
+        if not field["entry_text"].get("text"):
+            continue
+
+        page_info = page_info_by_number.get(page_num)
+        if not page_info:
+            continue
+
+        page = reader.pages[page_num - 1]
+        pdf_width = float(page.mediabox.width)
+        pdf_height = float(page.mediabox.height)
+        transformed_entry_box = _transform_entry_box(field, page_info, pdf_width, pdf_height)
+
+        draw_items_by_page.setdefault(page_num, []).append((transformed_entry_box, field["entry_text"]))
+
+    packet = BytesIO()
+    overlay_canvas = _RLCANVAS.Canvas(packet)
+    total_draw_items = 0
+
+    for page_num in range(1, len(reader.pages) + 1):
+        page = reader.pages[page_num - 1]
+        width = float(page.mediabox.width)
+        height = float(page.mediabox.height)
+        overlay_canvas.setPageSize((width, height))
+
+        for rect, entry_text in draw_items_by_page.get(page_num, []):
+            _draw_text_in_box(overlay_canvas, rect, entry_text)
+            total_draw_items += 1
+
+        overlay_canvas.showPage()
+
+    overlay_canvas.save()
+    packet.seek(0)
+    return PdfReader(packet), total_draw_items
+
+
 def fill_pdf_form(input_pdf_path, fields_json_path, output_pdf_path):
     
     with open(fields_json_path, "r") as f:
         fields_data = json.load(f)
     
     reader = PdfReader(input_pdf_path)
+    overlay_reader, draw_count = _build_overlay_pdf(reader, fields_data)
+
     writer = PdfWriter()
-    
-    writer.append(reader)
-    
-    pdf_dimensions = {}
-    for i, page in enumerate(reader.pages):
-        mediabox = page.mediabox
-        pdf_dimensions[i + 1] = [mediabox.width, mediabox.height]
-    
-    annotations = []
-    for field in fields_data["form_fields"]:
-        page_num = field["page_number"]
+    for i, base_page in enumerate(reader.pages):
+        overlay_page = overlay_reader.pages[i]
+        base_page.merge_page(overlay_page)
+        writer.add_page(base_page)
 
-        page_info = next(p for p in fields_data["pages"] if p["page_number"] == page_num)
-        pdf_width, pdf_height = pdf_dimensions[page_num]
-
-        if "pdf_width" in page_info:
-            transformed_entry_box = transform_from_pdf_coords(
-                field["entry_bounding_box"],
-                float(pdf_height)
-            )
-        else:
-            image_width = page_info["image_width"]
-            image_height = page_info["image_height"]
-            transformed_entry_box = transform_from_image_coords(
-                field["entry_bounding_box"],
-                image_width, image_height,
-                float(pdf_width), float(pdf_height)
-            )
-        
-        if "entry_text" not in field or "text" not in field["entry_text"]:
-            continue
-        entry_text = field["entry_text"]
-        text = entry_text["text"]
-        if not text:
-            continue
-        
-        font_name = entry_text.get("font", "Arial")
-        font_size = str(entry_text.get("font_size", 14)) + "pt"
-        font_color = entry_text.get("font_color", "000000")
-
-        annotation = FreeText(
-            text=text,
-            rect=transformed_entry_box,
-            font=font_name,
-            font_size=font_size,
-            font_color=font_color,
-            border_color=None,
-            background_color=None,
-        )
-        annotations.append(annotation)
-        writer.add_annotation(page_number=page_num - 1, annotation=annotation)
-        
     with open(output_pdf_path, "wb") as output:
         writer.write(output)
     
     print(f"Successfully filled PDF form and saved to {output_pdf_path}")
-    print(f"Added {len(annotations)} text annotations")
+    print(f"Rendered {draw_count} text boxes into page content")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Render filled text into PDF page content instead of relying on FreeText annotations
- Improve CJK and non-ASCII font handling with explicit font configuration and safer fallbacks
- Update the PDF skill docs to emphasize portable output across viewers and platforms

## Testing
- Manual verification only
- No automated tests added