### PR TITLE
fix: remove unnecessary f-string prefixes and unused imports

### DIFF
--- a/skills/pdf/scripts/extract_form_structure.py
+++ b/skills/pdf/scripts/extract_form_structure.py
@@ -102,7 +102,7 @@ def main():
     with open(output_path, "w") as f:
         json.dump(structure, f, indent=2)
 
-    print(f"Found:")
+    print("Found:")
     print(f"  - {len(structure['pages'])} pages")
     print(f"  - {len(structure['labels'])} text labels")
     print(f"  - {len(structure['lines'])} horizontal lines")

--- a/skills/skill-creator/eval-viewer/generate_review.py
+++ b/skills/skill-creator/eval-viewer/generate_review.py
@@ -447,8 +447,8 @@ def main() -> None:
         port = server.server_address[1]
 
     url = f"http://localhost:{port}"
-    print(f"\n  Eval Viewer")
-    print(f"  ─────────────────────────────────")
+    print("\n  Eval Viewer")
+    print("  ─────────────────────────────────")
     print(f"  URL:       {url}")
     print(f"  Workspace: {workspace}")
     print(f"  Feedback:  {feedback_path}")
@@ -456,7 +456,7 @@ def main() -> None:
         print(f"  Previous:  {args.previous_workspace} ({len(previous)} runs)")
     if benchmark_path:
         print(f"  Benchmark: {benchmark_path}")
-    print(f"\n  Press Ctrl+C to stop.\n")
+    print("\n  Press Ctrl+C to stop.\n")
 
     webbrowser.open(url)
 

--- a/skills/skill-creator/scripts/aggregate_benchmark.py
+++ b/skills/skill-creator/scripts/aggregate_benchmark.py
@@ -389,7 +389,7 @@ def main():
     configs = [k for k in run_summary if k != "delta"]
     delta = run_summary.get("delta", {})
 
-    print(f"\nSummary:")
+    print("\nSummary:")
     for config in configs:
         pr = run_summary[config]["pass_rate"]["mean"]
         label = config.replace("_", " ").title()

--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -4,7 +4,6 @@ Quick validation script for skills - minimal version
 """
 
 import sys
-import os
 import re
 import yaml
 from pathlib import Path

--- a/skills/skill-creator/scripts/run_loop.py
+++ b/skills/skill-creator/scripts/run_loop.py
@@ -188,7 +188,7 @@ def run_loop(
 
         # Improve the description based on train results
         if verbose:
-            print(f"\nImproving description...", file=sys.stderr)
+            print("\nImproving description...", file=sys.stderr)
 
         t0 = time.time()
         # Strip test scores from history so improvement model can't see them

--- a/skills/slack-gif-creator/core/frame_composer.py
+++ b/skills/slack-gif-creator/core/frame_composer.py
@@ -8,7 +8,6 @@ together to create animation frames.
 
 from typing import Optional
 
-import numpy as np
 from PIL import Image, ImageDraw, ImageFont
 
 

--- a/skills/slack-gif-creator/core/gif_builder.py
+++ b/skills/slack-gif-creator/core/gif_builder.py
@@ -7,7 +7,6 @@ generated frames, with automatic optimization for Slack's requirements.
 """
 
 from pathlib import Path
-from typing import Optional
 
 import imageio.v3 as imageio
 import numpy as np
@@ -247,7 +246,7 @@ class GIFBuilder:
         }
 
         # Print info
-        print(f"\n✓ GIF created successfully!")
+        print("\n✓ GIF created successfully!")
         print(f"  Path: {output_path}")
         print(f"  Size: {file_size_kb:.1f} KB ({file_size_mb:.2f} MB)")
         print(f"  Dimensions: {self.width}x{self.height}")
@@ -257,7 +256,7 @@ class GIFBuilder:
 
         # Size info
         if optimize_for_emoji:
-            print(f"  Optimized for emoji (128x128, reduced colors)")
+            print("  Optimized for emoji (128x128, reduced colors)")
         if file_size_mb > 1.0:
             print(f"\n  Note: Large file size ({file_size_kb:.1f} KB)")
             print("  Consider: fewer frames, smaller dimensions, or fewer colors")

--- a/skills/slack-gif-creator/core/validators.py
+++ b/skills/slack-gif-creator/core/validators.py
@@ -113,7 +113,7 @@ def validate_gif(
             )
 
         if size_mb > 5.0:
-            print(f"  Note: Large file size - consider fewer frames/colors")
+            print("  Note: Large file size - consider fewer frames/colors")
 
     return dim_pass, results
 

--- a/skills/webapp-testing/examples/console_logging.py
+++ b/skills/webapp-testing/examples/console_logging.py
@@ -32,4 +32,4 @@ with open('/mnt/user-data/outputs/console.log', 'w') as f:
     f.write('\n'.join(console_logs))
 
 print(f"\nCaptured {len(console_logs)} console messages")
-print(f"Logs saved to: /mnt/user-data/outputs/console.log")
+print("Logs saved to: /mnt/user-data/outputs/console.log")


### PR DESCRIPTION
## Summary
- Remove `f` prefix from 9 strings that contain no `{...}` placeholders (ruff F541) across 5 files
- Remove unused imports: `os` from `quick_validate.py`, `numpy` from `frame_composer.py`, `Optional` from `gif_builder.py` (ruff F401)

All fixes are safe, mechanical lint cleanup flagged by [ruff](https://docs.astral.sh/ruff/).

Found by [HUMMBL Arbiter](https://hummbl.io/audit) — deterministic code quality scoring for Python repositories.