### PR TITLE
Add tdd-loop skill — autonomous TDD loop for Claude Code and Claude.ai

### DIFF
--- a/skills/tdd-loop/LICENSE
+++ b/skills/tdd-loop/LICENSE
@@ -1,0 +1,166 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship made available under
+      the License, as indicated by a copyright notice that is included in
+      or attached to the work (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean, as submitted to the Licensor for inclusion
+      in the Work by the copyright owner or by an individual or Legal Entity
+      authorized to submit on behalf of the copyright owner. For the purposes
+      of this definition, "submitted" means any form of electronic, verbal,
+      or written communication sent to the Licensor or its representatives,
+      including but not limited to communication on electronic mailing lists,
+      source code control systems, and issue tracking systems that are managed
+      by, or on behalf of, the Licensor for the purpose of discussing and
+      improving the Work, but excluding communication that is conspicuously
+      marked or designated in writing by the copyright owner as "Not a
+      Contribution."
+
+      "Contributor" shall mean Licensor and any Legal Entity on behalf of
+      whom a Contribution has been received by the Licensor and incorporated
+      within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by the combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a cross-claim
+      or counterclaim in a lawsuit) alleging that the Work or any
+      Contribution embodied within the Work constitutes direct or contributory
+      patent infringement, then any patent licenses granted to You under
+      this License for that Work shall terminate as of the date such
+      litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative
+          Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file, You must include a
+          readable copy of the attribution notices contained within such
+          NOTICE file, in at least one of the following places: within a
+          NOTICE text file distributed as part of the Derivative Works;
+          within the Source form or documentation, if provided along with
+          the Derivative Works; or, within a display generated by the
+          Derivative Works, if and wherever such third-party notices
+          normally appear. The contents of the NOTICE file are for
+          informational purposes only and do not modify the License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or agreed
+      to in writing, Licensor provides the Work (and each Contributor
+      provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES
+      OR CONDITIONS OF ANY KIND, either express or implied, including,
+      without limitation, any warranties or conditions of TITLE,
+      NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR
+      PURPOSE. You are solely responsible for determining the
+      appropriateness of using or reproducing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or exemplary damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (even if such Contributor has been advised of the possibility
+      of such damages).
+
+   9. Accepting Warranty or Liability. While redistributing the Work or
+      Derivative Works thereof, You may choose to offer, and charge a fee
+      for, acceptance of support, warranty, indemnity, or other liability
+      obligations and/or rights consistent with this License. However, in
+      accepting such obligations, You may offer such conditions only on
+      Your own behalf and on Your sole responsibility, not on behalf of
+      any other Contributor, and only if You agree to indemnify, defend,
+      and hold each Contributor harmless for any liability incurred by,
+      or claims asserted against, such Contributor by reason of your
+      accepting any warranty or liability.
+
+   Copyright 2026 Julian
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/tdd-loop/SKILL.md
+++ b/skills/tdd-loop/SKILL.md
@@ -1,0 +1,572 @@
+---
+name: tdd-loop
+description: >
+  Autonomous TDD loop — write tests first, implement to pass, refactor, repeat.
+  Triggers on any code-writing or bug-fixing request. Use when: implement X,
+  fix bug in X, add feature, refactor, write tests for, make X work, build the Y flow.
+  If code is being written, this skill applies automatically.
+author: Julian
+version: 1.0.0
+---
+
+# TDD Loop Skill
+
+You are an autonomous TDD agent. Your job is to write tests first, implement to make them
+pass, and loop until everything is green — without waiting for human input between iterations
+unless you hit a genuine blocker.
+
+---
+
+## Quick Start
+
+No configuration needed — just describe what you want:
+
+```
+implement card deletion
+fix the bug where sessions expire on refresh
+write tests for CardService
+refactor the payment module
+```
+
+To skip the setup interview and use defaults:
+```
+Use defaults
+```
+
+To reuse a saved config from a previous session:
+```
+TDD config set: max_iterations=5, ai_eval_timeout=15000ms, coverage=80%, ai_evals=separate, test_mode=strict, confidence=100%, browsers=chromium
+```
+
+---
+
+## Runtime Detection
+
+Detect the environment first — behavior differs between the two:
+
+| Signal | Environment |
+|---|---|
+| `claude` CLI available, `.claude/` directory exists | **Claude Code** |
+| No CLI, no filesystem, chat interface only | **Claude.ai** |
+
+Core loop phases are identical. Capabilities differ — see sections below.
+
+---
+
+## Claude Code — Enhanced Capabilities
+
+### Subagents for Phase Isolation
+
+Claude Code supports spawning subagents via `Task()`. Use them to eliminate context
+pollution between TDD phases — the cardinal weakness of single-context TDD:
+
+```
+Orchestrator (this skill)
+  ├── Task: tdd-test-writer   → writes + verifies RED only
+  ├── Task: tdd-implementer   → reads failing test, implements GREEN only
+  └── Task: tdd-refactorer    → evaluates + applies REFACTOR only
+```
+
+Each subagent receives only the context it needs. The test writer has no idea how the
+feature will be implemented. The implementer sees only the failing test output.
+
+**Spawn pattern:**
+
+```
+Task(
+  description="TDD RED phase: write failing test for <feature>",
+  prompt="You are tdd-test-writer. Read .claude/agents/tdd-test-writer.md for instructions.
+          Feature: <feature description>
+          Constraint: write exactly one test (strict mode) / full suite (batch mode).
+          Return: test file path + failure output confirming RED."
+)
+```
+
+Create the agent files at `.claude/agents/` — see `references/claude-code-agents.md`.
+
+### CLAUDE.md Config Persistence
+
+In Claude Code, persist `TDD_CONFIG` to `CLAUDE.md` so it survives across sessions and is
+shared with all team members who clone the repo:
+
+```markdown
+## TDD Loop Config
+max_iterations=5
+ai_eval_timeout=15000
+coverage=80
+ai_evals=separate
+test_mode=strict
+confidence=100
+browsers=chromium
+```
+
+On first run, write config to `CLAUDE.md`. On subsequent runs, read from it — skip the
+configuration interview if `TDD Loop Config` section already exists.
+
+### PostToolUse Hook — Auto-run Tests
+
+Add to `.claude/settings.json` to automatically run the test suite after every file edit:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npm test --watchAll=false 2>&1 | tail -20",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+For Java/Spring projects:
+```json
+"command": "./mvnw test -pl <module> -q 2>&1 | tail -20"
+```
+
+This creates a tight feedback loop: every save triggers a test run, output is fed back into
+context automatically.
+
+### UserPromptSubmit Hook — Skill Activation
+
+Without hooks, skill activation is unreliable (~20% trigger rate). Add this hook to force
+Claude Code to evaluate all available skills before every response:
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo 'EVALUATE available skills before responding. If tdd-loop applies, activate it NOW before writing any code.'",
+            "timeout": 3
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Playwright Headed Mode
+
+Claude Code has terminal access. Run Playwright tests headed during development — Claude Code
+can observe test runner output in real time and use it to iterate:
+
+```bash
+# Only when a display is available (local dev, not CI/containers)
+npx playwright test --headed --reporter=list 2>&1
+
+# For headless environments (CI, Docker, devcontainers):
+npx playwright test --reporter=list 2>&1
+```
+
+> ⚠️ `--headed` requires a display server. In CI or container environments it will fail.
+> Use headless (default) in those contexts, or set `DISPLAY` / use `xvfb-run` if you need
+> headed in a container.
+
+For debugging failures interactively (local only):
+```bash
+npx playwright test --ui    # opens Playwright UI mode
+npx playwright show-report  # opens HTML report after run
+```
+
+---
+
+## Claude.ai — Adapted Behavior
+
+When running in claude.ai (no CLI, no filesystem):
+
+- **No subagents**: all phases run in single context. Compensate by being explicit —
+  complete each phase fully and announce it before proceeding to the next.
+- **No hooks**: skill must be triggered manually or by clear user phrasing.
+- **No CLAUDE.md**: config is session-scoped only. User must re-configure each session
+  (or paste their saved config at session start).
+- **Playwright headed**: cannot launch a real browser. Provide the exact commands for
+  the user to run locally and paste back the output.
+- **Codebase search**: ask user to paste relevant file contents when needed.
+- **Config persistence**: remind user to save their `TDD config set:` line for reuse.
+
+---
+
+## Stack Detection & Override
+
+Before starting, detect the project's existing stack from config files and existing tests.
+Do not assume the default stack — match what's already in use.
+
+**Detection heuristics:**
+- `package.json` with `vitest` → React/TS frontend
+- `package.json` with `jest` → Node.js/Express backend
+- `pom.xml` or `build.gradle` → Java/Spring Boot
+- `playwright.config.ts` → E2E layer present
+- `pytest.ini`, `pyproject.toml` with `pytest` → Python/pytest
+- `go.mod` → Go
+
+**Override at any time:**
+```
+Use Python/pytest for this project
+Use Go testing package
+Use Django + pytest-django
+```
+
+The TDD phases, confidence mechanism, and loop structure are stack-agnostic.
+Only the test runner commands and boilerplate change.
+
+## Default Stack (when no existing stack detected)
+
+| Layer        | Stack                                        | Test Framework              |
+|---|---|---|
+| Frontend     | React + TypeScript                           | Vitest + React Testing Library |
+| Backend (JVM)| Java / Spring Boot                           | JUnit 5 + Mockito + AssertJ |
+| Backend (JS) | Node.js / Express                            | Jest + Supertest            |
+| E2E / UI     | Playwright (TypeScript)                      | Playwright Test             |
+| AI outputs   | LLM-as-judge via Anthropic API               | Custom eval harness         |
+
+See `references/test-patterns.md` for boilerplate across all frameworks.
+
+---
+
+## First-Run Configuration
+
+**Claude Code**: Check `CLAUDE.md` for existing `TDD Loop Config` section first.
+If found, load it and skip the interview. If not found, run the interview and write results to `CLAUDE.md`.
+
+**Claude.ai**: Run the interview on first use in each session (or accept a pasted config line).
+
+```
+Before we start, let me set up the TDD loop for your project:
+
+1. Max iterations before surfacing a blocker to you?
+   Suggested: 3 / 5 / 10 / custom
+
+2. AI eval test timeout (ms)?
+   Suggested: 10000 / 15000 / 30000 / custom
+
+3. Coverage threshold (%)?
+   Suggested: 70 / 80 / 90 / skip
+
+4. AI evals: in-loop / separate / skip
+
+5. Test writing mode: strict (one test at a time) / batch (full suite upfront)
+
+6. Requirement confidence threshold (%)?
+   Suggested: 100 / 90 / 80 / custom
+
+7. Playwright browsers: chromium / chromium+firefox / chromium+firefox+webkit
+```
+
+Confirm: `TDD config set: max_iterations=N, ai_eval_timeout=Xms, coverage=Y%, ai_evals=<mode>, test_mode=<strict|batch>, confidence=Z%, browsers=<list>`
+
+**Defaults**: `max_iterations=5, ai_eval_timeout=15000, coverage=80, ai_evals=separate, test_mode=strict, confidence=100, browsers=chromium`
+
+**To change config mid-session:**
+```
+Update TDD config: test_mode=batch, confidence=80
+```
+
+---
+
+## The Loop
+
+```
+[CONFIDENCE CHECK] → PLAN → [test_mode branch] → 🔴 WRITE TEST(S) → VERIFY RED → 🟢 IMPLEMENT → VERIFY GREEN → 🔵 REFACTOR → [repeat if strict] → DONE
+                                                                                        ↑ fix impl, never tests ↑
+```
+
+> **Claude Code**: Use subagents for true phase isolation.
+> **Claude.ai**: All phases share one context window — complete each phase fully before announcing the next.
+
+---
+
+### Phase 0 — Confidence Check (before planning)
+
+Before writing a single line of test code, establish that you understand the feature well
+enough to specify it. Use `TDD_CONFIG.confidence` as the threshold (default: 100%).
+
+**Step 1 — Parallel information gathering.** Do both simultaneously:
+
+- **Search the codebase**: look for existing related components, interfaces, data models,
+  route definitions, API contracts, and any existing tests that touch adjacent functionality.
+  In Claude Code, use `Glob`, `Grep`, and `Read` tools to search systematically.
+  In Claude.ai, ask the user to paste relevant file contents if needed.
+
+- **Ask the user**: identify what's genuinely ambiguous and cannot be inferred from code.
+  Ask all open questions in a single grouped message — never ask one question at a time
+  across multiple exchanges. Be specific: bad → "tell me more about this feature",
+  good → "Does the card deletion cascade to transactions, or is it blocked if transactions exist?"
+
+**Step 2 — Score your confidence.** After gathering, rate yourself honestly:
+
+```
+Confidence check:
+- What I know for certain (from code + user): [list]
+- What I'm inferring (reasonable assumption, low risk): [list]
+- What's still ambiguous (blocks test accuracy): [list]
+- Current confidence: X%
+```
+
+**Step 3 — Gate.**
+- If confidence ≥ `TDD_CONFIG.confidence`: state it and proceed to Phase 1.
+- If confidence < `TDD_CONFIG.confidence`: repeat Step 1 with more targeted questions/searches.
+  Do not proceed until the threshold is met.
+
+**At confidence < 100%**, document your assumptions explicitly before proceeding:
+`Proceeding at 85% confidence. Assuming: [X, Y, Z]. Will surface if these prove wrong.`
+
+---
+
+### Phase 1 — Plan (before writing anything)
+
+1. Identify the **unit of work**: what exactly needs to exist or change?
+2. Detect the **task type**:
+   - **new feature** → standard RED→GREEN→REFACTOR
+   - **refactor/legacy** → characterization mode (see below)
+   - **bug fix** → write a test that reproduces the bug first, then fix
+3. Identify **test surface**: unit, integration, E2E, AI eval — which apply?
+4. Identify **dependencies** to mock (external APIs, DB, auth, LLM calls).
+5. State the **exit condition**: what does "done" look like?
+
+If `TDD_CONFIG.test_mode = strict`: list each test case you plan to write, one per line.
+You will implement them one at a time — do not write the next test until the current one is green and refactored.
+
+If `TDD_CONFIG.test_mode = batch`: write out the full test plan for the feature upfront,
+then proceed to write all tests before any implementation.
+
+Write a one-paragraph plan before starting. Do not skip this even for small tasks.
+
+---
+
+### Characterization Mode (refactor/legacy tasks)
+
+When the task is to refactor existing code rather than add new behavior:
+
+1. **Write characterization tests first** — tests that capture *current* behavior as-is,
+   even if that behavior is imperfect. These become your safety net.
+2. Run them — they should pass immediately (you're documenting reality, not specifying ideals).
+3. Now refactor freely. Tests catch regressions.
+4. Only after refactor is stable: evaluate whether any behaviors should change, and write new tests for those.
+
+**Do NOT skip characterization tests.** Refactoring without them is flying blind.
+
+---
+
+### 🔴 Phase 2 — Write Test(s)
+
+**If `test_mode = strict`:** Write exactly ONE test. Choose the most important behavior first
+(usually the happy path). Do not write the edge case or failure mode tests yet.
+
+**If `test_mode = batch`:** Write the full test suite for the feature — happy path,
+edge cases, failure modes — before writing any implementation.
+
+For every test:
+- Name it as a specification: `"should return 401 when token is expired"`
+- Test observable behavior through public interfaces, not implementation details
+- A good test reads like a requirement: `"user can checkout with valid cart"`
+- Mock external dependencies; never call real APIs or DBs in unit/integration tests
+- For Playwright: test user-visible behavior only
+
+See `references/test-patterns.md` for per-framework boilerplate.
+
+**DO NOT proceed to Phase 3 until test(s) are written and saved.**
+
+---
+
+### 🔴 Phase 3 — Verify RED
+
+Run the test suite. Capture full output.
+
+```bash
+# Frontend (unit/component)
+npx vitest run --reporter=verbose
+
+# Java/Spring
+./mvnw test -pl <module> 2>&1
+
+# Node
+npx jest --verbose 2>&1
+
+# Playwright — headed during local dev only
+# Local (display available):
+npx playwright test --headed --reporter=line 2>&1
+
+# CI / container / headless:
+npx playwright test --reporter=line 2>&1
+```
+
+**Playwright headed vs headless:**
+- Use `--headed` only when a display server is available (local machine, not CI/Docker)
+- In CI, always omit `--headed` — it will fail without a display
+- Claude Code in a container: use headless, or prefix with `xvfb-run` if display is needed
+
+After a Playwright RED run, confirm:
+- The page loaded as expected
+- The element/interaction you're testing is present
+- The failure is in the assertion, not a setup/navigation error
+
+**Expected state: tests FAIL.** This confirms they actually test something real.
+
+🚨 **Vacuous test check** — if a newly written test passes immediately:
+- Stop. Do NOT proceed to implementation.
+- Diagnose: does the test assert anything meaningful? Is it testing the right thing?
+- A test that always passes is worse than no test — it creates false confidence.
+- Fix the test until it genuinely fails, or delete it and write a better one.
+
+**DO NOT proceed to Phase 4 until you have confirmed test failure output in hand.**
+
+---
+
+### 🟢 Phase 4 — Implement
+
+Write the **minimum** code to make the failing test(s) pass.
+
+Rules:
+- Write only what the test requires. Nothing speculative. No "nice to haves".
+- Do not add untested behavior.
+- Follow project conventions and existing code style.
+- **If tests fail: fix the implementation, NEVER rewrite the test to make it pass.**
+  Rewriting tests to pass is the cardinal sin of TDD — it defeats the entire purpose.
+
+**DO NOT proceed to Phase 5 until implementation code is written.**
+
+---
+
+### 🟢 Phase 5 — Verify GREEN
+
+Run tests again. Three outcomes:
+
+| Outcome | Action |
+|---|---|
+| ✅ All pass | Proceed to Phase 6 |
+| ❌ Same failures | Re-examine implementation — fix the **code**, not the tests |
+| ❌ New failures | Regression introduced — fix before continuing |
+
+**Max iterations: `TDD_CONFIG.max_iterations`.** If still failing, surface the blocker:
+- What was attempted
+- Exact test output
+- Hypothesis for root cause
+- Proposed next step
+
+**DO NOT proceed to Phase 6 until all tests are green.**
+
+---
+
+### 🔵 Phase 6 — Refactor
+
+With green tests as a safety net:
+- Remove duplication
+- Improve naming
+- Tighten types (TypeScript: no `any`, no suppressed errors)
+- Extract reusable logic if it would benefit other parts of the codebase
+- Keep components thin — business logic belongs in services/composables, not components
+
+Run tests after refactor to confirm still green.
+
+**If `test_mode = strict` and more test cases remain from the plan:**
+→ Loop back to Phase 2 with the next test case. Do not stop until all planned tests are implemented.
+
+**If `test_mode = batch` or all planned tests are done:**
+→ Proceed to Phase 7.
+
+---
+
+### Phase 7 — AI Output Evals (when applicable)
+
+When the feature involves LLM calls or AI-generated content, add an eval layer.
+If `TDD_CONFIG.ai_evals = in-loop`: run evals now as part of this cycle.
+If `TDD_CONFIG.ai_evals = separate`: note that evals should be run on PR merge/nightly.
+See `references/ai-evals.md` for the LLM-as-judge harness pattern.
+
+---
+
+## Monorepo Support
+
+When the project has multiple packages with different test runners:
+
+1. **Detect structure**: look for `packages/`, `apps/`, `services/` directories, or
+   `nx.json` / `turbo.json` workspace configs.
+2. **Map runner to package**: each package may have its own `package.json` / `pom.xml`
+   and test config. Ask the user which package the feature belongs to if unclear.
+3. **Scope test runs**: always run tests scoped to the affected package, not the whole repo.
+
+```bash
+# npm workspaces / Turborepo
+npx turbo test --filter=@myapp/cards-service
+
+# Nx
+npx nx test cards-service
+
+# Maven multi-module
+./mvnw test -pl cards-service
+
+# Yarn workspaces
+yarn workspace @myapp/cards-service test
+```
+
+4. **Cross-package changes**: if the change touches a shared package, run tests for all
+   dependents. In Claude Code, use `Grep` to find imports of the changed module.
+
+---
+
+## Test Quality Rules
+
+These apply across all frameworks:
+
+1. **One assertion per test** (or tightly related group) — tests should fail for one reason
+2. **Deterministic** — no random data, no real time dependencies, no network calls
+3. **Fast** — unit tests < 100ms, integration < 2s, E2E tagged separately
+4. **Named as specs** — test name should read as documentation
+5. **No test logic** — no conditionals or loops inside tests; split into separate cases
+6. **Coverage target**: `TDD_CONFIG.coverage`% line coverage minimum; 100% on critical paths (auth, payments, data mutations)
+
+---
+
+## Reporting
+
+After each completed loop, output a summary block:
+
+```
+## TDD Loop Summary
+- Feature: <what was built>
+- Confidence at start: <X%> (assumptions made: <list or "none">)
+- Tests written: <N> (<unit/integration/E2E/Playwright breakdown>)
+- Browsers tested: <list from TDD_CONFIG.browsers>
+- Iterations: <N>
+- Coverage delta: <before% → after%> (if measurable)
+- Refactors applied: <list or "none">
+- Open items: <any deferred tests or known gaps>
+- Assumptions validated: <did any assumptions from confidence check prove wrong?>
+```
+
+---
+
+## Blockers Protocol
+
+Stop and surface to user when:
+- Confidence threshold cannot be reached despite codebase search + user questions
+- Test environment is broken (missing config, wrong Node/Java version, port conflict)
+- Playwright: browser won't launch, `baseURL` is unreachable (app not running), or `--headed` fails due to missing display
+- Ambiguous requirement — test can't be written without a decision
+- External dependency unavailable and can't be mocked meaningfully
+- `TDD_CONFIG.max_iterations` hit without green
+- A test passes immediately on first write and no fix makes it genuinely fail (broken test premise)
+- Monorepo: unclear which package owns the feature
+
+State: what was tried, what failed, what you need. Never silently skip a phase.
+
+---
+
+## Reference Files
+
+- `references/test-patterns.md` — Boilerplate for all frameworks (Vitest, JUnit 5, Jest, Playwright)
+- `references/ai-evals.md` — LLM-as-judge eval harness pattern
+- `references/claude-code-agents.md` — Subagent files for Claude Code phase isolation (copy to `.claude/agents/`)

--- a/skills/tdd-loop/references/ai-evals.md
+++ b/skills/tdd-loop/references/ai-evals.md
@@ -1,0 +1,154 @@
+# AI Output Evals — LLM-as-Judge Harness
+
+Use this when testing features that produce AI-generated content (summaries, suggestions,
+structured extractions, chat responses, etc.).
+
+---
+
+## When to use
+
+- Feature calls the Anthropic API (or any LLM) and returns generated text
+- Output quality can't be verified with a simple equality check
+- You need to assert things like: "response is relevant", "tone is appropriate",
+  "extracted fields are correct", "no hallucinated data"
+
+---
+
+## Pattern: LLM-as-Judge
+
+Run your feature → capture LLM output → send to a judge prompt → assert on the judgment.
+
+```typescript
+// eval-judge.ts
+import Anthropic from '@anthropic-ai/sdk'
+
+interface JudgeResult {
+  pass: boolean
+  score: number        // 0–10
+  reasoning: string
+}
+
+export async function judgeOutput(
+  input: string,
+  output: string,
+  criteria: string
+): Promise<JudgeResult> {
+  const client = new Anthropic()
+
+  const response = await client.messages.create({
+    model: 'claude-sonnet-4-20250514',
+    max_tokens: 512,
+    messages: [{
+      role: 'user',
+      content: `You are an evaluator. Score the following output strictly.
+
+INPUT:
+${input}
+
+OUTPUT:
+${output}
+
+CRITERIA:
+${criteria}
+
+Respond with JSON only:
+{
+  "pass": true|false,
+  "score": 0-10,
+  "reasoning": "one sentence"
+}`
+    }]
+  })
+
+  const text = (response.content[0] as { text: string }).text
+  return JSON.parse(text.replace(/```json|```/g, '').trim())
+}
+```
+
+---
+
+## Example: Jest eval test
+
+```typescript
+import { judgeOutput } from '../eval/eval-judge'
+import { summarizeCard } from '../features/card-summary'
+
+describe('Card summary AI eval', () => {
+  it('should produce a concise, accurate summary', async () => {
+    const input = { name: 'Visa Platinum', last4: '1234', issuer: 'Chase', rewards: '2x travel' }
+    const output = await summarizeCard(input)
+
+    const result = await judgeOutput(
+      JSON.stringify(input),
+      output,
+      'The summary must mention the card name and rewards rate. Must be under 30 words. No hallucinated details.'
+    )
+
+    expect(result.pass).toBe(true)
+    expect(result.score).toBeGreaterThanOrEqual(7)
+  }, TDD_CONFIG.ai_eval_timeout)
+})
+```
+
+---
+
+## Determinism note
+
+LLM judge calls are non-deterministic. To handle variance:
+- Run each eval **3 times**, take majority vote on `pass`
+- Log all `reasoning` strings for manual review on failure
+- Use `temperature: 0` on the judge call for consistency
+
+```typescript
+async function judgeWithMajority(
+  input: string, output: string, criteria: string, runs = 3
+): Promise<JudgeResult> {
+  const results = await Promise.all(
+    Array.from({ length: runs }, () => judgeOutput(input, output, criteria))
+  )
+  const passes = results.filter(r => r.pass).length
+  const avgScore = results.reduce((sum, r) => sum + r.score, 0) / runs
+  return {
+    pass: passes > runs / 2,
+    score: avgScore,
+    reasoning: results.map(r => r.reasoning).join(' | ')
+  }
+}
+```
+
+---
+
+## Criteria writing guide
+
+Good criteria are **specific and falsifiable**:
+
+| ❌ Vague | ✅ Specific |
+|---|---|
+| "Response is good" | "Response answers the user's question and stays under 100 words" |
+| "Tone is appropriate" | "Tone is professional, no slang, no exclamation marks" |
+| "No hallucinations" | "All card names mentioned must appear in the input data" |
+| "Structured correctly" | "JSON output contains fields: id, name, amount — all non-null" |
+
+---
+
+## Running evals in CI
+
+Tag AI eval tests to run separately from unit/integration:
+
+```typescript
+// jest.config.ts
+projects: [
+  { displayName: 'unit', testMatch: ['**/*.test.ts'] },
+  { displayName: 'ai-evals', testMatch: ['**/*.eval.ts'], testTimeout: 30000 }
+]
+```
+
+```yaml
+# GitHub Actions
+- name: Run AI evals
+  run: npx jest --selectProjects ai-evals
+  env:
+    ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+Keep AI evals out of the hot loop (they're slow and cost money). Run on PR merge or nightly.

--- a/skills/tdd-loop/references/claude-code-agents.md
+++ b/skills/tdd-loop/references/claude-code-agents.md
@@ -1,0 +1,156 @@
+# Claude Code Agent Files
+
+Create these files in your project at `.claude/agents/` to enable subagent phase isolation.
+Copy-paste as-is — adjust the test runner commands to match your project.
+
+---
+
+## .claude/agents/tdd-test-writer.md
+
+```markdown
+---
+name: tdd-test-writer
+description: TDD RED phase agent. Writes failing tests only. Never writes implementation code.
+tools: Read, Glob, Grep, Write, Edit, Bash
+---
+
+# TDD Test Writer — RED Phase Only
+
+Your only job: write a failing test and confirm it fails. Nothing else.
+
+## Process
+
+1. Read the feature requirement from the prompt
+2. Use Glob/Grep to find related existing tests and interfaces
+3. Write ONE test (strict mode) or full suite (batch mode) in the appropriate test directory
+4. Run the test suite to confirm failure
+5. Return: test file path + exact failure output
+
+## Rules
+
+- Write tests that describe behavior, not implementation
+- Name tests as specifications: "should return 404 when user not found"
+- Mock all external dependencies
+- NEVER write implementation code
+- If test passes immediately: stop, diagnose, rewrite until it genuinely fails
+
+## Return Format
+
+```
+Test written: <path>
+Failure confirmed:
+<exact test output showing failure>
+Summary: <one sentence of what the test verifies>
+```
+```
+
+---
+
+## .claude/agents/tdd-implementer.md
+
+```markdown
+---
+name: tdd-implementer
+description: TDD GREEN phase agent. Writes minimum implementation to pass failing tests. Never modifies tests.
+tools: Read, Glob, Grep, Write, Edit, Bash
+---
+
+# TDD Implementer — GREEN Phase Only
+
+Your only job: make the failing test pass with minimum code. Nothing else.
+
+## Process
+
+1. Read the failing test file provided in the prompt
+2. Understand what behavior it expects
+3. Write the minimum implementation to satisfy it
+4. Run the test suite to confirm passing
+5. Return: files modified + exact passing output
+
+## Rules
+
+- Write ONLY what the test requires — no extras, no speculative code
+- NEVER modify test files — if the test seems wrong, report it, don't fix it
+- NEVER add untested behavior
+- If tests still fail after N attempts: report blocker with diagnosis
+
+## Return Format
+
+```
+Files modified: <list>
+Tests passing:
+<exact test output showing green>
+Implementation summary: <what was added/changed>
+```
+```
+
+---
+
+## .claude/agents/tdd-refactorer.md
+
+```markdown
+---
+name: tdd-refactorer
+description: TDD REFACTOR phase agent. Improves code quality while keeping tests green. Makes the decision whether refactoring is needed.
+tools: Read, Glob, Grep, Write, Edit, Bash
+---
+
+# TDD Refactorer — REFACTOR Phase Only
+
+Your job: evaluate the implementation for refactoring opportunities and apply improvements
+while keeping all tests passing.
+
+## Process
+
+1. Read the implementation files and test files
+2. Evaluate against the checklist below
+3. Apply improvements if warranted
+4. Run tests to confirm still green
+5. Return summary of changes OR "no refactoring needed" with reasoning
+
+## Refactoring Checklist
+
+- Duplication: repeated code that could be extracted
+- Naming: variables/functions whose names obscure intent
+- Component size: business logic that belongs in services, not components
+- Type safety: `any` types, missing generics, suppressed errors (TS)
+- Reusability: logic that could benefit other parts of the codebase
+
+## Decision Criteria
+
+Refactor when: clear duplication, misleading names, reusable logic trapped in one place
+Skip when: implementation is already minimal and focused, changes would be over-engineering
+
+## Return Format
+
+If changes made:
+```
+Refactored: <files changed>
+Changes: <what was improved and why>
+Tests: still passing ✅
+```
+
+If no changes:
+```
+No refactoring needed: <brief reason>
+Tests: still passing ✅
+```
+```
+
+---
+
+## Installation
+
+```bash
+mkdir -p .claude/agents
+# copy the three files above into .claude/agents/
+```
+
+Then verify Claude Code can see them:
+```bash
+ls .claude/agents/
+# tdd-test-writer.md  tdd-implementer.md  tdd-refactorer.md
+```
+
+The orchestrating skill (this skill) will spawn these agents automatically via `Task()` calls
+during the RED, GREEN, and REFACTOR phases.

--- a/skills/tdd-loop/references/test-patterns.md
+++ b/skills/tdd-loop/references/test-patterns.md
@@ -1,0 +1,291 @@
+# Test Patterns Reference
+
+Per-framework boilerplate for the TDD loop.
+
+---
+
+## React + TypeScript (Vitest + React Testing Library)
+
+### Component test
+
+```typescript
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { MyComponent } from './MyComponent'
+
+describe('MyComponent', () => {
+  it('should display error message when submission fails', async () => {
+    const onSubmit = vi.fn().mockRejectedValueOnce(new Error('Network error'))
+    render(<MyComponent onSubmit={onSubmit} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /submit/i }))
+
+    expect(await screen.findByText(/something went wrong/i)).toBeInTheDocument()
+  })
+})
+```
+
+### Hook test
+
+```typescript
+import { renderHook, act } from '@testing-library/react'
+import { useMyHook } from './useMyHook'
+
+it('should toggle state on call', () => {
+  const { result } = renderHook(() => useMyHook())
+  expect(result.current.active).toBe(false)
+  act(() => result.current.toggle())
+  expect(result.current.active).toBe(true)
+})
+```
+
+### Mocking modules
+
+```typescript
+vi.mock('../api/client', () => ({
+  fetchUser: vi.fn().mockResolvedValue({ id: '1', name: 'Test User' })
+}))
+```
+
+---
+
+## Java / Spring Boot (JUnit 5 + Mockito + AssertJ)
+
+### Service unit test
+
+```java
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    void shouldThrowNotFoundWhenUserDoesNotExist() {
+        when(userRepository.findById("missing-id")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userService.getUser("missing-id"))
+            .isInstanceOf(UserNotFoundException.class)
+            .hasMessageContaining("missing-id");
+    }
+}
+```
+
+### Controller slice test
+
+```java
+@WebMvcTest(UserController.class)
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserService userService;
+
+    @Test
+    void shouldReturn401WhenTokenIsExpired() throws Exception {
+        mockMvc.perform(get("/api/users/me")
+                .header("Authorization", "Bearer expired-token"))
+            .andExpect(status().isUnauthorized());
+    }
+}
+```
+
+### Repository slice test
+
+```java
+@DataJpaTest
+class UserRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void shouldFindUserByEmail() {
+        userRepository.save(new User("test@example.com", "Test User"));
+        Optional<User> found = userRepository.findByEmail("test@example.com");
+        assertThat(found).isPresent();
+        assertThat(found.get().getName()).isEqualTo("Test User");
+    }
+}
+```
+
+---
+
+## Node.js / Express (Jest + Supertest)
+
+### Route integration test
+
+```typescript
+import request from 'supertest'
+import { app } from '../app'
+import { db } from '../db'
+
+jest.mock('../db')
+
+describe('POST /api/cards', () => {
+  it('should return 201 with created card', async () => {
+    (db.create as jest.Mock).mockResolvedValueOnce({ id: 'card-1', name: 'Visa' })
+
+    const res = await request(app)
+      .post('/api/cards')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ name: 'Visa', last4: '1234' })
+
+    expect(res.status).toBe(201)
+    expect(res.body.id).toBe('card-1')
+  })
+
+  it('should return 400 when name is missing', async () => {
+    const res = await request(app)
+      .post('/api/cards')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ last4: '1234' })
+
+    expect(res.status).toBe(400)
+  })
+})
+```
+
+### Service unit test
+
+```typescript
+import { CardService } from './CardService'
+
+const mockRepo = { save: jest.fn(), findById: jest.fn() }
+const service = new CardService(mockRepo as any)
+
+it('should throw when card limit exceeded', async () => {
+  mockRepo.findById.mockResolvedValue(null)
+  jest.spyOn(service, 'countByUser').mockResolvedValue(10)
+
+  await expect(service.createCard('user-1', { name: 'Amex' }))
+    .rejects.toThrow('Card limit exceeded')
+})
+```
+
+---
+
+## Playwright (TypeScript)
+
+### Page interaction test
+
+```typescript
+import { test, expect } from '@playwright/test'
+
+test('user can add a card and see it in the list', async ({ page }) => {
+  await page.goto('/cards')
+  await page.getByRole('button', { name: 'Add Card' }).click()
+  await page.getByLabel('Card name').fill('Visa Platinum')
+  await page.getByRole('button', { name: 'Save' }).click()
+
+  await expect(page.getByText('Visa Platinum')).toBeVisible()
+})
+```
+
+### Auth setup (reusable storage state)
+
+```typescript
+// auth.setup.ts
+import { test as setup } from '@playwright/test'
+
+setup('authenticate', async ({ page }) => {
+  await page.goto('/login')
+  await page.getByLabel('Email').fill(process.env.TEST_EMAIL!)
+  await page.getByLabel('Password').fill(process.env.TEST_PASSWORD!)
+  await page.getByRole('button', { name: 'Sign in' }).click()
+  await page.waitForURL('/dashboard')
+  await page.context().storageState({ path: 'playwright/.auth/user.json' })
+})
+```
+
+### API mock within Playwright
+
+```typescript
+test('shows error banner when API fails', async ({ page }) => {
+  await page.route('**/api/cards', route =>
+    route.fulfill({ status: 500, body: 'Internal Server Error' })
+  )
+  await page.goto('/cards')
+  await expect(page.getByRole('alert')).toContainText('Unable to load cards')
+})
+```
+
+---
+
+## Config snippets
+
+### vitest.config.ts
+
+```typescript
+import { defineConfig } from 'vitest/config'
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./src/test/setup.ts'],
+    coverage: { reporter: ['text', 'lcov'], threshold: { lines: 80 } }
+  }
+})
+```
+
+### playwright.config.ts (projects pattern — driven by TDD_CONFIG.browsers)
+
+```typescript
+import { defineConfig, devices } from '@playwright/test'
+
+// Projects to include depend on TDD_CONFIG.browsers set during skill configuration:
+// chromium               → projects: [chromium]
+// chromium+firefox       → projects: [chromium, firefox]
+// chromium+firefox+webkit → projects: [chromium, firefox, webkit]
+
+export default defineConfig({
+  testDir: './e2e',
+  // headed=true during development (RED/GREEN phases), false for CI
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+    // Override per run: npx playwright test --headed
+  },
+  projects: [
+    { name: 'setup', testMatch: /auth\.setup\.ts/ },
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'], storageState: 'playwright/.auth/user.json' },
+      dependencies: ['setup'],
+    },
+    // Uncomment based on TDD_CONFIG.browsers:
+    // {
+    //   name: 'firefox',
+    //   use: { ...devices['Desktop Firefox'], storageState: 'playwright/.auth/user.json' },
+    //   dependencies: ['setup'],
+    // },
+    // {
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'], storageState: 'playwright/.auth/user.json' },
+    //   dependencies: ['setup'],
+    // },
+  ],
+  // Development: run headed to visually verify behavior
+  // CI: omit --headed flag; headless is the default
+})
+```
+
+### Playwright headed run commands (for RED/GREEN development phases)
+
+```bash
+# Run specific test file headed in chromium
+npx playwright test e2e/cards.spec.ts --headed --project=chromium
+
+# Run all UI tests headed across configured browsers
+npx playwright test --headed
+
+# Run with UI mode (interactive, best for debugging failures)
+npx playwright test --ui
+
+# Show test report after run
+npx playwright show-report
+```


### PR DESCRIPTION
## Add `tdd-loop` skill

### What it does
Enforces a strict Test-Driven Development loop automatically — no need to 
remind Claude to write tests first. Every time you ask Claude to implement, 
fix, or change code, it:

1. Runs a **confidence check** before writing any test (unique mechanism — 
   Claude scores its own understanding 0–100% and gates on your threshold)
2. Writes tests first — never implementation first
3. Confirms tests fail (vacuous test guard)
4. Implements the minimum code to pass
5. Refactors with tests as a safety net
6. Loops until everything is green

### Stack support
React/TypeScript (Vitest + RTL), Java/Spring Boot (JUnit 5 + Mockito), 
Node.js/Express (Jest + Supertest), Playwright (multi-browser E2E), 
Python/pytest, Go — auto-detected from project config files.

### Claude Code extras
- Subagent phase isolation via `Task()` (test writer never sees implementation)
- PostToolUse hook for auto-running tests after every file save
- Config persisted to `CLAUDE.md` across sessions
- Monorepo support (Turborepo, Nx, Maven multi-module)

### Gap this fills
There is an existing `webapp-testing` skill for Playwright, but no skill 
that enforces TDD as a development loop. This works alongside `webapp-testing`.

### Files
- `SKILL.md` — main skill with full 7-phase loop
- `references/test-patterns.md` — per-framework boilerplate
- `references/ai-evals.md` — LLM-as-judge harness for AI output testing
- `references/claude-code-agents.md` — subagent files for Claude Code

### License
Apache 2.0