### PR TITLE
feat: add interfaces-that-feel skill

### DIFF
--- a/skills/interfaces-that-feel/LICENSE.txt
+++ b/skills/interfaces-that-feel/LICENSE.txt
@@ -1,0 +1,17 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   Copyright 2026 Marie Spreitzer
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/interfaces-that-feel/SKILL.md
+++ b/skills/interfaces-that-feel/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: interfaces-that-feel
+description: Apply emotional intelligence and craft to any user-facing interface. Use when building UI components, pages, flows, or writing copy — especially when the result feels technically correct but flat, generic, or soulless. Also use when asked to "review my UI", "improve this design", "make this feel better", "audit UX", or "add polish". Evaluates and builds through the feel lens: voice, earned emotion, and restraint. Covers motion craft, copy voice, empty states, error messages, loading states, onboarding, and micro-interactions. Reference aesthetic: How We Feel, Headspace, Gentler Streak, Amie, Arc Browser — warm, considered, emotionally intelligent.
+---
+
+# Interfaces That Feel
+
+You build and evaluate interfaces through one lens: does this feel like it was made by a human who cared about how you'd feel using it?
+
+Technical correctness is the floor. The ceiling is: does this product know you're a person?
+
+Warmth isn't decoration — it lives in every layer. The copy, the transition, the moment of feedback after an action, the voice in the error message. A product can be perfectly functional and feel like it was built by nobody. That's a failure.
+
+---
+
+## When to Use
+
+- Building any user-facing component, page, or flow
+- Reviewing UI code or designs for feel quality
+- Writing microcopy, empty states, error messages, onboarding
+- Any time the result is technically correct but emotionally flat
+- Any time someone says "it feels generic" or "make this feel more alive"
+
+---
+
+## The Feel Framework
+
+Before any product decision, answer these three questions in order.
+
+### 1. Does it have a voice?
+
+Read the copy out loud. Does it sound like one specific person wrote it, or like a committee approved it?
+
+Voice is not wit or jokes — it's specificity. Knowing what the user is doing and speaking to that exact moment. Voiceless copy sounds like it applies to everything. Copy with voice is written for this screen, this user, this action.
+
+### 2. Is the emotion earned?
+
+Every emotional moment — warmth, celebration, surprise — must be proportional to what the user did.
+
+| Action | What it earns |
+|---|---|
+| Every save, every click | Nothing extra. Correct, fast feedback. |
+| Completing a significant step | Quiet, clear confirmation |
+| Real milestone (first X, streak, 100%) | Proportional celebration |
+| First-time experience | Warmth and orientation |
+| Destructive action | A deliberate pause. Confirm before proceeding. |
+| Long wait | Progress indication with specific context |
+| Success after friction | Extra acknowledgment — the user worked for this |
+
+Confetti on a routine save is not earned. A warm message on completing a 7-day streak is.
+
+### 3. Does it know when to step back?
+
+The product that tries to feel at every moment is exhausting. The question is not "how do I add feeling here?" — it's "does this moment deserve feeling, or does it just need to work?"
+
+Arc Browser doesn't animate every tab switch. Amie doesn't celebrate every calendar event. They reserve expression for moments where it adds meaning.
+
+> Restraint is the skill.
+
+---
+
+## Anti-Patterns
+
+NEVER produce these — they perform emotion without creating it:
+
+- Confetti on routine saves
+- `"Herding pixels"` or `"Hang tight!"` loading messages
+- Quirky 404 pages on products that are otherwise cold everywhere else
+- Error messages that blame the user (`"Invalid input"`)
+- Empty states that just describe absence (`"No items found"`)
+- `ease-in` on any entering UI element
+- `transition: all` — unpredictable, lazy, causes repaints
+- Generic loading spinners with no character
+- Animations that animate everything (no hierarchy, no meaning)
+- Copy that sounds like it passed through a legal review
+
+---
+
+## Review Format
+
+When reviewing UI code or a flow, always produce a markdown table. Never use a list format.
+
+| Before | After | Why |
+|---|---|---|
+| `"No data available"` | `"Nothing here yet. [Create your first →]"` | Empty states are invitations, not descriptions of absence |
+| `"Error: Invalid input"` | `"That doesn't look right — check the format and try again"` | Errors are support moments, not system messages |
+| Generic spinner | Specific loading message or skeleton | Spinners say "wait"; skeletons and specific copy say "here's what's coming" |
+| `ease-in` on entering element | `ease-out` or custom cubic-bezier | ease-in starts slow — the exact moment users are watching |
+| `transition: all 300ms` | `transition: transform 200ms ease-out` | Specify properties; `all` causes unpredictable repaints |
+| Silent success redirect | Brief confirmation, then redirect | Acknowledge the action before moving on — make the user feel heard |
+| Same enter/exit duration | Enter slower, exit snappier | Users chose to dismiss; don't make them wait for it |
+| `"Are you sure?"` before delete | `"This can't be undone. Delete?"` | Specific, not vague — tells the user exactly what they're deciding |
+
+---
+
+## Motion
+
+Motion serves orientation and acknowledgment. Not decoration.
+
+**Ask first: should this animate at all?**
+
+| Frequency | Decision |
+|---|---|
+| Hundreds of times a day (keyboard shortcuts, nav) | No animation |
+| Many times a day (hover states, frequent toggles) | Minimal or none |
+| Occasional (modals, drawers, toasts) | Standard motion |
+| Rare or first-time (onboarding, milestones, celebrations) | Can carry more feeling |
+
+**Easing:**
+
+```css
+/* Entering or responding — starts fast, settles */
+--ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+
+/* Moving on screen — natural acceleration then deceleration */
+--ease-in-out: cubic-bezier(0.77, 0, 0.175, 1);
+
+/* Drawers and bottom sheets — iOS-like slide */
+--ease-drawer: cubic-bezier(0.32, 0.72, 0, 1);
+```
+
+Never use `ease-in` for UI interactions. It starts slow — the moment users are watching most closely.
+
+**Never animate from nothing:**
+
+```css
+/* Wrong — appears from nowhere */
+.entering { transform: scale(0); }
+
+/* Right — visible shape, arriving */
+.entering { transform: scale(0.95); opacity: 0; }
+```
+
+**Duration:**
+
+| Element | Duration |
+|---|---|
+| Button press | 100–160ms |
+| Tooltips, small popovers | 125–200ms |
+| Modals, drawers | 200–300ms |
+| Celebration or milestone | Can be slower — it was earned |
+
+Slow in, fast out. Entering takes a moment. Dismissal is always fast.
+
+---
+
+## Copy Voice
+
+Copy is the most underestimated layer of feel. It is the voice of the product.
+
+**Write to one person.** "Your changes are saved." not "Changes saved." The difference is small. The feeling is different.
+
+**Error messages are support, not blame.**
+
+| Avoid | Instead |
+|---|---|
+| `"Invalid email address"` | `"That doesn't look like an email — try name@example.com"` |
+| `"Passwords don't match"` | `"The passwords don't match — check the second field and try again"` |
+| `"Something went wrong"` | `"We couldn't connect — check your internet and try again"` |
+| `"Request failed (403)"` | `"You don't have access to this. [Contact your admin →]"` |
+
+**Empty states are invitations, not descriptions.**
+
+| Avoid | Instead |
+|---|---|
+| `"No projects"` | `"Your first project is one click away. [Create project →]"` |
+| `"Nothing here"` | `"Start by [specific action]"` |
+
+**Loading messages must be specific.**
+
+| Avoid | Instead |
+|---|---|
+| `"Loading..."` | `"Getting your [specific thing]..."` |
+| `"Please wait..."` | `"Almost there — loading your [X]"` |
+| `"Herding pixels"` | Never. |
+
+**Validation rewards, not just penalises.** Acknowledge correct input. Don't only catch wrong input.
+
+---
+
+## Review Checklist
+
+| Check | Pass condition |
+|---|---|
+| Voice | Copy sounds like one person wrote it, speaking to this specific moment |
+| Empty states | An invitation, not a description of emptiness |
+| Error messages | Specific, helpful, written for a human who tried something |
+| Motion purpose | Every animation has a reason: orientation, state change, or earned acknowledgment |
+| Earned emotion | Celebrations are proportional — milestones get moments, routine saves don't |
+| Restraint | Not every interaction is a feel moment |
+| Loading states | Specific to what's actually loading |
+| Destructive actions | Slowed down, confirmed, escapable |
+| First-time experiences | Warm and orienting — this is someone's introduction to the product |


### PR DESCRIPTION
## Summary

Adds `interfaces-that-feel` — a skill for building and reviewing user interfaces through an emotional intelligence lens.

Most AI-generated UIs are technically correct and emotionally empty. This skill teaches Claude to evaluate and build interfaces through one question: does this feel like it was made by a human who cared about how you'd feel using it?

**What it covers:**
- The Feel Framework — three questions before any product decision: voice, earned emotion, restraint
- Motion craft — easing values, duration tables, frequency rules (with specific CSS values)
- Copy voice — error messages, empty states, loading states, onboarding, validation
- Anti-patterns — the full list of things that perform emotion without creating it
- Structured before/after review table for auditing UI code or flows

**Reference aesthetic:** How We Feel, Headspace, Gentler Streak, Amie, Arc Browser.

**Author:** Marie Spreitzer — [github.com/mariespreitzer/interfaces-that-feel](https://github.com/mariespreitzer/interfaces-that-feel)