### PR TITLE
Update SKILL.md to include description character limit

### DIFF
--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -332,7 +332,7 @@ This is optional, requires subagents, and most users won't need it. The human re
 
 ## Description Optimization
 
-The description field in SKILL.md frontmatter is the primary mechanism that determines whether Claude invokes a skill. After creating or improving a skill, offer to optimize the description for better triggering accuracy.
+The description field in SKILL.md frontmatter is the primary mechanism that determines whether Claude invokes a skill. After creating or improving a skill, offer to optimize the description for better triggering accuracy. It can be at most 1024 characters.
 
 ### Step 1: Generate trigger eval queries
 


### PR DESCRIPTION
I constantly run into too long description error when refining my skills, so I have to waste a whole 'nother request just to get the description compacted.