### PR TITLE
feat: Add security-audit skill for codebase vulnerability analysis

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -40,8 +40,7 @@
         "./skills/web-artifacts-builder",
         "./skills/webapp-testing"
       ]
-    }
-    ,
+    },
     {
       "name": "claude-api",
       "description": "Claude API and SDK documentation skill for building LLM-powered applications",
@@ -49,6 +48,15 @@
       "strict": false,
       "skills": [
         "./skills/claude-api"
+      ]
+    },
+    {
+      "name": "security-audit",
+      "description": "Security audit skill for codebase vulnerability analysis \u2014 OWASP Top 10, dependency CVEs, secrets scanning, supply chain risks",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/security-audit"
       ]
     }
   ]

--- a/skills/security-audit/LICENSE.txt
+++ b/skills/security-audit/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -1,0 +1,254 @@
+---
+name: security-audit
+description: Perform comprehensive security audits on codebases, identifying vulnerabilities, dependency risks, and secrets exposure. Use when asked to review code for security issues, check for vulnerabilities, audit dependencies, scan for hardcoded secrets, assess OWASP Top 10 compliance, or evaluate the security posture of an application. Trigger on security review, vulnerability scan, security audit, pentest prep, OWASP check, dependency audit, secrets scan, threat modeling, or when the user mentions security concerns about their code.
+license: Complete terms in LICENSE.txt
+---
+
+# Security Audit
+
+Perform structured security audits on codebases to identify vulnerabilities, supply chain risks, exposed secrets, and common security anti-patterns. The audit produces actionable findings with severity ratings, file locations, and remediation guidance.
+
+A security audit is not a penetration test -- it is a systematic review of source code and configuration to surface risks before they reach production. The value comes from being thorough and methodical rather than rushing to report the first issue found.
+
+## Audit Workflow
+
+The audit follows four phases. Each phase builds on the previous one, so work through them in order. Depending on the scope the user requests, some phases may be abbreviated -- a "quick scan for secrets" does not need a full dependency audit, for example. Use judgment about what the user actually needs.
+
+---
+
+### Phase 1: Reconnaissance
+
+Before looking for specific vulnerabilities, understand what the codebase does and where its attack surface lies. This context prevents false positives and helps prioritize findings by actual risk rather than theoretical severity.
+
+**Map the technology stack:**
+- Identify languages, frameworks, and build systems in use
+- Check for manifest files: `package.json`, `requirements.txt`, `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, `build.gradle`, etc.
+- Note which web frameworks are present (Express, Django, Rails, Spring, etc.) since each has framework-specific security patterns
+
+**Identify entry points and trust boundaries:**
+- API route definitions and endpoint handlers
+- CLI argument parsers and stdin readers
+- File upload handlers and file system interactions
+- Database query construction points
+- WebSocket handlers and real-time endpoints
+- Message queue consumers and event handlers
+- Cron jobs and scheduled tasks
+
+**Trace data flows:**
+- Follow user-controlled input from entry points through to sensitive operations (database writes, shell commands, file system access, outbound HTTP requests)
+- Identify where input validation and sanitization occur -- or where they are missing
+- Note any trust boundary crossings (e.g., client-to-server, server-to-database, service-to-service)
+
+**Document authentication and authorization:**
+- How are users authenticated? (session cookies, JWTs, API keys, OAuth)
+- Where are authorization checks enforced? (middleware, per-route, per-function)
+- Are there admin or elevated-privilege endpoints?
+- Is there multi-tenancy? How is tenant isolation enforced?
+
+Record findings from this phase as context for the subsequent phases. Even if no vulnerabilities are found during reconnaissance, the mapping work makes the rest of the audit far more efficient.
+
+---
+
+### Phase 2: Dependency Audit
+
+Third-party dependencies are one of the most common vectors for supply chain attacks. Audit them before diving into first-party code, since a vulnerable dependency can undermine even well-written application code.
+
+**Check for known vulnerabilities:**
+
+Use the package manager's built-in audit tool when available:
+
+```bash
+# Node.js / npm
+npm audit
+
+# Node.js / yarn
+yarn audit
+
+# Python
+pip audit
+
+# Ruby
+bundle audit check --update
+
+# Go
+govulncheck ./...
+
+# Rust
+cargo audit
+
+# PHP
+composer audit
+```
+
+If the project uses a language without a built-in audit command, check the lock file against public vulnerability databases (NVD, GitHub Advisory Database, OSV) by searching for the dependency names and versions.
+
+**Evaluate dependency hygiene:**
+- Flag unpinned or loosely pinned versions (`*`, `latest`, `>=` without upper bound) -- these can silently pull in breaking or malicious updates
+- Check whether lock files (`package-lock.json`, `yarn.lock`, `Pipfile.lock`, `Cargo.lock`, `go.sum`) exist and are committed -- missing lock files mean builds are not reproducible
+- Look for vendored dependencies and verify they match their upstream sources
+- Identify dependencies that appear abandoned (no commits in 2+ years, unaddressed security issues, archived repositories)
+
+**Assess supply chain risk:**
+- Flag dependencies with very low download counts combined with broad permissions -- potential typosquatting targets
+- Note dependencies that request unusual system-level access for their stated purpose
+- Check for post-install scripts that execute arbitrary code during installation
+
+Summarize dependency findings separately from code findings. Dependency vulnerabilities often have straightforward remediations (version bumps) and can be addressed quickly.
+
+---
+
+### Phase 3: Code Analysis
+
+This is the core of the audit. Systematically examine the codebase for vulnerability classes, working through each category rather than doing a single unstructured pass. The categories below cover the OWASP Top 10 and additional common vulnerability classes.
+
+**Injection (SQL, NoSQL, Command, LDAP, XPath):**
+- Search for string concatenation or template literals in database queries
+- Look for raw SQL queries that embed user input directly
+- Check for ORM methods that accept raw query fragments
+- Find shell command construction using functions that invoke a shell interpreter with user-influenced arguments
+- Search for dynamic code evaluation (`eval()`, `Function()`, Python `exec()`, Ruby `instance_eval`) with user-influenced arguments
+- Verify that parameterized queries or prepared statements are used consistently
+
+**Cross-Site Scripting (XSS):**
+- Identify where user input is rendered in HTML responses
+- Check whether the templating engine auto-escapes output (Jinja2, React JSX, and Go html/template do by default; EJS, Pug, and raw string templates do not)
+- Search for explicit bypass of escaping: `| safe` in Jinja2, `dangerouslySetInnerHTML` in React, `{!! !!}` in Blade, `v-html` in Vue
+- Look for user input reflected in JavaScript contexts, HTML attributes, URLs, and CSS values -- each requires different encoding
+- Check Content Security Policy headers if applicable
+
+**Authentication and Session Management:**
+- Verify passwords are hashed with a modern algorithm (bcrypt, scrypt, Argon2) -- not MD5, SHA-1, or plain SHA-256
+- Check for timing-safe comparison on authentication tokens
+- Look for session fixation vulnerabilities (session ID not regenerated after login)
+- Verify session tokens have appropriate expiry, and that logout actually invalidates server-side state
+- Check for credential exposure in logs, error messages, or URL parameters
+- Verify rate limiting on authentication endpoints
+
+**Broken Access Control:**
+- Look for authorization checks that rely solely on client-side enforcement
+- Check for Insecure Direct Object References (IDOR): can a user access another user's resources by changing an ID in the URL or request body?
+- Verify that role-based or attribute-based access control is enforced consistently, not just on some endpoints
+- Check for path traversal in file serving: `../../etc/passwd` patterns
+- Look for missing authorization checks on state-changing operations (PUT, POST, DELETE)
+
+**Secrets and Credential Exposure:**
+- Search for hardcoded API keys, tokens, passwords, and connection strings in source code
+- Common patterns to look for:
+  - `password = "..."`, `api_key = "..."`, `secret = "..."`
+  - `Authorization: Bearer ...` with a literal token value
+  - AWS access keys: strings matching `AKIA[0-9A-Z]{16}`
+  - Private keys: `-----BEGIN RSA PRIVATE KEY-----` and similar PEM headers
+  - Connection strings with embedded credentials: `://user:password@host`
+  - Base64-encoded JWT tokens: strings starting with `eyJ`
+- Check `.env` files, configuration files, and CI/CD definitions for committed secrets
+- Verify that `.gitignore` excludes sensitive files (`.env`, `*.pem`, `*.key`, credentials files)
+- Check git history for secrets that were committed and then removed -- they are still in the repository
+
+**Cryptography:**
+- Flag use of deprecated algorithms: MD5, SHA-1 for security purposes, DES, 3DES, RC4, ECB mode
+- Check that random number generation uses cryptographically secure sources (`crypto.randomBytes`, `secrets` module, `/dev/urandom`) rather than `Math.random()` or language-level `random` for security-sensitive values
+- Verify TLS configuration: minimum version, cipher suites, certificate validation
+- Check for hardcoded encryption keys or initialization vectors
+
+**Insecure Deserialization:**
+- Search for deserialization of untrusted data: `pickle.loads()`, `yaml.load()` (without `SafeLoader`), Java `ObjectInputStream`, PHP `unserialize()`
+- Check for prototype pollution in JavaScript (deep merge of user-controlled objects)
+
+**Server-Side Request Forgery (SSRF):**
+- Find places where the server makes HTTP requests to URLs influenced by user input
+- Check for URL validation: is it allowlist-based? Blocklist approaches (blocking `localhost`, `127.0.0.1`) are typically bypassable
+- Look for internal service URLs or cloud metadata endpoints (`169.254.169.254`) that could be reached through SSRF
+
+**Race Conditions and TOCTOU:**
+- Identify check-then-act patterns where the check and the action are not atomic
+- Look for financial operations (balance checks, inventory counts) without proper locking
+- Check for file system operations where existence checks are separate from file operations
+- Note any shared mutable state accessed from concurrent handlers without synchronization
+
+**Security Misconfiguration:**
+- Check for debug mode enabled in production configurations
+- Look for overly permissive CORS settings (`Access-Control-Allow-Origin: *` with credentials)
+- Verify that error responses do not leak stack traces, internal paths, or database schema details
+- Check for missing security headers: `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options`
+- Review Dockerfile or container configurations for running as root, exposed ports, or unnecessary packages
+
+**Logging and Monitoring:**
+- Check whether authentication events (login, logout, failed attempts) are logged
+- Verify that sensitive data (passwords, tokens, PII) is not written to logs
+- Look for log injection vulnerabilities (user input written to logs without sanitization)
+
+---
+
+### Phase 4: Report
+
+Present findings in a structured format that makes it easy to prioritize and act on them. The report has two parts: a summary table for quick triage and detailed findings for remediation.
+
+**Summary Table:**
+
+Start the report with a severity breakdown:
+
+```
+| Severity | Count |
+|----------|-------|
+| Critical |     X |
+| High     |     X |
+| Medium   |     X |
+| Low      |     X |
+| Info     |     X |
+```
+
+**Detailed Findings:**
+
+Group findings by severity (critical first), then by category within each severity level. For each finding, include:
+
+```
+### [SEVERITY] Category: Short Title
+
+**File:** `path/to/file.ext` (line N)
+**Confidence:** High | Medium
+**Category:** Injection | XSS | Auth | Access Control | Secrets | Crypto | Deserialization | SSRF | Race Condition | Misconfiguration | Dependency | ...
+
+**Description:**
+What the vulnerability is and why it matters in this specific codebase. Reference the actual code pattern found, not a generic description.
+
+**Evidence:**
+The specific code snippet or pattern that triggered this finding.
+
+**Remediation:**
+Concrete steps to fix this specific instance. Include a code example of the fix when practical.
+```
+
+**Confidence threshold:** Only include findings where you are reasonably confident the issue is real. If something looks suspicious but you cannot confirm it is exploitable from the source code alone, note it as an informational finding rather than inflating severity. False positives erode trust in the audit.
+
+**Severity definitions:**
+- **Critical**: Directly exploitable for remote code execution, authentication bypass, or mass data exposure. Fix immediately.
+- **High**: Exploitable vulnerability that requires some preconditions (e.g., authenticated attacker, specific configuration). Fix before next release.
+- **Medium**: Vulnerability that requires significant preconditions to exploit, or a security weakness that increases risk without being directly exploitable. Plan remediation.
+- **Low**: Minor security concern, defense-in-depth improvement, or best practice violation. Address when convenient.
+- **Info**: Observation about security posture that does not represent a specific vulnerability. No action required.
+
+**Closing the report:**
+
+End with a brief summary paragraph noting the overall security posture, the most significant risks found, and any areas that could not be fully assessed from source code alone (e.g., runtime configuration, infrastructure, or network-level controls).
+
+---
+
+## Scope Adjustments
+
+Not every audit needs all four phases at full depth. Adjust based on what the user requests:
+
+- **"Quick security scan"** -- Focus on Phase 3 (secrets, injection, and obvious misconfigurations). Skip deep dependency analysis.
+- **"Dependency audit"** -- Focus on Phase 2. Briefly scan Phase 3 for secrets.
+- **"Check for secrets"** -- Search for credential patterns in Phase 3. Report findings directly.
+- **"Full security audit"** -- All four phases at full depth.
+- **"OWASP Top 10 review"** -- Phase 1 for context, then Phase 3 covering all OWASP categories. Include Phase 2 for "Vulnerable and Outdated Components" (A06:2021).
+
+When in doubt about scope, start with the full workflow and let the size of the codebase and the user's time constraints guide how deep to go.
+
+## Tips for Effective Audits
+
+- **Read configuration files early.** Framework configuration (Django `settings.py`, Express middleware setup, Spring `application.properties`) often reveals security posture faster than scanning individual source files.
+- **Follow the data.** The most impactful vulnerabilities sit along data flow paths from user input to sensitive operations. Trace these paths rather than scanning files alphabetically.
+- **Check tests for security assumptions.** Test files sometimes reveal security expectations that are not enforced in the main code. They also sometimes contain hardcoded credentials used for test fixtures.
+- **Look at error handling.** Poor error handling (catching all exceptions silently, returning stack traces, inconsistent error responses) is a strong signal of broader security issues.
+- **Consider the deployment context.** A vulnerability in a local-only CLI tool has different impact than the same pattern in a public-facing web service. Adjust severity accordingly.


### PR DESCRIPTION
## Summary

Adds a new `security-audit` skill — the first security-focused skill in the repository (16 existing skills, 0 security).

The skill provides a structured 4-phase audit workflow:

1. **Reconnaissance** — Map attack surface, entry points, trust boundaries, auth model, and data flows
2. **Dependency Audit** — Supply chain analysis with built-in audit commands for 7 ecosystems (npm, pip, cargo, go, bundle, composer, yarn)
3. **Code Analysis** — Systematic review covering OWASP Top 10 plus additional categories (12 total): injection, XSS, auth, access control, secrets, crypto, deserialization, SSRF, race conditions, misconfiguration, logging
4. **Report** — Structured findings with severity ratings, file locations, confidence thresholds, evidence, and remediation guidance

Includes scope adjustment guidance for partial audits (quick scan, dependency-only, secrets-only, OWASP-only).

**Design decisions:**
- Follows existing skill conventions (studied `mcp-builder`, `webapp-testing`, `frontend-design`, and others for style/structure)
- Practical over academic — concrete patterns to search for, actual commands to run
- Confidence threshold to reduce false positives (only report findings with reasonable confidence)
- Severity definitions aligned with industry standards (Critical → Info)

## Test plan

- [ ] Skill loads correctly in Claude Code via `/security-audit`
- [ ] Frontmatter parses correctly (name, description, license)
- [ ] Phase workflow produces structured output
- [ ] Scope adjustments work for partial audits

🤖 Generated with [Claude Code](https://claude.com/claude-code)