### PR TITLE
skill-creator: recommend quoting description for strict YAML parsers

### DIFF
--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -83,6 +83,22 @@ skill-name/
     └── assets/     - Files used in output (templates, icons, fonts)
 ```
 
+#### Frontmatter YAML
+
+The `name` and `description` fields are parsed as YAML. Parsers vary in
+strictness: Claude Code is lenient, but stricter parsers (e.g. Codex) reject
+descriptions that contain an unquoted `:`, which is common in natural prose
+(`Use when: ...`, `X: Y`). To stay portable across tools, wrap the
+`description` value in single quotes and escape literal apostrophes by
+doubling them:
+
+```yaml
+---
+name: my-skill
+description: 'Does X. Use when: the user needs Y, or asks about Z. Don''t trigger for W.'
+---
+```
+
 #### Progressive Disclosure
 
 Skills use a three-level loading system:


### PR DESCRIPTION
## Problem

SKILL.md files authored following `skill-creator` often end up with an unquoted `description:` value containing `:` (e.g. `Use when: ...`, `X: Y`). Claude Code's YAML parser is lenient and accepts this, but stricter parsers (Codex CLI) reject the file with `mapping values are not allowed in this context`, and the skill is silently skipped at load time.

In our repo, 6 skills broke this way before we noticed, because nothing in the authoring loop surfaces the incompatibility.

## Change

Add a short "Frontmatter YAML" subsection under "Anatomy of a Skill" that:

- Notes that `name` / `description` are YAML, and parsers differ in strictness.
- Recommends wrapping `description` in single quotes.
- Shows how to escape literal apostrophes (`''`).

## Why in skill-creator

This is the skill Claude follows when authoring new skills, so the guidance has to live here to prevent the footgun from being reintroduced by future runs.