### PR TITLE
fix(skill-creator): close run_eval's 0% recall and harden the loop

### DIFF
--- a/skills/skill-creator/scripts/generate_report.py
+++ b/skills/skill-creator/scripts/generate_report.py
@@ -202,8 +202,12 @@ def generate_html(data: dict, auto_refresh: bool = False, skill_name: str = "") 
         <tbody>
 """)
 
-    # Find best iteration for highlighting
-    if test_queries:
+    # Find best iteration for highlighting. A run that exits before the first
+    # history entry (e.g. --max-iterations 0) leaves history empty, and max()
+    # over it would raise.
+    if not history:
+        best_iter = None
+    elif test_queries:
         best_iter = max(history, key=lambda h: h.get("test_passed") or 0).get("iteration")
     else:
         best_iter = max(history, key=lambda h: h.get("train_passed", h.get("passed", 0))).get("iteration")

--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -3,26 +3,61 @@
 
 Tests whether a skill's description causes Claude to trigger (read the skill)
 for a set of queries. Outputs results as JSON.
+
+Mechanism: each run creates an isolated temporary project containing the
+candidate description installed as a real skill at
+<tmp>/.claude/skills/<name>/SKILL.md, and `claude -p` executes with that
+project as its working directory. Skills are the only surface `claude -p`
+exposes to the model for auto-triggering (files under .claude/commands/
+appear in slash_commands but never in the model's available_skills list).
+Running in a throwaway project keeps the skill's real name (no suffix) and
+makes concurrent runs collision-free by construction: every run gets its own
+project directory keyed by a full UUID4. The directory is shared by the run's
+parallel workers and removed when the run ends; directories left behind by
+killed runs are swept once they are older than --stale-artifact-hours.
+
+Skill name resolution is user > project, so a same-name skill installed under
+~/.claude/skills would override the candidate; run_eval moves such a copy
+aside for the run's duration (see _shadow_user_skill) so the eval measures the
+candidate description, not the installed one.
 """
 
 import argparse
 import json
 import os
-import select
+import shutil
 import subprocess
 import sys
+import tempfile
+import threading
 import time
 import uuid
+from collections import deque
 from concurrent.futures import ProcessPoolExecutor, as_completed
+from contextlib import contextmanager
 from pathlib import Path
+from queue import Empty, Queue
 
 from scripts.utils import parse_skill_md
+
+# Bounds conversation length for queries that never trigger, so cost and
+# wall-clock time stay capped without cutting off legitimate multi-turn
+# runs where Claude explores (TodoWrite/Glob/Bash) before invoking the skill.
+MAX_CLAUDE_TURNS = 8
+
+# All eval projects live under this root in the OS temp directory.
+EVAL_PROJECTS_ROOT = Path(tempfile.gettempdir()) / "claude-skill-evals"
+
+# Leftover eval projects must be at least this old (hours) before the sweep
+# removes them: long enough to survive a paused debugging session, short
+# enough not to accumulate cruft. Override with --stale-artifact-hours.
+DEFAULT_STALE_ARTIFACT_HOURS = 12.0
 
 
 def find_project_root() -> Path:
     """Find the project root by walking up from cwd looking for .claude/.
 
-    Mimics how Claude Code discovers its project root, so the command file
+    Mimics how Claude Code discovers its project root, so the eval skill
     we create ends up where claude -p will look for it.
     """
     current = Path.cwd()
@@ -32,153 +67,315 @@ def find_project_root() -> Path:
     return current
 
 
+def resolve_claude_cli() -> str:
+    """Resolve the claude executable to a full path.
+
+    On Windows, Popen(["claude", ...]) only finds claude.exe; npm installs
+    provide a claude.cmd shim that raises FileNotFoundError unless resolved
+    to a full path first. shutil.which handles both via PATHEXT.
+    """
+    resolved = shutil.which("claude")
+    if not resolved:
+        raise RuntimeError(
+            "Could not find the `claude` CLI on PATH. Install Claude Code or "
+            "add its install directory to PATH before running evals."
+        )
+    return resolved
+
+
+def _pump_lines(stream, sink) -> None:
+    """Read a binary stream line by line into sink; signal EOF with None."""
+    try:
+        for raw in iter(stream.readline, b""):
+            sink(raw)
+    finally:
+        sink(None)
+
+
+def _tool_use_mentions(eval_skill_name: str, tool_name: str, tool_input: dict) -> bool:
+    """Whether a tool_use block is Claude consulting the eval skill.
+
+    Field-scoped on purpose. A plain substring test (the skill name anywhere
+    in the serialized input) produces false positives for short names that
+    collide with common words or extensions: a skill named "pdf" would count
+    a Read of "report.pdf" or a Bash command touching a .pdf as a trigger.
+    Only an exact Skill invocation, or a Read of a path inside the skill's
+    own directory, is a genuine consult.
+    """
+    if tool_name == "Skill":
+        return (tool_input.get("skill") or "").strip() == eval_skill_name
+    if tool_name == "Read":
+        # Normalize separators so the match holds on Windows paths too.
+        path = (tool_input.get("file_path") or "").replace("\\", "/")
+        return f"/{eval_skill_name}/" in path
+    return False
+
+
+def _detect_trigger(events, eval_skill_name: str) -> bool:
+    """Whether an event stream shows Claude consulting the eval skill.
+
+    Kept pure so the decision that silently read 0% recall for months is
+    unit-testable without spawning claude. True on the first field-scoped
+    Skill/Read match, False on a terminal `result` event or once the stream
+    ends. Non-Skill/Read tool calls are ignored, not scored as misses, since
+    Claude often explores before consulting a skill.
+    """
+    pending_tool_name = None
+    accumulated_json = ""
+    for event in events:
+        etype = event.get("type")
+        if etype == "stream_event":
+            se = event.get("event", {})
+            se_type = se.get("type", "")
+
+            if se_type == "content_block_start":
+                cb = se.get("content_block", {})
+                if cb.get("type") == "tool_use" and cb.get("name", "") in ("Skill", "Read"):
+                    pending_tool_name = cb.get("name", "")
+                    accumulated_json = ""
+                else:
+                    pending_tool_name = None
+
+            elif se_type == "content_block_delta" and pending_tool_name:
+                delta = se.get("delta", {})
+                if delta.get("type") == "input_json_delta":
+                    # Accumulate only; the input must be parsed whole to
+                    # field-scope the match, which partial JSON can't be.
+                    accumulated_json += delta.get("partial_json", "")
+
+            elif se_type == "content_block_stop":
+                if pending_tool_name:
+                    try:
+                        tool_input = json.loads(accumulated_json) if accumulated_json else {}
+                    except json.JSONDecodeError:
+                        tool_input = {}
+                    if _tool_use_mentions(eval_skill_name, pending_tool_name, tool_input):
+                        return True
+                pending_tool_name = None
+
+        elif etype == "assistant":
+            for content_item in event.get("message", {}).get("content", []):
+                if content_item.get("type") != "tool_use":
+                    continue
+                if _tool_use_mentions(
+                    eval_skill_name,
+                    content_item.get("name", ""),
+                    content_item.get("input") or {},
+                ):
+                    return True
+
+        elif etype == "result":
+            return False
+
+    return False
+
+
 def run_single_query(
     query: str,
-    skill_name: str,
-    skill_description: str,
+    eval_skill_name: str,
     timeout: int,
-    project_root: str,
+    eval_project_dir: str,
     model: str | None = None,
+    claude_cli: str | None = None,
 ) -> bool:
-    """Run a single query and return whether the skill was triggered.
+    """Run a single query and return whether the eval skill was triggered.
 
-    Creates a command file in .claude/commands/ so it appears in Claude's
-    available_skills list, then runs `claude -p` with the raw query.
-    Uses --include-partial-messages to detect triggering early from
-    stream events (content_block_start) rather than waiting for the
-    full assistant message, which only arrives after tool execution.
+    Runs `claude -p` with the isolated eval project as its working directory,
+    streams its output, and returns True as soon as a Skill/Read tool_use
+    referencing the eval skill appears. Returns False on a terminal `result`
+    event, process exit, or timeout.
     """
-    unique_id = uuid.uuid4().hex[:8]
-    clean_name = f"{skill_name}-skill-{unique_id}"
-    project_commands_dir = Path(project_root) / ".claude" / "commands"
-    command_file = project_commands_dir / f"{clean_name}.md"
+    cmd = [
+        claude_cli or resolve_claude_cli(),
+        "-p", query,
+        "--output-format", "stream-json",
+        "--verbose",
+        "--include-partial-messages",
+        "--max-turns", str(MAX_CLAUDE_TURNS),
+    ]
+    if model:
+        cmd.extend(["--model", model])
+
+    # Remove CLAUDECODE env var to allow nesting claude -p inside a
+    # Claude Code session. The guard is for interactive terminal conflicts;
+    # programmatic subprocess usage is safe.
+    env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+
+    process = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=eval_project_dir,
+        env=env,
+    )
+
+    # select() only works on sockets on Windows, so stream reading goes
+    # through reader threads + a queue, which behaves the same everywhere.
+    stdout_queue: Queue = Queue()
+    stderr_tail: deque = deque(maxlen=40)
+    threading.Thread(
+        target=_pump_lines, args=(process.stdout, stdout_queue.put), daemon=True
+    ).start()
+    threading.Thread(
+        target=_pump_lines,
+        args=(process.stderr, lambda raw: stderr_tail.append(raw) if raw else None),
+        daemon=True,
+    ).start()
+
+    def stderr_excerpt() -> str:
+        return b"".join(stderr_tail).decode("utf-8", errors="replace").strip()[:500]
+
+    deadline = time.time() + timeout
+    timed_out = False
+
+    def stream_events():
+        nonlocal timed_out
+        while True:
+            if time.time() > deadline:
+                timed_out = True
+                return
+            try:
+                raw = stdout_queue.get(timeout=0.5)
+            except Empty:
+                continue
+            if raw is None:  # EOF: process finished and output is drained
+                return
+            line = raw.decode("utf-8", errors="replace").strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError:
+                continue
 
     try:
-        project_commands_dir.mkdir(parents=True, exist_ok=True)
-        # Use YAML block scalar to avoid breaking on quotes in description
-        indented_desc = "\n  ".join(skill_description.split("\n"))
-        command_content = (
-            f"---\n"
-            f"description: |\n"
-            f"  {indented_desc}\n"
-            f"---\n\n"
-            f"# {skill_name}\n\n"
-            f"This skill handles: {skill_description}\n"
-        )
-        command_file.write_text(command_content)
-
-        cmd = [
-            "claude",
-            "-p", query,
-            "--output-format", "stream-json",
-            "--verbose",
-            "--include-partial-messages",
-        ]
-        if model:
-            cmd.extend(["--model", model])
-
-        # Remove CLAUDECODE env var to allow nesting claude -p inside a
-        # Claude Code session. The guard is for interactive terminal conflicts;
-        # programmatic subprocess usage is safe.
-        env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
-
-        process = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            cwd=project_root,
-            env=env,
-        )
-
-        triggered = False
-        start_time = time.time()
-        buffer = ""
-        # Track state for stream event detection
-        pending_tool_name = None
-        accumulated_json = ""
-
-        try:
-            while time.time() - start_time < timeout:
-                if process.poll() is not None:
-                    remaining = process.stdout.read()
-                    if remaining:
-                        buffer += remaining.decode("utf-8", errors="replace")
-                    break
-
-                ready, _, _ = select.select([process.stdout], [], [], 1.0)
-                if not ready:
-                    continue
-
-                chunk = os.read(process.stdout.fileno(), 8192)
-                if not chunk:
-                    break
-                buffer += chunk.decode("utf-8", errors="replace")
-
-                while "\n" in buffer:
-                    line, buffer = buffer.split("\n", 1)
-                    line = line.strip()
-                    if not line:
-                        continue
-
-                    try:
-                        event = json.loads(line)
-                    except json.JSONDecodeError:
-                        continue
-
-                    # Early detection via stream events
-                    if event.get("type") == "stream_event":
-                        se = event.get("event", {})
-                        se_type = se.get("type", "")
-
-                        if se_type == "content_block_start":
-                            cb = se.get("content_block", {})
-                            if cb.get("type") == "tool_use":
-                                tool_name = cb.get("name", "")
-                                if tool_name in ("Skill", "Read"):
-                                    pending_tool_name = tool_name
-                                    accumulated_json = ""
-                                else:
-                                    return False
-
-                        elif se_type == "content_block_delta" and pending_tool_name:
-                            delta = se.get("delta", {})
-                            if delta.get("type") == "input_json_delta":
-                                accumulated_json += delta.get("partial_json", "")
-                                if clean_name in accumulated_json:
-                                    return True
-
-                        elif se_type in ("content_block_stop", "message_stop"):
-                            if pending_tool_name:
-                                return clean_name in accumulated_json
-                            if se_type == "message_stop":
-                                return False
-
-                    # Fallback: full assistant message
-                    elif event.get("type") == "assistant":
-                        message = event.get("message", {})
-                        for content_item in message.get("content", []):
-                            if content_item.get("type") != "tool_use":
-                                continue
-                            tool_name = content_item.get("name", "")
-                            tool_input = content_item.get("input", {})
-                            if tool_name == "Skill" and clean_name in tool_input.get("skill", ""):
-                                triggered = True
-                            elif tool_name == "Read" and clean_name in tool_input.get("file_path", ""):
-                                triggered = True
-                            return triggered
-
-                    elif event.get("type") == "result":
-                        return triggered
-        finally:
-            # Clean up process on any exit path (return, exception, timeout)
-            if process.poll() is None:
-                process.kill()
-                process.wait()
-
-        return triggered
+        if _detect_trigger(stream_events(), eval_skill_name):
+            return True
+        # Not triggered: surface why, so a silent all-zero run is debuggable.
+        if timed_out:
+            print(
+                f"Warning: query timed out after {timeout}s; counting as "
+                f"not-triggered: {query[:60]}",
+                file=sys.stderr,
+            )
+        else:
+            try:
+                process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                return False
+            if process.returncode != 0:
+                print(
+                    f"Warning: claude -p exited with code {process.returncode} "
+                    f"for query: {query[:60]}\n  stderr: {stderr_excerpt()}",
+                    file=sys.stderr,
+                )
+        return False
     finally:
-        if command_file.exists():
-            command_file.unlink()
+        # Clean up process on any exit path (return, exception, timeout)
+        if process.poll() is None:
+            process.kill()
+            process.wait()
+
+
+def _sweep_stale_eval_projects(stale_hours: float) -> None:
+    """Remove eval projects left behind by previous crashed/killed runs.
+
+    Only directories older than the threshold are removed, so the sweep
+    never deletes the live project of a concurrent eval run and survives
+    paused debugging sessions.
+    """
+    if not EVAL_PROJECTS_ROOT.is_dir():
+        return
+    cutoff = time.time() - stale_hours * 3600
+    for entry in EVAL_PROJECTS_ROOT.iterdir():
+        if entry.is_dir():
+            try:
+                if entry.stat().st_mtime < cutoff:
+                    shutil.rmtree(entry, ignore_errors=True)
+            except OSError:
+                pass
+
+
+@contextmanager
+def _shadow_user_skill(skill_name: str):
+    """Move an installed ~/.claude/skills/<name> aside for the run's duration.
+
+    Skill resolution is user > project, so a same-name installed skill would
+    override the candidate this eval installs at project level, and claude -p
+    would trigger on and measure the installed description instead of the one
+    under test — pinning the score to the installed copy regardless of the
+    description being optimized. Moving it aside makes the candidate the only
+    <name> skill, restored afterward.
+
+    The backup lives under ~/.claude/, outside skills/, not in system temp:
+    keeping it out of skills/ prevents it re-registering as a skill during the
+    run, staying on the same volume makes the move an atomic rename that can't
+    be reaped by an OS temp cleaner or fail across devices and preserves a
+    symlinked skill as a symlink, and a hard-killed run leaves the skill
+    recoverable under a stable path. A failed move (e.g. a concurrent eval of
+    the same name moved it first) is logged and the run proceeds rather than
+    crashing.
+    """
+    installed = Path.home() / ".claude" / "skills" / skill_name
+    backup_dir = Path.home() / ".claude" / "skill-creator-eval-shadows" / uuid.uuid4().hex
+    backup = backup_dir / skill_name
+    moved = False
+    if installed.is_dir():
+        try:
+            backup_dir.mkdir(parents=True, exist_ok=True)
+            os.replace(installed, backup)
+            moved = True
+            print(
+                f"Moved installed skill {installed} aside to {backup} for the "
+                f"eval; it is restored when the run finishes.",
+                file=sys.stderr,
+            )
+        except OSError as e:
+            print(
+                f"Warning: could not move {installed} aside ({e}); proceeding "
+                f"without shadowing it.",
+                file=sys.stderr,
+            )
+    try:
+        yield
+    finally:
+        if moved:
+            installed.parent.mkdir(parents=True, exist_ok=True)
+            if installed.exists():
+                # Re-created during the run; the backup is the original.
+                shutil.rmtree(installed, ignore_errors=True)
+            os.replace(backup, installed)
+            shutil.rmtree(backup_dir, ignore_errors=True)
+
+
+def create_eval_project(skill_name: str, skill_description: str, stale_hours: float) -> Path:
+    """Create an isolated throwaway project with the candidate skill.
+
+    The skill keeps its real name — isolation comes from the project
+    directory, which is keyed by a full UUID4 so concurrent runs (parallel
+    CI jobs included) can never collide. Returns the project directory;
+    the caller is responsible for removing it when the run finishes.
+    """
+    _sweep_stale_eval_projects(stale_hours)
+
+    project_dir = EVAL_PROJECTS_ROOT / f"{skill_name}-{uuid.uuid4().hex}"
+    skill_dir = project_dir / ".claude" / "skills" / skill_name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    # Use YAML block scalar to avoid breaking on quotes in description
+    indented_desc = "\n  ".join(skill_description.split("\n"))
+    skill_content = (
+        f"---\n"
+        f"name: {skill_name}\n"
+        f"description: |\n"
+        f"  {indented_desc}\n"
+        f"---\n\n"
+        f"# {skill_name}\n\n"
+        f"This skill handles: {skill_description}\n\n"
+        f"(Temporary trigger-eval artifact created by skill-creator's "
+        f"run_eval.py; safe to delete.)\n"
+    )
+    (skill_dir / "SKILL.md").write_text(skill_content)
+    return project_dir
 
 
 def run_eval(
@@ -187,42 +384,63 @@ def run_eval(
     description: str,
     num_workers: int,
     timeout: int,
-    project_root: Path,
+    project_root: Path | None = None,
     runs_per_query: int = 1,
     trigger_threshold: float = 0.5,
     model: str | None = None,
+    stale_artifact_hours: float = DEFAULT_STALE_ARTIFACT_HOURS,
 ) -> dict:
-    """Run the full eval set and return results."""
+    """Run the full eval set and return results.
+
+    `project_root` is retained for backward compatibility but no longer
+    used: evals run inside an isolated temporary project so they keep the
+    skill's real name, never touch the caller's project, and cannot collide
+    across concurrent runs.
+    """
+    del project_root  # Deprecated; see docstring.
     results = []
+    claude_cli = resolve_claude_cli()
+    # One shared artifact per run: per-worker copies with distinct names but
+    # identical descriptions made Claude pick one arbitrarily, so each
+    # worker missed triggers that landed on a sibling's copy.
+    eval_project_dir = create_eval_project(skill_name, description, stale_artifact_hours)
 
-    with ProcessPoolExecutor(max_workers=num_workers) as executor:
-        future_to_info = {}
-        for item in eval_set:
-            for run_idx in range(runs_per_query):
-                future = executor.submit(
-                    run_single_query,
-                    item["query"],
-                    skill_name,
-                    description,
-                    timeout,
-                    str(project_root),
-                    model,
-                )
-                future_to_info[future] = (item, run_idx)
+    try:
+        with _shadow_user_skill(skill_name):
+            with ProcessPoolExecutor(max_workers=num_workers) as executor:
+                future_to_info = {}
+                for item in eval_set:
+                    for run_idx in range(runs_per_query):
+                        future = executor.submit(
+                            run_single_query,
+                            item["query"],
+                            skill_name,
+                            timeout,
+                            str(eval_project_dir),
+                            model,
+                            claude_cli,
+                        )
+                        future_to_info[future] = (item, run_idx)
 
-        query_triggers: dict[str, list[bool]] = {}
-        query_items: dict[str, dict] = {}
-        for future in as_completed(future_to_info):
-            item, _ = future_to_info[future]
-            query = item["query"]
-            query_items[query] = item
-            if query not in query_triggers:
-                query_triggers[query] = []
-            try:
-                query_triggers[query].append(future.result())
-            except Exception as e:
-                print(f"Warning: query failed: {e}", file=sys.stderr)
-                query_triggers[query].append(False)
+                query_triggers: dict[str, list[bool]] = {}
+                query_items: dict[str, dict] = {}
+                for future in as_completed(future_to_info):
+                    item, _ = future_to_info[future]
+                    query = item["query"]
+                    query_items[query] = item
+                    if query not in query_triggers:
+                        query_triggers[query] = []
+                    try:
+                        query_triggers[query].append(future.result())
+                    except Exception as e:
+                        print(
+                            f"Warning: query failed ({type(e).__name__}: {e}); "
+                            f"counting as not-triggered: {query[:60]}",
+                            file=sys.stderr,
+                        )
+                        query_triggers[query].append(False)
+    finally:
+        shutil.rmtree(eval_project_dir, ignore_errors=True)
 
     for query, triggers in query_triggers.items():
         item = query_items[query]
@@ -266,6 +484,12 @@ def main():
     parser.add_argument("--runs-per-query", type=int, default=3, help="Number of runs per query")
     parser.add_argument("--trigger-threshold", type=float, default=0.5, help="Trigger rate threshold")
     parser.add_argument("--model", default=None, help="Model to use for claude -p (default: user's configured model)")
+    parser.add_argument(
+        "--stale-artifact-hours",
+        type=float,
+        default=DEFAULT_STALE_ARTIFACT_HOURS,
+        help="Age (hours) before leftover eval projects from crashed runs are swept",
+    )
     parser.add_argument("--verbose", action="store_true", help="Print progress to stderr")
     args = parser.parse_args()
 
@@ -293,6 +517,7 @@ def main():
         runs_per_query=args.runs_per_query,
         trigger_threshold=args.trigger_threshold,
         model=args.model,
+        stale_artifact_hours=args.stale_artifact_hours,
     )
 
     if args.verbose:

--- a/skills/skill-creator/scripts/run_loop.py
+++ b/skills/skill-creator/scripts/run_loop.py
@@ -196,22 +196,48 @@ def run_loop(
             {k: v for k, v in h.items() if not k.startswith("test_")}
             for h in history
         ]
-        new_description = improve_description(
-            skill_name=name,
-            skill_content=content,
-            current_description=current_description,
-            eval_results=train_results,
-            history=blinded_history,
-            model=model,
-            log_dir=log_dir,
-            iteration=iteration,
-        )
+        try:
+            new_description = improve_description(
+                skill_name=name,
+                skill_content=content,
+                current_description=current_description,
+                eval_results=train_results,
+                history=blinded_history,
+                model=model,
+                log_dir=log_dir,
+                iteration=iteration,
+            )
+        except Exception as e:
+            # A failed improvement (rate limit, model error, expired creds)
+            # must not discard the iterations already collected.
+            exit_reason = f"improve_description failed on iteration {iteration}: {e}"
+            if verbose:
+                print(f"\nDescription improvement failed — keeping partial results.\n  {e}", file=sys.stderr)
+            break
         improve_elapsed = time.time() - t0
 
         if verbose:
             print(f"Proposed ({improve_elapsed:.1f}s): {new_description}", file=sys.stderr)
 
         current_description = new_description
+
+    # A run that exits before the first eval appends (e.g. --max-iterations 0)
+    # leaves history empty, and max() below would raise on it.
+    if not history:
+        return {
+            "exit_reason": exit_reason,
+            "original_description": original_description,
+            "best_description": original_description,
+            "best_score": None,
+            "best_train_score": None,
+            "best_test_score": None,
+            "final_description": current_description,
+            "iterations_run": 0,
+            "holdout": holdout,
+            "train_size": len(train_set),
+            "test_size": len(test_set),
+            "history": history,
+        }
 
     # Find the best iteration by TEST score (or train if no test set)
     if test_set:

--- a/skills/skill-creator/scripts/tests/test_loop_guards.py
+++ b/skills/skill-creator/scripts/tests/test_loop_guards.py
@@ -1,0 +1,44 @@
+"""Offline tests for the optimize loop's degenerate-run guards.
+
+A run that exits before the first eval (e.g. --max-iterations 0) once crashed
+on max([]); these pin that it returns cleanly instead. No `claude` subprocess
+and no API cost — with zero iterations run_loop never spawns an eval. Run from
+the skill-creator directory:
+
+    python -m unittest scripts.tests.test_loop_guards
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.generate_report import generate_html
+from scripts.run_loop import run_loop
+
+
+class TestDegenerateLoop(unittest.TestCase):
+    def _skill_dir(self) -> Path:
+        d = Path(tempfile.mkdtemp())
+        (d / "SKILL.md").write_text("---\nname: pdf\ndescription: test\n---\n\n# pdf\n")
+        return d
+
+    def test_run_loop_zero_iterations_returns_cleanly(self):
+        # --max-iterations 0 exits before any eval, leaving history empty;
+        # the loop must return the original description, not raise on max([]).
+        out = run_loop(
+            eval_set=[{"query": "q", "should_trigger": True}],
+            skill_path=self._skill_dir(),
+            description_override=None,
+            num_workers=1, timeout=1, max_iterations=0, runs_per_query=1,
+            trigger_threshold=0.5, holdout=0, model="unused", verbose=False,
+        )
+        self.assertEqual(out["iterations_run"], 0)
+        self.assertEqual(out["best_description"], "test")
+
+    def test_generate_html_empty_history(self):
+        html = generate_html({"history": [], "original_description": "test"})
+        self.assertIn("Skill Description Optimization", html)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/skill-creator/scripts/tests/test_trigger_detection.py
+++ b/skills/skill-creator/scripts/tests/test_trigger_detection.py
@@ -1,0 +1,138 @@
+"""Offline tests for the eval's trigger detection.
+
+The 0%-recall bug (#556) hid for months because nothing pinned the metric.
+These tests pin the detection logic with no `claude` subprocess and no API
+cost: they feed canned stream-json events to the pure functions. Run from
+the skill-creator directory:
+
+    python -m unittest scripts.tests.test_trigger_detection
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from scripts.run_eval import _detect_trigger, _shadow_user_skill, _tool_use_mentions
+
+
+def _skill_start(name):
+    return {"type": "stream_event", "event": {"type": "content_block_start",
+            "content_block": {"type": "tool_use", "name": name}}}
+
+
+def _delta(partial):
+    return {"type": "stream_event", "event": {"type": "content_block_delta",
+            "delta": {"type": "input_json_delta", "partial_json": partial}}}
+
+
+def _stop():
+    return {"type": "stream_event", "event": {"type": "content_block_stop"}}
+
+
+class TestToolUseMentions(unittest.TestCase):
+    def test_skill_exact_match(self):
+        self.assertTrue(_tool_use_mentions("pdf", "Skill", {"skill": "pdf"}))
+
+    def test_skill_other_name(self):
+        self.assertFalse(_tool_use_mentions("pdf", "Skill", {"skill": "docx"}))
+
+    def test_read_inside_skill_dir(self):
+        self.assertTrue(_tool_use_mentions(
+            "pdf", "Read", {"file_path": "/home/u/.claude/skills/pdf/SKILL.md"}))
+
+    def test_short_name_not_matched_in_filename(self):
+        # A skill named "pdf" must not count reading report.pdf as a trigger.
+        self.assertFalse(_tool_use_mentions("pdf", "Read", {"file_path": "report.pdf"}))
+
+    def test_windows_backslash_path_normalized(self):
+        self.assertTrue(_tool_use_mentions(
+            "pdf", "Read", {"file_path": r"C:\Users\x\.claude\skills\pdf\SKILL.md"}))
+
+    def test_non_skill_read_tool_ignored(self):
+        self.assertFalse(_tool_use_mentions("pdf", "Bash", {"command": "cat report.pdf"}))
+
+
+class TestDetectTrigger(unittest.TestCase):
+    def test_streamed_skill_invocation(self):
+        events = [_skill_start("Skill"), _delta('{"skill": "pd'), _delta('f"}'), _stop()]
+        self.assertTrue(_detect_trigger(events, "pdf"))
+
+    def test_explore_then_trigger(self):
+        # A Bash detour before the Skill call is not a miss.
+        events = [
+            _skill_start("Bash"), _delta('{"command": "ls"}'), _stop(),
+            _skill_start("Skill"), _delta('{"skill": "pdf"}'), _stop(),
+        ]
+        self.assertTrue(_detect_trigger(events, "pdf"))
+
+    def test_result_without_trigger(self):
+        events = [
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "done"}]}},
+            {"type": "result"},
+        ]
+        self.assertFalse(_detect_trigger(events, "pdf"))
+
+    def test_short_name_filename_not_a_trigger(self):
+        events = [_skill_start("Read"), _delta('{"file_path": "report.pdf"}'), _stop(),
+                  {"type": "result"}]
+        self.assertFalse(_detect_trigger(events, "pdf"))
+
+    def test_assistant_fallback_path(self):
+        events = [{"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "name": "Skill", "input": {"skill": "pdf"}}]}}]
+        self.assertTrue(_detect_trigger(events, "pdf"))
+
+    def test_malformed_delta_does_not_crash(self):
+        events = [_skill_start("Skill"), _delta('{"skill": "pd'), _stop(), {"type": "result"}]
+        self.assertFalse(_detect_trigger(events, "pdf"))
+
+
+class TestShadowUserSkill(unittest.TestCase):
+    """The crux fix: an installed same-name skill (user > project) must be
+    moved aside during the run and always restored, so the eval measures the
+    candidate. A fake HOME keeps this off the real ~/.claude."""
+
+    def _fake_home_with_skill(self, tmp):
+        skill = Path(tmp) / ".claude" / "skills" / "pdf"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text("installed")
+        return Path(tmp), skill
+
+    def test_moves_aside_then_restores(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home, skill = self._fake_home_with_skill(tmp)
+            with mock.patch("scripts.run_eval.Path.home", return_value=home):
+                with _shadow_user_skill("pdf"):
+                    self.assertFalse(skill.exists())
+                self.assertTrue(skill.exists())
+                self.assertEqual((skill / "SKILL.md").read_text(), "installed")
+
+    def test_restores_on_exception(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home, skill = self._fake_home_with_skill(tmp)
+            with mock.patch("scripts.run_eval.Path.home", return_value=home):
+                with self.assertRaises(RuntimeError), _shadow_user_skill("pdf"):
+                    raise RuntimeError("boom")
+                self.assertTrue(skill.exists())
+
+    def test_restore_replaces_recreated_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home, skill = self._fake_home_with_skill(tmp)
+            with mock.patch("scripts.run_eval.Path.home", return_value=home):
+                with _shadow_user_skill("pdf"):
+                    skill.mkdir(parents=True)  # something re-creates it mid-run
+                    (skill / "SKILL.md").write_text("recreated")
+                # the original is restored, not buried under the re-created dir
+                self.assertEqual((skill / "SKILL.md").read_text(), "installed")
+                self.assertFalse((skill / "pdf").exists())
+
+    def test_noop_when_not_installed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch("scripts.run_eval.Path.home", return_value=Path(tmp)):
+                with _shadow_user_skill("pdf"):
+                    pass
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes the 0% trigger-rate bug in `skill-creator`'s description eval (#556) end to end. `run_eval.py` reported 0% recall for every query, so `run_loop.py` was optimizing against a metric that was always zero.

This builds directly on @MartinCajiao's #1298 — I've folded its isolated-project rewrite in here with credit, added the one fix it was missing, and pinned the whole thing with tests, so there's a single reviewable change instead of scattered halves.

Root causes:

- **Wrong surface.** The candidate was installed as a `.claude/commands/` file, which `claude -p` never auto-triggers. It now installs as a real skill in an isolated, UUID-keyed temp project — the surface that actually auto-triggers.
- **Shadowing (the missing half).** Skill name resolution is **user > project** ([docs](https://code.claude.com/docs/en/skills)), so a same-name skill already under `~/.claude/skills` overrode the candidate and the eval measured the *installed* description. #1298 warns about this; here `run_eval` moves the installed copy aside for the run and restores it after. Without it, recall still reads 0% whenever you optimize a skill you already have installed — the common case.
- **Detection.** Field-scoped, so a short name like `pdf` no longer counts reading `report.pdf` as a hit. Windows stream reading uses reader threads over `select()`, and `shutil.which` resolves the `claude.cmd` shim.
- **Loop robustness.** `run_loop` and `generate_report` crashed on `max()` over empty history for runs that exit before the first iteration; an `improve_description` failure discarded every collected iteration. Both are guarded.

## What's new since #1298

- The user > project shadow is fixed, not just warned.
- Detection is extracted to a pure `_detect_trigger`, and the repo gets its first test scaffolding: 18 offline tests pinning the metric — short-name false positives, Windows paths, explore-then-trigger, shadow move/restore, the loop guards. Stdlib only, no API cost.

Consolidates the scattered attempts at this bug (#1298, #1323). Merging this closes #556 in one pass.

## Test plan

- [ ] `cd skills/skill-creator && python3 -m unittest discover -s scripts/tests` — 18 pass
- [ ] `python -m scripts.run_eval --eval-set <set>.json --skill-path <installed-skill>`: recall reflects the description under test, not the installed copy
- [ ] `python -m scripts.run_loop --eval-set <set>.json --skill-path <skill> --model <m> --max-iterations 0` exits cleanly

Fixes #556. Credit: @MartinCajiao (isolated-project rewrite), @KhalifaGad (field-scoped detection), @Vaikri-costume (loop guards), @xg-gh-25 (review that shaped the isolation).
