### PR TITLE
fix: merge duplicate plugins to prevent double skill loading

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,23 +10,15 @@
   },
   "plugins": [
     {
-      "name": "document-skills",
-      "description": "Collection of document processing suite including Excel, Word, PowerPoint, and PDF capabilities",
+      "name": "anthropic-skills",
+      "description": "Anthropic skill collection: document processing (Excel, Word, PowerPoint, PDF), visual design, algorithmic art, MCP building, skill creation, web testing, artifact building, Slack GIFs, theme styling, and internal communications",
       "source": "./",
       "strict": false,
       "skills": [
         "./skills/xlsx",
         "./skills/docx",
         "./skills/pptx",
-        "./skills/pdf"
-      ]
-    },
-    {
-      "name": "example-skills",
-      "description": "Collection of example skills demonstrating various capabilities including skill creation, MCP building, visual design, algorithmic art, internal communications, web testing, artifact building, Slack GIFs, and theme styling",
-      "source": "./",
-      "strict": false,
-      "skills": [
+        "./skills/pdf",
         "./skills/algorithmic-art",
         "./skills/brand-guidelines",
         "./skills/canvas-design",
@@ -40,8 +32,7 @@
         "./skills/web-artifacts-builder",
         "./skills/webapp-testing"
       ]
-    }
-    ,
+    },
     {
       "name": "claude-api",
       "description": "Claude API and SDK documentation skill for building LLM-powered applications",


### PR DESCRIPTION
## Summary

Both `document-skills` and `example-skills` plugins reference the same source directory (`"source": "./"`), causing Claude Code to cache all 17 skills identically under two different prefixes. This wastes context tokens and causes routing ambiguity.

## Problem

When both plugins are enabled (default after marketplace install), Claude loads every skill twice:
- `document-skills:pdf`, `document-skills:xlsx`, `document-skills:algorithmic-art`, ...
- `example-skills:pdf`, `example-skills:xlsx`, `example-skills:algorithmic-art`, ...

Both cache directories have identical file counts (376 files) and content.

## Fix

Merged `document-skills` and `example-skills` into a single `anthropic-skills` plugin that exposes all 16 non-API skills under one prefix. The `claude-api` plugin remains separate.

Users who previously disabled one plugin as a workaround can remove that setting.

Fixes #919