### PR TITLE
Add graphic design skills specific to posters and flyers

### DIFF
--- a/skills/lica-brochure-design/LICENSE.txt
+++ b/skills/lica-brochure-design/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/lica-brochure-design/SKILL.md
+++ b/skills/lica-brochure-design/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: lica-brochure-design
+description: Brochure-specific multi-panel layout, typography, fold reading order, and critique guidance from the LICA dataset’s folded-marketing category—not generic multi-page design. Use when the user asks to design or critique tri-fold, bi-fold, or informational brochures, panel roles, bleed/safe area, or print-ready spacing in design tools (e.g. Figma including via MCP). Prefer this when folds and panel flow matter.
+license: Complete terms in LICENSE.txt
+---
+
+Brochure guidance is derived from the [LICA (Layout Intent and Composition Annotations) dataset](https://github.com/purvanshi/lica-dataset). Apply these principles when designing or critiquing brochures.
+
+## Why LICA maps to **one skill per document type**
+
+LICA encodes **per-category** structure: user intent, element placement, hierarchy, and composition differ systematically between document classes. Brochures introduce **fold logic, panel identity, and reading order** that single-page skills do not cover; merging everything into one “layout” skill dilutes those constraints. Category-specific skills let agents load **only** the rules that match the artifact—aligned with how LICA is organized by use case.
+
+This skill is the **folded brochure** slice. Together with `lica-flyer-design`, it demonstrates a **repeatable pattern**: one focused skill per LICA-aligned category, with room to add resume, poster, logo, etc., as separate skills (see category list in [design-skills](https://github.com/purvanshi-lica/design-skills)).
+
+## Sub-tasks: concrete outputs (execution discipline)
+
+Unless the user restricts scope, run a full brochure pass through the sub-tasks **in order**. Each sub-task must emit a **concrete block** (table, numbered panel spec, wireframe in text, or checklist)—not a loose paragraph of advice.
+
+### Sub-task A — Intake gaps (only what is missing)
+Ask only for what is absent: fold type (tri / bi / gate / z), flat size (A4/Letter/custom), **panel count and fold direction**, print bleed/safe specs, audience, brand kit, must-win message, mandatory sections (pricing, map, team, legal), and imagery rules.
+
+### Sub-task B — Fold + panel map
+Generate:
+1. **Diagram in text**: list panels as **P1, P2, …** in **reading order after folding** (unfolded flat map + folded user path).
+2. A **table**:
+
+| Panel ID | Role (cover / spread / back / flap) | WxH (flat) | Fold edges | Bleed | Safe inset |
+|----------|--------------------------------------|------------|------------|-------|------------|
+| | | | | | |
+
+### Sub-task C — Narrative arc (content spine)
+Generate **five bullets**: problem → promise → proof → details → CTA. Map each bullet to **one or more panel IDs** (where it will appear).
+
+### Sub-task D — Per-panel content outline
+For **each panel**, output:
+
+```text
+Panel Px — <role>
+- Headline (if any): ...
+- Subheads / bullets (max N lines): ...
+- Body: ...
+- Visual: (photo / icon row / diagram / none)
+- CTA / contact: (yes/no + copy)
+```
+
+Keep body **scannable**; prefer bullets over long paragraphs on inside panels.
+
+### Sub-task E — Per-panel wireframe (zones)
+For **each panel**, give a **vertical or horizontal zone stack** with **approximate % heights or widths** (e.g. “top 40% hero image, middle 45% two-column bullets, bottom 15% CTA strip”). Note **what crosses a fold** (nothing critical in the gutter).
+
+### Sub-task F — Shared typography system
+One **master table** for the whole brochure:
+
+| Role | Size (px or pt eq.) | Weight | Application (cover / inside / back) |
+|------|---------------------|--------|----------------------------------------|
+| Cover headline | | | |
+| Section head | | | |
+| Body | | | |
+| Caption / legal | | | |
+
+State **max font families** (typically ≤2) and rules for **consistent section heads** across panels.
+
+### Sub-task G — Repeating components
+List **reusable patterns** with rules: feature cards, icon+bullet rows, pull quotes, stat callouts, footer strip. For each: **structure** (e.g. “icon 24px, title, 2-line max”) and **which panels** reuse it.
+
+### Sub-task H — Color + imagery consistency
+Generate **brand application rules**: primary/secondary/neutral usage per panel type; **image crop alignment** to folds; **callout/card** fill vs stroke. Flag panels that should stay **mostly white** for readability.
+
+### Sub-task I — Build plan (execution order)
+Numbered checklist tailored to fold type, e.g.:
+
+1. Flat master frame + margins guides  
+2. Panel grid + fold guides  
+3. Cover (P…) hero + headline  
+4. Inside spread modules in reading order  
+5. Back panel contact + legal  
+6. Cross-panel **style sync** (type + color + cards)  
+7. Fold simulation: **re-check trim and gutter**  
+8. Final critique pass  
+
+Use 10–18 steps as needed; reference **panel IDs** from sub-task B.
+
+### Sub-task J — Critique pass
+Apply the **Critique Checklist** in this skill: each item **Pass / Fail**; every Fail gets **one specific fix** (panel ID + change).
+
+**Partial runs:** Match the user’s ask to sub-tasks only (e.g. “rewrite inside copy” → D for those panels only; “print setup” → B table + I steps 1–2 and 7).
+
+## Canvas & Format
+- Common print formats: tri-fold A4/Letter, bi-fold A4/Letter
+- Set panel widths accurately for fold behavior
+- Include bleed and safe area in every panel
+
+## Layout Principles
+### Tri-fold Brochure
+- Front cover: brand + headline + hero image
+- Inside spread: value proposition, features, visuals
+- Back panel: contact details, social, legal/footer
+
+### Bi-fold Brochure
+- Cover with strong story hook
+- Inside spread for narrative + feature blocks
+- Back for company/about + CTA/contact
+
+### Information Brochure
+- Sectioned modules with clear dividers
+- Consistent iconography for categories
+- Scannable bullets over long paragraphs
+
+## Typography
+- Cover headline: 32–56px equivalent
+- Section heads: 18–28px
+- Body: 10–12pt print equivalent
+- Keep line length comfortable and consistent
+
+## Visual & Brand
+- Keep brand colors consistent across all panels
+- Use image crops aligned with fold boundaries
+- Maintain consistent card/callout styles
+- Avoid overcrowding any single panel
+
+## Content Architecture
+- Start with audience problem
+- Present solution and differentiators
+- Add trust proof (stats/testimonials/certifications)
+- End with direct CTA and contact path
+
+## Critique Checklist
+- [ ] Does each panel have a clear role?
+- [ ] Is reading flow intuitive after folding?
+- [ ] Are headings and body text consistently styled?
+- [ ] Is spacing sufficient around folds and edges?
+- [ ] Are CTA and contact details easy to find?
+
+## Usage
+When designing or reviewing brochures, default to the **Sub-tasks** section so every response includes **specific generations** (panel map table, per-panel outlines, wireframes, type system, build plan, critique). Use **Sub-task A** only for missing facts; do not repeat questions the user already answered.

--- a/skills/lica-flyer-design/LICENSE.txt
+++ b/skills/lica-flyer-design/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/lica-flyer-design/SKILL.md
+++ b/skills/lica-flyer-design/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: lica-flyer-design
+description: Flyer-specific layout, typography, color, and critique guidance distilled from the LICA dataset’s promotional-layout category—not generic design advice. Use when the user asks to design, critique, or improve flyers, event promos, sale announcements, or similar single-page marketing layouts in design tools (e.g. Figma including via MCP) or static mockups. Prefer this over broad “design” skills when the artifact is explicitly a flyer.
+license: Complete terms in LICENSE.txt
+---
+
+Flyer guidance is derived from the [LICA (Layout Intent and Composition Annotations) dataset](https://github.com/purvanshi/lica-dataset). Apply these principles when designing or critiquing flyers.
+
+## Why LICA maps to **one skill per document type**
+
+LICA’s strength is **granularity**: annotations and patterns are tied to **real layouts in a specific category** (flyer vs brochure vs resume vs logo system, etc.). Rules that fit a tri-fold brochure misfire on a single-page promo; a logo skill should not own flyer hierarchy. That is why LICA-backed agent skills should be **small and category-specific**: each `SKILL.md` encodes one document class so the model loads **narrow, evidence-shaped** constraints at invocation time—similar to picking the right tool for the job.
+
+This skill covers the **flyer / promotional single-page** slice of LICA. A full LICA-aligned library is a **family** of such skills (see [design-skills](https://github.com/purvanshi-lica/design-skills) for the category matrix). This PR intentionally ships **two** categories first to establish the pattern before expanding coverage.
+
+## Sub-tasks: concrete outputs (execution discipline)
+
+When running a full flyer pass, complete the sub-tasks below **in order** so the user gets inspectable artifacts (tables, trees, copy deck)—not only prose. Each sub-task must produce a **visible block** (table, list, tree, or short spec).
+
+### Sub-task A — Intake gaps (only what is missing)
+Ask only for inputs not already provided: purpose/event, audience, channel (print / digital / social + exact size if known), must-have copy (headline, date, venue, CTA), brand colors/fonts/logo, legal or fine print, and imagery constraints (stock ok or not).
+
+### Sub-task B — Intent + pattern choice
+Generate:
+1. **Intent label** (one of: event promo, sale/discount, community/nonprofit, corporate announcement, party/nightlife, or hybrid) with one sentence why it fits.
+2. **Layout pattern** (one sentence): e.g. “hero-top + overlay text stack + isolated CTA bar.”
+3. **Anti-patterns to avoid** (2 bullets) for this intent.
+
+### Sub-task C — Canvas spec (numbers)
+Generate a markdown **table** with exact values:
+
+| Field | Value |
+|--------|--------|
+| Final WxH (px) | … |
+| Bleed (if print) | … |
+| Safe margin inset | … |
+| Baseline grid / spacing unit | e.g. 8px |
+| Export / platform | … |
+
+### Sub-task D — Zone map (percentages + anchors)
+Generate:
+1. A **3-zone breakdown** with **percentage bands** of canvas height (hero / middle / bottom) and what lives in each.
+2. For each zone: **alignment** (left / center / full-bleed) and **max text lines** allowed.
+
+### Sub-task E — Type scale (roles → numbers)
+Generate a **table**:
+
+| Role | Size (px eq.) | Weight | Line-height | Font slot (1 or 2) |
+|------|----------------|--------|-------------|---------------------|
+| Headline | | | | |
+| Subhead | | | | |
+| Body | | | | |
+| CTA | | | | |
+| Footer | | | | |
+
+State **max distinct sizes** (must be ≤4) and headline **max line count** (≤2).
+
+### Sub-task F — Color tokens
+Generate a **token list** (name, hex, role: background / headline / body / CTA fill / CTA text / accent). Include one sentence on **contrast strategy** (e.g. dark field + light headline) and note **WCAG** target (AA body 4.5:1, large text 3:1).
+
+### Sub-task G — Layer / component tree
+Output the **tree** from “Component Placement” for *this* flyer (not generic): every node that will exist, top to bottom, including overlay GROUP and CTA GROUP. If using Figma/MCP vocabulary, label nodes as FRAME / TEXT / GROUP / IMAGE consistently.
+
+### Sub-task H — Copy deck (final strings)
+Generate the **exact strings** to place (use placeholders in square brackets only where still unknown after intake):
+
+- Headline (≤2 lines)
+- Subhead (optional, 1 line)
+- Body (2–4 short lines max)
+- CTA label
+- Footer / legal (if any)
+
+### Sub-task I — Hero image brief
+Generate a **5-bullet art direction**: subject, crop/aspect, mood, **overlay need** (yes/no + opacity range), and **what must stay text-free** for legibility.
+
+### Sub-task J — Build plan (execution order)
+Generate a **numbered checklist** (8–14 steps) for building in the design tool: e.g. set frame → background → hero image → overlay → headline stack → body → CTA → logo → footer → contrast pass. Tailor steps to the user’s tool (Figma layers, slides, etc.).
+
+### Sub-task K — Critique pass
+Run the **Critique Checklist** in this skill: output each item as **Pass / Fail**; for every Fail, give **one specific fix** (metric or layer change).
+
+**Partial runs:** If the user only asks for one thing, still use the matching sub-task format (e.g. “only K” → full checklist table with fixes; “only typography” → sub-task E + contrast notes).
+
+## Canvas & Dimensions
+- Portrait standard: 816×1056px (US Letter) or 794×1123px (A4)
+- Landscape promo: 1200×628px (social/web flyer)
+- Square: 1080×1080px (Instagram/social)
+- Choose based on distribution channel: print → portrait letter/A4, digital social → square or landscape
+
+## Layout Principles (from LICA annotations)
+- **One dominant headline**: The largest text element must answer "what is this?" instantly
+- **3-zone structure**: Hero image zone (top 50%) → Headline + body (middle 30%) → CTA + details (bottom 20%)
+- **Visual entry point**: Image or large typographic element anchors the eye at top-center
+- **CTA must be isolated**: Surround call-to-action text with a GROUP background shape (button)
+- Never let text overlap image without a contrast-ensuring overlay (semi-transparent GROUP)
+
+## Typography Rules
+- Headline: max 2 lines, extremely large (48–96px equivalent), bold or black weight
+- Subheadline: 50–60% of headline size, medium weight
+- Body copy: 12–16px, regular weight, line-height 1.4–1.6
+- CTA button text: all-caps or title-case, bold, contrasting color to button background
+- Maximum 2 font families; display font for headline, readable sans for body
+
+## Color & Visual
+- Use a bold, energetic palette — flyers compete for attention
+- Background: can be rich/dark; let headline color pop against it
+- Images: use `opacity: 1.0` for hero images, overlay GROUP at `opacity: 0.4–0.6` for text legibility
+- Accent shapes via `GROUP` with `clip_path: true` — diagonal cuts, circles, and ribbons signal promotions
+- Consistent color theme: event flyers use analogous colors; sale flyers use high-contrast complementary
+
+## Component Placement (JSON structure awareness)
+```
+Canvas (width × height)
+├── Background IMAGE or GROUP (full bleed)
+├── Overlay GROUP (semi-transparent, for text zones)
+├── Hero IMAGE (top 40–55% of canvas)
+├── Headline TEXT (largest, centered or left-aligned)
+├── Subheadline TEXT
+├── Body TEXT (event details, 2–4 lines max)
+├── Divider GROUP (decorative line or shape)
+├── CTA GROUP (button container)
+│   └── CTA TEXT
+├── Logo IMAGE (top-left corner, small)
+└── Footer TEXT (fine print, address, date/time)
+```
+
+## Design Intents (LICA user_intent patterns)
+- **Event promo**: Date/time/venue dominant; energetic palette; countdown urgency
+- **Sale/discount**: % or $ figure as giant hero text; red/yellow; "LIMITED TIME" urgency cue
+- **Community/nonprofit**: Warm imagery; approachable sans-serif; pastel or earth tones
+- **Corporate announcement**: Clean grid; brand colors; minimal imagery; formal hierarchy
+- **Party/nightlife**: Dark background; neon accents; textured or gradient overlays
+
+## Aesthetics Guidelines (LICA aesthetics field patterns)
+- Contrast ratio: text on backgrounds must meet WCAG AA (4.5:1 for body, 3:1 for large text)
+- Focal density: top third should have the highest visual weight
+- Breathing room: even busy flyers need one "quiet" zone to rest the eye
+- Consistency: margins, padding within text blocks should be uniform multiples (8px grid)
+
+## Critique Checklist
+When reviewing a flyer design, evaluate:
+- [ ] Can you read the headline in under 2 seconds from normal viewing distance?
+- [ ] Is the CTA visually distinct and easy to find?
+- [ ] Does text have sufficient contrast against its background?
+- [ ] Is the hierarchy (headline > subheadline > body > CTA) unambiguous?
+- [ ] Are there fewer than 4 distinct font sizes?
+- [ ] Is there a clear visual entry point at the top of the design?
+- [ ] Does the overall color palette match the emotional tone of the message?
+
+## Usage
+When a user asks to design, critique, or improve a flyer, apply all principles above. Default to the **Sub-tasks** section: produce the concrete generations (tables, trees, copy deck, build plan, critique). Use **Sub-task A** first only for missing inputs; do not re-ask for information the user already gave.


### PR DESCRIPTION
## Summary

Adds two **category-specific** Agent Skills distilled from **[LICA](https://github.com/purvanshi/lica-dataset)** (Layout Intent and Composition Annotations): **`lica-flyer-design`** and **`lica-brochure-design`**.

## Why one skill per document type

LICA annotates real layouts **by document class** (flyer, brochure, resume, logo, etc.). Composition rules, fold logic, and CTA patterns are **not interchangeable** across those classes. Shipping **small, focused skills**—one per category—matches how the dataset is organized and improves when each skill should activate (via `description`) versus a single merged “design everything” prompt.

This PR is intentionally **two categories** to establish packaging (Apache `LICENSE.txt` per skill, consistent with other example skills) before adding more LICA-aligned categories.

## Source

- Dataset: https://github.com/purvanshi/lica-dataset  
- Broader category matrix / prompt library: https://github.com/purvanshi-lica/design-skills  

## License

Each new skill folder includes `LICENSE.txt` (Apache 2.0), copied from the same pattern as existing skills in this repository (e.g. `brand-guidelines`).
