### PR TITLE
fix(skill-creator): correct path in package_skill.py docstring and usage

### DIFF
--- a/skills/skill-creator/scripts/package_skill.py
+++ b/skills/skill-creator/scripts/package_skill.py
@@ -3,11 +3,11 @@
 Skill Packager - Creates a distributable .skill file of a skill folder
 
 Usage:
-    python utils/package_skill.py <path/to/skill-folder> [output-directory]
+    python scripts/package_skill.py <path/to/skill-folder> [output-directory]
 
 Example:
-    python utils/package_skill.py skills/public/my-skill
-    python utils/package_skill.py skills/public/my-skill ./dist
+    python scripts/package_skill.py skills/my-skill
+    python scripts/package_skill.py skills/my-skill ./dist
 """
 
 import fnmatch
@@ -110,10 +110,10 @@ def package_skill(skill_path, output_dir=None):
 
 def main():
     if len(sys.argv) < 2:
-        print("Usage: python utils/package_skill.py <path/to/skill-folder> [output-directory]")
+        print("Usage: python scripts/package_skill.py <path/to/skill-folder> [output-directory]")
         print("\nExample:")
-        print("  python utils/package_skill.py skills/public/my-skill")
-        print("  python utils/package_skill.py skills/public/my-skill ./dist")
+        print("  python scripts/package_skill.py skills/my-skill")
+        print("  python scripts/package_skill.py skills/my-skill ./dist")
         sys.exit(1)
 
     skill_path = sys.argv[1]


### PR DESCRIPTION
## Summary

- Fix incorrect path `utils/package_skill.py` -> `scripts/package_skill.py` in docstring and usage output
- Fix incorrect example path `skills/public/my-skill` -> `skills/my-skill` (no `public/` subdirectory exists)

Fixes #904