### PR TITLE
Add multi-language support to mcp-builder skill

### DIFF
--- a/skills/mcp-builder/SKILL.md
+++ b/skills/mcp-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcp-builder
-description: Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Use when building MCP servers to integrate external APIs or services, whether in Python (FastMCP) or Node/TypeScript (MCP SDK).
+description: Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Use when building MCP servers to integrate external APIs or services in any language — TypeScript, Python, Go, Java, Kotlin, C#, Rust, Swift, Ruby, or PHP.
 license: Complete terms in LICENSE.txt
 ---
 
@@ -65,6 +65,38 @@ Key pages to review:
 - **Python SDK**: Use WebFetch to load `https://raw.githubusercontent.com/modelcontextprotocol/python-sdk/main/README.md`
 - [🐍 Python Guide](./reference/python_mcp_server.md) - Python patterns and examples
 
+**For Go:**
+- **Go SDK**: Use WebFetch to load `https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/main/README.md`
+- [🔷 Go Guide](./reference/go_mcp_server.md) - Go patterns and examples
+
+**For Java:**
+- **Java SDK**: `io.modelcontextprotocol.sdk:mcp` (Maven/Gradle)
+- [☕ Java Guide](./reference/java_mcp_server.md) - Reactive streams, Spring Boot integration
+
+**For Kotlin:**
+- **Kotlin SDK**: `io.modelcontextprotocol:kotlin-sdk` (Gradle)
+- [🟠 Kotlin Guide](./reference/kotlin_mcp_server.md) - Coroutines, Ktor SSE transport
+
+**For C#:**
+- **C# SDK**: `ModelContextProtocol` NuGet package
+- [🟣 C# Guide](./reference/csharp_mcp_server.md) - Attribute-based tools, DI, ASP.NET Core
+
+**For Rust:**
+- **Rust SDK**: `rmcp` crate
+- [🦀 Rust Guide](./reference/rust_mcp_server.md) - Macro-based tools, Axum transport
+
+**For Swift:**
+- **Swift SDK**: `modelcontextprotocol/swift-sdk` (SPM)
+- [🍎 Swift Guide](./reference/swift_mcp_server.md) - Actor concurrency, ServiceLifecycle
+
+**For Ruby:**
+- **Ruby SDK**: `gem 'mcp'`
+- [💎 Ruby Guide](./reference/ruby_mcp_server.md) - Class and block-based tools, Rails integration
+
+**For PHP:**
+- **PHP SDK**: `mcp/sdk` (Composer)
+- [🐘 PHP Guide](./reference/php_mcp_server.md) - Attribute discovery, Laravel/Symfony integration
+
 #### 1.4 Plan Your Implementation
 
 **Understand the API:**
@@ -80,8 +112,16 @@ Prioritize comprehensive API coverage. List endpoints to implement, starting wit
 #### 2.1 Set Up Project Structure
 
 See language-specific guides for project setup:
-- [⚡ TypeScript Guide](./reference/node_mcp_server.md) - Project structure, package.json, tsconfig.json
+- [⚡ TypeScript Guide](./reference/node_mcp_server.md) - package.json, tsconfig.json
 - [🐍 Python Guide](./reference/python_mcp_server.md) - Module organization, dependencies
+- [🔷 Go Guide](./reference/go_mcp_server.md) - go.mod, package layout
+- [☕ Java Guide](./reference/java_mcp_server.md) - Maven/Gradle, Spring Boot
+- [🟠 Kotlin Guide](./reference/kotlin_mcp_server.md) - build.gradle.kts, multiplatform
+- [🟣 C# Guide](./reference/csharp_mcp_server.md) - .csproj, NuGet, Host builder
+- [🦀 Rust Guide](./reference/rust_mcp_server.md) - Cargo.toml, project layout
+- [🍎 Swift Guide](./reference/swift_mcp_server.md) - Package.swift, SPM
+- [💎 Ruby Guide](./reference/ruby_mcp_server.md) - Gemfile, project layout
+- [🐘 PHP Guide](./reference/php_mcp_server.md) - composer.json, attribute discovery
 
 #### 2.2 Implement Core Infrastructure
 
@@ -96,7 +136,7 @@ Create shared utilities:
 For each tool:
 
 **Input Schema:**
-- Use Zod (TypeScript) or Pydantic (Python)
+- Use the language-appropriate validation: Zod (TypeScript), Pydantic (Python), struct tags (Go), JsonSchema builder (Java), kotlinx.serialization (Kotlin), `[Description]` attributes (C#), schemars derive (Rust), Value type (Swift), hash schemas (Ruby), `#[Schema]` attributes (PHP)
 - Include constraints and clear descriptions
 - Add examples in field descriptions
 
@@ -143,6 +183,43 @@ Review for:
 **Python:**
 - Verify syntax: `python -m py_compile your_server.py`
 - Test with MCP Inspector
+
+**Go:**
+- Build: `go build ./...`
+- Vet: `go vet ./...`
+- Test: `go test ./...`
+- Test with MCP Inspector: `npx @modelcontextprotocol/inspector go run .`
+
+**Java:**
+- Build: `mvn compile` or `gradle build`
+- Test: `mvn test` or `gradle test`
+
+**Kotlin:**
+- Build: `gradle build`
+- Test: `gradle test`
+
+**C#:**
+- Build: `dotnet build`
+- Test: `dotnet test`
+
+**Rust:**
+- Build: `cargo build`
+- Lint: `cargo clippy`
+- Test: `cargo test`
+
+**Swift:**
+- Build: `swift build`
+- Test: `swift test`
+
+**Ruby:**
+- Verify: `ruby server.rb`
+- Test: `bundle exec rake test`
+
+**PHP:**
+- Verify: `php server.php`
+- Test: `vendor/bin/phpunit`
+
+All languages can be tested with MCP Inspector: `npx @modelcontextprotocol/inspector <run command>`
 
 See language-specific guides for detailed testing approaches and quality checklists.
 
@@ -209,8 +286,16 @@ Load these resources as needed during development:
   - Security and error handling standards
 
 ### SDK Documentation (Load During Phase 1/2)
-- **Python SDK**: Fetch from `https://raw.githubusercontent.com/modelcontextprotocol/python-sdk/main/README.md`
 - **TypeScript SDK**: Fetch from `https://raw.githubusercontent.com/modelcontextprotocol/typescript-sdk/main/README.md`
+- **Python SDK**: Fetch from `https://raw.githubusercontent.com/modelcontextprotocol/python-sdk/main/README.md`
+- **Go SDK**: Fetch from `https://raw.githubusercontent.com/modelcontextprotocol/go-sdk/main/README.md`
+- **Java SDK**: `io.modelcontextprotocol.sdk:mcp` — see [☕ Java Guide](./reference/java_mcp_server.md)
+- **Kotlin SDK**: `io.modelcontextprotocol:kotlin-sdk` — see [🟠 Kotlin Guide](./reference/kotlin_mcp_server.md)
+- **C# SDK**: `ModelContextProtocol` NuGet — see [🟣 C# Guide](./reference/csharp_mcp_server.md)
+- **Rust SDK**: `rmcp` crate — see [🦀 Rust Guide](./reference/rust_mcp_server.md)
+- **Swift SDK**: `modelcontextprotocol/swift-sdk` SPM — see [🍎 Swift Guide](./reference/swift_mcp_server.md)
+- **Ruby SDK**: `mcp` gem — see [💎 Ruby Guide](./reference/ruby_mcp_server.md)
+- **PHP SDK**: `mcp/sdk` Composer — see [🐘 PHP Guide](./reference/php_mcp_server.md)
 
 ### Language-Specific Implementation Guides (Load During Phase 2)
 - [🐍 Python Implementation Guide](./reference/python_mcp_server.md) - Complete Python/FastMCP guide with:
@@ -225,6 +310,59 @@ Load these resources as needed during development:
   - Zod schema patterns
   - Tool registration with `server.registerTool`
   - Complete working examples
+  - Quality checklist
+
+- [🔷 Go Implementation Guide](./reference/go_mcp_server.md) - Complete Go guide with:
+  - Project structure and `go.mod` setup
+  - Server initialization (stdio and HTTP)
+  - Tool registration with `mcp.AddTool`
+  - Schema definition with struct tags
+  - Complete working examples
+  - Quality checklist
+
+- [☕ Java Implementation Guide](./reference/java_mcp_server.md) - Complete Java guide with:
+  - Reactive Streams (Project Reactor) handlers
+  - `Tool.builder()` and `JsonSchema` fluent API
+  - Spring Boot starter integration
+  - Synchronous facade for blocking use cases
+  - Quality checklist
+
+- [🟠 Kotlin Implementation Guide](./reference/kotlin_mcp_server.md) - Complete Kotlin guide with:
+  - Coroutine-based tool handlers
+  - `kotlinx.serialization` JSON schema DSL
+  - Ktor SSE transport
+  - Multiplatform support (JVM, Wasm, iOS)
+  - Quality checklist
+
+- [🟣 C# Implementation Guide](./reference/csharp_mcp_server.md) - Complete C# guide with:
+  - `[McpServerToolType]` / `[McpServerTool]` attribute registration
+  - Dependency injection with `Microsoft.Extensions.Hosting`
+  - ASP.NET Core HTTP transport
+  - Sampling (client LLM) integration
+  - Quality checklist
+
+- [🦀 Rust Implementation Guide](./reference/rust_mcp_server.md) - Complete Rust guide with:
+  - `#[tool]` and `#[tool_router]` macro-based registration
+  - `schemars` for automatic JSON Schema derivation
+  - Axum streamable HTTP transport
+  - Quality checklist
+
+- [🍎 Swift Implementation Guide](./reference/swift_mcp_server.md) - Complete Swift guide with:
+  - Actor-based `Server` with `withMethodHandler`
+  - `Value` type for JSON Schema construction
+  - `StdioTransport` and ServiceLifecycle shutdown
+  - Quality checklist
+
+- [💎 Ruby Implementation Guide](./reference/ruby_mcp_server.md) - Complete Ruby guide with:
+  - Class-based and block-based tool definitions
+  - `MCP::Resource` and `MCP::Prompt` patterns
+  - Rails integration
+  - Quality checklist
+
+- [🐘 PHP Implementation Guide](./reference/php_mcp_server.md) - Complete PHP guide with:
+  - `#[McpTool]` attribute-based discovery
+  - `#[Schema]` validation attributes
+  - Laravel/Symfony integration
   - Quality checklist
 
 ### Evaluation Guide (Load During Phase 4)

--- a/skills/mcp-builder/reference/csharp_mcp_server.md
+++ b/skills/mcp-builder/reference/csharp_mcp_server.md
@@ -1,0 +1,338 @@
+# C# MCP Server Implementation Guide
+
+## Overview
+
+This document provides C#-specific best practices and examples for implementing MCP servers using the official `ModelContextProtocol` NuGet package. It covers attribute-based tool registration, dependency injection, transport configuration, and complete working examples.
+
+---
+
+## Quick Reference
+
+### Key Package
+```bash
+dotnet add package ModelContextProtocol --prerelease
+```
+
+### Server Initialization
+```csharp
+var builder = Host.CreateApplicationBuilder(args);
+builder.Logging.AddConsole(options =>
+    options.LogToStandardErrorThreshold = LogLevel.Trace);
+builder.Services
+    .AddMcpServer()
+    .WithStdioServerTransport()
+    .WithToolsFromAssembly();
+await builder.Build().RunAsync();
+```
+
+### Tool Registration Pattern
+```csharp
+[McpServerToolType]
+public static class MyTools
+{
+    [McpServerTool, Description("What this tool does")]
+    public static string ToolName(
+        [Description("Parameter description")] string param) =>
+        $"Result: {param}";
+}
+```
+
+---
+
+## ModelContextProtocol SDK
+
+The official C# SDK provides:
+- `[McpServerToolType]` and `[McpServerTool]` attributes for tool registration
+- `[McpServerPromptType]` and `[McpServerPrompt]` for prompts
+- `WithToolsFromAssembly()` for auto-discovery of all annotated tools
+- Full dependency injection support — inject `HttpClient`, `McpServer`, or custom services
+- `WithStdioServerTransport()` for local and `ModelContextProtocol.AspNetCore` for HTTP
+
+**Package variants:**
+- `ModelContextProtocol` — full server SDK (recommended)
+- `ModelContextProtocol.AspNetCore` — HTTP transport for ASP.NET Core
+- `ModelContextProtocol.Core` — minimal dependencies for clients or low-level APIs
+
+## Server Naming Convention
+
+C# MCP servers should follow this naming pattern:
+- **Format**: `{Service}.Mcp.Server` (PascalCase with dots, .NET convention)
+- **Assembly/project name**: `{Service}.Mcp.Server`
+- **Server info name**: `{service}-mcp-server` (lowercase with hyphens for MCP protocol)
+- **Examples**: project `GitHub.Mcp.Server`, server name `github-mcp-server`
+
+## Project Structure
+
+```
+{Service}.Mcp.Server/
+├── {Service}.Mcp.Server.csproj
+├── Program.cs           # Host builder, DI, transport setup
+├── Tools/
+│   ├── SearchTools.cs
+│   └── ManageTools.cs
+├── Prompts/
+│   └── AnalyzePrompts.cs
+├── Services/
+│   └── ApiClient.cs     # HTTP client, auth
+└── Tests/
+    └── ToolsTests.cs
+```
+
+## Tool Implementation
+
+### Simple Tool
+
+```csharp
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+
+[McpServerToolType]
+public static class SearchTools
+{
+    [McpServerTool, Description("Search for items by query. Returns matching records with ID, name, and status.")]
+    public static string ServiceSearch(
+        [Description("Search query string")] string query,
+        [Description("Maximum results to return (1-100)")] int limit = 20)
+    {
+        var results = ApiClient.Search(query, limit);
+        return JsonSerializer.Serialize(new { total = results.Count, results });
+    }
+}
+```
+
+### Async Tool with Dependency Injection
+
+```csharp
+[McpServerToolType]
+public static class DataTools
+{
+    [McpServerTool, Description("Fetch data from a URL. Returns the response body as text.")]
+    public static async Task<string> ServiceFetchData(
+        HttpClient httpClient,
+        [Description("The URL to fetch")] string url,
+        CancellationToken cancellationToken) =>
+        await httpClient.GetStringAsync(url, cancellationToken);
+}
+```
+
+### Tool with Sampling (Client LLM)
+
+```csharp
+[McpServerToolType]
+public static class AnalysisTools
+{
+    [McpServerTool, Description("Analyze content using the client's LLM capabilities.")]
+    public static async Task<string> ServiceAnalyze(
+        McpServer server,
+        [Description("Content to analyze")] string content,
+        CancellationToken cancellationToken)
+    {
+        var messages = new ChatMessage[]
+        {
+            new(ChatRole.User, $"Analyze this: {content}")
+        };
+        return await server.AsSamplingChatClient()
+            .GetResponseAsync(messages, cancellationToken: cancellationToken);
+    }
+}
+```
+
+### Tool with Complex Return Types
+
+Tools can return simple types or complex objects (auto-serialized to JSON):
+
+```csharp
+[McpServerTool, Description("Get user details by ID. Returns user profile with name, email, and role.")]
+public static async Task<UserProfile> ServiceGetUser(
+    IUserService userService,
+    [Description("User ID")] string userId,
+    CancellationToken cancellationToken) =>
+    await userService.GetProfileAsync(userId, cancellationToken);
+```
+
+## Prompt Implementation
+
+```csharp
+[McpServerPromptType]
+public static class AnalyzePrompts
+{
+    [McpServerPrompt, Description("Analyze a topic in depth")]
+    public static ChatMessage[] Analyze(
+        [Description("Topic to analyze")] string topic,
+        [Description("Analysis depth")] string depth = "basic") =>
+        new[]
+        {
+            new ChatMessage(ChatRole.User, $"Please analyze this topic at {depth} depth: {topic}")
+        };
+}
+```
+
+## Transport Configuration
+
+### stdio (local, default)
+
+```csharp
+builder.Services
+    .AddMcpServer()
+    .WithStdioServerTransport()
+    .WithToolsFromAssembly();
+```
+
+### ASP.NET Core HTTP
+
+```bash
+dotnet add package ModelContextProtocol.AspNetCore --prerelease
+```
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddMcpServer().WithToolsFromAssembly();
+
+var app = builder.Build();
+app.MapMcp();
+app.Run();
+```
+
+## Dependency Injection
+
+Register services in the DI container and inject into tool methods:
+
+```csharp
+var builder = Host.CreateApplicationBuilder(args);
+
+// Register services
+builder.Services.AddHttpClient();
+builder.Services.AddSingleton<IApiClient, ApiClient>();
+
+// Register MCP server
+builder.Services
+    .AddMcpServer()
+    .WithStdioServerTransport()
+    .WithToolsFromAssembly();
+
+await builder.Build().RunAsync();
+```
+
+## Error Handling
+
+Use `McpProtocolException` for protocol-level errors:
+
+```csharp
+[McpServerTool, Description("Get item by ID")]
+public static async Task<string> ServiceGetItem(
+    IApiClient client,
+    [Description("Item ID")] string id,
+    CancellationToken ct)
+{
+    if (string.IsNullOrWhiteSpace(id))
+        throw new McpProtocolException(McpErrorCode.InvalidParams, "Item ID cannot be empty");
+
+    var item = await client.GetItemAsync(id, ct)
+        ?? throw new McpProtocolException(McpErrorCode.InvalidParams,
+            $"Item '{id}' not found — verify the ID; use service_list_items to discover available items");
+
+    return JsonSerializer.Serialize(item);
+}
+```
+
+## Logging
+
+Always log to stderr to avoid interfering with stdio transport:
+
+```csharp
+builder.Logging.AddConsole(options =>
+    options.LogToStandardErrorThreshold = LogLevel.Trace);
+```
+
+## Fine-Grained Control with McpServerOptions
+
+For advanced scenarios, use custom handlers:
+
+```csharp
+builder.Services.AddMcpServer(options =>
+{
+    options.ServerInfo = new() { Name = "service-mcp-server", Version = "1.0.0" };
+    options.Capabilities = new()
+    {
+        Tools = new() { ListChanged = true },
+        Resources = new() { ListChanged = true }
+    };
+});
+```
+
+## Complete Example
+
+```csharp
+using System.ComponentModel;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+
+var builder = Host.CreateApplicationBuilder(args);
+builder.Logging.AddConsole(options =>
+    options.LogToStandardErrorThreshold = LogLevel.Trace);
+
+builder.Services.AddHttpClient();
+builder.Services
+    .AddMcpServer()
+    .WithStdioServerTransport()
+    .WithToolsFromAssembly();
+
+await builder.Build().RunAsync();
+
+[McpServerToolType]
+public static class RepoTools
+{
+    [McpServerTool, Description("List repositories for an owner. Returns name, description, and star count.")]
+    public static async Task<string> ListRepos(
+        HttpClient httpClient,
+        [Description("GitHub org or username")] string owner,
+        [Description("Results per page (1-100)")] int perPage = 30,
+        CancellationToken cancellationToken = default)
+    {
+        var token = Environment.GetEnvironmentVariable("API_TOKEN")
+            ?? throw new InvalidOperationException("API_TOKEN environment variable is required");
+
+        // ... fetch repos ...
+        var result = new { repos = new[] { new { name = "example", stars = 42 } }, total = 1 };
+        return JsonSerializer.Serialize(result);
+    }
+}
+```
+
+---
+
+## Quality Checklist
+
+Before finalizing your C# MCP server implementation, ensure:
+
+### Strategic Design
+- [ ] Tools enable complete workflows, not just API endpoint wrappers
+- [ ] Tool names are `snake_case` with consistent service prefix (in `[Description]`)
+- [ ] Error messages guide agents toward correct usage
+
+### Implementation Quality
+- [ ] All tool classes use `[McpServerToolType]` attribute
+- [ ] All tool methods use `[McpServerTool]` with `[Description]`
+- [ ] All parameters have `[Description]` attributes
+- [ ] `CancellationToken` included in async tool methods
+- [ ] `McpProtocolException` used for validation errors with `McpErrorCode.InvalidParams`
+
+### C# Quality
+- [ ] Uses `Microsoft.Extensions.Hosting` for DI and lifecycle
+- [ ] Logging configured to stderr (`LogToStandardErrorThreshold`)
+- [ ] Async methods return `Task<T>` with proper `await`
+- [ ] No hardcoded credentials — all secrets via `Environment.GetEnvironmentVariable`
+- [ ] Services registered in DI container and injected into tool methods
+
+### Project Configuration
+- [ ] `.csproj` references `ModelContextProtocol` NuGet package
+- [ ] `dotnet build` succeeds with no errors
+- [ ] Project name follows format: `{Service}.Mcp.Server`
+
+### Testing
+- [ ] `dotnet build` compiles without errors
+- [ ] `dotnet test` passes
+- [ ] Manual test with MCP Inspector: `npx @modelcontextprotocol/inspector dotnet run`

--- a/skills/mcp-builder/reference/go_mcp_server.md
+++ b/skills/mcp-builder/reference/go_mcp_server.md
@@ -1,0 +1,801 @@
+# Go MCP Server Implementation Guide
+
+## Overview
+
+This document provides Go-specific best practices and examples for implementing MCP servers using the official `modelcontextprotocol/go-sdk`. It covers project structure, server setup, tool registration patterns, schema definition with struct tags, error handling, and complete working examples.
+
+---
+
+## Quick Reference
+
+### Key Imports
+```go
+import (
+    "context"
+    "fmt"
+    "log"
+
+    "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+```
+
+### Server Initialization
+```go
+server := mcp.NewServer(&mcp.Implementation{
+    Name:    "service-mcp",
+    Version: "1.0.0",
+}, nil)
+```
+
+### Tool Registration Pattern
+```go
+mcp.AddTool(server, &mcp.Tool{
+    Name:        "service_action",
+    Description: "What this tool does and returns",
+    Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
+}, handlerFunc)
+```
+
+---
+
+## MCP Go SDK
+
+The official Go SDK (`github.com/modelcontextprotocol/go-sdk/mcp`) provides:
+- `mcp.NewServer` for server initialization
+- `mcp.AddTool` generic function for type-safe tool registration
+- Automatic JSON Schema inference from Go struct tags
+- `mcp.StdioTransport` and `mcp.NewStreamableHTTPHandler` for transport
+
+**IMPORTANT - Use the Generic API:**
+- **DO use**: `mcp.AddTool[In, Out](server, tool, handler)` with typed handler functions
+- **DO NOT use**: Low-level request handler registration or manual schema construction (unless you need custom constraints)
+- The generic `AddTool` function provides automatic schema inference, type-safe handlers, and input validation before your code runs
+
+## Server Naming Convention
+
+Go MCP servers must follow this naming pattern:
+- **Format**: `{service}-mcp` (lowercase with hyphens)
+- **Examples**: `github-mcp`, `jira-mcp`, `stripe-mcp`
+
+The name should be:
+- General (not tied to specific features)
+- Descriptive of the service/API being integrated
+- Easy to infer from the task description
+- Without version numbers or dates
+
+## Project Structure
+
+Create the following structure for Go MCP servers:
+
+```
+{service}-mcp/
+├── main.go          # Entry point: wire server, register tools, start transport
+├── tools/
+│   ├── repos.go     # Tool types and handlers for repository operations
+│   └── issues.go    # Tool types and handlers for issue operations
+├── client/
+│   └── client.go    # HTTP client, auth, base URL config
+└── go.mod
+```
+
+## Tool Implementation
+
+### Tool Naming
+
+Use snake_case for tool names (e.g., `search_users`, `create_project`, `get_channel_info`) with clear, action-oriented names.
+
+**Avoid Naming Conflicts**: Include the service context to prevent overlaps:
+- Use `slack_send_message` instead of just `send_message`
+- Use `github_create_issue` instead of just `create_issue`
+- Use `asana_list_tasks` instead of just `list_tasks`
+
+### Tool Structure
+
+Tools are registered using the generic `mcp.AddTool` function. The handler signature is:
+
+```go
+func(ctx context.Context, req *mcp.CallToolRequest, input In) (*mcp.CallToolResult, Out, error)
+```
+
+The SDK automatically:
+- Infers the JSON Schema from your `In` struct type
+- Validates input against that schema before calling your handler
+- Serializes the `Out` value as structured JSON content
+
+```go
+// Input type — struct tags define the schema
+type UserSearchInput struct {
+    Query   string `json:"query"   jsonschema:"Search string to match against names/emails"`
+    Limit   *int   `json:"limit,omitempty"   jsonschema:"Maximum results to return (1-100), default 20"`
+    Offset  *int   `json:"offset,omitempty"  jsonschema:"Number of results to skip for pagination"`
+}
+
+// Output type
+type UserSearchOutput struct {
+    Total   int           `json:"total"   jsonschema:"Total number of matches found"`
+    Count   int           `json:"count"   jsonschema:"Number of results in this response"`
+    Users   []UserSummary `json:"users"   jsonschema:"Matching user records"`
+    HasMore bool          `json:"hasMore" jsonschema:"Whether more results are available"`
+}
+
+type UserSummary struct {
+    ID    string `json:"id"`
+    Name  string `json:"name"`
+    Email string `json:"email"`
+    Team  string `json:"team,omitempty"`
+}
+
+// Register the tool
+mcp.AddTool(server, &mcp.Tool{
+    Name: "example_search_users",
+    Description: `Search for users in the Example system by name, email, or team.
+
+Returns matching user records with ID, name, email, and team. Supports pagination
+via limit and offset parameters. Use example_get_user for full details on a single user.`,
+    Annotations: &mcp.ToolAnnotations{
+        ReadOnlyHint:   true,
+        IdempotentHint: true,
+        OpenWorldHint:  mcp.Ptr(true),
+    },
+}, handleSearchUsers)
+
+// Handler implementation
+func handleSearchUsers(ctx context.Context, req *mcp.CallToolRequest, in UserSearchInput) (*mcp.CallToolResult, UserSearchOutput, error) {
+    limit := 20
+    if in.Limit != nil {
+        limit = *in.Limit
+    }
+    offset := 0
+    if in.Offset != nil {
+        offset = *in.Offset
+    }
+
+    data, err := apiClient.SearchUsers(ctx, in.Query, limit, offset)
+    if err != nil {
+        return nil, UserSearchOutput{}, fmt.Errorf("searching users for %q: %w", in.Query, err)
+    }
+
+    users := data.Users
+    if len(users) == 0 {
+        return nil, UserSearchOutput{}, fmt.Errorf("no users found matching %q", in.Query)
+    }
+
+    return nil, UserSearchOutput{
+        Total:   data.Total,
+        Count:   len(users),
+        Users:   users,
+        HasMore: data.Total > offset+len(users),
+    }, nil
+}
+```
+
+## Schema Definition with Struct Tags
+
+### Basic — auto-inferred from struct tags
+
+```go
+type Input struct {
+    // Non-pointer = required field in the generated schema
+    Owner string `json:"owner" jsonschema:"GitHub organization or username"`
+
+    // Pointer = optional field
+    PerPage *int    `json:"perPage,omitempty" jsonschema:"Results per page (1-100), default 30"`
+    Sort    *string `json:"sort,omitempty"    jsonschema:"Sort field: created, updated, pushed, or full_name"`
+}
+```
+
+The `jsonschema:"..."` tag value becomes the field's description in the schema.
+
+### Custom constraints — enum, min/max
+
+When you need enum values, numeric ranges, or other constraints, override the schema:
+
+```go
+import (
+    "reflect"
+    "github.com/google/jsonschema-go/jsonschema"
+)
+
+type SortField string
+
+const (
+    SortCreated  SortField = "created"
+    SortUpdated  SortField = "updated"
+    SortPushed   SortField = "pushed"
+    SortFullName SortField = "full_name"
+)
+
+// Build the schema with custom type overrides
+inputSchema, err := jsonschema.For[ListReposInput](&jsonschema.ForOptions{
+    TypeSchemas: map[reflect.Type]*jsonschema.Schema{
+        reflect.TypeFor[SortField](): {
+            Type: "string",
+            Enum: []any{SortCreated, SortUpdated, SortPushed, SortFullName},
+        },
+    },
+})
+if err != nil {
+    log.Fatal(err)
+}
+
+// Optionally mutate individual properties after inference
+inputSchema.Properties["perPage"].Minimum = jsonschema.Ptr(1.0)
+inputSchema.Properties["perPage"].Maximum = jsonschema.Ptr(100.0)
+
+// Pass the override when registering the tool
+mcp.AddTool(server, &mcp.Tool{
+    Name:        "github_list_repos",
+    Description: "List repositories for an organization or user.",
+    InputSchema: inputSchema,
+}, handleListRepos)
+```
+
+> Only import `github.com/google/jsonschema-go/jsonschema` when you need schema customization. For most tools, struct tags alone are sufficient.
+
+## Handler Patterns
+
+### Minimal handler (structured output only)
+
+Return `nil` for `*mcp.CallToolResult` — the SDK auto-populates content from your output value as JSON:
+
+```go
+func handleListRepos(ctx context.Context, req *mcp.CallToolRequest, in ListReposInput) (*mcp.CallToolResult, ListReposOutput, error) {
+    perPage := 30
+    if in.PerPage != nil {
+        perPage = *in.PerPage
+    }
+
+    repos, err := apiClient.ListRepos(ctx, in.Owner, perPage)
+    if err != nil {
+        return nil, ListReposOutput{}, fmt.Errorf("listing repos for %q: %w", in.Owner, err)
+    }
+    return nil, ListReposOutput{Repos: repos, Total: len(repos)}, nil
+}
+```
+
+### Handler with explicit text content
+
+Return a `*mcp.CallToolResult` when you want to control the text shown in the content field:
+
+```go
+func handleGetSummary(ctx context.Context, req *mcp.CallToolRequest, in SummaryInput) (*mcp.CallToolResult, any, error) {
+    text, err := apiClient.GetSummary(ctx, in.ID)
+    if err != nil {
+        return nil, nil, fmt.Errorf("getting summary for %q: %w", in.ID, err)
+    }
+    return &mcp.CallToolResult{
+        Content: []mcp.Content{&mcp.TextContent{Text: text}},
+    }, nil, nil
+}
+```
+
+### Handler with no output type
+
+Use `any` as the output type when you have no structured output:
+
+```go
+mcp.AddTool(server, &mcp.Tool{Name: "ping", Description: "Check connectivity"},
+    func(ctx context.Context, req *mcp.CallToolRequest, _ any) (*mcp.CallToolResult, any, error) {
+        return &mcp.CallToolResult{
+            Content: []mcp.Content{&mcp.TextContent{Text: "pong"}},
+        }, nil, nil
+    })
+```
+
+## Response and Error Handling
+
+### Tool errors vs protocol errors
+
+| Situation | How to return |
+| --------- | ------------- |
+| Business/tool error (not found, bad input, API 404) | `return nil, zero, fmt.Errorf("message")` — SDK sets `IsError: true` |
+| Explicit tool error with custom content | `return &mcp.CallToolResult{IsError: true, Content: [...]}, zero, nil` |
+| Infrastructure/protocol failure (unrecoverable) | `return nil, zero, err` — framework-level error |
+
+**Critical distinction**: returning a non-nil `error` from a handler is treated as a **tool error** — the SDK packs it into `CallToolResult.Content` with `IsError: true`. This is the correct behavior for business logic failures.
+
+### Actionable error messages
+
+```go
+// Bad
+return nil, out, fmt.Errorf("not found")
+
+// Good
+return nil, out, fmt.Errorf("repository %q/%q not found — verify the owner login and repository name; use list_repos to discover available repositories", owner, repo)
+```
+
+### Wrapping API errors
+
+```go
+repos, err := apiClient.ListRepos(ctx, in.Owner, perPage)
+if err != nil {
+    var apiErr *APIError
+    if errors.As(err, &apiErr) {
+        switch apiErr.StatusCode {
+        case 404:
+            return nil, ListReposOutput{}, fmt.Errorf("owner %q not found", in.Owner)
+        case 403:
+            return nil, ListReposOutput{}, fmt.Errorf("access denied — check that your API token has the required scopes")
+        case 429:
+            return nil, ListReposOutput{}, fmt.Errorf("rate limit exceeded — wait before making more requests")
+        }
+    }
+    return nil, ListReposOutput{}, fmt.Errorf("API request failed: %w", err)
+}
+```
+
+## Shared Utilities
+
+Extract common functionality into reusable packages:
+
+```go
+// client/client.go
+package client
+
+import (
+    "context"
+    "encoding/json"
+    "fmt"
+    "net/http"
+    "time"
+)
+
+type Client struct {
+    token   string
+    baseURL string
+    http    *http.Client
+}
+
+func New(token, baseURL string) *Client {
+    return &Client{
+        token:   token,
+        baseURL: baseURL,
+        http:    &http.Client{Timeout: 30 * time.Second},
+    }
+}
+
+func (c *Client) Do(ctx context.Context, method, endpoint string, body, result any) error {
+    // Build request, set auth header, execute, decode response
+    req, err := http.NewRequestWithContext(ctx, method, c.baseURL+"/"+endpoint, nil)
+    if err != nil {
+        return fmt.Errorf("creating request: %w", err)
+    }
+    req.Header.Set("Authorization", "Bearer "+c.token)
+    req.Header.Set("Accept", "application/json")
+
+    resp, err := c.http.Do(req)
+    if err != nil {
+        return fmt.Errorf("executing request: %w", err)
+    }
+    defer resp.Body.Close()
+
+    if resp.StatusCode >= 400 {
+        return &APIError{StatusCode: resp.StatusCode}
+    }
+
+    if result != nil {
+        if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
+            return fmt.Errorf("decoding response: %w", err)
+        }
+    }
+    return nil
+}
+
+type APIError struct {
+    StatusCode int
+    Message    string
+}
+
+func (e *APIError) Error() string {
+    return fmt.Sprintf("API %d: %s", e.StatusCode, e.Message)
+}
+```
+
+## Tool Annotations
+
+Set annotations on `&mcp.Tool{}` via the `Annotations` field:
+
+```go
+&mcp.Tool{
+    Name:        "delete_repo",
+    Description: "Permanently delete a repository. This cannot be undone.",
+    Annotations: &mcp.ToolAnnotations{
+        ReadOnlyHint:    false,
+        DestructiveHint: mcp.Ptr(true),  // *bool fields use mcp.Ptr()
+        IdempotentHint:  false,
+        OpenWorldHint:   mcp.Ptr(true),
+    },
+}
+```
+
+| Field | Type | Default | When to set |
+| ----- | ---- | ------- | ----------- |
+| `ReadOnlyHint` | `bool` | `false` | `true` for GET-equivalent operations |
+| `DestructiveHint` | `*bool` | `true` | `false` for additive-only operations |
+| `IdempotentHint` | `bool` | `false` | `true` for PUT/UPSERT operations |
+| `OpenWorldHint` | `*bool` | `true` | `false` only for closed-world (e.g. in-memory) tools |
+
+> `*bool` fields (`DestructiveHint`, `OpenWorldHint`) use pointer types because `nil` means "unset" (use default). Use `mcp.Ptr(true)` or `mcp.Ptr(false)`.
+
+## Transport: stdio vs HTTP
+
+### stdio (local, default)
+
+For servers invoked directly by an MCP client (e.g., Claude Desktop, VS Code extension):
+
+```go
+if err := server.Run(context.Background(), &mcp.StdioTransport{}); err != nil {
+    log.Fatalf("server error: %v", err)
+}
+```
+
+Configure in `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "myserver": {
+      "command": "/path/to/myserver",
+      "env": { "API_TOKEN": "your-token" }
+    }
+  }
+}
+```
+
+Or via `go run`:
+
+```json
+{
+  "mcpServers": {
+    "myserver": {
+      "command": "go",
+      "args": ["run", "/path/to/myserver"],
+      "env": { "API_TOKEN": "your-token" }
+    }
+  }
+}
+```
+
+### Streamable HTTP (remote)
+
+```go
+import "net/http"
+
+handler := mcp.NewStreamableHTTPHandler(func(req *http.Request) *mcp.Server {
+    return server
+}, nil)
+
+log.Println("MCP server listening on :8080")
+if err := http.ListenAndServe(":8080", handler); err != nil {
+    log.Fatalf("HTTP server error: %v", err)
+}
+```
+
+**Transport selection:**
+- **stdio**: Command-line tools, local development, subprocess integration
+- **Streamable HTTP**: Web services, remote access, multiple clients
+
+## Graceful Shutdown
+
+Handle shutdown signals properly:
+
+```go
+ctx, cancel := context.WithCancel(context.Background())
+defer cancel()
+
+sigCh := make(chan os.Signal, 1)
+signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+
+go func() {
+    <-sigCh
+    cancel()
+}()
+
+if err := server.Run(ctx, &mcp.StdioTransport{}); err != nil {
+    log.Fatal(err)
+}
+```
+
+## Pagination Implementation
+
+For tools that list resources:
+
+```go
+type ListInput struct {
+    Limit  *int `json:"limit,omitempty"  jsonschema:"Maximum results to return (1-100), default 20"`
+    Offset *int `json:"offset,omitempty" jsonschema:"Number of results to skip for pagination"`
+}
+
+type ListOutput struct {
+    Total      int  `json:"total"      jsonschema:"Total number of items"`
+    Count      int  `json:"count"      jsonschema:"Number of items in this response"`
+    Offset     int  `json:"offset"     jsonschema:"Current pagination offset"`
+    HasMore    bool `json:"hasMore"    jsonschema:"Whether more results are available"`
+    NextOffset *int `json:"nextOffset,omitempty" jsonschema:"Offset for next page if hasMore is true"`
+    // Items field added by the specific list type
+}
+```
+
+## Complete Example
+
+```go
+package main
+
+import (
+    "context"
+    "errors"
+    "fmt"
+    "log"
+    "net/http"
+    "os"
+    "time"
+
+    "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// --- Input/Output types ---
+
+type ListReposInput struct {
+    Owner   string `json:"owner"              jsonschema:"GitHub organization or username"`
+    PerPage *int   `json:"perPage,omitempty"  jsonschema:"Results per page (1-100), defaults to 30"`
+}
+
+type RepoSummary struct {
+    Name        string `json:"name"`
+    Description string `json:"description"`
+    Stars       int    `json:"stars"`
+    Language    string `json:"language,omitempty"`
+}
+
+type ListReposOutput struct {
+    Repos []RepoSummary `json:"repos" jsonschema:"list of matching repositories"`
+    Total int           `json:"total" jsonschema:"total number of repos returned"`
+}
+
+// --- API client ---
+
+type APIError struct {
+    StatusCode int
+    Message    string
+}
+
+func (e *APIError) Error() string { return fmt.Sprintf("API %d: %s", e.StatusCode, e.Message) }
+
+type Client struct {
+    token string
+    http  *http.Client
+}
+
+func NewClient(token string) *Client {
+    return &Client{token: token, http: &http.Client{Timeout: 30 * time.Second}}
+}
+
+func (c *Client) ListRepos(ctx context.Context, owner string, perPage int) ([]RepoSummary, error) {
+    // ... make HTTP request, parse response ...
+    return []RepoSummary{{Name: "example", Stars: 42}}, nil
+}
+
+// --- Tool handler ---
+
+var apiClient *Client
+
+func handleListRepos(ctx context.Context, req *mcp.CallToolRequest, in ListReposInput) (*mcp.CallToolResult, ListReposOutput, error) {
+    perPage := 30
+    if in.PerPage != nil {
+        perPage = *in.PerPage
+    }
+
+    repos, err := apiClient.ListRepos(ctx, in.Owner, perPage)
+    if err != nil {
+        var apiErr *APIError
+        if errors.As(err, &apiErr) && apiErr.StatusCode == 404 {
+            return nil, ListReposOutput{}, fmt.Errorf("owner %q not found — verify the login name", in.Owner)
+        }
+        return nil, ListReposOutput{}, fmt.Errorf("listing repos: %w", err)
+    }
+
+    return nil, ListReposOutput{Repos: repos, Total: len(repos)}, nil
+}
+
+// --- Main ---
+
+func main() {
+    token := os.Getenv("API_TOKEN")
+    if token == "" {
+        log.Fatal("API_TOKEN environment variable is required")
+    }
+    apiClient = NewClient(token)
+
+    server := mcp.NewServer(&mcp.Implementation{
+        Name:    "example-mcp",
+        Version: "1.0.0",
+    }, nil)
+
+    mcp.AddTool(server, &mcp.Tool{
+        Name:        "list_repos",
+        Description: "List repositories for an owner. Returns name, description, stars, and language.",
+        Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
+    }, handleListRepos)
+
+    if err := server.Run(context.Background(), &mcp.StdioTransport{}); err != nil {
+        log.Fatalf("server error: %v", err)
+    }
+}
+```
+
+---
+
+## Advanced MCP Features
+
+### Resource Registration
+
+Expose data as resources for URI-based access:
+
+```go
+mcp.AddResource(server,
+    &mcp.Resource{
+        URI:         "config://settings",
+        Name:        "Server Settings",
+        Description: "Current server configuration",
+        MIMEType:    "application/json",
+    },
+    func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+        settings, err := loadSettings(ctx)
+        if err != nil {
+            return nil, err
+        }
+        return &mcp.ReadResourceResult{
+            Contents: []any{
+                &mcp.TextResourceContents{
+                    ResourceContents: mcp.ResourceContents{
+                        URI:      req.URI,
+                        MIMEType: "application/json",
+                    },
+                    Text: settings,
+                },
+            },
+        }, nil
+    },
+)
+```
+
+**When to use Resources vs Tools:**
+- **Resources**: For data access with simple URI-based parameters
+- **Tools**: For complex operations requiring validation and business logic
+
+### Prompt Registration
+
+Expose reusable prompt templates:
+
+```go
+type AnalyzeInput struct {
+    Topic string `json:"topic" jsonschema:"the topic to analyze"`
+}
+
+mcp.AddPrompt(server,
+    &mcp.Prompt{
+        Name:        "analyze",
+        Description: "Analyze a topic in depth",
+        Arguments: []mcp.PromptArgument{
+            {Name: "topic", Description: "The topic to analyze", Required: true},
+        },
+    },
+    func(ctx context.Context, req *mcp.GetPromptRequest, input AnalyzeInput) (*mcp.GetPromptResult, error) {
+        return &mcp.GetPromptResult{
+            Description: "Analyze the given topic",
+            Messages: []mcp.PromptMessage{
+                {
+                    Role:    mcp.RoleUser,
+                    Content: mcp.TextContent{Text: fmt.Sprintf("Analyze this topic: %s", input.Topic)},
+                },
+            },
+        }, nil
+    },
+)
+```
+
+---
+
+## Code Best Practices
+
+### Code Composability and Reusability
+
+Your implementation MUST prioritize composability and code reuse:
+
+1. **Extract Common Functionality**:
+   - Create reusable helper functions for operations used across multiple tools
+   - Build shared API clients for HTTP requests instead of duplicating code
+   - Centralize error handling logic in utility functions
+   - Extract business logic into dedicated functions that can be composed
+
+2. **Avoid Duplication**:
+   - NEVER copy-paste similar code between tools
+   - If you find yourself writing similar logic twice, extract it into a function
+   - Common operations like pagination, filtering, and formatting should be shared
+   - Authentication/authorization logic should be centralized
+
+### Go-Specific Best Practices
+
+1. **Use `context.Context`**: Always pass and respect context for cancellation and deadlines
+2. **Struct tags for schemas**: Use `json` and `jsonschema` tags on all input/output types
+3. **Pointer types for optionals**: Non-pointer fields are required; use `*Type` for optional fields
+4. **Error wrapping**: Use `fmt.Errorf("context: %w", err)` to preserve error chains
+5. **No panics in handlers**: Always return errors; never `log.Fatal` or `panic` in tool handlers
+6. **Structured logging**: Use `log/slog` for structured, leveled logging to stderr
+7. **Constants**: Define module-level constants for configuration values
+
+## Building and Running
+
+```bash
+# Build the project
+go build ./...
+
+# Run vet and lint
+go vet ./...
+
+# Run tests
+go test ./...
+
+# Run the server
+go run .
+
+# Test with MCP Inspector
+npx @modelcontextprotocol/inspector go run .
+```
+
+Always ensure `go build ./...` and `go vet ./...` complete successfully before considering the implementation complete.
+
+## Quality Checklist
+
+Before finalizing your Go MCP server implementation, ensure:
+
+### Strategic Design
+- [ ] Tools enable complete workflows, not just API endpoint wrappers
+- [ ] Tool names reflect natural task subdivisions
+- [ ] Response formats optimize for agent context efficiency
+- [ ] Human-readable identifiers used where appropriate
+- [ ] Error messages guide agents toward correct usage
+
+### Implementation Quality
+- [ ] FOCUSED IMPLEMENTATION: Most important and valuable tools implemented
+- [ ] All tools registered using `mcp.AddTool` with complete configuration
+- [ ] All tools include `Name`, `Description`, and `Annotations`
+- [ ] Annotations correctly set (ReadOnlyHint, DestructiveHint, IdempotentHint, OpenWorldHint)
+- [ ] All input types use struct tags (`json`, `jsonschema`) for schema generation
+- [ ] Required fields are non-pointer; optional fields use pointer types
+- [ ] All tools have comprehensive descriptions that state what they return
+- [ ] Error messages are clear, actionable, and educational
+
+### Go Quality
+- [ ] `context.Context` passed through all I/O operations
+- [ ] No panics or `log.Fatal` in tool handlers — errors returned properly
+- [ ] Error chains preserved with `fmt.Errorf("...: %w", err)`
+- [ ] API errors mapped to descriptive messages with recovery hints
+- [ ] No hardcoded credentials — all secrets via environment variables
+- [ ] Token validated at startup with clear error message if missing
+
+### Advanced Features (where applicable)
+- [ ] Resources registered for appropriate data endpoints
+- [ ] Prompts registered for reusable templates
+- [ ] Appropriate transport configured (stdio or streamable HTTP)
+- [ ] Graceful shutdown with signal handling
+
+### Project Configuration
+- [ ] `go.mod` includes correct module path and SDK dependency
+- [ ] Server name follows format: `{service}-mcp`
+- [ ] `go build ./...` succeeds with no errors
+- [ ] `go vet ./...` passes with no warnings
+
+### Code Quality
+- [ ] Pagination is properly implemented where applicable
+- [ ] List endpoints support `limit` and `offset` (or `page`/`perPage`) parameters
+- [ ] Common functionality is extracted into reusable functions
+- [ ] Return types are consistent across similar operations
+- [ ] All network operations handle timeouts via context or client config
+
+### Testing and Build
+- [ ] `go build ./...` compiles without errors
+- [ ] `go vet ./...` passes
+- [ ] `go test ./...` passes
+- [ ] Manual test with MCP Inspector: `npx @modelcontextprotocol/inspector go run .`
+- [ ] Sample tool calls work as expected

--- a/skills/mcp-builder/reference/java_mcp_server.md
+++ b/skills/mcp-builder/reference/java_mcp_server.md
@@ -1,0 +1,457 @@
+# Java MCP Server Implementation Guide
+
+## Overview
+
+This document provides Java-specific best practices and examples for implementing MCP servers using the official MCP Java SDK (`io.modelcontextprotocol.sdk:mcp`). It covers server setup with reactive streams, tool registration, Spring Boot integration, and complete working examples.
+
+---
+
+## Quick Reference
+
+### Key Dependency (Maven)
+```xml
+<dependency>
+    <groupId>io.modelcontextprotocol.sdk</groupId>
+    <artifactId>mcp</artifactId>
+    <version>0.14.1</version>
+</dependency>
+```
+
+### Server Initialization
+```java
+McpServer server = McpServerBuilder.builder()
+    .serverInfo("service-mcp-server", "1.0.0")
+    .capabilities(cap -> cap.tools(true).resources(true).prompts(true))
+    .build();
+```
+
+### Tool Registration Pattern
+```java
+server.addToolHandler("service_action", (args) -> {
+    return Mono.just(ToolResponse.success()
+        .addTextContent("Result")
+        .build());
+});
+```
+
+---
+
+## MCP Java SDK
+
+The official Java SDK provides:
+- `McpServerBuilder` for fluent server construction
+- `Tool.builder()` for tool definitions with JSON Schema
+- Reactive Streams (Project Reactor) for async handlers returning `Mono<T>`
+- `McpSyncServer` for synchronous blocking facade
+- `StdioServerTransport`, `ServletServerTransport`
+- Spring Boot starter for enterprise integration
+
+**Two programming models:**
+- **Reactive** (recommended): Return `Mono<ToolResponse>` for non-blocking async
+- **Synchronous**: Use `server.toSyncServer()` for blocking handlers
+
+## Server Naming Convention
+
+Java MCP servers should follow this naming pattern:
+- **Artifact**: `{service}-mcp-server` (lowercase with hyphens)
+- **Server info name**: `{service}-mcp-server`
+- **Examples**: `github-mcp-server`, `jira-mcp-server`, `stripe-mcp-server`
+
+## Project Structure
+
+### Maven
+```
+{service}-mcp-server/
+├── pom.xml
+├── src/main/java/
+│   └── com/example/mcp/
+│       ├── Application.java    # Entry point
+│       ├── tools/
+│       │   ├── SearchTools.java
+│       │   └── ManageTools.java
+│       ├── prompts/
+│       │   └── AnalyzePrompts.java
+│       └── client/
+│           └── ApiClient.java
+└── src/test/java/
+    └── com/example/mcp/
+        └── ToolsTest.java
+```
+
+### Gradle (build.gradle.kts)
+```kotlin
+dependencies {
+    implementation("io.modelcontextprotocol.sdk:mcp:0.14.1")
+}
+```
+
+## Tool Implementation
+
+### Defining Tools
+
+```java
+Tool searchTool = Tool.builder()
+    .name("service_search")
+    .description("Search for items by query. Returns matching records with ID, name, and status.")
+    .inputSchema(JsonSchema.object()
+        .property("query", JsonSchema.string()
+            .description("Search query string")
+            .required(true))
+        .property("limit", JsonSchema.integer()
+            .description("Maximum results to return (1-100)")
+            .minimum(1).maximum(100)
+            .defaultValue(20))
+        .additionalProperties(false))
+    .build();
+```
+
+### Reactive Tool Handler
+
+```java
+server.addToolHandler("service_search", (args) -> {
+    return Mono.fromCallable(() -> {
+        String query = args.get("query").asText();
+        int limit = args.has("limit") ? args.get("limit").asInt() : 20;
+
+        List<Item> results = apiClient.search(query, limit);
+
+        if (results.isEmpty()) {
+            return ToolResponse.error()
+                .message("No results found for '" + query + "'")
+                .build();
+        }
+
+        return ToolResponse.success()
+            .addTextContent(objectMapper.writeValueAsString(
+                Map.of("total", results.size(), "results", results)))
+            .build();
+    }).subscribeOn(Schedulers.boundedElastic());
+});
+```
+
+### Synchronous Tool Handler
+
+```java
+McpSyncServer syncServer = server.toSyncServer();
+
+syncServer.addToolHandler("service_ping", (args) -> {
+    return ToolResponse.success()
+        .addTextContent("pong")
+        .build();
+});
+```
+
+## JSON Schema Construction
+
+Use the fluent schema builder:
+
+```java
+JsonSchema schema = JsonSchema.object()
+    .property("name", JsonSchema.string()
+        .description("User's full name")
+        .minLength(1).maxLength(100)
+        .required(true))
+    .property("email", JsonSchema.string()
+        .description("Email address")
+        .format("email")
+        .required(true))
+    .property("age", JsonSchema.integer()
+        .description("User's age")
+        .minimum(0).maximum(150))
+    .property("tags", JsonSchema.array()
+        .items(JsonSchema.string())
+        .uniqueItems(true))
+    .additionalProperties(false)
+    .build();
+```
+
+## Resource Implementation
+
+```java
+server.addResourceListHandler(() -> {
+    return Mono.just(List.of(
+        Resource.builder()
+            .uri("config://settings")
+            .name("Settings")
+            .description("Server configuration")
+            .mimeType("application/json")
+            .build()
+    ));
+});
+
+server.addResourceReadHandler((uri) -> {
+    if (uri.equals("config://settings")) {
+        String content = loadSettings();
+        return Mono.just(ResourceContent.text(content, uri));
+    }
+    throw new ResourceNotFoundException(uri);
+});
+```
+
+## Prompt Implementation
+
+```java
+server.addPromptListHandler(() -> {
+    return Mono.just(List.of(
+        Prompt.builder()
+            .name("analyze")
+            .description("Analyze a topic in depth")
+            .argument(PromptArgument.builder()
+                .name("topic").description("Topic to analyze").required(true).build())
+            .argument(PromptArgument.builder()
+                .name("depth").description("Analysis depth").required(false).build())
+            .build()
+    ));
+});
+
+server.addPromptGetHandler((name, arguments) -> {
+    if ("analyze".equals(name)) {
+        String topic = arguments.getOrDefault("topic", "general");
+        String depth = arguments.getOrDefault("depth", "basic");
+
+        return Mono.just(PromptResult.builder()
+            .description("Analysis of " + topic)
+            .messages(List.of(
+                PromptMessage.user("Analyze: " + topic + " at " + depth + " depth")
+            ))
+            .build());
+    }
+    throw new PromptNotFoundException(name);
+});
+```
+
+## Transport Configuration
+
+### stdio (local, default)
+
+```java
+StdioServerTransport transport = new StdioServerTransport();
+server.start(transport).block();
+```
+
+### HTTP Servlet Transport
+
+```java
+public class McpServlet extends HttpServlet {
+    private final McpServer server = createMcpServer();
+    private final ServletServerTransport transport = new ServletServerTransport();
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) {
+        transport.handleRequest(server, req, resp).block();
+    }
+}
+```
+
+## Spring Boot Integration
+
+### Dependency
+
+```xml
+<dependency>
+    <groupId>io.modelcontextprotocol.sdk</groupId>
+    <artifactId>mcp-spring-boot-starter</artifactId>
+    <version>0.14.1</version>
+</dependency>
+```
+
+### Configuration
+
+```java
+@Configuration
+public class McpConfiguration {
+    @Bean
+    public McpServerConfigurer mcpServerConfigurer() {
+        return server -> server
+            .serverInfo("service-mcp-server", "1.0.0")
+            .capabilities(cap -> cap.tools(true).resources(true));
+    }
+}
+```
+
+### Spring Bean Tool Handler
+
+```java
+@Component
+public class SearchToolHandler implements ToolHandler {
+    @Override
+    public String getName() { return "service_search"; }
+
+    @Override
+    public Tool getTool() {
+        return Tool.builder()
+            .name("service_search")
+            .description("Search for items")
+            .inputSchema(JsonSchema.object()
+                .property("query", JsonSchema.string().required(true)))
+            .build();
+    }
+
+    @Override
+    public Mono<ToolResponse> handle(JsonNode arguments) {
+        String query = arguments.get("query").asText();
+        return Mono.just(ToolResponse.success()
+            .addTextContent("Results for: " + query)
+            .build());
+    }
+}
+```
+
+## Error Handling
+
+```java
+server.addToolHandler("service_risky", (args) -> {
+    return Mono.fromCallable(() -> {
+        try {
+            String result = riskyOperation(args);
+            return ToolResponse.success().addTextContent(result).build();
+        } catch (ValidationException e) {
+            return ToolResponse.error()
+                .message("Invalid input: " + e.getMessage())
+                .build();
+        } catch (NotFoundException e) {
+            return ToolResponse.error()
+                .message("Resource not found — verify the ID; use service_list to discover available items")
+                .build();
+        }
+    });
+});
+```
+
+## Reactive Best Practices
+
+```java
+// Use bounded elastic scheduler for blocking calls
+server.addToolHandler("service_blocking", (args) -> {
+    return Mono.fromCallable(() -> blockingApiCall(args))
+        .timeout(Duration.ofSeconds(30))
+        .onErrorResume(TimeoutException.class, e ->
+            Mono.just(ToolResponse.error().message("Operation timed out").build()))
+        .subscribeOn(Schedulers.boundedElastic());
+});
+
+// Propagate reactive context
+server.addToolHandler("service_traced", (args) -> {
+    return Mono.deferContextual(ctx -> {
+        String traceId = ctx.get("traceId");
+        log.info("Processing with traceId: {}", traceId);
+        return Mono.just(ToolResponse.success().addTextContent("Done").build());
+    });
+});
+```
+
+## Logging
+
+Use SLF4J (not System.out):
+
+```java
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+private static final Logger log = LoggerFactory.getLogger(MyServer.class);
+
+server.addToolHandler("service_process", (args) -> {
+    log.info("Tool called: service_process, args: {}", args);
+    return Mono.fromCallable(() -> {
+        String result = process(args);
+        log.debug("Processing completed");
+        return ToolResponse.success().addTextContent(result).build();
+    }).doOnError(error -> log.error("Processing failed", error));
+});
+```
+
+## Server Lifecycle
+
+```java
+Disposable serverDisposable = server.start(transport).subscribe();
+
+Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+    log.info("Shutting down MCP server");
+    serverDisposable.dispose();
+    server.stop().block();
+}));
+```
+
+## Complete Example
+
+```java
+import io.mcp.server.*;
+import io.mcp.server.tool.*;
+import io.mcp.server.transport.StdioServerTransport;
+import reactor.core.publisher.Mono;
+
+public class Application {
+    public static void main(String[] args) {
+        String token = System.getenv("API_TOKEN");
+        if (token == null || token.isEmpty()) {
+            System.err.println("API_TOKEN environment variable is required");
+            System.exit(1);
+        }
+
+        McpServer server = McpServerBuilder.builder()
+            .serverInfo("example-mcp-server", "1.0.0")
+            .capabilities(cap -> cap.tools(true))
+            .build();
+
+        Tool listRepos = Tool.builder()
+            .name("list_repos")
+            .description("List repos for an owner. Returns name, description, and star count.")
+            .inputSchema(JsonSchema.object()
+                .property("owner", JsonSchema.string()
+                    .description("GitHub org or username").required(true))
+                .property("perPage", JsonSchema.integer()
+                    .description("Results per page (1-100)").defaultValue(30)))
+            .build();
+
+        server.addToolHandler("list_repos", (arguments) -> {
+            String owner = arguments.get("owner").asText();
+            return Mono.just(ToolResponse.success()
+                .addTextContent("{\"repos\": [{\"name\": \"example\", \"stars\": 42}], \"total\": 1}")
+                .build());
+        });
+
+        StdioServerTransport transport = new StdioServerTransport();
+        server.start(transport).block();
+    }
+}
+```
+
+---
+
+## Quality Checklist
+
+Before finalizing your Java MCP server implementation, ensure:
+
+### Strategic Design
+- [ ] Tools enable complete workflows, not just API endpoint wrappers
+- [ ] Tool names are `snake_case` with consistent service prefix
+- [ ] Error messages guide agents toward correct usage
+
+### Implementation Quality
+- [ ] All tools defined with `Tool.builder()` including `name`, `description`, `inputSchema`
+- [ ] JSON schemas use `JsonSchema.object()` with property descriptions and constraints
+- [ ] Required fields marked with `.required(true)`
+- [ ] Error responses use `ToolResponse.error().message(...)` with actionable messages
+- [ ] All async handlers return `Mono<ToolResponse>`
+
+### Java Quality
+- [ ] Uses SLF4J for logging (not `System.out`)
+- [ ] `Schedulers.boundedElastic()` for blocking operations in reactive chains
+- [ ] Proper `try`/`catch` with specific exception types
+- [ ] No hardcoded credentials — all secrets via `System.getenv`
+- [ ] Graceful shutdown with `Runtime.addShutdownHook`
+
+### Project Configuration
+- [ ] `pom.xml` or `build.gradle.kts` includes `mcp` SDK dependency
+- [ ] `mvn compile` / `gradle build` succeeds with no errors
+- [ ] Server name follows format: `{service}-mcp-server`
+
+### Spring Boot (if applicable)
+- [ ] `mcp-spring-boot-starter` dependency added
+- [ ] `McpServerConfigurer` bean defined
+- [ ] Tool handlers registered as Spring `@Component` beans
+
+### Testing
+- [ ] Build compiles without errors
+- [ ] Unit tests pass (use `McpSyncServer` for simpler test setup)
+- [ ] Manual test with MCP Inspector: `npx @modelcontextprotocol/inspector java -jar target/*.jar`

--- a/skills/mcp-builder/reference/kotlin_mcp_server.md
+++ b/skills/mcp-builder/reference/kotlin_mcp_server.md
@@ -1,0 +1,365 @@
+# Kotlin MCP Server Implementation Guide
+
+## Overview
+
+This document provides Kotlin-specific best practices and examples for implementing MCP servers using the official `io.modelcontextprotocol:kotlin-sdk`. It covers server setup, tool registration, coroutine-based handlers, transport options, and complete working examples.
+
+---
+
+## Quick Reference
+
+### Key Dependencies (build.gradle.kts)
+```kotlin
+dependencies {
+    implementation("io.modelcontextprotocol:kotlin-sdk:0.7.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
+}
+```
+
+### Server Initialization
+```kotlin
+val server = Server(
+    serverInfo = Implementation(name = "service-mcp", version = "1.0.0"),
+    options = ServerOptions(
+        capabilities = ServerCapabilities(tools = ServerCapabilities.Tools())
+    )
+) { "Service MCP Server" }
+```
+
+### Tool Registration Pattern
+```kotlin
+server.addTool(
+    name = "service_action",
+    description = "What this tool does and returns",
+    inputSchema = buildJsonObject { /* ... */ }
+) { request -> CallToolResult(content = listOf(TextContent(text = "result"))) }
+```
+
+---
+
+## Kotlin SDK
+
+The official Kotlin SDK provides:
+- `Server` class for server initialization with DSL-style configuration
+- `addTool`, `addResource`, `addPrompt` methods for registration
+- Full Kotlin coroutines support (`suspend` functions)
+- `kotlinx.serialization` for JSON schema construction
+- `StdioServerTransport` for local and Ktor SSE for remote
+- Kotlin Multiplatform support (JVM, Wasm, iOS)
+
+## Server Naming Convention
+
+Kotlin MCP servers should follow this naming pattern:
+- **Format**: `{service}-mcp` (lowercase with hyphens)
+- **Artifact**: `{service}-mcp-server`
+- **Examples**: `github-mcp`, `jira-mcp`, `stripe-mcp`
+
+## Project Structure
+
+```
+{service}-mcp-server/
+├── build.gradle.kts
+├── settings.gradle.kts
+├── src/main/kotlin/
+│   └── com/example/mcp/
+│       ├── Main.kt        # Entry point, server setup
+│       ├── Tools.kt       # Tool definitions and handlers
+│       ├── Resources.kt
+│       ├── Prompts.kt
+│       └── Client.kt      # API client, auth
+└── src/test/kotlin/
+    └── com/example/mcp/
+        └── ServerTest.kt
+```
+
+## Tool Implementation
+
+### Registering Tools
+
+```kotlin
+import io.modelcontextprotocol.kotlin.sdk.*
+import kotlinx.serialization.json.*
+
+server.addTool(
+    name = "service_search",
+    description = "Search for items by query. Returns matching records with ID, name, and status.",
+    inputSchema = buildJsonObject {
+        put("type", "object")
+        putJsonObject("properties") {
+            putJsonObject("query") {
+                put("type", "string")
+                put("description", "Search query string")
+            }
+            putJsonObject("limit") {
+                put("type", "integer")
+                put("description", "Maximum results to return (1-100)")
+                put("default", 20)
+            }
+        }
+        putJsonArray("required") { add("query") }
+    }
+) { request ->
+    val query = request.params.arguments["query"] as? String
+        ?: throw IllegalArgumentException("query is required")
+    val limit = (request.params.arguments["limit"] as? Number)?.toInt() ?: 20
+
+    val results = apiClient.search(query, limit)
+
+    if (results.isEmpty()) {
+        CallToolResult(
+            content = listOf(TextContent(text = "No results found for '$query'")),
+            isError = true
+        )
+    } else {
+        CallToolResult(
+            content = listOf(TextContent(text = Json.encodeToString(results)))
+        )
+    }
+}
+```
+
+### Parallel Operations with Coroutines
+
+```kotlin
+server.addTool(
+    name = "service_parallel_search",
+    description = "Search multiple sources in parallel"
+) { request ->
+    coroutineScope {
+        val source1 = async { searchSource1(query) }
+        val source2 = async { searchSource2(query) }
+
+        val combined = source1.await() + source2.await()
+        CallToolResult(content = listOf(TextContent(text = combined.joinToString("\n"))))
+    }
+}
+```
+
+## JSON Schema with kotlinx.serialization
+
+Build schemas using the JSON DSL:
+
+```kotlin
+fun createSearchSchema(): JsonObject = buildJsonObject {
+    put("type", "object")
+    putJsonObject("properties") {
+        putJsonObject("query") {
+            put("type", "string")
+            put("description", "Search query")
+        }
+        putJsonObject("limit") {
+            put("type", "integer")
+            put("default", 10)
+            put("minimum", 1)
+            put("maximum", 100)
+        }
+        putJsonObject("filters") {
+            put("type", "array")
+            putJsonObject("items") { put("type", "string") }
+        }
+    }
+    putJsonArray("required") { add("query") }
+}
+```
+
+## Resource Implementation
+
+```kotlin
+server.addResource(
+    uri = "config://settings",
+    name = "App Settings",
+    description = "Current application configuration",
+    mimeType = "application/json"
+) { request ->
+    val content = loadSettings()
+    ReadResourceResult(
+        contents = listOf(
+            TextResourceContents(text = content, uri = request.uri, mimeType = "application/json")
+        )
+    )
+}
+
+// Notify clients when resources change
+server.notifyResourceListChanged()
+```
+
+## Prompt Implementation
+
+```kotlin
+server.addPrompt(
+    name = "analyze",
+    description = "Analyze a topic in depth",
+    arguments = listOf(
+        PromptArgument(name = "topic", description = "Topic to analyze", required = true),
+        PromptArgument(name = "depth", description = "Analysis depth", required = false)
+    )
+) { request ->
+    val topic = request.params.arguments?.get("topic") as? String
+        ?: throw IllegalArgumentException("topic is required")
+    val depth = request.params.arguments?.get("depth") as? String ?: "basic"
+
+    GetPromptResult(
+        description = "Analysis of $topic",
+        messages = listOf(
+            PromptMessage(role = Role.User, content = TextContent(text = "Analyze: $topic at $depth depth"))
+        )
+    )
+}
+```
+
+## Transport Configuration
+
+### stdio (local, default)
+
+```kotlin
+import io.modelcontextprotocol.kotlin.sdk.server.StdioServerTransport
+
+suspend fun main() {
+    val transport = StdioServerTransport()
+    server.connect(transport)
+}
+```
+
+### SSE with Ktor
+
+```kotlin
+import io.ktor.server.engine.*
+import io.ktor.server.netty.*
+import io.modelcontextprotocol.kotlin.sdk.server.mcp
+
+fun main() {
+    embeddedServer(Netty, port = 8080) {
+        mcp {
+            Server(
+                serverInfo = Implementation(name = "service-mcp", version = "1.0.0"),
+                options = ServerOptions(capabilities = ServerCapabilities(tools = ServerCapabilities.Tools()))
+            ) { "SSE-based MCP server" }
+        }
+    }.start(wait = true)
+}
+```
+
+## Error Handling
+
+```kotlin
+server.addTool(name = "service_get_item", description = "Get item by ID") { request ->
+    try {
+        val id = request.params.arguments["id"] as? String
+            ?: throw IllegalArgumentException("id is required")
+
+        require(id.isNotBlank()) { "id cannot be blank" }
+
+        val result = apiClient.getItem(id)
+        CallToolResult(content = listOf(TextContent(text = Json.encodeToString(result))))
+    } catch (e: IllegalArgumentException) {
+        CallToolResult(isError = true, content = listOf(TextContent(text = "Validation error: ${e.message}")))
+    } catch (e: NotFoundException) {
+        CallToolResult(isError = true, content = listOf(
+            TextContent(text = "Item not found — verify the ID; use service_list_items to discover available items")
+        ))
+    }
+}
+```
+
+## Gradle Configuration
+
+```kotlin
+plugins {
+    kotlin("jvm") version "2.1.0"
+    kotlin("plugin.serialization") version "2.1.0"
+}
+
+repositories { mavenCentral() }
+
+dependencies {
+    implementation("io.modelcontextprotocol:kotlin-sdk:0.7.2")
+    implementation("io.ktor:ktor-client-cio:3.0.0")        // Client transport
+    implementation("io.ktor:ktor-server-netty:3.0.0")       // Server transport (SSE)
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
+}
+```
+
+## Complete Example
+
+```kotlin
+import io.modelcontextprotocol.kotlin.sdk.*
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
+import io.modelcontextprotocol.kotlin.sdk.server.StdioServerTransport
+import kotlinx.serialization.json.*
+
+suspend fun main() {
+    val token = System.getenv("API_TOKEN")
+        ?: error("API_TOKEN environment variable is required")
+
+    val server = Server(
+        serverInfo = Implementation(name = "example-mcp", version = "1.0.0"),
+        options = ServerOptions(capabilities = ServerCapabilities(tools = ServerCapabilities.Tools()))
+    ) { "Example MCP Server" }
+
+    server.addTool(
+        name = "list_repos",
+        description = "List repositories for an owner. Returns name, description, and star count.",
+        inputSchema = buildJsonObject {
+            put("type", "object")
+            putJsonObject("properties") {
+                putJsonObject("owner") {
+                    put("type", "string")
+                    put("description", "GitHub org or username")
+                }
+                putJsonObject("perPage") {
+                    put("type", "integer")
+                    put("description", "Results per page (1-100)")
+                    put("default", 30)
+                }
+            }
+            putJsonArray("required") { add("owner") }
+        }
+    ) { request ->
+        val owner = request.params.arguments["owner"] as? String ?: ""
+        CallToolResult(content = listOf(
+            TextContent(text = """{"repos": [{"name": "example", "stars": 42}], "total": 1}""")
+        ))
+    }
+
+    val transport = StdioServerTransport()
+    server.connect(transport)
+}
+```
+
+---
+
+## Quality Checklist
+
+Before finalizing your Kotlin MCP server implementation, ensure:
+
+### Strategic Design
+- [ ] Tools enable complete workflows, not just API endpoint wrappers
+- [ ] Tool names are `snake_case` with consistent service prefix
+- [ ] Error messages guide agents toward correct usage
+
+### Implementation Quality
+- [ ] All tools registered with `name`, `description`, and `inputSchema`
+- [ ] JSON schemas built with `buildJsonObject` DSL with property descriptions
+- [ ] `required` arrays list all mandatory parameters
+- [ ] Error responses use `isError = true` with actionable messages
+- [ ] All handlers use Kotlin coroutines properly
+
+### Kotlin Quality
+- [ ] Uses `suspend` functions for I/O operations
+- [ ] `coroutineScope` used for parallel operations
+- [ ] Proper `try`/`catch` with specific exception types
+- [ ] No hardcoded credentials — all secrets via `System.getenv`
+- [ ] `kotlinx.serialization` used for JSON handling
+
+### Project Configuration
+- [ ] `build.gradle.kts` includes `kotlin-sdk`, `kotlinx-serialization`, `kotlinx-coroutines`
+- [ ] `gradle build` succeeds with no errors
+- [ ] Server name follows format: `{service}-mcp`
+
+### Testing
+- [ ] `gradle build` compiles without errors
+- [ ] `gradle test` passes
+- [ ] Manual test with MCP Inspector: `npx @modelcontextprotocol/inspector gradle run`

--- a/skills/mcp-builder/reference/mcp_best_practices.md
+++ b/skills/mcp-builder/reference/mcp_best_practices.md
@@ -4,7 +4,15 @@
 
 ### Server Naming
 - **Python**: `{service}_mcp` (e.g., `slack_mcp`)
+- **Ruby**: `{service}_mcp` (e.g., `slack_mcp`)
 - **Node/TypeScript**: `{service}-mcp-server` (e.g., `slack-mcp-server`)
+- **Java**: `{service}-mcp-server` (e.g., `slack-mcp-server`)
+- **PHP**: `{service}-mcp-server` (e.g., `slack-mcp-server`)
+- **Go**: `{service}-mcp` (e.g., `slack-mcp`)
+- **Kotlin**: `{service}-mcp` (e.g., `slack-mcp`)
+- **Swift**: `{service}-mcp` (e.g., `slack-mcp`)
+- **Rust**: `{service}-mcp-server` crate, `{service}-mcp` server name
+- **C#**: `{Service}.Mcp.Server` project, `{service}-mcp-server` server name
 
 ### Tool Naming
 - Use snake_case with service prefix
@@ -35,8 +43,32 @@ Follow these standardized naming patterns:
 **Python**: Use format `{service}_mcp` (lowercase with underscores)
 - Examples: `slack_mcp`, `github_mcp`, `jira_mcp`
 
+**Ruby**: Use format `{service}_mcp` (lowercase with underscores)
+- Examples: `slack_mcp`, `github_mcp`, `jira_mcp`
+
 **Node/TypeScript**: Use format `{service}-mcp-server` (lowercase with hyphens)
 - Examples: `slack-mcp-server`, `github-mcp-server`, `jira-mcp-server`
+
+**Java**: Use format `{service}-mcp-server` (lowercase with hyphens)
+- Examples: `slack-mcp-server`, `github-mcp-server`, `jira-mcp-server`
+
+**PHP**: Use format `{service}-mcp-server` (lowercase with hyphens)
+- Examples: `slack-mcp-server`, `github-mcp-server`, `jira-mcp-server`
+
+**Go**: Use format `{service}-mcp` (lowercase with hyphens)
+- Examples: `slack-mcp`, `github-mcp`, `jira-mcp`
+
+**Kotlin**: Use format `{service}-mcp` (lowercase with hyphens)
+- Examples: `slack-mcp`, `github-mcp`, `jira-mcp`
+
+**Swift**: Use format `{service}-mcp` (lowercase with hyphens)
+- Examples: `slack-mcp`, `github-mcp`, `jira-mcp`
+
+**Rust**: Crate name `{service}-mcp-server`, server info name `{service}-mcp`
+- Examples: crate `slack-mcp-server`, server name `slack-mcp`
+
+**C#**: Project `{Service}.Mcp.Server` (PascalCase), server info `{service}-mcp-server`
+- Examples: project `Slack.Mcp.Server`, server name `slack-mcp-server`
 
 The name should be general, descriptive of the service being integrated, easy to infer from the task description, and without version numbers.
 
@@ -169,7 +201,7 @@ Example pagination response:
 - Validate URLs and external identifiers
 - Check parameter sizes and ranges
 - Prevent command injection in system calls
-- Use schema validation (Pydantic/Zod) for all inputs
+- Use schema validation (Pydantic, Zod, Go struct tags, schemars, JsonSchema builder, `[Description]`/`#[Schema]` attributes) for all inputs
 
 ### Error Handling
 

--- a/skills/mcp-builder/reference/php_mcp_server.md
+++ b/skills/mcp-builder/reference/php_mcp_server.md
@@ -1,0 +1,367 @@
+# PHP MCP Server Implementation Guide
+
+## Overview
+
+This document provides PHP-specific best practices and examples for implementing MCP servers using the official PHP SDK (`mcp/sdk`), maintained in collaboration with The PHP Foundation. It covers attribute-based tool discovery, resource and prompt handlers, transport options, and complete working examples.
+
+---
+
+## Quick Reference
+
+### Installation
+```bash
+composer require mcp/sdk
+```
+
+### Server Initialization (Attribute Discovery)
+```php
+$server = Server::builder()
+    ->setServerInfo('service-mcp-server', '1.0.0')
+    ->setDiscovery(__DIR__, ['src'])
+    ->build();
+```
+
+### Tool Registration Pattern (Attribute)
+```php
+#[McpTool(name: 'service_action')]
+public function myAction(string $param): string {
+    return "Result: $param";
+}
+```
+
+---
+
+## MCP PHP SDK
+
+The official PHP SDK provides:
+- `Server::builder()` for fluent server construction
+- `#[McpTool]` attribute for automatic tool discovery
+- `#[McpResource]` and `#[McpResourceTemplate]` for resources
+- `#[McpPrompt]` for prompt templates
+- `#[Schema]` attribute for input validation constraints
+- `#[CompletionProvider]` for parameter autocompletion
+- `StdioTransport` and `StreamableHttpTransport`
+
+**Two approaches:**
+- **Attribute discovery** (recommended): Annotate methods with `#[McpTool]` and let the SDK auto-discover them
+- **Manual registration**: Use `addTool()` on the builder for programmatic control
+
+## Server Naming Convention
+
+PHP MCP servers should follow this naming pattern:
+- **Format**: `{service}-mcp-server` (lowercase with hyphens)
+- **Examples**: `github-mcp-server`, `jira-mcp-server`, `stripe-mcp-server`
+
+## Project Structure
+
+```
+{service}-mcp-server/
+├── composer.json
+├── server.php           # Entry point
+├── src/
+│   ├── Tools/
+│   │   ├── Search.php
+│   │   └── Manage.php
+│   ├── Resources/
+│   │   └── Config.php
+│   ├── Prompts/
+│   │   └── Analyze.php
+│   └── Client.php       # API client, auth
+└── tests/
+    └── ToolsTest.php
+```
+
+## Tool Implementation
+
+### Simple Tool with Attribute
+
+```php
+<?php
+namespace App\Tools;
+
+use Mcp\Capability\Attribute\McpTool;
+
+class Search
+{
+    /**
+     * Search for items by query. Returns matching records with ID, name, and status.
+     *
+     * @param string $query Search query string
+     * @param int $limit Maximum results to return (1-100)
+     * @return array Search results
+     */
+    #[McpTool(name: 'service_search')]
+    public function search(string $query, int $limit = 20): array
+    {
+        $results = $this->apiClient->search($query, $limit);
+
+        if (empty($results)) {
+            throw new \InvalidArgumentException("No results found for '{$query}'");
+        }
+
+        return [
+            'total' => count($results),
+            'results' => $results,
+        ];
+    }
+}
+```
+
+### Tool with Schema Validation
+
+```php
+use Mcp\Capability\Attribute\{McpTool, Schema};
+
+class UserManager
+{
+    #[McpTool(name: 'service_create_user')]
+    public function createUser(
+        #[Schema(format: 'email')]
+        string $email,
+
+        #[Schema(minimum: 18, maximum: 120)]
+        int $age,
+
+        #[Schema(pattern: '^[A-Z][a-z]+$', description: 'Capitalized first name')]
+        string $firstName
+    ): array {
+        return ['id' => uniqid(), 'email' => $email, 'age' => $age, 'firstName' => $firstName];
+    }
+}
+```
+
+### Tool with Rich Content
+
+```php
+use Mcp\Schema\Content\{TextContent, ImageContent};
+
+class Reports
+{
+    #[McpTool(name: 'service_generate_report')]
+    public function generateReport(string $type): array
+    {
+        return [
+            new TextContent('Report generated:'),
+            TextContent::code($this->buildReport($type), 'json'),
+            new TextContent('Summary: All checks passed.'),
+        ];
+    }
+}
+```
+
+## Resource Implementation
+
+### Static Resource
+
+```php
+use Mcp\Capability\Attribute\McpResource;
+
+class ConfigProvider
+{
+    #[McpResource(uri: 'config://app/settings', name: 'app_settings', mimeType: 'application/json')]
+    public function getSettings(): array
+    {
+        return ['version' => '1.0.0', 'debug' => false, 'features' => ['auth', 'logging']];
+    }
+}
+```
+
+### Resource Template
+
+```php
+use Mcp\Capability\Attribute\McpResourceTemplate;
+
+class UserProvider
+{
+    #[McpResourceTemplate(
+        uriTemplate: 'user://{userId}/profile/{section}',
+        name: 'user_profile',
+        description: 'User profile data by section',
+        mimeType: 'application/json'
+    )]
+    public function getUserProfile(string $userId, string $section): array
+    {
+        return $this->users[$userId][$section]
+            ?? throw new \InvalidArgumentException("Profile section not found");
+    }
+}
+```
+
+## Prompt Implementation
+
+```php
+use Mcp\Capability\Attribute\McpPrompt;
+
+class PromptGenerator
+{
+    #[McpPrompt(name: 'code_review')]
+    public function reviewCode(string $language, string $code, string $focus = 'general'): array
+    {
+        return [
+            ['role' => 'assistant', 'content' => 'You are an expert code reviewer.'],
+            ['role' => 'user', 'content' => "Review this {$language} code focusing on {$focus}:\n\n```{$language}\n{$code}\n```"],
+        ];
+    }
+}
+```
+
+## Completion Providers
+
+```php
+use Mcp\Capability\Attribute\{McpPrompt, CompletionProvider};
+
+#[McpPrompt]
+public function generateContent(
+    #[CompletionProvider(values: ['blog', 'article', 'tutorial', 'guide'])]
+    string $contentType,
+
+    #[CompletionProvider(values: ['beginner', 'intermediate', 'advanced'])]
+    string $difficulty
+): array {
+    return [['role' => 'user', 'content' => "Create a {$difficulty} level {$contentType}"]];
+}
+```
+
+## Transport Configuration
+
+### stdio (local, default)
+
+```php
+use Mcp\Server\Transport\StdioTransport;
+
+$transport = new StdioTransport();
+$server->run($transport);
+```
+
+### Streamable HTTP
+
+```php
+use Mcp\Server\Transport\StreamableHttpTransport;
+use Nyholm\Psr7\Factory\Psr17Factory;
+
+$psr17Factory = new Psr17Factory();
+$request = $psr17Factory->createServerRequestFromGlobals();
+$transport = new StreamableHttpTransport($request, $psr17Factory, $psr17Factory);
+$response = $server->run($transport);
+```
+
+### Session Management
+
+```php
+$server = Server::builder()
+    ->setServerInfo('service-mcp-server', '1.0.0')
+    ->setSession(ttl: 7200)  // 2 hours
+    ->build();
+```
+
+## Error Handling
+
+The SDK automatically converts exceptions into JSON-RPC error responses:
+
+```php
+#[McpTool(name: 'service_divide')]
+public function divide(float $a, float $b): float
+{
+    if ($b === 0.0) {
+        throw new \InvalidArgumentException('Division by zero is not allowed');
+    }
+    return $a / $b;
+}
+```
+
+## Caching for Performance
+
+```php
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Psr16Cache;
+
+$cache = new Psr16Cache(new FilesystemAdapter('mcp-discovery'));
+
+$server = Server::builder()
+    ->setServerInfo('service-mcp-server', '1.0.0')
+    ->setDiscovery(basePath: __DIR__, scanDirs: ['src'], excludeDirs: ['vendor', 'tests'], cache: $cache)
+    ->build();
+```
+
+## Complete Example
+
+```php
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+require_once __DIR__ . '/vendor/autoload.php';
+
+use Mcp\Server;
+use Mcp\Server\Transport\StdioTransport;
+use Mcp\Capability\Attribute\McpTool;
+
+class RepoTools
+{
+    /**
+     * List repositories for an owner. Returns name, description, and star count.
+     */
+    #[McpTool(name: 'list_repos')]
+    public function listRepos(string $owner, int $perPage = 30): array
+    {
+        $token = getenv('API_TOKEN') ?: throw new \RuntimeException('API_TOKEN required');
+        // ... fetch repos ...
+        return ['repos' => [['name' => 'example', 'stars' => 42]], 'total' => 1];
+    }
+}
+
+$server = Server::builder()
+    ->setServerInfo('example-mcp-server', '1.0.0')
+    ->setDiscovery(__DIR__, ['.'])
+    ->build();
+
+$transport = new StdioTransport();
+$server->run($transport);
+```
+
+### Claude Desktop Configuration
+
+```json
+{
+  "mcpServers": {
+    "php-server": {
+      "command": "php",
+      "args": ["/absolute/path/to/server.php"]
+    }
+  }
+}
+```
+
+---
+
+## Quality Checklist
+
+Before finalizing your PHP MCP server implementation, ensure:
+
+### Strategic Design
+- [ ] Tools enable complete workflows, not just API endpoint wrappers
+- [ ] Tool names are `snake_case` with consistent service prefix
+- [ ] Error messages guide agents toward correct usage
+
+### Implementation Quality
+- [ ] All tools use `#[McpTool]` attribute with explicit `name`
+- [ ] PHPDoc comments serve as tool descriptions (auto-extracted)
+- [ ] `#[Schema]` attributes used for input validation constraints
+- [ ] Exceptions thrown for invalid inputs (SDK converts to error responses)
+- [ ] Return types are arrays or content objects
+
+### PHP Quality
+- [ ] PHP 8.2+ with `declare(strict_types=1)`
+- [ ] PSR-4 autoloading configured in `composer.json`
+- [ ] No hardcoded credentials — all secrets via `getenv()`
+- [ ] Discovery caching enabled for production
+- [ ] Proper exception handling in all tool methods
+
+### Project Configuration
+- [ ] `composer.json` includes `mcp/sdk`
+- [ ] `composer install` succeeds
+- [ ] Server name follows format: `{service}-mcp-server`
+
+### Testing
+- [ ] `php server.php` starts without errors
+- [ ] PHPUnit tests pass for all tool methods
+- [ ] Manual test with MCP Inspector: `npx @modelcontextprotocol/inspector php server.php`

--- a/skills/mcp-builder/reference/ruby_mcp_server.md
+++ b/skills/mcp-builder/reference/ruby_mcp_server.md
@@ -1,0 +1,374 @@
+# Ruby MCP Server Implementation Guide
+
+## Overview
+
+This document provides Ruby-specific best practices and examples for implementing MCP servers using the official MCP Ruby SDK gem (`mcp`). It covers server setup, tool registration with classes and blocks, resource and prompt handlers, transport options, and complete working examples.
+
+---
+
+## Quick Reference
+
+### Key Imports
+```ruby
+require 'mcp'
+```
+
+### Server Initialization
+```ruby
+server = MCP::Server.new(
+  name: 'service_mcp',
+  version: '1.0.0',
+  tools: [MyTool],
+  resources: [my_resource],
+  prompts: [MyPrompt]
+)
+```
+
+### Tool Registration Pattern (Class)
+```ruby
+class MyTool < MCP::Tool
+  tool_name 'service_action'
+  description 'What this tool does and returns'
+  input_schema(properties: { ... }, required: [...])
+  annotations(read_only_hint: true)
+  def self.call(**args, server_context:)
+    MCP::Tool::Response.new([{ type: 'text', text: result }])
+  end
+end
+```
+
+### Tool Registration Pattern (Block)
+```ruby
+server.define_tool(name: 'service_action', description: '...', input_schema: { ... }) do |args, server_context|
+  MCP::Tool::Response.new([{ type: 'text', text: result }])
+end
+```
+
+---
+
+## MCP Ruby SDK
+
+The official Ruby SDK gem provides:
+- `MCP::Server` for server initialization
+- `MCP::Tool` base class for class-based tool definitions
+- `define_tool` for block-based tool definitions
+- `MCP::Resource` and `MCP::ResourceTemplate` for resources
+- `MCP::Prompt` base class for prompt templates
+- `StdioTransport` and `StreamableHTTPTransport`
+
+**Two approaches for tools:**
+- **Class-based** (recommended for complex tools): Subclass `MCP::Tool`
+- **Block-based** (good for simple tools): Use `server.define_tool`
+
+## Server Naming Convention
+
+Ruby MCP servers should follow this naming pattern:
+- **Format**: `{service}_mcp` (lowercase with underscores)
+- **Examples**: `github_mcp`, `jira_mcp`, `stripe_mcp`
+
+## Project Structure
+
+```
+{service}_mcp/
+├── Gemfile
+├── server.rb            # Entry point
+├── lib/
+│   ├── tools/
+│   │   ├── search.rb
+│   │   └── create.rb
+│   ├── resources/
+│   │   └── config.rb
+│   ├── prompts/
+│   │   └── analyze.rb
+│   └── client.rb        # API client, auth
+└── test/
+    └── tools_test.rb
+```
+
+## Tool Implementation
+
+### Class-Based Tool
+
+```ruby
+class SearchTool < MCP::Tool
+  tool_name 'service_search'
+  description 'Search for items by query. Returns matching records with ID, name, and status.'
+
+  input_schema(
+    properties: {
+      query: { type: 'string', description: 'Search query string' },
+      limit: { type: 'integer', description: 'Max results (1-100)', default: 20 }
+    },
+    required: ['query']
+  )
+
+  output_schema(
+    properties: {
+      total: { type: 'integer' },
+      results: { type: 'array', items: { type: 'object' } }
+    },
+    required: ['total', 'results']
+  )
+
+  annotations(
+    read_only_hint: true,
+    destructive_hint: false,
+    idempotent_hint: true,
+    open_world_hint: true
+  )
+
+  def self.call(query:, limit: 20, server_context:)
+    results = ApiClient.search(query, limit: limit)
+
+    if results.empty?
+      return MCP::Tool::Response.new(
+        [{ type: 'text', text: "No results found for '#{query}'" }],
+        is_error: true
+      )
+    end
+
+    output = { total: results.length, results: results }
+
+    MCP::Tool::Response.new(
+      [{ type: 'text', text: output.to_json }],
+      structured_content: output
+    )
+  end
+end
+```
+
+### Block-Based Tool
+
+```ruby
+server.define_tool(
+  name: 'service_ping',
+  description: 'Check service connectivity. Returns status and latency.',
+  input_schema: { properties: {}, required: [] },
+  annotations: { read_only_hint: true, idempotent_hint: true }
+) do |_args, server_context|
+  start = Time.now
+  status = ApiClient.ping
+  latency = ((Time.now - start) * 1000).round(2)
+
+  MCP::Tool::Response.new([{
+    type: 'text',
+    text: { status: status, latency_ms: latency }.to_json
+  }])
+end
+```
+
+## Resource Implementation
+
+```ruby
+resource = MCP::Resource.new(
+  uri: 'config://app/settings',
+  name: 'app-settings',
+  description: 'Current application configuration',
+  mime_type: 'application/json'
+)
+
+server = MCP::Server.new(name: 'service_mcp', resources: [resource])
+
+server.resources_read_handler do |params|
+  case params[:uri]
+  when 'config://app/settings'
+    [{ uri: params[:uri], mimeType: 'application/json', text: load_settings.to_json }]
+  else
+    raise "Unknown resource: #{params[:uri]}"
+  end
+end
+```
+
+### Resource Templates
+
+```ruby
+template = MCP::ResourceTemplate.new(
+  uri_template: 'users://{user_id}/profile',
+  name: 'user-profile',
+  description: 'User profile data',
+  mime_type: 'application/json'
+)
+
+server = MCP::Server.new(name: 'service_mcp', resource_templates: [template])
+```
+
+## Prompt Implementation
+
+```ruby
+class AnalyzePrompt < MCP::Prompt
+  prompt_name 'analyze'
+  description 'Analyze a topic in depth'
+
+  arguments [
+    MCP::Prompt::Argument.new(name: 'topic', description: 'Topic to analyze', required: true),
+    MCP::Prompt::Argument.new(name: 'depth', description: 'Analysis depth', required: false)
+  ]
+
+  def self.template(args, server_context:)
+    topic = args['topic'] || 'general'
+    depth = args['depth'] || 'basic'
+
+    MCP::Prompt::Result.new(
+      description: "Analysis of #{topic}",
+      messages: [
+        MCP::Prompt::Message.new(role: 'user', content: MCP::Content::Text.new("Analyze: #{topic} at #{depth} depth"))
+      ]
+    )
+  end
+end
+```
+
+## Server Context
+
+Pass contextual information to tools and prompts:
+
+```ruby
+server = MCP::Server.new(
+  name: 'service_mcp',
+  tools: [AuthenticatedTool],
+  server_context: {
+    user_id: current_user.id,
+    auth_token: session[:token]
+  }
+)
+```
+
+## Transport Configuration
+
+### stdio (local, default)
+
+```ruby
+transport = MCP::Server::Transports::StdioTransport.new(server)
+transport.open
+```
+
+### Streamable HTTP
+
+```ruby
+transport = MCP::Server::Transports::StreamableHTTPTransport.new(server)
+server.transport = transport
+```
+
+### Rails Integration
+
+```ruby
+class McpController < ApplicationController
+  def index
+    server = MCP::Server.new(
+      name: 'rails_mcp',
+      tools: [SearchTool],
+      server_context: { user_id: current_user.id }
+    )
+    render json: server.handle_json(request.body.read)
+  end
+end
+```
+
+## Configuration
+
+### Exception Reporting
+```ruby
+MCP.configure do |config|
+  config.exception_reporter = ->(exception, server_context) {
+    Bugsnag.notify(exception) { |report| report.add_metadata(:mcp, server_context) }
+  }
+end
+```
+
+### Instrumentation
+```ruby
+MCP.configure do |config|
+  config.instrumentation_callback = ->(data) {
+    StatsD.timing("mcp.#{data[:method]}.duration", data[:duration])
+  }
+end
+```
+
+## Error Handling
+
+```ruby
+class RiskyTool < MCP::Tool
+  def self.call(data:, server_context:)
+    result = risky_operation(data)
+    MCP::Tool::Response.new([{ type: 'text', text: result }])
+  rescue ValidationError => e
+    MCP::Tool::Response.new(
+      [{ type: 'text', text: "Invalid input: #{e.message}" }],
+      is_error: true
+    )
+  end
+end
+```
+
+## Complete Example
+
+```ruby
+#!/usr/bin/env ruby
+require 'mcp'
+require 'json'
+require 'net/http'
+
+class ListReposTool < MCP::Tool
+  tool_name 'list_repos'
+  description 'List repositories for an owner. Returns name, description, and star count.'
+
+  input_schema(
+    properties: {
+      owner: { type: 'string', description: 'GitHub org or username' },
+      per_page: { type: 'integer', description: 'Results per page (1-100)', default: 30 }
+    },
+    required: ['owner']
+  )
+
+  annotations(read_only_hint: true, idempotent_hint: true, open_world_hint: true)
+
+  def self.call(owner:, per_page: 30, server_context:)
+    token = ENV.fetch('API_TOKEN') { raise 'API_TOKEN required' }
+    # ... fetch repos ...
+    output = { repos: [{ name: 'example', stars: 42 }], total: 1 }
+    MCP::Tool::Response.new(
+      [{ type: 'text', text: output.to_json }],
+      structured_content: output
+    )
+  end
+end
+
+server = MCP::Server.new(name: 'example_mcp', version: '1.0.0', tools: [ListReposTool])
+transport = MCP::Server::Transports::StdioTransport.new(server)
+transport.open
+```
+
+---
+
+## Quality Checklist
+
+Before finalizing your Ruby MCP server implementation, ensure:
+
+### Strategic Design
+- [ ] Tools enable complete workflows, not just API endpoint wrappers
+- [ ] Tool names are `snake_case` with consistent service prefix
+- [ ] Error messages guide agents toward correct usage
+
+### Implementation Quality
+- [ ] All tools define `tool_name`, `description`, `input_schema`, and `annotations`
+- [ ] Input schemas include property types, descriptions, and required arrays
+- [ ] `output_schema` defined where applicable for structured content
+- [ ] Error responses use `is_error: true` with actionable messages
+- [ ] `structured_content` returned alongside text content where useful
+
+### Ruby Quality
+- [ ] Uses class-based tools for complex logic, blocks for simple tools
+- [ ] Proper `rescue` error handling in all tool `call` methods
+- [ ] No hardcoded credentials — all secrets via `ENV`
+- [ ] Server context used for auth and request-scoped data
+- [ ] Exception reporting configured for production
+
+### Project Configuration
+- [ ] Gemfile includes `gem 'mcp'`
+- [ ] `bundle install` succeeds
+- [ ] Server name follows format: `{service}_mcp`
+
+### Testing
+- [ ] `ruby server.rb` starts without errors
+- [ ] Unit tests pass for all tool `call` methods
+- [ ] Manual test with MCP Inspector: `npx @modelcontextprotocol/inspector ruby server.rb`

--- a/skills/mcp-builder/reference/rust_mcp_server.md
+++ b/skills/mcp-builder/reference/rust_mcp_server.md
@@ -1,0 +1,411 @@
+# Rust MCP Server Implementation Guide
+
+## Overview
+
+This document provides Rust-specific best practices and examples for implementing MCP servers using the official `rmcp` crate. It covers project structure, server setup, tool registration with macros, error handling, transport options, and complete working examples.
+
+---
+
+## Quick Reference
+
+### Key Dependencies (Cargo.toml)
+```toml
+[dependencies]
+rmcp = { version = "0.8.1", features = ["server"] }
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+schemars = { version = "0.8", features = ["derive"] }
+anyhow = "1.0"
+tracing = "0.1"
+tracing-subscriber = "0.3"
+```
+
+### Server Initialization
+```rust
+let server = Server::builder()
+    .with_handler(handler)
+    .with_capabilities(ServerCapabilities {
+        tools: Some(Default::default()),
+        ..Default::default()
+    })
+    .build(transport)?;
+```
+
+### Tool Registration Pattern (Macro)
+```rust
+#[tool(name = "service_action", annotations(read_only_hint = true))]
+pub async fn my_tool(params: Parameters<MyInput>) -> Result<String, String> {
+    // Implementation
+}
+```
+
+---
+
+## rmcp SDK
+
+The official Rust SDK (`rmcp`) provides:
+- `Server` builder for server initialization
+- `ServerHandler` trait for implementing tool/resource/prompt handlers
+- `#[tool]`, `#[tool_router]`, and `#[tool_handler]` macros for declarative registration
+- `schemars` integration for automatic JSON Schema generation from Rust types
+- `StdioTransport`, `SseServerTransport`, and `StreamableHttpTransport`
+
+**Two approaches:**
+- **Macro-based** (recommended): Use `#[tool]` and `#[tool_router]` for declarative tool definitions with automatic schema generation
+- **Manual**: Implement `ServerHandler` trait directly for full control
+
+## Server Naming Convention
+
+Rust MCP servers should follow this naming pattern:
+- **Crate name**: `{service}-mcp-server` (lowercase with hyphens)
+- **Server info name**: `{service}-mcp`
+- **Examples**: crate `github-mcp-server`, server name `github-mcp`
+
+## Project Structure
+
+```
+{service}-mcp-server/
+├── Cargo.toml
+├── src/
+│   ├── main.rs           # Server entry point
+│   ├── handler.rs        # ServerHandler implementation
+│   ├── tools/
+│   │   ├── mod.rs
+│   │   └── repos.rs      # Tool params, handlers
+│   ├── resources/
+│   │   └── mod.rs
+│   └── client.rs         # HTTP client, auth
+└── tests/
+    └── integration.rs
+```
+
+## Tool Implementation
+
+### Using the `#[tool]` Macro
+
+```rust
+use rmcp::tool;
+use rmcp::model::Parameters;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SearchInput {
+    /// Search query string
+    pub query: String,
+    /// Maximum results to return (1-100)
+    #[serde(default = "default_limit")]
+    pub limit: Option<u32>,
+}
+
+fn default_limit() -> Option<u32> { Some(20) }
+
+/// Search for items by query. Returns matching records with ID, name, and status.
+#[tool(
+    name = "service_search",
+    description = "Search for items. Returns matching records.",
+    annotations(read_only_hint = true, idempotent_hint = true)
+)]
+pub async fn search(params: Parameters<SearchInput>) -> Result<String, String> {
+    let input = params.inner();
+    let limit = input.limit.unwrap_or(20);
+
+    let results = api_client::search(&input.query, limit)
+        .await
+        .map_err(|e| format!("Search failed: {e}"))?;
+
+    serde_json::to_string_pretty(&results)
+        .map_err(|e| format!("Serialization failed: {e}"))
+}
+```
+
+### Tool Router with Multiple Tools
+
+```rust
+use rmcp::{tool_router, tool_handler};
+
+pub struct ToolsHandler {
+    tool_router: ToolRouter,
+    client: ApiClient,
+}
+
+#[tool_router]
+impl ToolsHandler {
+    #[tool(annotations(read_only_hint = true))]
+    async fn list_repos(&self, params: Parameters<ListReposInput>) -> Result<String, String> {
+        let repos = self.client.list_repos(&params.inner().owner).await
+            .map_err(|e| format!("Failed to list repos: {e}"))?;
+        serde_json::to_string_pretty(&repos).map_err(|e| e.to_string())
+    }
+
+    #[tool(annotations(destructive_hint = true))]
+    async fn delete_repo(&self, params: Parameters<DeleteRepoInput>) -> Result<String, String> {
+        self.client.delete_repo(&params.inner().owner, &params.inner().name).await
+            .map_err(|e| format!("Failed to delete repo: {e}"))?;
+        Ok("Repository deleted successfully".to_string())
+    }
+
+    pub fn new(client: ApiClient) -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+            client,
+        }
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for ToolsHandler {}
+```
+
+### Tool Annotations
+
+```rust
+#[tool(
+    name = "delete_resource",
+    annotations(
+        destructive_hint = true,
+        read_only_hint = false,
+        idempotent_hint = false,
+        open_world_hint = true
+    )
+)]
+```
+
+| Annotation | When to set |
+| ---------- | ----------- |
+| `read_only_hint = true` | GET-equivalent, no side effects |
+| `destructive_hint = true` | DELETE or irreversible operations |
+| `idempotent_hint = true` | PUT/UPSERT, safe to retry |
+| `open_world_hint = true` | Calls external APIs |
+
+## Schema Definition with schemars
+
+Derive `JsonSchema` for automatic schema generation:
+
+```rust
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CreateUserInput {
+    /// User's full name
+    pub name: String,
+    /// Email address
+    pub email: String,
+    /// User's age (0-150)
+    #[schemars(range(min = 0, max = 150))]
+    pub age: u32,
+    /// Optional team assignment
+    pub team: Option<String>,
+}
+```
+
+## Error Handling
+
+### ErrorData for MCP errors
+
+```rust
+use rmcp::ErrorData;
+
+fn validate_params(value: &str) -> Result<(), ErrorData> {
+    if value.is_empty() {
+        return Err(ErrorData::invalid_params("Value cannot be empty"));
+    }
+    Ok(())
+}
+```
+
+### Actionable tool errors
+
+```rust
+#[tool]
+async fn get_repo(params: Parameters<GetRepoInput>) -> Result<String, String> {
+    let input = params.inner();
+    match client.get_repo(&input.owner, &input.name).await {
+        Ok(repo) => serde_json::to_string_pretty(&repo).map_err(|e| e.to_string()),
+        Err(ApiError::NotFound) => Err(format!(
+            "Repository {}/{} not found — verify the owner and repo name; use list_repos to discover available repositories",
+            input.owner, input.name
+        )),
+        Err(ApiError::Forbidden) => Err(
+            "Access denied — check that your API token has the required scopes".to_string()
+        ),
+        Err(e) => Err(format!("API request failed: {e}")),
+    }
+}
+```
+
+## Transport Configuration
+
+### stdio (local, default)
+
+```rust
+use rmcp::transport::StdioTransport;
+
+let transport = StdioTransport::new();
+let server = Server::builder()
+    .with_handler(handler)
+    .build(transport)?;
+server.run(signal::ctrl_c()).await?;
+```
+
+### Streamable HTTP with Axum
+
+```rust
+use rmcp::transport::StreamableHttpTransport;
+use axum::{Router, routing::post};
+
+let transport = StreamableHttpTransport::new();
+let app = Router::new().route("/mcp", post(transport.handler()));
+
+let listener = tokio::net::TcpListener::bind("127.0.0.1:3000").await?;
+axum::serve(listener, app).await?;
+```
+
+### SSE Transport
+
+```rust
+use rmcp::transport::SseServerTransport;
+
+let addr: std::net::SocketAddr = "127.0.0.1:8000".parse()?;
+let transport = SseServerTransport::new(addr);
+let server = Server::builder().with_handler(handler).build(transport)?;
+server.run(signal::ctrl_c()).await?;
+```
+
+## Resource Implementation
+
+```rust
+async fn list_resources(
+    &self,
+    _request: Option<PaginatedRequestParam>,
+    _context: RequestContext<RoleServer>,
+) -> Result<ListResourcesResult, ErrorData> {
+    Ok(ListResourcesResult {
+        resources: vec![Resource {
+            uri: "config://settings".to_string(),
+            name: "Settings".to_string(),
+            description: Some("Server configuration".to_string()),
+            mime_type: Some("application/json".to_string()),
+        }],
+    })
+}
+
+async fn read_resource(
+    &self,
+    request: ReadResourceRequestParam,
+    _context: RequestContext<RoleServer>,
+) -> Result<ReadResourceResult, ErrorData> {
+    match request.uri.as_str() {
+        "config://settings" => Ok(ReadResourceResult {
+            contents: vec![ResourceContents::text(load_settings())
+                .with_uri(request.uri)
+                .with_mime_type("application/json")],
+        }),
+        _ => Err(ErrorData::invalid_params("Unknown resource")),
+    }
+}
+```
+
+## Complete Example
+
+```rust
+use rmcp::{tool, tool_router, tool_handler};
+use rmcp::model::Parameters;
+use rmcp::server::{Server, ServerHandler};
+use rmcp::transport::StdioTransport;
+use rmcp::protocol::ServerCapabilities;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tokio::signal;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ListReposInput {
+    /// GitHub organization or username
+    pub owner: String,
+    /// Results per page (1-100)
+    pub per_page: Option<u32>,
+}
+
+pub struct MyHandler {
+    tool_router: ToolRouter,
+}
+
+#[tool_router]
+impl MyHandler {
+    /// List repositories for an owner. Returns name, description, and star count.
+    #[tool(name = "list_repos", annotations(read_only_hint = true))]
+    async fn list_repos(&self, params: Parameters<ListReposInput>) -> Result<String, String> {
+        let input = params.inner();
+        let per_page = input.per_page.unwrap_or(30);
+        Ok(format!(r#"{{"repos": [{{"name": "example", "stars": 42}}], "total": 1}}"#))
+    }
+
+    pub fn new() -> Self {
+        Self { tool_router: Self::tool_router() }
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for MyHandler {}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let api_token = std::env::var("API_TOKEN")
+        .expect("API_TOKEN environment variable is required");
+
+    let handler = MyHandler::new();
+    let transport = StdioTransport::new();
+
+    let server = Server::builder()
+        .with_handler(handler)
+        .with_capabilities(ServerCapabilities {
+            tools: Some(Default::default()),
+            ..Default::default()
+        })
+        .build(transport)?;
+
+    server.run(signal::ctrl_c()).await?;
+    Ok(())
+}
+```
+
+---
+
+## Quality Checklist
+
+Before finalizing your Rust MCP server implementation, ensure:
+
+### Strategic Design
+- [ ] Tools enable complete workflows, not just API endpoint wrappers
+- [ ] Tool names are `snake_case` with consistent service prefix
+- [ ] Error messages guide agents toward correct usage with recovery hints
+
+### Implementation Quality
+- [ ] Tools use `#[tool]` macro with `name`, `description`, and `annotations`
+- [ ] Input types derive `Deserialize` and `JsonSchema` with doc comments on fields
+- [ ] Annotations correctly set (read_only_hint, destructive_hint, idempotent_hint, open_world_hint)
+- [ ] Tool errors return `Result::Err(String)` with actionable messages
+- [ ] `ErrorData::invalid_params` used for validation failures
+
+### Rust Quality
+- [ ] All async operations use `tokio` runtime
+- [ ] No `unwrap()` or `expect()` in tool handlers — return `Result` errors
+- [ ] Error chains preserved with `map_err` and context
+- [ ] No hardcoded credentials — all secrets via environment variables
+- [ ] `tracing` used for structured logging
+
+### Project Configuration
+- [ ] `Cargo.toml` includes `rmcp`, `tokio`, `serde`, `schemars`, `tracing`
+- [ ] Crate name follows format: `{service}-mcp-server`
+- [ ] `cargo build` succeeds with no errors
+- [ ] `cargo clippy` passes with no warnings
+
+### Testing
+- [ ] `cargo build` compiles without errors
+- [ ] `cargo clippy` passes
+- [ ] `cargo test` passes
+- [ ] Manual test with MCP Inspector: `npx @modelcontextprotocol/inspector cargo run`

--- a/skills/mcp-builder/reference/swift_mcp_server.md
+++ b/skills/mcp-builder/reference/swift_mcp_server.md
@@ -1,0 +1,431 @@
+# Swift MCP Server Implementation Guide
+
+## Overview
+
+This document provides Swift-specific best practices and examples for implementing MCP servers using the official MCP Swift SDK (`modelcontextprotocol/swift-sdk`). It covers server setup, tool registration, resource and prompt handlers, transport configuration, and complete working examples.
+
+---
+
+## Quick Reference
+
+### Key Imports
+```swift
+import MCP
+import Logging
+```
+
+### Server Initialization
+```swift
+let server = Server(
+    name: "service-mcp",
+    version: "1.0.0",
+    capabilities: .init(
+        tools: .init(listChanged: true),
+        resources: .init(subscribe: true, listChanged: true),
+        prompts: .init(listChanged: true)
+    )
+)
+```
+
+### Tool Registration Pattern
+```swift
+await server.withMethodHandler(ListTools.self) { _ in
+    .init(tools: [myTool])
+}
+await server.withMethodHandler(CallTool.self) { params in
+    // Handle tool call by params.name
+}
+```
+
+---
+
+## MCP Swift SDK
+
+The official Swift SDK provides:
+- `Server` class with actor-based concurrency safety
+- `withMethodHandler` for registering tool, resource, and prompt handlers
+- `StdioTransport` for local subprocess communication
+- Full Swift concurrency (`async`/`await`) integration
+
+**IMPORTANT - Use `withMethodHandler`:**
+- Register `ListTools.self` and `CallTool.self` handlers for tools
+- Register `ListResources.self` and `ReadResource.self` handlers for resources
+- Register `ListPrompts.self` and `GetPrompt.self` handlers for prompts
+- All handlers are `async` and run in the server's actor context
+
+## Server Naming Convention
+
+Swift MCP servers should follow this naming pattern:
+- **Format**: `{service}-mcp` (lowercase with hyphens)
+- **Examples**: `github-mcp`, `jira-mcp`, `stripe-mcp`
+
+The name should be:
+- General (not tied to specific features)
+- Descriptive of the service/API being integrated
+- Easy to infer from the task description
+- Without version numbers or dates
+
+## Project Structure
+
+```
+{service}-mcp/
+├── Package.swift         # Swift Package Manager manifest
+├── Sources/
+│   └── {Service}MCP/
+│       ├── main.swift    # Entry point, server setup, transport start
+│       ├── Tools.swift   # Tool definitions and handlers
+│       ├── Resources.swift
+│       ├── Prompts.swift
+│       └── Client.swift  # API client and auth helpers
+└── Tests/
+    └── {Service}MCPTests/
+        └── ServerTests.swift
+```
+
+## Tool Implementation
+
+### Defining Tools
+
+Tools are defined as `Tool` instances with JSON Schema input:
+
+```swift
+let searchTool = Tool(
+    name: "service_search",
+    description: "Search for items. Returns matching records with ID, name, and status.",
+    inputSchema: .object([
+        "properties": .object([
+            "query": .object([
+                "type": .string("string"),
+                "description": .string("Search query string")
+            ]),
+            "limit": .object([
+                "type": .string("integer"),
+                "description": .string("Maximum results to return (1-100)"),
+                "default": .number(20)
+            ])
+        ]),
+        "required": .array([.string("query")])
+    ])
+)
+```
+
+### Registering Tool Handlers
+
+```swift
+await server.withMethodHandler(ListTools.self) { _ in
+    .init(tools: [searchTool, createTool, deleteTool])
+}
+
+await server.withMethodHandler(CallTool.self) { params in
+    switch params.name {
+    case "service_search":
+        let query = params.arguments?["query"]?.stringValue ?? ""
+        let limit = params.arguments?["limit"]?.intValue ?? 20
+
+        let results = try await apiClient.search(query: query, limit: limit)
+
+        if results.isEmpty {
+            return .init(
+                content: [.text("No results found for '\(query)'")],
+                isError: true
+            )
+        }
+
+        let json = try JSONEncoder().encode(results)
+        return .init(
+            content: [.text(String(data: json, encoding: .utf8)!)],
+            isError: false
+        )
+
+    default:
+        return .init(
+            content: [.text("Unknown tool: \(params.name)")],
+            isError: true
+        )
+    }
+}
+```
+
+## JSON Schema with Value Type
+
+Build schemas using the `Value` enum:
+
+```swift
+let schema = Value.object([
+    "type": .string("object"),
+    "properties": .object([
+        "name": .object([
+            "type": .string("string"),
+            "description": .string("User's name")
+        ]),
+        "age": .object([
+            "type": .string("integer"),
+            "minimum": .number(0),
+            "maximum": .number(150)
+        ]),
+        "email": .object([
+            "type": .string("string"),
+            "format": .string("email")
+        ])
+    ]),
+    "required": .array([.string("name"), .string("email")])
+])
+```
+
+## Resource Implementation
+
+```swift
+await server.withMethodHandler(ListResources.self) { _ in
+    .init(resources: [
+        Resource(
+            name: "App Config",
+            uri: "config://app/settings",
+            description: "Current application configuration",
+            mimeType: "application/json"
+        )
+    ], nextCursor: nil)
+}
+
+await server.withMethodHandler(ReadResource.self) { params in
+    switch params.uri {
+    case "config://app/settings":
+        let content = try await loadSettings()
+        return .init(contents: [
+            Resource.Content.text(content, uri: params.uri, mimeType: "application/json")
+        ])
+    default:
+        throw MCPError.invalidParams("Unknown resource URI: \(params.uri)")
+    }
+}
+```
+
+## Prompt Implementation
+
+```swift
+await server.withMethodHandler(ListPrompts.self) { _ in
+    .init(prompts: [
+        Prompt(
+            name: "analyze",
+            description: "Analyze a topic in depth",
+            arguments: [
+                .init(name: "topic", description: "Topic to analyze", required: true),
+                .init(name: "depth", description: "Analysis depth", required: false)
+            ]
+        )
+    ], nextCursor: nil)
+}
+
+await server.withMethodHandler(GetPrompt.self) { params in
+    let topic = params.arguments?["topic"]?.stringValue ?? "general"
+    let depth = params.arguments?["depth"]?.stringValue ?? "basic"
+
+    return .init(
+        description: "Analysis of \(topic)",
+        messages: [
+            .user("Please analyze this topic: \(topic) at \(depth) depth")
+        ]
+    )
+}
+```
+
+## Transport Configuration
+
+### stdio (local, default)
+
+```swift
+import MCP
+import Logging
+
+let logger = Logger(label: "com.example.service-mcp")
+let transport = StdioTransport(logger: logger)
+try await server.start(transport: transport)
+```
+
+### HTTP Transport (client side)
+
+```swift
+let transport = HTTPClientTransport(
+    endpoint: URL(string: "http://localhost:8080")!,
+    streaming: true
+)
+try await client.connect(transport: transport)
+```
+
+## Concurrency and Actors
+
+The server is an actor, ensuring thread-safe access. Use additional actors for shared state:
+
+```swift
+actor ServerState {
+    private var subscriptions: Set<String> = []
+
+    func addSubscription(_ uri: String) { subscriptions.insert(uri) }
+    func getSubscriptions() -> Set<String> { subscriptions }
+}
+
+let state = ServerState()
+
+await server.withMethodHandler(ResourceSubscribe.self) { params in
+    await state.addSubscription(params.uri)
+    return .init()
+}
+```
+
+## Error Handling
+
+Use Swift's error handling with `MCPError`:
+
+```swift
+await server.withMethodHandler(CallTool.self) { params in
+    do {
+        guard let query = params.arguments?["query"]?.stringValue else {
+            throw MCPError.invalidParams("Missing required parameter: query")
+        }
+
+        let result = try await performOperation(query: query)
+        return .init(content: [.text(result)], isError: false)
+    } catch let error as MCPError {
+        return .init(content: [.text(error.localizedDescription)], isError: true)
+    } catch {
+        return .init(content: [.text("Unexpected error: \(error.localizedDescription)")], isError: true)
+    }
+}
+```
+
+## Graceful Shutdown with ServiceLifecycle
+
+```swift
+import ServiceLifecycle
+
+struct MCPService: Service {
+    let server: Server
+    let transport: Transport
+
+    func run() async throws {
+        try await server.start(transport: transport)
+        try await Task.sleep(for: .days(365 * 100))
+    }
+}
+
+let serviceGroup = ServiceGroup(
+    services: [MCPService(server: server, transport: transport)],
+    configuration: .init(gracefulShutdownSignals: [.sigterm, .sigint]),
+    logger: logger
+)
+try await serviceGroup.run()
+```
+
+## Swift Package Manager Setup
+
+```swift
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "{Service}MCP",
+    platforms: [.macOS(.v13), .iOS(.v16)],
+    dependencies: [
+        .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.10.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0")
+    ],
+    targets: [
+        .executableTarget(
+            name: "{Service}MCP",
+            dependencies: [
+                .product(name: "MCP", package: "swift-sdk"),
+                .product(name: "Logging", package: "swift-log")
+            ]
+        )
+    ]
+)
+```
+
+## Complete Example
+
+```swift
+import MCP
+import Logging
+
+@main
+struct ExampleMCP {
+    static func main() async throws {
+        let logger = Logger(label: "com.example.mcp")
+
+        let server = Server(
+            name: "example-mcp",
+            version: "1.0.0",
+            capabilities: .init(tools: .init(listChanged: true))
+        )
+
+        let listReposTool = Tool(
+            name: "list_repos",
+            description: "List repositories for an owner. Returns name and star count.",
+            inputSchema: .object([
+                "properties": .object([
+                    "owner": .object([
+                        "type": .string("string"),
+                        "description": .string("GitHub org or username")
+                    ])
+                ]),
+                "required": .array([.string("owner")])
+            ])
+        )
+
+        await server.withMethodHandler(ListTools.self) { _ in
+            .init(tools: [listReposTool])
+        }
+
+        await server.withMethodHandler(CallTool.self) { params in
+            switch params.name {
+            case "list_repos":
+                let owner = params.arguments?["owner"]?.stringValue ?? ""
+                return .init(
+                    content: [.text("Repos for \(owner): [example-repo (42 stars)]")],
+                    isError: false
+                )
+            default:
+                return .init(content: [.text("Unknown tool")], isError: true)
+            }
+        }
+
+        let transport = StdioTransport(logger: logger)
+        try await server.start(transport: transport)
+    }
+}
+```
+
+---
+
+## Quality Checklist
+
+Before finalizing your Swift MCP server implementation, ensure:
+
+### Strategic Design
+- [ ] Tools enable complete workflows, not just API endpoint wrappers
+- [ ] Tool names reflect natural task subdivisions with service prefix
+- [ ] Error messages guide agents toward correct usage
+
+### Implementation Quality
+- [ ] All tools registered via `withMethodHandler(ListTools.self)` and `withMethodHandler(CallTool.self)`
+- [ ] Tool `inputSchema` uses `Value` type with proper property types and descriptions
+- [ ] `required` arrays list all mandatory parameters
+- [ ] Error responses use `isError: true` with actionable messages
+- [ ] All handlers are `async` and use `await` for I/O
+
+### Swift Quality
+- [ ] Uses Swift concurrency (`async`/`await`) throughout
+- [ ] Actor isolation used for shared mutable state
+- [ ] Proper `do`/`catch` error handling in all handlers
+- [ ] No force-unwraps in production paths
+- [ ] Logging via `swift-log` to stderr (not stdout)
+
+### Project Configuration
+- [ ] Package.swift targets macOS 13+ / iOS 16+
+- [ ] `swift-sdk` and `swift-log` dependencies declared
+- [ ] `swift build` succeeds with no errors
+- [ ] Server name follows format: `{service}-mcp`
+
+### Testing
+- [ ] `swift build` compiles without errors
+- [ ] `swift test` passes
+- [ ] Manual test with MCP Inspector: `npx @modelcontextprotocol/inspector swift run`


### PR DESCRIPTION
## Summary
- Adds 8 new language-specific implementation guides to the `mcp-builder` skill: **Go**, **Java**, **Kotlin**, **C#**, **Rust**, **Swift**, **Ruby**, and **PHP**
- Updates `SKILL.md` to reference all 10 supported languages across all workflow phases (framework docs, project setup, schema validation, build/test, reference library)
- Updates `mcp_best_practices.md` with server naming conventions and validation tool references for all languages

Each new guide follows the same structure as the existing TypeScript and Python guides: Quick Reference, SDK overview, server naming convention, project structure, tool implementation patterns, error handling, transport configuration, complete working example, and quality checklist.

## Files changed
- `skills/mcp-builder/SKILL.md` — updated description, Phase 1–3 sections, and Reference Files
- `skills/mcp-builder/reference/mcp_best_practices.md` — added naming conventions for all languages
- 8 new files in `skills/mcp-builder/reference/`:
  - `go_mcp_server.md` (official `modelcontextprotocol/go-sdk`)
  - `java_mcp_server.md` (official `io.modelcontextprotocol.sdk:mcp` + Spring Boot)
  - `kotlin_mcp_server.md` (official `io.modelcontextprotocol:kotlin-sdk`)
  - `csharp_mcp_server.md` (official `ModelContextProtocol` NuGet)
  - `rust_mcp_server.md` (official `rmcp` crate)
  - `swift_mcp_server.md` (official `modelcontextprotocol/swift-sdk`)
  - `ruby_mcp_server.md` (official `mcp` gem)
  - `php_mcp_server.md` (official `mcp/sdk` Composer package)

## Test plan
- [ ] Verify SKILL.md renders correctly with all language links
- [ ] Spot-check each reference file for consistent structure
- [ ] Confirm `mcp_best_practices.md` naming table is complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)