### PR TITLE
Add cost-estimate skill

### DIFF
--- a/skills/cost-estimate/SKILL.md
+++ b/skills/cost-estimate/SKILL.md
@@ -1,0 +1,363 @@
+---
+name: cost-estimate
+description: Estimates what a codebase would have cost to build with a traditional human team — the replacement cost to rebuild, not market value. Use when the user asks "how much did this cost?", "what's the ROI of Claude/Copilot on this repo?", "how long would a human team have taken?", or mentions COCOMO, LOCOMO, Function Points, LOC analysis, or codebase cost. Produces P10/P50/P90 ranges with a four-way cross-check (bottom-up × COCOMO II × Function Points × LOCOMO), real Claude-session token costs, market-rate research, org overhead, and a machine-readable artifact.
+---
+
+# Cost Estimate Skill
+
+You are a senior software engineering consultant producing a defensible cost estimate for the current codebase.
+
+## Philosophy (read first, do not skip)
+
+**This skill estimates "replacement cost to rebuild"** — what it would cost a traditional human team to recreate this codebase from scratch today, starting from specs that already exist. It is **NOT** market value. It is **NOT** a quote. It does **NOT** capture discovery time, failed experiments, PMF iteration, institutional knowledge, or the customer-support feedback loop that shaped what's in the code.
+
+Say this explicitly in the report — in the TL;DR, not buried. Readers (especially non-technical ones) will mistake the number for "what this codebase is worth," and the difference between those two things can be an order of magnitude in either direction.
+
+## Core invariants (read and internalize)
+
+1. **LOC is a proxy.** Ten lines of dense regex ≠ ten lines of boilerplate. Cross-validate with process signals (git history) and top-down models (COCOMO II, Function Points, LOCOMO).
+2. **Exclude anything humans didn't write.** Generated code, vendored deps, minified bundles, lockfiles, binary blobs — filter before counting.
+3. **Every number gets a range.** P10 (optimistic) / P50 (median) / P90 (pessimistic). Single-point estimates misrepresent confidence.
+4. **Two kinds of signals.** *Code signals* = LOC + complexity + quality. *Process signals* = commits, contributors, duration, churn. Use both; when they disagree, investigate.
+5. **Don't double-count.** A well-tested codebase earns a quality bump *or* a smaller integration-test overhead — not both.
+6. **Compound overheads.** Architecture, debugging, review, docs multiply sequentially on base coding time — they don't sum.
+7. **Size-aware.** Micro projects (<500 LOC) don't need 10-page reports. Macro projects (>500k LOC) need monorepo decomposition.
+8. **State your limits.** Every report lists what's counted, what's excluded, what's fragile, and what the reader should spot-check.
+
+If you catch yourself writing a single dollar figure without a range, stop and add one. If you find yourself reporting four significant figures of precision, drop to two — overly precise numbers signal false confidence.
+
+## Bundled resources (progressive disclosure)
+
+Read or execute these on demand — don't pre-load everything.
+
+**Scripts** (execute, don't read as code):
+- `scripts/resolve_outdir.py` — derives the platform-appropriate temp dir for artifacts
+- `scripts/count_loc.sh` — LOC count via cloc/tokei/scc with graceful find+wc fallback
+- `scripts/compute_dryness.py` — DRYness (ULOC/LOC) via scc
+- `scripts/git_signals.sh` — duration, commits, contributors, churn
+- `scripts/claude_token_cost.py` — ground-truth token usage + equivalent API cost from session logs
+- `scripts/git_session_clustering.py` — fallback Claude-hour estimate when session logs are absent
+
+**References** (read when the step runs):
+- `references/category-rates.md` — category LOC/hr table + quality-signal scoring (Steps 1, 3)
+- `references/cocomo-ii.md` — top-down COCOMO II (Step 4)
+- `references/function-points.md` — QSM backfiring table (Step 4a)
+- `references/locomo.md` — LLM-regeneration counterfactual (Step 4b)
+- `references/overhead-multipliers.md` — Step 5 formula
+- `references/market-rates.md` — Step 6 query templates + fallback anchors
+- `references/team-cost.md` — org overhead + team composition (Steps 7, 8)
+- `references/claude-roi.md` — session-aware ROI methodology (Step 9)
+- `references/cross-validation.md` — sensitivity + Harvard + Capers Jones (Step 10)
+
+**Assets** (used verbatim for output):
+- `assets/report-template.md` — copy into the generated Markdown report (Step 11)
+- `assets/artifact-schema.json` — shape of the JSON artifact (Step 12)
+
+---
+
+## Workflow — 12 steps
+
+Copy this checklist and check items off as you complete them:
+
+```
+- [ ] Step 0:  Pick a strategy (size-aware)
+- [ ] Step 1:  Measure the codebase (LOC, quality, stack)
+- [ ] Step 2:  Gather process signals (git)
+- [ ] Step 3:  Categorize & compute base hours (P10 / P50 / P90)
+- [ ] Step 4:  Cross-check (COCOMO II + Function Points + LOCOMO)
+- [ ] Step 5:  Apply overhead multipliers
+- [ ] Step 6:  Research market rates
+- [ ] Step 7:  Convert to calendar time
+- [ ] Step 8:  Compute full-team cost
+- [ ] Step 9:  Compute Claude ROI
+- [ ] Step 10: Sensitivity + cross-validation
+- [ ] Step 11: Generate the report
+- [ ] Step 12: Write artifacts to temp dir + print to terminal
+```
+
+---
+
+## Step 0: Pick a strategy (size-aware)
+
+Run a size sniff:
+
+```bash
+bash .claude/skills/cost-estimate/scripts/count_loc.sh
+```
+
+| Project size | Strategy | Report shape |
+|---|---|---|
+| **Micro** (<500 LOC) | Nominal estimate only | One paragraph + one line item. Skip Steps 4 (full cross-check), 8 (full team), 10 (sensitivity). Output: "~X days of senior dev work; ~$Y-Z at typical rates; confidence: low." |
+| **Small** (500 – 10k LOC) | Full methodology, short report | Keep all steps; drop Step 8 role-by-role table (keep stage totals only); single-sentence sensitivity. |
+| **Normal** (10k – 500k LOC) | Full skill, full report | All steps, all tables. Default. |
+| **Macro** (>500k LOC) | Decompose first | Break by top-level directory/service; run the full skill per subsystem; sum and report per-subsystem + aggregate. Don't categorize 500k lines in one pass. |
+
+State which strategy you chose and why at the top of the report.
+
+---
+
+## Step 1: Measure the codebase (code signals)
+
+### 1a. Count LOC
+
+```bash
+bash .claude/skills/cost-estimate/scripts/count_loc.sh
+```
+
+The script tries `cloc` → `tokei` → `scc` → `find+wc`, each with proper exclusions. Emits a single integer.
+
+### 1b. DRYness / ULOC (copy-paste deflator)
+
+```bash
+python3 .claude/skills/cost-estimate/scripts/compute_dryness.py
+```
+
+Apply a deflator to base hours (only if DRYness is known):
+
+```
+dryness_deflator = 1 − (1 − DRYness) × 0.5       # 1.0 → no change; 0.6 → 0.80×
+```
+
+If DRYness can't be computed (no `scc`), skip — don't invent a number. Note it in the report.
+
+### 1c. Explicit exclusions (do NOT count)
+
+Report these separately as "excluded LOC" for transparency: vendored deps (`node_modules/`, `vendor/`, `.venv/`, `third_party/`, `target/`, `dist/`, `build/`); generated code (`*.pb.go`, `*_pb2.py`, `*.g.dart`, `*.freezed.dart`, `*_generated.*`, OpenAPI clients, Prisma client, GraphQL types; headers like `// Code generated by …`, `@generated`, `DO NOT EDIT`); minified / bundles (`*.min.js`, `*.min.css`, sourcemaps, webpack chunks); lockfiles (`package-lock.json`, `yarn.lock`, `Cargo.lock`, `poetry.lock`, `go.sum`, `Gemfile.lock`); binary / assets (images, fonts, PDFs, videos, `*.wasm`); framework auto-migrations.
+
+### 1d. Detect quality signals
+
+See `references/category-rates.md` section 1 for the per-signal scoring table. Compute `quality_multiplier` in the range 0.7 – 1.3 (max ±30%).
+
+### 1e. Detect the stack
+
+Examine: `package.json`, `Cargo.toml`, `go.mod`, `pyproject.toml`, `Gemfile`, `pom.xml`, `build.gradle`, `Dockerfile`, `docker-compose.yml`, `.github/workflows/`, `terraform/`, `k8s/`, framework configs. Output a one-paragraph stack summary before moving on.
+
+---
+
+## Step 2: Gather process signals (git)
+
+```bash
+bash .claude/skills/cost-estimate/scripts/git_signals.sh
+```
+
+Emits `first=… last=… duration_days=… commits=… contributors=… adds=… dels=… net=… churn_ratio=…` on one line.
+
+### What the signals mean
+
+| Signal | Interpretation |
+|---|---|
+| `churn_ratio` > 2.0 | Heavy rework — add 15% to Total hours to reflect iteration cost the LOC count misses |
+| `contributor_count` ≥ 3 | Real team; coordination overhead already implicit — don't inflate further |
+| `commit_count` < 10 with >5k LOC | Likely a one-shot import; LOC may overstate bespoke work |
+| `project_duration_days` short vs LOC | Heavy AI/automation assist — flag for ROI step |
+
+### AI-authored detector
+
+```
+loc_per_day = net_adds / max(project_duration_days, 1)
+```
+
+| `loc_per_day` | Interpretation | Effect on report |
+|---|---|---|
+| < 100 | Normal human pace | No flag |
+| 100 – 500 | Productive / small team | No flag |
+| 500 – 2000 | Likely AI-assisted | Flag: "human-cost is a counterfactual, not elapsed time" |
+| 2000+ | Clearly AI-assisted / one-shot import | Flag strongly; Claude ROI leads the report |
+
+**When AI-authored**, bottom-up / COCOMO / FP numbers are *hypothetical human rebuild costs*, not what the project took in calendar time. The report must say: *"This codebase was built in [X] calendar days with AI assistance. The $[Y] figure is what a human team *would* cost to rebuild it from scratch — the actual cost-to-build was a fraction."*
+
+### Process-signal bounds check
+
+```
+process_hours ≈ commit_count × avg_commit_hours    # 0.5 (small) to 3.0 (large rewrites)
+```
+
+Use only as a bounds check: if your Step 4 total is <0.3× or >3× the process estimate, something is off (likely misclassification or excluded/generated code leaked in).
+
+---
+
+## Step 3: Categorize & calculate base hours (with ranges)
+
+Read `references/category-rates.md` for the full rate table (15 categories, Low/Mid/High LOC-per-hour) and the formula mapping LOC → P10/P50/P90 hours.
+
+Sum across categories → **Base Coding Hours (P10 / P50 / P90)**.
+
+**Per-feature breakdown**: for any top-level directory with > 5% of counted LOC, also report a sub-estimate ("what did `src/checkout/` cost?"). See the reference for the shell one-liner and table format.
+
+**Scoped mode** (`--since <commit>` or `--path <dir>`): restrict Steps 1-3 to that slice; keep every other step. See the reference.
+
+When reporting, show which files/directories fell into each category so the reader can audit the classification.
+
+---
+
+## Step 4: Cross-checks (three independent sanity checks)
+
+### 4a. COCOMO II
+
+Read `references/cocomo-ii.md` — contains the `A × KSLOC^E × EAF` formula, the 5-bucket EAF lookup, and the divergence rules vs bottom-up.
+
+**Divergence rule**: if bottom-up vs COCOMO diverges by >2×, **stop and investigate** before reporting. Likely causes: wrong category weighting, generated code leaked in, wrong E/EAF.
+
+### 4b. Function Point backfiring
+
+Read `references/function-points.md` — QSM language conversion table + hours-per-FP by domain. Gives a fourth independent number.
+
+### 4c. LOCOMO (LLM-regeneration counterfactual)
+
+Read `references/locomo.md` — answers "what would it cost an LLM to re-generate this code today?". The ratio `COCOMO_cost / LOCOMO_cost` is the human premium; flag it in Step 9.
+
+Report COCOMO, bottom-up, and LOCOMO side-by-side in a single table. Never publish LOCOMO alone.
+
+---
+
+## Step 5: Overhead multipliers (compounding, no double-count)
+
+Read `references/overhead-multipliers.md` for the exact formula. Key points:
+
+- Multiplicative, not additive.
+- If a quality signal already bumped per-LOC value in Step 1d, **use the low end** of the related overhead (tests, docs, CI) — don't double-count.
+- Stacked overhead (before `quality_multiplier`) typically falls **1.8× – 2.6×** of base. Outside that range → investigate.
+
+Apply to P10/P50/P90 each → **Total Engineering Hours (P10 / P50 / P90)**.
+
+---
+
+## Step 6: Market rates
+
+Read `references/market-rates.md` for the WebSearch query templates and the fallback anchor table. Use WebSearch for current rates. Collect 3 – 5 data points across regions (global remote / US remote / SF/NYC / specialist).
+
+Pick a **Recommended Rate** with one sentence of justification. If WebSearch is unavailable, use the anchor table and explicitly flag "rates from skill defaults, not live search".
+
+---
+
+## Step 7: Organizational overhead → calendar time
+
+Read `references/team-cost.md` — covers coding-efficiency by company stage (solo / lean / growth / enterprise / bureaucracy) and the calendar-months formula. Report across all five company types.
+
+---
+
+## Step 8: Full team cost
+
+Same reference (`references/team-cost.md`) — role ratios, rates, and stage multipliers (1.0× solo / 1.45× lean / 2.2× growth / 2.65× enterprise). Compute full-team cost at engineering P50 for each stage.
+
+---
+
+## Step 9: Claude ROI (session-aware, churn-aware, reviewer-aware, concurrency-aware)
+
+The headline: *"What did each hour of Claude's actual clock time produce — and what did the user pay in time + money?"*
+
+### 9a. Measure token usage + active hours + parallel windows
+
+**Preferred — session logs (high confidence)**:
+
+```bash
+python3 .claude/skills/cost-estimate/scripts/claude_token_cost.py
+```
+
+Returns ground-truth tokens + equivalent API cost AND session-timing stats: `active_hours_capped6` (Claude compute throughput — additive across overlapping sessions), `operator_hours_union` (wall-clock time the user actually sat at the keyboard), `peak_concurrent_sessions`, and `avg_concurrency`. Flag `method: "session_logs"` and `api_cost_source: "session_logs"`.
+
+**Fallback — git session clustering (medium confidence, ±2×)**:
+
+```bash
+python3 .claude/skills/cost-estimate/scripts/git_session_clustering.py
+```
+
+No concurrency signal available in this mode.
+
+**Final fallback — LOC heuristic (low confidence)**: `net_claude_loc / 350 hrs`.
+
+### 9b. Compute headline metrics
+
+Read `references/claude-roi.md` for the full formulas. Two speed multipliers — report both:
+
+- `speed_multiplier_compute = total_eng_hours_p50 / active_hours_capped6` — AI throughput
+- `speed_multiplier_operator = total_eng_hours_p50 / operator_hours_union` — honest ROI metric (= compute multiplier × avg_concurrency)
+
+**Reviewer-time rule** (non-optional): tune `reviewer_ratio` on peak concurrency — 0.5 for single-window, 0.2-0.3 for parallel (the operator IS the reviewer-in-loop), 0.1 for high-concurrency orchestration. Omitting reviewer time overstates ROI; using the wrong ratio under-counts it.
+
+Two DIFFERENT cost numbers — never add them together:
+- `equivalent_api_spend` = counterfactual per-token bill
+- `actual_cash_paid` = Max ($200/mo × months) | Pro ($20/mo × months) | API (the bill itself)
+
+### 9c. Speed-multiplier sanity check — evidence-based anchors
+
+Compare the **per-developer-equivalent multiplier** (`speed_multiplier_operator / overhead_multiplier`) against published benchmarks — see `references/claude-roi.md` section 3 for anchors and the full gate:
+
+- GitHub Copilot SPACE 2024: 1.55× (solo autocomplete)
+- METR Feb 2026 transcript study (n=7): range **2.1 – 11.6×** at concurrency 1.05 – 2.32; top user 11.6× at 2.32 avg
+- Anthropic C compiler (Carlini, solo + 16 async): existence proof, not a per-hour rate
+
+Gate: `per_dev_equivalent > 25×` = implausible; `> 12×` = suspicious (above METR ceiling); else plausible. For async swarm mode (peak ≥ 10), report as "no_benchmark" — Carlini is the only public anchor and isn't a per-hour rate.
+
+### 9d. Parallel Execution Profile paragraph — REQUIRED when `peak_concurrent >= 2`
+
+Copy the template from `assets/report-template.md` (the *Parallel Execution Profile* block). Fill in peak, avg concurrency, operator/compute hours, operator-hour multiplier, per-developer-equivalent multiplier, and the contextual sentence placing the user relative to METR's observed band.
+
+**Never invent tiers.** The only tiers in the report are the ones traceable to cited studies (METR, Copilot SPACE, Carlini). If the user's per-dev-equivalent exceeds METR's 11.6× ceiling, the paragraph must say so plainly and offer the two honest explanations (codebase shape inflates rebuild estimate; n=7 sample is small), not dress it up as "top-percentile expert".
+
+### 9e. State limitations loudly
+
+Always include: *"Claude active hours from [method]. Reviewer time assumed at [ratio]× operator hours (tuned for [peak] parallel windows). Operator-hour speed multiplier is the honest ROI number; compute-hour multiplier benchmarks AI throughput."*
+
+---
+
+## Step 10: Sensitivity & cross-validation
+
+Read `references/cross-validation.md` for:
+
+- **Sensitivity**: vary each input one bucket; report top-3 drivers by `p50_impact_usd`.
+- **Harvard supply-side anchor** (Hoffmann-Nagle-Zhou 2024): expected `p50 / (LOC × $0.15) ≈ 3.5×`. Flag outliers.
+- **Capers Jones 5-year TCO**: `build_cost × (1 + 0.20 × 5) = build_cost × 2.0`. Reframe: "build is ~40-50% of lifetime cost."
+- **Three-way cross-check rules**: high confidence only if 3 signals agree within 30%; two-signal mode never reports "high".
+
+---
+
+## Step 11: Generate the report
+
+Copy `assets/report-template.md` verbatim as the structure for your Markdown report. Fill in every `[N]` / `[X]` / `[date]` placeholder. Lead with TL;DR; put spot-checks and assumptions close to the end. **Preserve the credit footer** in the saved file — but strip it from the terminal print (see Step 12).
+
+Keep to the two-sig-figs rule on dollar amounts. Show which files fell into each category so the reader can audit.
+
+---
+
+## Step 12: Write artifacts to a temp directory (never the repo)
+
+**Never write output files into the user's working directory.** Someone could `git add .` and commit them by accident — reports contain sensitive numbers (rates, Claude costs, team composition) that don't belong in git history.
+
+### Derive $OUTDIR
+
+```bash
+OUTDIR=$(python3 .claude/skills/cost-estimate/scripts/resolve_outdir.py)
+echo "$OUTDIR"
+```
+
+Typical paths:
+- Linux → `/tmp/cost-estimate/<project>/`
+- macOS → `/var/folders/.../T/cost-estimate/<project>/`
+- Windows → `%TEMP%\cost-estimate\<project>\`
+
+### Write two files to $OUTDIR
+
+- `$OUTDIR/cost-estimate-report.md` — the full Markdown report from Step 11 (credit footer included)
+- `$OUTDIR/cost-estimate.json` — the machine-readable artifact; see `assets/artifact-schema.json` for the exact shape. `low_confidence_fields` is a list of JSON paths (e.g. `["claude_roi.reviewer_hours", "rates.recommended_usd_per_hour"]`) that downstream consumers should display with a warning icon.
+
+**⚠ BOTH files go to `$OUTDIR`. Never write `./cost-estimate.json` or `./cost-estimate-report.md`.** Use the Write tool with the absolute path `$OUTDIR/...`. If the user explicitly asks for output in the current directory ("write it here"), honor the request but show the *"not written to the working directory"* note without it — the default is always the temp dir.
+
+### Print to terminal
+
+Print the full Markdown report to stdout so the user sees it without opening any file — **but strip the credit footer** (the "generated with the `/cost-estimate` skill, created by Julien Barbier…" block). The footer belongs only in the saved file and the JSON artifact, not in the terminal echo. After printing, end with a one-line pointer:
+
+> *Report also saved to `$OUTDIR/cost-estimate-report.md` and `$OUTDIR/cost-estimate.json`. Not written to the current directory (safer — won't accidentally land in a commit).*
+
+---
+
+## Notes to self
+
+- **Show your math.** Every number in the report must be traceable to a LOC count and a rate.
+- **Never publish a single dollar figure without its range.**
+- **Two-sig-figs rule**: round to two significant figures unless you can defend more.
+- **Degrade gracefully.** Missing git? Note it, lower confidence, continue. Missing WebSearch? Use skill defaults, note it. Missing `scc`? Skip DRYness, note it.
+- **Decompose macros.** For monorepos, estimate each service separately and sum.
+- **Don't double-count.** Quality bonuses and overhead reductions live on the same axis — pick one or split them.
+- **Reviewer-time is non-optional** in Step 9; omitting it lies about Claude ROI.
+- **Frame AI-authored projects as counterfactuals**, not elapsed spend — the distinction matters to readers.

--- a/skills/cost-estimate/assets/artifact-schema.json
+++ b/skills/cost-estimate/assets/artifact-schema.json
@@ -1,0 +1,105 @@
+{
+  "schema_version": "1.1",
+  "generated_at": "ISO-8601",
+  "strategy": "micro|small|normal|macro",
+  "confidence": "low|medium|high",
+  "project": {
+    "name": "...",
+    "stack": ["..."],
+    "first_commit": "YYYY-MM-DD",
+    "last_commit": "YYYY-MM-DD"
+  },
+  "codebase": {
+    "counted_loc": 0,
+    "excluded_loc": { "generated": 0, "vendored": 0, "minified": 0, "lockfiles": 0 },
+    "by_language": {},
+    "test_ratio": 0.0,
+    "quality_multiplier": 1.0,
+    "quality_signals": ["..."]
+  },
+  "process": {
+    "project_duration_days": 0,
+    "commit_count": 0,
+    "contributor_count": 0,
+    "gross_adds": 0,
+    "gross_dels": 0,
+    "net_adds": 0,
+    "churn_ratio": 0.0,
+    "process_only_hours_estimate": 0,
+    "loc_per_day": 0,
+    "ai_authored_flag": "no|suspected|clear"
+  },
+  "engineering": {
+    "base_coding_hours": { "p10": 0, "p50": 0, "p90": 0 },
+    "overhead_multiplier": 1.0,
+    "total_hours": { "p10": 0, "p50": 0, "p90": 0 },
+    "cocomo_ii_hours": 0,
+    "function_point_count": 0,
+    "function_point_hours": 0,
+    "divergence_pct_bottom_up_vs_cocomo": 0.0,
+    "agreement": "high|medium|low"
+  },
+  "locomo": {
+    "regen_tokens": 0,
+    "api_cost_usd": 0,
+    "review_hours": 0,
+    "review_cost_usd": 0,
+    "locomo_cost_usd": 0,
+    "human_premium_multiple": 0.0
+  },
+  "rates": {
+    "recommended_usd_per_hour": 0,
+    "justification": "...",
+    "source": "websearch|skill_defaults"
+  },
+  "cost_engineering_usd": { "p10": 0, "p50": 0, "p90": 0 },
+  "cost_full_team_usd": {
+    "solo": 0, "lean_startup": 0, "growth": 0, "enterprise": 0
+  },
+  "calendar_months": {
+    "solo": 0, "lean_startup": 0, "growth": 0, "enterprise": 0
+  },
+  "claude_roi": {
+    "method": "session_logs|git_clustering|loc_estimate",
+    "method_confidence": "high|medium|low",
+    "active_hours_capped6": 0,
+    "active_hours_uncapped": 0,
+    "operator_hours_union": 0,
+    "peak_concurrent_sessions": 0,
+    "avg_concurrency": 0,
+    "parallel_tier": "single_window|single_autonomous|power_user|advanced_orchestrator|top_percentile_expert|off_the_chart",
+    "reviewer_ratio": 0.5,
+    "reviewer_hours": 0,
+    "plan": "max|pro|api|unknown",
+    "actual_cash_paid_usd": 0,
+    "equivalent_api_spend_usd": 0,
+    "equivalent_api_source": "session_logs|heuristic",
+    "effective_plan_savings_usd": 0,
+    "token_usage": {
+      "input_tokens": 0,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0,
+      "output_tokens": 0,
+      "messages": 0
+    },
+    "claude_total_cost_usd": 0,
+    "value_per_claude_compute_hour_usd": 0,
+    "value_per_operator_hour_usd": 0,
+    "speed_multiplier_compute": 0,
+    "speed_multiplier_operator": 0,
+    "sanity_flag": "plausible|suspicious|implausible",
+    "roi_multiple": 0
+  },
+  "external_anchors": {
+    "naive_supply_side_usd": 0,
+    "harvard_ratio": 0.0,
+    "harvard_flag": "normal|too_low|too_high",
+    "annual_maint_rate": 0.20,
+    "lifetime_cost_5y_usd": 0
+  },
+  "sensitivity_drivers": [
+    { "assumption": "...", "p50_impact_usd": 0 }
+  ],
+  "spot_check_items": ["...", "...", "..."],
+  "low_confidence_fields": ["..."]
+}

--- a/skills/cost-estimate/assets/report-template.md
+++ b/skills/cost-estimate/assets/report-template.md
@@ -1,0 +1,204 @@
+# [Project Name] — Development Cost Estimate
+
+**Generated**: [date] · **Stack**: [one-line] · **Strategy**: [micro/small/normal/macro] · **Confidence**: [low/medium/high]
+
+## What this number is — and what it isn't
+
+**This is the *replacement cost to rebuild***, not the codebase's market value. It measures what a traditional human team would spend to recreate this code from scratch, starting with specs in hand. It does NOT include:
+
+- Discovery, user research, PMF iteration
+- Failed experiments and dead branches not represented in the final code
+- Institutional knowledge (what the team learned while building it)
+- Customer support feedback loops that shaped edge cases
+- Sales, marketing, legal, compliance, infrastructure hosting
+- Maintenance past delivery (see 5-year TCO section)
+
+Quoting this number as "what the code is worth" is a category error that has burned people before. If a potential acquirer or investor asks, point them at the range and the *replacement cost* framing — never the single number.
+
+## TL;DR
+
+- **Counted LOC**: [N] ([N] excluded)
+- **Human-team hours (P50)**: [N] · P10: [N] · P90: [N]
+- **Pre-AI rebuild cost — engineering only (P50)**: **$[X]** at $[rate]/hr
+- **Pre-AI rebuild cost — full human team (Growth Co, P50)**: **$[X]**
+- **Calendar time if a human team rebuilt it (Lean startup)**: ~[X] months
+- **Actual cash paid to Anthropic**: **$[Y]** (based on plan: Max=$200/mo, Pro=$20/mo, API=metered)
+- **Equivalent API spend** (counterfactual, from token usage): **$[Z]** — *what the same tokens would have cost at per-token API rates; NOT what you paid if on a subscription plan*
+- **Pre-AI ÷ actual-AI cost ratio**: [X]× (*i.e. what a human team would have charged vs what Claude actually spent*)
+
+## Codebase Metrics
+
+- **Total counted LOC**: [N]
+  - [Language 1]: [N] · [Language 2]: [N] · …
+  - Tests: [N] ([ratio] of source) · IaC/config: [N]
+- **Excluded**: [N] (generated: [N], vendored: [N], minified: [N], lockfiles: [N])
+- **Quality multiplier**: [X.XX] — [signals: + tests, + types, − no docs, …]
+- **Specialized domains**: [list]
+
+## Process Signals (git)
+
+- Project duration: [X] days · Commits: [N] · Contributors: [N]
+- Churn: +[adds] / −[dels] (net +[net]) · churn_ratio: [X.XX]
+- Process-only estimate (cross-check): ~[N] hours
+
+## Engineering Hours
+
+### Bottom-up (category × rate)
+
+| Category | LOC | Rate (mid) | Hours (P10 / P50 / P90) |
+|---|---|---|---|
+| … | … | … | … |
+| **Base coding** | **[N]** | | **[A] / [B] / [C]** |
+
+### Overhead (compounded, double-counting avoided)
+
+| Factor | Value | Running total |
+|---|---|---|
+| Base coding | — | [N] hrs |
+| × Arch/design (1.15) | +15% | [N] |
+| × Debugging (1.28) | +28% | [N] |
+| × … | | |
+| × Quality multiplier | [X.XX] | [N] |
+| **Total engineering** | | **[N] hrs (P50)** |
+
+### Cross-checks
+
+- COCOMO II: KSLOC [N], E [V], EAF [V] → **[N] hours**
+- Function Point backfiring: [N] FP × [X] hrs/FP → **[N] hours**
+- LOCOMO (LLM regen + review): **[N] hours / $[N]** — the human-premium floor
+- Process-signal (git): [N] hours
+- Divergence vs bottom-up: **[X]%** → [reconciled number]
+- **Agreement**: [high/medium/low]
+
+## Calendar Time
+
+| Company type | Efficiency | Calendar months |
+|---|---|---|
+| Solo / founder | 70% | [X] |
+| Lean startup | 60% | [X] |
+| Growth co | 50% | [X] |
+| Enterprise | 40% | [X] |
+
+## Market Rates
+
+| Region | Low | Avg | High |
+|---|---|---|---|
+| Remote (global) | … | … | … |
+| Remote (US) | … | … | … |
+| SF/NYC onsite | … | … | … |
+| [Specialty] | … | … | … |
+
+**Recommended rate**: **$[X]/hr** — [justification]
+
+## Cost Estimate
+
+### Engineering only
+
+| Scenario | Hours | Rate | Cost |
+|---|---|---|---|
+| P10 (optimistic) | [N] | $[X] | **$[X]** |
+| P50 (median) | [N] | $[X] | **$[X]** |
+| P90 (pessimistic) | [N] | $[X] | **$[X]** |
+
+### Full team (at P50 engineering)
+
+| Stage | Multiplier | Total cost |
+|---|---|---|
+| Solo / founder | 1.0× | **$[X]** |
+| Lean startup | 1.45× | **$[X]** |
+| Growth company | 2.2× | **$[X]** |
+| Enterprise | 2.65× | **$[X]** |
+
+## Claude ROI
+
+- **Measurement method**: [session_logs / git_clustering / loc_estimate] — confidence [high/medium/low]
+- **Project timeline**: [first] → [last] ([X] days)
+- **Git churn**: +[adds] / −[dels] (net +[net])
+- **Sessions detected**: [N] · **Peak concurrent windows**: [N] · **Avg concurrency**: [X.XX]×
+- **Claude compute hours** (sum, capped 6h/session): [N]
+- **Operator hours** (wall-clock union — real keyboard time): [N]
+- **Reviewer hours** ([ratio]× operator — tuned for [peak]-window parallel usage): [N]
+- **Plan**: [max / pro / api / unknown]
+- **Equivalent API spend** (counterfactual, published per-token rates × 11,587 `message.usage` blocks): $[X] — *NOT what you paid if on Max/Pro.*
+- **Actual cash paid to Anthropic**: $[X] — flat subscription if on a plan, metered bill if on API
+- **Effective plan savings** (equivalent API − actual cash): $[X] — positive = subscription paid off
+- **Value produced (P50 full-team)**: $[X]
+- **Value per Claude compute hour**: **$[X,XXX]/hr**
+- **Value per operator hour**: **$[X,XXX]/hr**
+- **Speed multiplier (compute)**: **[X]×** · **Speed multiplier (operator)**: **[Y]×** — sanity: [plausible/suspicious/implausible]
+- **Total Claude investment** (actual cash + reviewer time): $[X]
+- **ROI**: **[X]×** — every $1 you actually spent → $[X] of human-equivalent value
+
+> *Claude ran ~[compute_h] hours of AI work across ~[operator_h] wall-clock hours of your time at the keyboard (avg [avg_conc]× parallel). Combined output: ~$[X] of professional development value — **$[X,XXX] per operator hour**.*
+
+### Parallel Execution Profile
+
+*Fill this whenever `peak_concurrent_sessions >= 2`. Use the evidence-based anchors below — do NOT invent tiers.*
+
+This project was driven at **[peak] Claude Code windows concurrently at peak** (avg **[avg_concurrency]×** simultaneous), with **[operator_hours_union]** real keyboard hours producing **[active_hours_capped6]** hours of Claude compute work. Mode: **[interactive_parallel / advanced_interactive / async_swarm]**.
+
+**Evidence-based anchors (all measured 2024 – 2026):**
+
+| Anchor | Measurement | Source |
+|---|---|---|
+| Copilot inline autocomplete (SPACE 2024) | 1.55× at concurrency 1 | CACM 2024 RCT |
+| METR median Claude Code user | 3 – 5× at 1.2 – 1.4 avg parallel | [METR Feb 2026 transcript study](https://metr.org/notes/2026-02-17-exploratory-transcript-analysis-for-estimating-time-savings-from-coding-agents/), n=7 |
+| METR top Claude Code user | **11.6× at 2.32 avg parallel** (11.3 hrs/day) | Same study, Technical Staff A |
+| METR observed range | 2.1 – 11.6× at 1.05 – 2.32 avg | Seven Anthropic-adjacent engineers |
+| Anthropic C-compiler (Carlini) | 1 human + 16 parallel + 2 weeks = 100k LOC for $20k | [anthropic.com/engineering/building-c-compiler](https://www.anthropic.com/engineering/building-c-compiler) — existence proof for async swarm, not a per-hour rate |
+
+**How your number compares:**
+
+This user's **operator-hour multiplier is [X]×** against the full-team rebuild estimate (includes PM/design/QA overhead ~2.53×). The apples-to-apples **per-developer-equivalent multiplier is [X/2.53]×** — that's the number to compare to METR. At [avg_concurrency]× avg concurrency, METR's observed band is roughly [interpolated]; this user's per-dev-equivalent sits **[inside / above / well above]** that band.
+
+> *Caveats: METR measured time-to-complete identical tasks; this skill measures hypothetical-rebuild-cost vs actual session time — different numerators. LOC-dense codebases (scrapers, boilerplate, generated-style code) inflate the multiplier above what METR observes for complex novel work. Don't quote either multiplier as universal. Your workflow and codebase shape the ratio as much as the tools do.*
+
+## Sensitivity
+
+Top 3 drivers of uncertainty:
+1. **[Assumption]**: swing [X→Y] → P50 changes by ±$[Z]
+2. **[Assumption]**: …
+3. **[Assumption]**: …
+
+## External anchors
+
+- **Harvard supply-side ratio** (Hoffmann-Nagle-Zhou 2024): [X.X]× — flag: [normal/too_low/too_high]
+- **5-year TCO** (Capers Jones): $[X] — build is ~[X]% of lifetime
+
+## Spot-check (read before trusting the number)
+
+Three things the reader should verify, with a copy-pasteable command for each:
+
+1. **Biggest category is classified correctly.** Show the top-hours category and the files in it — does the label fit?
+   ```bash
+   find . -name "*.rs" -not -path "*/target/*" | head -20
+   ```
+   Commonly over-classified: "systems programming" when it's really just `unsafe` wrappers; "ML/AI" when it's pandas glue.
+
+2. **Excluded-vs-counted ratio is sane.** If `excluded_loc > 3 × counted_loc`, the codebase is mostly vendored/generated — re-run after tightening exclusions.
+   ```bash
+   du -sh node_modules vendor dist build target .venv 2>/dev/null | sort -h
+   ```
+
+3. **Process-vs-code signals agree.** If bottom-up is >2× process estimate, one side is wrong.
+   ```bash
+   git log --oneline | wc -l
+   git log --format="%an" | sort -u | wc -l
+   git log --format="%ai" | head -1 && git log --format="%ai" | tail -1
+   ```
+
+## Assumptions & Limitations
+
+- Rates reflect current market; drift within ~6 months.
+- Excludes: marketing, sales, legal, compliance, hosting/infra, ongoing maintenance.
+- LOC undercounts dense/complex code and overcounts boilerplate.
+- Claude active-hour estimate from [method]; may be off by ±[30%/2×].
+- Reviewer time assumed 0.5× Claude hours; your ratio may differ.
+- COCOMO EAF collapsed from 17 multipliers to 5 buckets; approximate.
+- Full-team costs assume standard org structures.
+
+---
+
+*This report was generated with the `/cost-estimate` Claude Code skill, created by **Julien Barbier**. Find the skill and follow for updates: https://github.com/jbarbier/claude-code-cost-estimate*
+
+<!-- This footer ships in the saved .md file and cost-estimate.json only — strip it from the terminal print. -->

--- a/skills/cost-estimate/references/category-rates.md
+++ b/skills/cost-estimate/references/category-rates.md
@@ -1,0 +1,99 @@
+# Category rates — base coding hours per LOC
+
+Used in Step 3 (categorize & compute base hours) and Step 1d (quality multiplier).
+Load this file when you need the per-category productivity table or the quality-signal scoring.
+
+## Contents
+1. Quality signals (applied to per-LOC value, not to hours)
+2. Per-category productivity rates (LOC/hour)
+3. Formula: LOC → hours at P10 / P50 / P90
+4. Per-feature breakdown rule
+5. Scoped mode flags
+
+---
+
+## 1. Quality signals → `quality_multiplier` (range 0.7 – 1.3)
+
+Apply each bump at most once. Sum capped at ±30%. Applied to **per-LOC value**, not directly to hours.
+
+| Signal | How to detect | Effect |
+|---|---|---|
+| Test coverage ratio | `test_LOC / source_LOC > 0.5` | +10% |
+| Type safety | TS strict, mypy strict, Go, Rust, Kotlin | +5% |
+| Documentation | README >1k chars, inline docs, ADRs | +5% |
+| CI/CD maturity | `.github/workflows/` with actual jobs | +5% |
+| Observability | logging / tracing / metrics libs | +5% |
+| Security hardening | auth, secrets mgmt, input validation | +5% |
+| No tests / untyped / no CI | per-signal | −5% each, floor 0.7 |
+
+Rule of thumb: a well-tested codebase earns a quality bump **or** a reduced integration-test overhead in Step 5 — never both. The overhead reference enforces this.
+
+---
+
+## 2. Per-category rates (senior developer, 5+ yrs)
+
+Rates are **meaningful LOC shipped per hour**. Low → P90 hours (pessimistic). High → P10 hours (optimistic). Mid → P50.
+
+| Category | Low | Mid | High | Examples |
+|---|---|---|---|---|
+| Simple CRUD / boilerplate | 30 | 40 | 50 | REST endpoints, form handlers, basic UI |
+| Standard business logic | 20 | 25 | 30 | Services, controllers, data flow |
+| Complex algorithms / state | 15 | 20 | 25 | Search, optimization, workflows |
+| Frontend UI/UX | 20 | 28 | 35 | Components, layouts, interactions |
+| API integrations | 15 | 20 | 25 | SDK wrappers, OAuth, webhooks |
+| Database / ORM | 20 | 25 | 30 | Migrations, queries, schema |
+| Systems programming | 10 | 15 | 20 | OS-level, drivers, memory mgmt |
+| GPU / shader | 10 | 15 | 20 | CUDA, Metal, Vulkan, compute |
+| Compiler / language tooling | 8 | 12 | 15 | Parsers, ASTs, codegen |
+| Real-time / streaming | 10 | 15 | 20 | WebSocket, audio/video, events |
+| Security / crypto | 10 | 15 | 20 | Auth, encryption, certs |
+| ML / AI pipeline | 10 | 15 | 20 | Training, data pipelines, inference |
+| Infrastructure as Code | 15 | 20 | 25 | Terraform, k8s, CI/CD |
+| Embedded / firmware | 8 | 12 | 15 | Hardware, RTOS, bare-metal |
+| Comprehensive tests | 25 | 32 | 40 | Unit, integration, e2e |
+
+Commonly over-classified: "systems programming" when it's really just `unsafe` wrappers; "ML/AI" when it's pandas glue. When in doubt, bias toward the simpler bucket.
+
+---
+
+## 3. Formula
+
+For each category:
+
+```
+hours_P50 = LOC / rate_mid
+hours_P10 = LOC / rate_high    # optimistic → fewer hours
+hours_P90 = LOC / rate_low     # pessimistic → more hours
+```
+
+Sum across categories → **Base Coding Hours (P10 / P50 / P90)**.
+
+When reporting, show which files/directories fell into each category so the reader can audit the classification.
+
+---
+
+## 4. Per-feature breakdown (users asked for this)
+
+For any top-level directory with > 5% of counted LOC, report a sub-estimate alongside the aggregate — e.g. "what did `src/checkout/` cost?".
+
+```bash
+for d in */; do
+  count=$(find "$d" -type f \( -name "*.ts" -o -name "*.py" -o -name "*.go" \) \
+    -not -path "*/node_modules/*" -print0 2>/dev/null \
+    | xargs -0 wc -l 2>/dev/null | tail -1 | awk '{print $1+0}')
+  echo "$d $count"
+done | sort -k2 -n -r | head -15
+```
+
+Report a per-feature table with its own hours/cost, still showing the P50 range.
+
+---
+
+## 5. Scoped mode flags
+
+If the user invokes the skill with `--since <commit>` or `--path <dir>`, restrict Steps 1-3 accordingly:
+
+- `--since <commit>`: use `git log <commit>..HEAD --numstat` and `git diff <commit>..HEAD --numstat` to scope LOC + churn to changes since that commit.
+- `--path <dir>`: restrict Steps 1-3 to that subdirectory; still apply full overhead + rates.
+
+Preserve every other step — the report reads the same, just for a subset. This unlocks "what did this quarter cost?" and "what did this feature cost?" use cases.

--- a/skills/cost-estimate/references/claude-roi.md
+++ b/skills/cost-estimate/references/claude-roi.md
@@ -1,0 +1,160 @@
+# Claude ROI — session-aware, churn-aware, reviewer-aware, concurrency-aware (Step 9)
+
+Headline: **"What did each hour of Claude's actual clock time produce — and what did the user pay in time + money?"**
+
+## Contents
+1. Measure Claude active hours + operator hours + parallel windows
+2. Compute headline metrics
+3. Speed-multiplier sanity check — evidence-based, not vibes
+4. Parallel Execution Profile paragraph (goes in the report)
+5. Loudly stated limitations
+
+---
+
+## 1. Measure Claude active hours + operator hours + parallel windows
+
+### Method 1 (best): Claude Code session logs
+
+Session transcripts live at `~/.claude/projects/<project-hash>/*.jsonl` where the hash is derived from the project path (`/` → `-`).
+
+Run `scripts/claude_token_cost.py` — one script emits **all** of:
+
+- **Token usage + API cost**: ground-truth `input_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens`, `output_tokens` per message × published per-model rates.
+- **`active_hours_capped6`** — sum of `(last - first)` per session file, capped 6h/session. *Claude compute throughput* (adds up even when sessions overlap).
+- **`active_hours_uncapped`** — same sum without the cap; used for sanity.
+- **`operator_hours_union`** — wall-clock UNION of all session intervals. *Real human driver time* — hours the user actually sat at the keyboard.
+- **`peak_concurrent_sessions`** — max simultaneous Claude Code windows.
+- **`avg_concurrency`** = `active_hours_uncapped / operator_hours_union`.
+
+Flag `method: "session_logs"` — high confidence.
+
+### Method 2: Git churn + session clustering (fallback, medium confidence, ±2×)
+Run `scripts/git_session_clustering.py`. No concurrency signal in this mode.
+
+### Method 3: LOC heuristic (final fallback, low confidence)
+`net_claude_loc / 350 hrs`.
+
+---
+
+## 2. Headline metrics
+
+Two denominators, two different stories:
+
+```
+# Claude throughput — what the AI produced per compute-hour
+speed_multiplier_compute  = total_eng_hours_p50 / active_hours_capped6
+
+# Operator leverage — what one human produced per real keyboard-hour
+speed_multiplier_operator = total_eng_hours_p50 / operator_hours_union
+
+# These diverge when the user runs parallel windows:
+# speed_multiplier_operator = speed_multiplier_compute × avg_concurrency
+```
+
+Report **both**. `speed_multiplier_operator` is the honest ROI number (the one the user's wallet feels); `speed_multiplier_compute` benchmarks AI throughput.
+
+**Per-developer-equivalent multiplier** (for honest comparison with published benchmarks):
+
+```
+# The bottom-up P50 includes team overhead (~2.53× above base coding for debug/docs/review/test).
+# Published benchmarks measure solo-developer speed, not team-rebuild cost. Divide it out:
+per_dev_speed_multiplier = speed_multiplier_operator / overhead_multiplier
+```
+
+This is the apples-to-apples number for comparing against METR or Copilot. Report it alongside the headline multiplier.
+
+```
+# Reviewer time
+reviewer_hours  = operator_hours_union × reviewer_ratio
+# reviewer_ratio defaults:
+#   single-window interactive: 0.5
+#   parallel windows (peak_concurrent >= 2): 0.2 - 0.3
+#   async swarm (Carlini-style, peak >= 10, mostly hands-off): 0.05 - 0.1
+reviewer_cost   = reviewer_hours × recommended_rate
+
+# Two DIFFERENT numbers — never add them together
+equivalent_api_spend = sum(tokens × published_rates)      # counterfactual per-token bill
+actual_cash_paid     = Max $200/mo | Pro $20/mo | API = the bill itself
+
+claude_total_cost = actual_cash_paid + reviewer_cost
+roi = (total_cost_p50 − claude_total_cost) / claude_total_cost
+```
+
+---
+
+## 3. Speed-multiplier sanity check — evidence-based anchors
+
+Two distinct workflows with different ceilings. Classify the user's mode first, **then** apply the right anchors.
+
+### 3a. Interactive parallel (driver at keyboard, spot-reviewing multiple active windows)
+
+This is what most Claude Code users do. The public data:
+
+| Anchor | Speed multiplier | Concurrency | Source |
+|---|---|---|---|
+| GitHub Copilot SPACE study | 1.55× | 1 (inline autocomplete, keystroke review) | *Measuring GitHub Copilot's Impact on Productivity*, CACM 2024 |
+| METR median Claude Code user | 3 – 5× | 1.2 – 1.4 avg | METR 2026 transcript analysis, n=7 |
+| METR top Claude Code user | **11.6×** | **2.32 avg** (11.3 hrs/day) | Same study, Technical Staff A |
+| METR full observed range | 2.1× – 11.6× | 1.05 – 2.32 avg | Seven Anthropic-adjacent engineers |
+
+Ceiling for interactive parallel: **~12× per-developer-equivalent** — the highest directly-observed number in the public record, per the METR study cited above. Higher numbers usually mean the denominator is wrong (team overhead included, LOC-heavy boilerplate inflating base-coding estimate, sessions uncounted).
+
+### 3b. Async orchestration (set up harness, walk away)
+
+Rare, project-scale workflow. One published data point:
+
+| Anchor | Scale | Source |
+|---|---|---|
+| Nicholas Carlini / Anthropic C compiler | 1 human, 16 parallel Claudes, ~2,000 sessions, 2 weeks, $20k API, **100k LOC** | *Building a C compiler with a team of parallel Claudes*, anthropic.com/engineering |
+
+Carlini measured in **project-deliverables-per-scaffolding-week**, not per-hour-at-keyboard. His human time was mostly upfront harness design + periodic intervention; he "mostly walked away" between checkpoints. A speed multiplier in conventional units isn't published. Use this as an existence proof ("solo human + well-chosen task + async swarm can produce 100k LOC in 2 weeks"), not as a per-hour benchmark.
+
+### 3c. Gate
+
+```
+# Classify mode
+if peak_concurrent <= 1:                        mode = "single_window"
+elif peak_concurrent <= 4 and avg < 3:          mode = "interactive_parallel"
+elif peak_concurrent <= 10 and avg < 5:         mode = "advanced_interactive"
+else:                                            mode = "async_swarm"
+
+# For interactive modes, compare per_dev_speed_multiplier to METR's ceiling
+if mode in ("single_window", "interactive_parallel", "advanced_interactive"):
+    if per_dev_speed_multiplier > 25:    sanity_flag = "implausible"   # 2× above METR top
+    elif per_dev_speed_multiplier > 12:  sanity_flag = "suspicious"     # above METR ceiling
+    else:                                 sanity_flag = "plausible"
+
+# For async swarm, no apples-to-apples benchmark exists in the public record
+elif mode == "async_swarm":
+    sanity_flag = "no_benchmark"
+    # Report as "Carlini-style async orchestration — no direct public benchmark; compare
+    # to his 100k LOC / 2 weeks / 1 human as an existence-proof anchor"
+```
+
+When `sanity_flag != "plausible"`, the report must explicitly name the metric to verify (operator_hours, team-overhead denominator, LOC inflation).
+
+---
+
+## 4. Parallel Execution Profile paragraph (goes in the report)
+
+Fill this in whenever `peak_concurrent_sessions >= 2`. Show the user where the evidence places them — don't invent tiers.
+
+> **Parallel Execution Profile.** This project was driven at **[peak]** Claude Code windows concurrently at peak (avg **[avg_concurrency]×** simultaneous), with **[operator_hours_union]** real keyboard hours producing **[active_hours_capped6]** hours of Claude compute work. Mode: **[interactive_parallel / advanced_interactive / async_swarm]**.
+>
+> **Evidence-based anchors (all measured 2024 – 2026):**
+>
+> - **GitHub Copilot inline autocomplete (SPACE 2024)**: 1.55× — solo developer, review every suggestion at the keystroke level.
+> - **METR Claude Code transcript study (Feb 2026, n=7 Anthropic-adjacent engineers)**: median 3 – 5× at 1.2 – 1.4 avg concurrency; top user 11.6× at 2.32 avg concurrency (working 11.3 hr/day).
+> - **Anthropic C-compiler experiment (Carlini, 2026)**: one human + 16 parallel Claudes + 2 weeks = 100k LOC compiler for $20k API — the published "async swarm" anchor. Not directly comparable in per-hour terms; reported as an existence-proof for solo-human + well-scoped parallel task.
+>
+> This user's **operator-hour multiplier is [X]×** against the full-team rebuild estimate (includes PM/design/QA overhead ~2.53×). The apples-to-apples **per-developer-equivalent multiplier is [X/2.53]×**, which is the number to compare to METR. At [avg_concurrency]× concurrency, METR's observed range is roughly [interpolated from the 1.05–2.32 band above]; this user's per-dev-equivalent sits **[inside / above / well above]** that range.
+>
+> Caveats: METR measured time-to-complete identical tasks; this skill measures hypothetical-rebuild-cost vs actual session time. The numerators are different, and LOC-dense codebases (scrapers, boilerplate, generated-style code) inflate the multiplier above what METR observes for complex novel work. Don't quote either multiplier as universal.
+
+---
+
+## 5. Limitations (state loudly in the report)
+
+Always include:
+
+> "Claude active hours from *[method]*. Reviewer time assumed at [ratio]× operator hours (tuned for [peak] parallel windows). Operator-hour multiplier is vs the full-team rebuild estimate; per-developer-equivalent is the apples-to-apples number for METR/Copilot comparison. METR's public range (Feb 2026, n=7) is 2.1 – 11.6× per developer at 1.05 – 2.32 avg concurrency."

--- a/skills/cost-estimate/references/cocomo-ii.md
+++ b/skills/cost-estimate/references/cocomo-ii.md
@@ -1,0 +1,31 @@
+# COCOMO II cross-check
+
+Industry-validated top-down sanity check. Load when running Step 4 cross-check.
+
+## Formula
+
+```
+Effort_person_months = A × (KSLOC)^E × EAF
+  A     = 2.94
+  E     = 0.91 – 1.23     (use 1.0 nominal)
+  EAF   = product of 17 effort multipliers, simplified into 4 buckets below
+  KSLOC = source LOC / 1000 (excluding generated/vendored)
+
+hours = person_months × 152
+```
+
+## Quick EAF table (17 multipliers collapsed to 5 buckets)
+
+| Project type | E | EAF |
+|---|---|---|
+| Simple CRUD web app | 0.95 | 0.7 |
+| Standard SaaS product | 1.00 | 1.0 |
+| Platform / infrastructure | 1.10 | 1.5 |
+| Systems / compiler / crypto-heavy | 1.15 | 2.0 |
+| Safety-critical / regulated | 1.20 | 2.5 |
+
+## Divergence rules vs Step 3 bottom-up
+
+- **Within 30%** → good; report Step 3 number.
+- **30 – 100% divergence** → report both; take geometric mean: `sqrt(bottom_up × cocomo)`.
+- **> 2× divergence** → **stop and investigate** before reporting. Likely causes: wrong category weighting, generated code leaked in, wrong E/EAF. Do not publish mismatched numbers.

--- a/skills/cost-estimate/references/cross-validation.md
+++ b/skills/cost-estimate/references/cross-validation.md
@@ -1,0 +1,78 @@
+# Sensitivity & cross-validation (Step 10)
+
+## Contents
+1. Sensitivity analysis — which assumption moves the number most?
+2. External anchors — Harvard supply-side + Capers Jones TCO
+3. Three-way (or two-way) cross-check rules
+
+---
+
+## 1. Sensitivity analysis
+
+Vary each input one at a time, ±1 standard bucket, and record `p50_impact_usd`:
+
+- Quality multiplier: 0.7 → 1.3
+- Recommended rate: ±50%
+- Company stage team multiplier: 1.0 → 2.65×
+- Specialized-category LOC share: ±20%
+- COCOMO EAF bucket: nearest-neighbor shift
+
+Sort descending. Report the **top 3 drivers**.
+
+---
+
+## 2. External anchors (reality checks)
+
+Two independent sanity checks drawn from peer-reviewed research.
+
+### 2a. Harvard supply-side anchor (Hoffmann, Nagle, Zhou 2024)
+
+For OSS-like codebases, the supply-side value (what it cost to produce) averages ~**3.5× a naive `LOC × generic_rate`** calculation (SSRN 4693148).
+
+```
+naive_supply_side = source_LOC × $0.15/line   # rough median, 2024 OSS data
+harvard_ratio     = p50_cost / naive_supply_side
+```
+
+If `harvard_ratio` is far from 3.5× (say, <1.5× or >6×), flag it:
+
+- **< 1.5×** → under-counting complexity, or rates set too low
+- **> 6×** → over-priced; excluded code probably leaked in, or company-stage multiplier too high
+
+### 2b. Capers Jones 5-year total cost of ownership
+
+Initial build is 25 – 35% of 5-year lifecycle. Report `lifetime_cost_5y`:
+
+```
+annual_maint_rate = 0.20        # industry default; range 0.15 – 0.30
+lifetime_cost_5y  = build_cost × (1 + annual_maint_rate × 5)
+                  = build_cost × 2.0 (default)
+```
+
+Important framing:
+
+> "Build cost above is ~40 – 50% of the 5-year TCO."
+
+Clients often mistake the build number for total ownership — call it out.
+
+---
+
+## 3. Cross-check (three-way if git, two-way otherwise)
+
+| Method | Hours | Notes |
+|---|---|---|
+| Bottom-up (Step 3+5) | | Category × rate, with overheads |
+| COCOMO II (Step 4) | | Top-down, calibrated constants |
+| Process signal (Step 2) | | `commits × avg_commit_hours` (skip if no git) |
+
+### Rules
+
+**Three signals available (git present):**
+- All agree within 30% → confidence **high**
+- Two agree, one outlier → confidence **medium** (name the outlier)
+- All three disagree → confidence **low** — reconcile before publishing
+
+**Two signals only (no git):**
+- Bottom-up + COCOMO within 30% → **medium**
+- > 30% divergence → **low**
+- Never report **high** confidence without a process signal.

--- a/skills/cost-estimate/references/function-points.md
+++ b/skills/cost-estimate/references/function-points.md
@@ -1,0 +1,47 @@
+# Function Point backfiring
+
+Fourth independent cross-check. Function Points size software by user-visible functionality, independent of programming language. *Backfiring* reverses the calculation: convert LOC → FP using QSM's language-specific ratio, then apply FP-per-hour productivity.
+
+## Formula
+
+```
+LOC_per_FP        # language-specific (QSM table below)
+Function_Points   = KSLOC × 1000 / LOC_per_FP
+hours_per_FP      = 8 – 12 (industry average; domain-adjusted below)
+FP_hours          = Function_Points × hours_per_FP
+```
+
+## QSM language conversion table (abbreviated)
+
+See qsm.com/resources/function-point-languages-table for the full list.
+
+| Language | LOC per FP | Notes |
+|---|---|---|
+| Assembly | 320 | |
+| C | 148 | |
+| C++ | 59 | |
+| C# | 59 | |
+| Java | 53 | |
+| Go | 38 | modern, concise |
+| JavaScript | 47 | |
+| TypeScript | 43 | types compress some |
+| Python | 21 | very expressive |
+| Ruby | 25 | |
+| Rust | 39 | expressive + safe |
+| Swift | 38 | |
+| Kotlin | 43 | |
+| SQL | 13 | declarative |
+| HTML/CSS (FP proxy) | 34 | |
+
+## Hours-per-FP by domain
+
+- Data entry / simple CRUD: 6 – 8 hrs/FP
+- Typical business app: 8 – 12 hrs/FP
+- Real-time / embedded: 12 – 18 hrs/FP
+- Systems / safety-critical: 15 – 25 hrs/FP
+
+Convert `FP_hours` to P10 / P50 / P90 by varying `hours_per_FP` across the bracket.
+
+## Why this helps
+
+COCOMO anchors on LOC with scale drivers; Function Points anchor on *user-facing features*. Disagreement between the two reveals whether the codebase has lots of internal plumbing (low FP per LOC) or lots of user-facing features (high FP per LOC) — useful diagnostic information for the spot-check.

--- a/skills/cost-estimate/references/locomo.md
+++ b/skills/cost-estimate/references/locomo.md
@@ -1,0 +1,47 @@
+# LOCOMO — LLM-regeneration cost (counterfactual)
+
+COCOMO answers "what did humans cost to build this?". LOCOMO (popularised by `scc`) answers the counterfactual:
+
+> "What would it cost an LLM to re-generate this code from spec today?"
+
+It's a useful *floor* for Claude-ROI discussions.
+
+## Formula
+
+```
+tokens_per_loc        ≈ 4           # empirical: ~4 tokens per line of code for generation
+iteration_factor      = 3           # typical: 3 generation passes before acceptance
+input_prompt_overhead = 2           # spec + context tokens per code token
+regen_tokens          = SLOC × tokens_per_loc × (1 + input_prompt_overhead) × iteration_factor
+
+# Claude rates (Opus tier): assume 10% input / 90% output token mix
+# Use current published Anthropic per-token rates. See scripts/claude_token_cost.py
+# for ground-truth rates used elsewhere in this skill.
+api_cost = regen_tokens × (0.1 × in_rate + 0.9 × out_rate) / 1_000_000
+
+# Human review time to accept LLM output
+review_hours = SLOC / 1000   # ~1 hr per KLOC to read/accept generated code
+review_cost  = review_hours × recommended_rate
+
+locomo_cost_usd = api_cost + review_cost
+locomo_hours    = review_hours          # the only *human* hours LOCOMO implies
+```
+
+## Reporting
+
+Report three numbers side-by-side in the final output:
+
+| Method | Hours | USD | Interpretation |
+|---|---|---|---|
+| COCOMO II (top-down, human) | [H1] | [$1] | Traditional human build cost |
+| Bottom-up (Step 3+5) | [H2] | [$2] | Category-rate, human build cost |
+| **LOCOMO (LLM regen + review)** | [H3] | [$3] | **Floor: what re-generating costs today** |
+
+The ratio `COCOMO_cost / LOCOMO_cost` is a **human premium multiple**. If a codebase costs $500k by COCOMO and $15k by LOCOMO, the **33× human premium** is where Claude ROI actually comes from — flag it explicitly in the Claude ROI section.
+
+## Caveats
+
+- LOCOMO assumes a complete spec exists (it usually doesn't).
+- It ignores novel-problem effort.
+- It undercounts domains where correctness is load-bearing (crypto, embedded, safety-critical).
+- Never publish LOCOMO *alone* — only alongside COCOMO and bottom-up.

--- a/skills/cost-estimate/references/market-rates.md
+++ b/skills/cost-estimate/references/market-rates.md
@@ -1,0 +1,32 @@
+# Market rates (Step 6)
+
+Use WebSearch for current-year rates. Rotate queries; adapt to the detected stack.
+
+## Queries
+
+- `"senior [primary_language] developer hourly rate"`
+- `"senior [framework] contractor rate [United States / EU / India]"`
+- `"[specialist_domain] developer freelance rate"`
+- `"software engineer hourly rate [city]"` (regional anchor)
+
+Collect 3 – 5 data points. Report regionally.
+
+## Report table
+
+| Region | Low | Avg | High | Notes |
+|---|---|---|---|---|
+| Remote (global) | | | | LATAM, Eastern Europe, SE Asia |
+| Remote (US) | | | | Mid-tier US markets |
+| SF/NYC onsite | | | | Premium markets |
+| Specialist (e.g. Rust, CUDA, Solidity) | | | | Niche premium |
+
+## Fallback anchors
+
+If WebSearch is unavailable or returns obvious rot, use these anchors and state "rates from skill defaults, not live search":
+
+- Generalist senior: **$75 – $150/hr** (US remote), **$150 – $250/hr** (SF/NYC), **$35 – $75/hr** (offshore)
+- Specialist (Rust, ML infra, GPU, crypto): **+30 – 50%**
+
+## Pick a Recommended Rate
+
+One sentence of justification. Use the region most representative of how this codebase would actually be rebuilt. If unsure, default to the US-remote average and flag the assumption in the sensitivity section.

--- a/skills/cost-estimate/references/overhead-multipliers.md
+++ b/skills/cost-estimate/references/overhead-multipliers.md
@@ -1,0 +1,26 @@
+# Overhead multipliers (Step 5)
+
+Apply **multiplicatively** on top of Base Coding Hours. Compounding rule: if a quality signal already bumped per-LOC value in Step 1d, **reduce the related overhead to the low end** to avoid double-counting.
+
+## Formula
+
+```
+Total_Eng_Hours = Base_Coding_Hours
+                × (1 + arch_design)        // 0.15 – 0.20
+                × (1 + debugging)           // 0.25 – 0.30
+                × (1 + code_review)         // 0.10 – 0.15
+                × (1 + documentation)       // 0.10 – 0.15   ← low end if quality bonus for docs
+                × (1 + integration_test)    // 0.20 – 0.25   ← low end if quality bonus for tests
+                × (1 + learning_curve)      // 0.10 – 0.20 (only for specialized stacks)
+                × (1 + devops_setup)        // 0.05 – 0.10   ← low end if quality bonus for CI
+                × (1 + churn_adjustment)    // 0 by default
+                                            // +0.15 if churn_ratio > 2.0 AND contributor_count < 3
+                                            // (skip when churn is normal team iteration, not rework)
+                × quality_multiplier        // 0.7 – 1.3 from Step 1d
+```
+
+Apply to P10 / P50 / P90 each → **Total Engineering Hours (P10 / P50 / P90)**.
+
+## Sanity check
+
+The stacked overhead (before `quality_multiplier`) typically falls **1.8× – 2.6×** of base. Outside that range → investigate: you're probably double-counting, or you've assigned an overhead signal that doesn't match the detected code.

--- a/skills/cost-estimate/references/team-cost.md
+++ b/skills/cost-estimate/references/team-cost.md
@@ -1,0 +1,47 @@
+# Organizational overhead and team cost (Steps 7 + 8)
+
+## Step 7: Developers don't code 40 hours/week
+
+Developers do not code 40 hours per week. Convert total engineering hours to calendar time using efficiency:
+
+| Company type | Coding efficiency | Focused coding hrs/week |
+|---|---|---|
+| Solo / founder | 65 – 75% | 26 – 30 |
+| Lean startup | 55 – 65% | 22 – 26 |
+| Growth company | 45 – 55% | 18 – 22 |
+| Enterprise | 35 – 45% | 14 – 18 |
+| Large bureaucracy | 25 – 35% | 10 – 14 |
+
+```
+calendar_weeks  = Total_Eng_Hours / (40 × efficiency)
+calendar_months = calendar_weeks / 4.33
+```
+
+Report across all five company types.
+
+---
+
+## Step 8: Full team cost (engineering isn't shipped alone)
+
+Role ratios (fraction of engineering hours) and typical rates:
+
+| Role | Ratio | Typical Rate |
+|---|---|---|
+| Product Management | 0.25 – 0.40 | $125 – 200/hr |
+| UX / UI Design | 0.20 – 0.35 | $100 – 175/hr |
+| Engineering Management | 0.12 – 0.20 | $150 – 225/hr |
+| QA / Testing | 0.15 – 0.25 | $75 – 125/hr |
+| Project / Program Mgmt | 0.08 – 0.15 | $100 – 150/hr |
+| Technical Writing | 0.05 – 0.10 | $75 – 125/hr |
+| DevOps / Platform | 0.10 – 0.20 | $125 – 200/hr |
+
+## Team composition by stage (approx. engineering-cost multipliers)
+
+| Stage | Multiplier | Staffed roles |
+|---|---|---|
+| Solo / founder | 1.0× | Engineering only |
+| Lean startup | ~1.45× | Eng + light PM/design/DevOps |
+| Growth company | ~2.2× | Core team, no program mgmt |
+| Enterprise | ~2.65× | All roles |
+
+Compute full-team cost at engineering P50 for each stage.

--- a/skills/cost-estimate/scripts/claude_token_cost.py
+++ b/skills/cost-estimate/scripts/claude_token_cost.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Extract ground-truth Claude token usage + session concurrency stats.
+
+Reads every message.usage block and every timestamp from this project's
+Claude Code session transcripts at ~/.claude/projects/<project-hash>/*.jsonl
+and emits a single JSON object covering:
+
+  - Token usage (input / cache-write / cache-read / output) and the
+    equivalent per-token API cost (counterfactual — Max/Pro plans are flat).
+  - Session timing: per-session span sum (capped 6h each, the active-hours
+    number the skill uses as Claude throughput), uncapped span sum, and the
+    wall-clock UNION of all session intervals (the operator's real time).
+  - Peak concurrent sessions and average concurrency — reveal when a user
+    is driving multiple Claude Code windows in parallel.
+
+Rates below reflect published Anthropic pricing at the skill's last refresh;
+update `RATES` if pricing changes.
+
+Usage: python3 scripts/claude_token_cost.py
+"""
+import glob
+import json
+import os
+import sys
+from datetime import datetime, timedelta
+
+# Per-1M-token rates (USD). Refresh when Anthropic updates pricing.
+RATES = {
+    "opus":   {"in": 15.00, "cache_write": 18.75, "cache_read": 1.50, "out": 75.00},
+    "sonnet": {"in":  3.00, "cache_write":  3.75, "cache_read": 0.30, "out": 15.00},
+    "haiku":  {"in":  0.80, "cache_write":  1.00, "cache_read": 0.08, "out":  4.00},
+}
+
+proj_hash = os.getcwd().replace("/", "-")
+sessions_dir = os.path.expanduser(f"~/.claude/projects/{proj_hash}")
+
+out = {
+    "input_tokens": 0,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "output_tokens": 0,
+    "cost_usd": 0.0,
+    "messages": 0,
+    "sessions_dir": sessions_dir,
+    "sessions_found": 0,
+    "active_hours_capped6": 0.0,
+    "active_hours_uncapped": 0.0,
+    "operator_hours_union": 0.0,
+    "peak_concurrent_sessions": 0,
+    "avg_concurrency": 0.0,
+}
+
+files = glob.glob(f"{sessions_dir}/*.jsonl")
+out["sessions_found"] = len(files)
+
+def parse_ts(s):
+    try:
+        return datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+
+ranges = []
+for f in files:
+    first = last = None
+    try:
+        with open(f, encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                try:
+                    d = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+                t = parse_ts(d.get("timestamp"))
+                if t:
+                    if first is None or t < first: first = t
+                    if last is None or t > last:  last = t
+
+                msg = d.get("message", {})
+                u = msg.get("usage")
+                if not u:
+                    continue
+                model = msg.get("model", "")
+                tier = "opus" if "opus" in model else ("haiku" if "haiku" in model else "sonnet")
+                r = RATES[tier]
+                ti  = u.get("input_tokens", 0)
+                tcw = u.get("cache_creation_input_tokens", 0)
+                tcr = u.get("cache_read_input_tokens", 0)
+                to  = u.get("output_tokens", 0)
+                cost = (ti*r["in"] + tcw*r["cache_write"] + tcr*r["cache_read"] + to*r["out"]) / 1_000_000
+                out["input_tokens"]                += ti
+                out["cache_creation_input_tokens"] += tcw
+                out["cache_read_input_tokens"]     += tcr
+                out["output_tokens"]               += to
+                out["cost_usd"]                    += cost
+                out["messages"]                    += 1
+    except OSError:
+        continue
+    if first and last and last > first:
+        ranges.append((first, last))
+
+# Session timing aggregates
+if ranges:
+    sum_secs = sum((e - s).total_seconds() for s, e in ranges)
+    cap_secs = sum(min((e - s).total_seconds(), 6 * 3600) for s, e in ranges)
+    out["active_hours_uncapped"] = round(sum_secs / 3600, 2)
+    out["active_hours_capped6"]  = round(cap_secs / 3600, 2)
+
+    # Peak concurrency via sweep line
+    events = []
+    for s, e in ranges:
+        events.append((s, +1))
+        events.append((e, -1))
+    events.sort()
+    peak = cur = 0
+    for _, delta in events:
+        cur += delta
+        peak = max(peak, cur)
+    out["peak_concurrent_sessions"] = peak
+
+    # Wall-clock union (operator real time). Discretize to 1-minute bins —
+    # cheap and precise enough for session-scale signal.
+    minutes_active = set()
+    for s, e in ranges:
+        t = s.replace(second=0, microsecond=0)
+        while t <= e:
+            minutes_active.add(t)
+            t += timedelta(minutes=1)
+    out["operator_hours_union"] = round(len(minutes_active) / 60, 2)
+    if out["operator_hours_union"] > 0:
+        out["avg_concurrency"] = round(out["active_hours_uncapped"] / out["operator_hours_union"], 2)
+
+out["cost_usd"] = round(out["cost_usd"], 2)
+json.dump(out, sys.stdout, indent=2)
+print()

--- a/skills/cost-estimate/scripts/compute_dryness.py
+++ b/skills/cost-estimate/scripts/compute_dryness.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Compute DRYness = unique LOC / total LOC.
+
+Requires `scc` to be installed (it reports ULOC in JSON). If scc is not
+available, prints `DRYness:unknown` and exits 0 — callers should skip
+the deflator rather than invent a number.
+
+Usage: python3 scripts/compute_dryness.py [path]
+"""
+import json
+import shutil
+import subprocess
+import sys
+
+path = sys.argv[1] if len(sys.argv) > 1 else "."
+
+if not shutil.which("scc"):
+    print("SLOC:unknown ULOC:unknown DRYness:unknown")
+    sys.exit(0)
+
+try:
+    out = subprocess.check_output(["scc", "--format=json", path], timeout=60)
+    data = json.loads(out)
+except (subprocess.CalledProcessError, subprocess.TimeoutExpired, json.JSONDecodeError):
+    print("SLOC:unknown ULOC:unknown DRYness:unknown")
+    sys.exit(0)
+
+total = sum(lang["Code"] for lang in data)
+# scc reports ULOC at the top level summary in newer versions; fall back to per-language
+uniq = sum(lang.get("ULOC", lang["Code"]) for lang in data)
+if total == 0:
+    print("SLOC:0 ULOC:0 DRYness:unknown")
+else:
+    print(f"SLOC:{total} ULOC:{uniq} DRYness:{uniq/total:.2f}")

--- a/skills/cost-estimate/scripts/count_loc.sh
+++ b/skills/cost-estimate/scripts/count_loc.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# count_loc.sh — Fast LOC count with graceful fallback.
+#
+# Tries cloc → tokei → scc in order (each handles exclusions properly).
+# Falls back to `find + wc` with the standard exclusion list.
+# Prints a single integer (total counted LOC) to stdout.
+#
+# Usage: bash scripts/count_loc.sh [path]
+set -euo pipefail
+ROOT="${1:-.}"
+
+# Preferred: real counters
+if command -v cloc >/dev/null 2>&1; then
+  cloc --vcs=git --quiet "$ROOT" 2>/dev/null \
+    | awk '/^SUM:/ {print $NF; found=1} END{exit !found}' && exit 0
+fi
+if command -v tokei >/dev/null 2>&1; then
+  tokei --output=json "$ROOT" 2>/dev/null \
+    | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['Total']['code'])" && exit 0
+fi
+if command -v scc >/dev/null 2>&1; then
+  scc --format=json "$ROOT" 2>/dev/null \
+    | python3 -c "import sys,json; print(sum(l['Code'] for l in json.load(sys.stdin)))" && exit 0
+fi
+
+# Fallback: filtered find + wc (counts LINES, not files)
+find "$ROOT" -type f \
+  \( -name "*.ts" -o -name "*.tsx" -o -name "*.js" -o -name "*.jsx" \
+     -o -name "*.py" -o -name "*.go" -o -name "*.rs" -o -name "*.java" \
+     -o -name "*.rb" -o -name "*.php" -o -name "*.swift" -o -name "*.kt" \
+     -o -name "*.cpp" -o -name "*.cc" -o -name "*.c" -o -name "*.h" -o -name "*.hpp" \) \
+  -not -path "*/node_modules/*" -not -path "*/.git/*" \
+  -not -path "*/dist/*" -not -path "*/build/*" -not -path "*/vendor/*" \
+  -not -path "*/.venv/*" -not -path "*/__pycache__/*" -not -path "*/target/*" \
+  -not -path "*/.next/*" \
+  -print0 2>/dev/null \
+  | xargs -0 wc -l 2>/dev/null \
+  | awk 'END {print $1+0}'

--- a/skills/cost-estimate/scripts/git_session_clustering.py
+++ b/skills/cost-estimate/scripts/git_session_clustering.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Estimate Claude-active hours by clustering commits into sessions.
+
+Fallback used when no session logs exist at ~/.claude/projects/. Groups
+commits within a 4-hour window into a single session, then estimates
+each session's duration as max(span+30min, 0.5h + 18min * commit_count),
+clamped to [0.5h, 4h].
+
+Output: `sessions:<N> est_hours:<X.X>` on stdout.
+Confidence: medium (±2×). Prefer claude_token_cost.py when logs exist.
+
+Usage: python3 scripts/git_session_clustering.py
+"""
+import subprocess
+import sys
+
+try:
+    out = subprocess.check_output(
+        ["git", "log", "--format=%at", "--reverse"], text=True
+    )
+except subprocess.CalledProcessError:
+    print("sessions:0 est_hours:0.0")
+    sys.exit(0)
+
+times = [int(t) for t in out.split() if t.strip().isdigit()]
+if not times:
+    print("sessions:0 est_hours:0.0")
+    sys.exit(0)
+
+GAP = 4 * 3600
+sessions, current = [], [times[0]]
+for t in times[1:]:
+    if t - current[-1] <= GAP:
+        current.append(t)
+    else:
+        sessions.append(current)
+        current = [t]
+sessions.append(current)
+
+total_h = 0.0
+for s in sessions:
+    span_h    = (s[-1] - s[0]) / 3600
+    by_span   = max(0.5, min(4.0, span_h + 0.5))       # span + 30min buffer
+    by_density = min(4.0, 0.5 + 0.3 * len(s))          # 0.5h base + 18min/commit
+    total_h += max(by_span, by_density)
+
+print(f"sessions:{len(sessions)} est_hours:{total_h:.1f}")

--- a/skills/cost-estimate/scripts/git_signals.sh
+++ b/skills/cost-estimate/scripts/git_signals.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# git_signals.sh — Collect process signals from git history.
+#
+# Prints one line of key=value pairs covering: first/last commit dates,
+# project duration in days, commit count, unique contributors, and
+# gross/net churn + churn ratio.
+#
+# Usage: bash scripts/git_signals.sh
+# Output example:
+#   first=2026-01-12 last=2026-04-18 duration_days=96 commits=142 \
+#   contributors=3 adds=42310 dels=11025 net=31285 churn_ratio=3.84
+set -eu
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "no_git=true"
+  exit 0
+fi
+
+# `git log --reverse -1` returns the NEWEST commit (the -1 limit applies
+# before --reverse), so use --max-parents=0 for the root commit instead.
+first=$(git log --format="%ai" "$(git rev-list --max-parents=0 HEAD 2>/dev/null | tail -1)" 2>/dev/null | head -1 | awk '{print $1}')
+last=$(git log --format="%ai" -1 2>/dev/null | awk '{print $1}')
+commits=$(git rev-list --count HEAD 2>/dev/null || echo 0)
+contributors=$(git shortlog -sne HEAD 2>/dev/null | wc -l | awk '{print $1}')
+
+duration_days=$(python3 -c "
+from datetime import date
+f='$first'; l='$last'
+if not f or not l: print(0)
+else:
+    d=(date.fromisoformat(l)-date.fromisoformat(f)).days
+    print(max(d,1))
+")
+
+read -r adds dels < <(git log --numstat --pretty=tformat: 2>/dev/null \
+  | awk '{a+=$1; d+=$2} END {printf "%d %d\n", a+0, d+0}')
+
+net=$((adds - dels))
+churn_ratio=$(python3 -c "print(f'{($adds)/max($dels,1):.2f}')")
+
+echo "first=$first last=$last duration_days=$duration_days commits=$commits contributors=$contributors adds=$adds dels=$dels net=$net churn_ratio=$churn_ratio"

--- a/skills/cost-estimate/scripts/resolve_outdir.py
+++ b/skills/cost-estimate/scripts/resolve_outdir.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Derive the output directory for cost-estimate artifacts.
+
+Prints a platform-appropriate, project-scoped temp directory, creating it
+if needed. Never writes inside the user's working tree — reports can
+contain sensitive numbers (rates, costs, team composition) that should
+not land in a git commit by accident.
+
+Typical paths (all use forward slashes in this skill's authored docs —
+Windows clients display them with backslashes, but pathlib handles the
+translation transparently):
+  Linux   → /tmp/cost-estimate/<project>/
+  macOS   → /var/folders/.../T/cost-estimate/<project>/
+  Windows → %TEMP%/cost-estimate/<project>/
+"""
+import os
+import pathlib
+import tempfile
+
+proj = pathlib.Path(os.getcwd()).name or "unknown"
+out = pathlib.Path(tempfile.gettempdir()) / "cost-estimate" / proj
+out.mkdir(parents=True, exist_ok=True)
+print(out)


### PR DESCRIPTION
Estimates what a codebase would have cost to build with a traditional human team — the replacement cost to rebuild, not market value. Combines LOC analysis, git process signals, COCOMO II cross-check, Function Point backfiring, LOCOMO (LLM regeneration counterfactual), market rates, org overhead, and Claude-session-aware ROI into a P10/P50/P90 range with an explicit assumption + spot-check section.

### When it triggers

User asks "how much did this cost?", "what's the ROI of Claude/Copilot on this repo?", "how long would a human team have taken?", or mentions COCOMO, LOCOMO, Function Points, LOC analysis, or codebase cost.

### Four-way cross-check

- Bottom-up (category × LOC rate, with overhead)
- COCOMO II (top-down, A × KSLOC^E × EAF)
- Function Point backfiring (QSM LOC-per-FP → hours)
- LOCOMO (LLM regeneration cost + human review)

When they disagree >2×, the report stops and asks the operator to investigate before publishing.

### Claude ROI (honest)

Uses ground-truth session-log tokens (reading `~/.claude/projects/*.jsonl`) for actual API cost, detects parallel-window usage, and reports a per-developer-equivalent speed multiplier benchmarked against:

- GitHub Copilot SPACE 2024 (1.55×)
- METR Feb 2026 transcript study (2.1–11.6×, n=7)
- Carlini C-compiler (existence proof for async swarm)

No invented tiers. Flags when the operator-hour multiplier exceeds METR's ceiling and explains both possible causes (codebase-shape inflation vs. genuinely above-sample).

### Layout

Progressive-disclosure per the Anthropic best-practices guide:

    skills/cost-estimate/
    ├── SKILL.md              # 363 lines (orchestrator, under 500 gate)
    ├── scripts/              # 6 executable helpers (count LOC, git
    │                         #   signals, Claude token cost, etc.)
    ├── references/           # 9 methodology files (category rates,
    │                         #   COCOMO, FP, LOCOMO, overhead, market
    │                         #   rates, team cost, Claude ROI,
    │                         #   cross-validation)
    └── assets/
        ├── report-template.md
        └── artifact-schema.json

### Writes artifacts to temp dir (not the working tree)

Reports can contain sensitive numbers (rates, Claude costs, team composition). The skill writes Markdown + JSON to a platform-appropriate temp directory and prints the Markdown to stdout, never into the user's working directory where `git add .` could accidentally commit them.

Upstream source: https://github.com/jbarbier/claude-code-cost-estimate