### PR TITLE
fix(skill-creator): eval-viewer HTML breakout + metadata search depth

### DIFF
--- a/skills/skill-creator/eval-viewer/generate_review.py
+++ b/skills/skill-creator/eval-viewer/generate_review.py
@@ -88,7 +88,7 @@ def build_run(root: Path, run_dir: Path) -> dict | None:
     eval_id = None
 
     # Try eval_metadata.json
-    for candidate in [run_dir / "eval_metadata.json", run_dir.parent / "eval_metadata.json"]:
+    for candidate in [run_dir / "eval_metadata.json", run_dir.parent / "eval_metadata.json", run_dir.parent.parent / "eval_metadata.json"]:
         if candidate.exists():
             try:
                 metadata = json.loads(candidate.read_text())
@@ -276,7 +276,7 @@ def generate_html(
     if benchmark:
         embedded["benchmark"] = benchmark
 
-    data_json = json.dumps(embedded)
+    data_json = json.dumps(embedded).replace("</", r"<\/")
 
     return template.replace("/*__EMBEDDED_DATA__*/", f"const EMBEDDED_DATA = {data_json};")
 


### PR DESCRIPTION
## Summary

Two bugs in `skills/skill-creator/eval-viewer/generate_review.py`:

- **HTML breakout via `</script>` in user content.** `json.dumps()` doesn't escape `/`, so when eval outputs contain `</script>` (common in code samples showing gtag.js, GTM snippets, etc.), the embedded `<script>` block terminates prematurely, corrupting the entire viewer. Fix: `.replace("</", r"<\/")` after `json.dumps()` — valid JSON per RFC 8259 §7, standard XSS-safe-embed pattern.

- **`eval_metadata.json` not found at canonical depth.** The viewer searches `run_dir` and `run_dir.parent` for metadata, but the workspace layout documented in SKILL.md places it at `eval-N/eval_metadata.json` — two levels above `eval-N/with_skill/run-1/`. All prompts render as "(No prompt found)". Fix: add `run_dir.parent.parent` to the search path.

## Test plan

- [x] Generated eval viewer with code-sample outputs containing literal `</script>` — renders correctly after fix
- [x] Prompts now populate from `eval_metadata.json` at the `eval-N/` level
- [x] Verified `<\/` round-trips through `JSON.parse()` identically to `</` (RFC 8259 permits both)

🤖 Generated with [Claude Code](https://claude.com/claude-code)