### PR TITLE
Add `xiao` — Xiaomi Robot Vacuum agent-ready skill

### DIFF
--- a/skills/xiao/README.md
+++ b/skills/xiao/README.md
@@ -1,0 +1,31 @@
+# xiao — Xiaomi Robot Vacuum skill
+
+Demo skill contributed from the upstream repo
+[dacrypt/xiao](https://github.com/dacrypt/xiao) — a CLI that controls a
+Xiaomi Robot Vacuum X20+ (`xiaomi.vacuum.c102gl`) via the Xiaomi Cloud API.
+
+This SKILL.md is the same one that ships in the upstream repo at
+`.claude/skills/xiao/SKILL.md`. For the full agent guide, machine-readable
+contract (`--json`, exit codes, error-recovery protocol), and setup
+instructions, see:
+
+- Upstream repo: https://github.com/dacrypt/xiao
+- Canonical agent reference: https://github.com/dacrypt/xiao/blob/main/AGENTS.md
+- llms.txt: https://raw.githubusercontent.com/dacrypt/xiao/main/llms.txt
+
+## Quick install
+
+```bash
+pip install xiao
+playwright install chromium
+xiao setup cloud
+xiao --help
+```
+
+Then paste this skill into `~/.claude/skills/xiao/SKILL.md` (or fork the
+upstream repo for the latest copy) and Claude Code will pick it up
+automatically.
+
+## License
+
+MIT (same as upstream).

--- a/skills/xiao/SKILL.md
+++ b/skills/xiao/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: xiao
+description: >
+  Control a Xiaomi Robot Vacuum X20+ (model xiaomi.vacuum.c102gl) through the `xiao`
+  CLI. Use this skill whenever the user mentions anything vacuum-related: robot
+  vacuum, Xiaomi, Roborock, cleaning the house, mopping, sweeping, dock, base
+  station, consumables (brush, filter, mop pad), rooms, map, zones, DND mode, fan
+  speed, vacuum status, battery, cleaning schedule. Also trigger on Spanish
+  equivalents (aspiradora, limpiar, trapear, cargar, habitaciones, cepillo,
+  filtro, base, programar limpieza) and casual phrasings (limpia la casa, pon la
+  aspiradora, qué batería tiene, mándala al dock). When in doubt, trigger — the
+  CLI handles all vacuum ops.
+---
+
+# xiao — Xiaomi Vacuum CLI Skill
+
+The `xiao` CLI controls a Xiaomi Robot Vacuum X20+ via Xiaomi Cloud. Full
+reference lives in [`AGENTS.md`](../../../AGENTS.md) at the repo root — **read
+that first** for canonical commands, intent mapping, and error recovery.
+
+## Prerequisites
+
+Before any command will succeed:
+
+1. `pip install xiao && playwright install chromium` (once per machine).
+2. `xiao setup cloud` completed — produces `config.toml`.
+3. Chromium on port `18800` with an active `account.xiaomi.com` session:
+   ```bash
+   chromium --remote-debugging-port=18800 --user-data-dir=~/.xiao-chromium
+   ```
+
+## Workflow for any user request
+
+1. **Parse intent.** Check the "Intent mapping" table in `AGENTS.md`.
+2. **Resolve room IDs** with `xiao map rooms` before any `xiao clean -r <id>`.
+   Never guess. IDs are per-vacuum and regenerate when the Xiaomi Home app
+   re-maps the house.
+3. **Run the command.** Prefer `--json` for status-type commands so you can
+   parse deterministically:
+   ```bash
+   xiao status --json
+   xiao consumables --json
+   ```
+4. **On error**, apply the recovery protocol in `AGENTS.md#error-recovery`
+   before asking the user:
+   - Exit `77` or stderr contains `token`/`401` → retry once; if still bad,
+     `xiao cloud-login` and retry.
+   - Exit `2` or stderr says "Cloud mode enabled but not configured" → guide
+     user through `xiao setup cloud`.
+   - `Cannot connect to browser CDP on port 18800` → launch the Chromium
+     instance described above and have the user log in once.
+   - State 21 / "WashingMopPause" → user must refill clean water / empty
+     dirty water, then `xiao start`.
+
+## Exit codes (agent-meaningful)
+
+| Code | Meaning | Action |
+|---|---|---|
+| `0` | Success | Continue |
+| `2` | Not configured | Run `xiao setup cloud` |
+| `77` | Cloud auth failed | Run `xiao cloud-login` |
+| Other non-zero | Generic failure | Parse stderr / ask user |
+
+## Hard rules
+
+- **Never** print or commit the contents of `config.toml` — it holds the user's
+  Xiaomi password hash and service tokens.
+- **Never** call `xiao raw` unless the user explicitly asks. It's an unchecked
+  escape hatch into MIoT that can brick settings.
+- **Always** verify room IDs with `xiao map rooms` before using them in a
+  `clean -r` call.
+- `xiao start` always triggers a mop wash first. Warn the user if they asked
+  for sweep-only; there's no flag to skip the wash.


### PR DESCRIPTION
## What

Adds the `xiao` skill to the community demo set. `xiao` is an open-source
Python CLI (MIT) that controls a Xiaomi Robot Vacuum X20+
(`xiaomi.vacuum.c102gl`) via the Xiaomi Cloud API. It was built CLI-first
specifically so Claude (and any other agent that can exec a subprocess)
can drive the vacuum end to end: start / stop / dock / find / rooms / zones
/ base-station / settings / consumables.

## Why add it here

- Clean, minimal `SKILL.md` with complete YAML frontmatter: `name: xiao`
  (lowercase, 4/64 chars), `description` 649/1024 chars with both WHAT
  (controls the vacuum via the `xiao` CLI) and WHEN (trigger keywords).
- Upstream repo also ships `AGENTS.md` (cross-tool canonical reference,
  agents.md spec) and `llms.txt` (llmstxt.org spec) alongside the skill.
- Machine-readable agent contract: `xiao status --json`, canonical exit
  codes (`2 = not configured`, `77 = auth failed`), explicit
  error-recovery decision tree in AGENTS.md for autonomous retries.
- CI green on Python 3.12 and 3.13 (ruff + mypy + pytest).
- MIT-licensed upstream.

## Files

```
skills/xiao/
├── README.md            # short intro + link back to upstream
└── SKILL.md             # copy of upstream .claude/skills/xiao/SKILL.md
```

## Upstream

- Repo: https://github.com/dacrypt/xiao
- AGENTS.md: https://github.com/dacrypt/xiao/blob/main/AGENTS.md
- llms.txt: https://raw.githubusercontent.com/dacrypt/xiao/main/llms.txt
- npm wrapper (for skills.sh): `@dacrypt/xiao-skill` (pending publish)

Happy to iterate on wording / path / anything else that fits the repo's
conventions better.