### PR TITLE
fix(docx): generate valid, self-rendering TOC with unique bookmark IDs

### DIFF
--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -353,7 +353,15 @@ Force a column break with a new section using `type: SectionType.NEXT_COLUMN`.
 
 ```javascript
 // CRITICAL: Headings must use HeadingLevel ONLY - no custom styles
-new TableOfContents("Table of Contents", { hyperlink: true, headingStyleRange: "1-3" })
+// CRITICAL: Pass cachedEntries - Google Docs shows empty TOC without it
+new TableOfContents("Table of Contents", {
+  hyperlink: true,
+  headingStyleRange: "1-3",
+  cachedEntries: [
+    { title: "Chapter 1", level: 1, page: 2, href: "chapter1" },
+    // one entry per heading; href must match the Bookmark id on that heading
+  ],
+})
 ```
 
 ### Headers/Footers
@@ -392,6 +400,7 @@ sections: [{
 - **TOC requires HeadingLevel only** - no custom styles on heading paragraphs
 - **Override built-in styles** - use exact IDs: "Heading1", "Heading2", etc.
 - **Include `outlineLevel`** - required for TOC (0 for H1, 1 for H2, etc.)
+- **TOC needs `cachedEntries`** - Google Docs shows empty TOC otherwise; manual refresh breaks links
 
 ---
 

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -61,7 +61,7 @@ Generate .docx files with JavaScript, then validate. Install: `npm install -g do
 ```javascript
 const { Document, Packer, Paragraph, TextRun, Table, TableRow, TableCell, ImageRun,
         Header, Footer, AlignmentType, PageOrientation, LevelFormat, ExternalHyperlink,
-        InternalHyperlink, Bookmark, FootnoteReferenceRun, PositionalTab,
+        InternalHyperlink, BookmarkStart, BookmarkEnd, FootnoteReferenceRun, PositionalTab,
         PositionalTabAlignment, PositionalTabRelativeTo, PositionalTabLeader,
         TabStopType, TabStopPosition, Column, SectionType,
         TableOfContents, HeadingLevel, BorderStyle, WidthType, ShadingType,
@@ -256,9 +256,13 @@ new Paragraph({
 })
 
 // Internal link (bookmark + reference)
-// 1. Create bookmark at destination
+// 1. Create bookmark at destination - use BookmarkStart/BookmarkEnd with a unique
+//    numeric linkId per bookmark. The `Bookmark` convenience class emits
+//    w:id="1" for every bookmark, which fails OOXML ID-uniqueness.
 new Paragraph({ heading: HeadingLevel.HEADING_1, children: [
-  new Bookmark({ id: "chapter1", children: [new TextRun("Chapter 1")] }),
+  new BookmarkStart("chapter1", 1),
+  new TextRun("Chapter 1"),
+  new BookmarkEnd(1),
 ]})
 // 2. Link to it
 new Paragraph({ children: [new InternalHyperlink({
@@ -359,7 +363,7 @@ new TableOfContents("Table of Contents", {
   headingStyleRange: "1-3",
   cachedEntries: [
     { title: "Chapter 1", level: 1, page: 2, href: "chapter1" },
-    // one entry per heading; href must match the Bookmark id on that heading
+    // one entry per heading; href must match the BookmarkStart w:name on that heading
   ],
 })
 ```
@@ -401,6 +405,7 @@ sections: [{
 - **Override built-in styles** - use exact IDs: "Heading1", "Heading2", etc.
 - **Include `outlineLevel`** - required for TOC (0 for H1, 1 for H2, etc.)
 - **TOC needs `cachedEntries`** - Google Docs shows empty TOC otherwise; manual refresh breaks links
+- **Use `BookmarkStart`/`BookmarkEnd`, not `Bookmark`** - `Bookmark` emits `w:id="1"` for every bookmark, failing ID-uniqueness. Pass a unique numeric `linkId` to each `BookmarkStart`/`BookmarkEnd` pair
 
 ---
 

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -357,7 +357,9 @@ Force a column break with a new section using `type: SectionType.NEXT_COLUMN`.
 
 ```javascript
 // CRITICAL: Headings must use HeadingLevel ONLY - no custom styles
-// CRITICAL: Pass cachedEntries - Google Docs shows empty TOC without it
+// CRITICAL: Pass cachedEntries - without them the TOC field ships empty and
+//   renders blank until a reader triggers "Update fields"; Google Docs, PDF
+//   export, and other non-interactive consumers render it blank permanently
 new TableOfContents("Table of Contents", {
   hyperlink: true,
   headingStyleRange: "1-3",
@@ -404,7 +406,7 @@ sections: [{
 - **TOC requires HeadingLevel only** - no custom styles on heading paragraphs
 - **Override built-in styles** - use exact IDs: "Heading1", "Heading2", etc.
 - **Include `outlineLevel`** - required for TOC (0 for H1, 1 for H2, etc.)
-- **TOC needs `cachedEntries`** - Google Docs shows empty TOC otherwise; manual refresh breaks links
+- **TOC needs `cachedEntries`** - without them the TOC field ships empty; Word requires "Update fields" to render it, non-interactive consumers (Google Docs, PDF export) render it blank
 - **Use `BookmarkStart`/`BookmarkEnd`, not `Bookmark`** - `Bookmark` emits `w:id="1"` for every bookmark, failing ID-uniqueness. Pass a unique numeric `linkId` to each `BookmarkStart`/`BookmarkEnd` pair
 
 ---


### PR DESCRIPTION
Summary
-------

Two correctness bugs in the docx skill's guidance produce .docx files that are (a) technically valid but rely on interactive "Update fields" to render, and (b) malformed per OOXML ID-uniqueness. Neither bug is specific to any particular consumer — they're docx-level issues that surface in multiple tools.

- Update `### Table of Contents` example to pass `cachedEntries` so the generated TOC field ships with populated content and self-renders on open
- Update `### Hyperlinks` internal-link example and setup imports to use `BookmarkStart`/`BookmarkEnd` with explicit per-bookmark numeric `linkId`s instead of the `Bookmark` convenience class, which emits duplicate `w:id`s
- Add two bullets to `### Critical Rules for docx-js`

Why
---

Fixes #1002.

**Bug 1 — TOC field ships empty.** `docx-js`'s `TableOfContents` emits an `<w:sdt>` field with no cached content unless `cachedEntries` is supplied. That field is *valid* OOXML but it is *unrendered*: until a reader updates fields, the TOC is blank. Different consumers expose this differently:

- Microsoft Word: opens with a blank TOC; user must press `F9` or click "Update fields" to populate it. Users tolerate this because Word prompts them to update.
- Google Docs (via Drive conversion): renders the cached content as-is, which is empty. The user's manual "refresh" inside Google Docs produces broken links (docx-js uses different link mechanics when the field is re-evaluated client-side).
- PDF export / headless conversion / any non-interactive consumer: renders whatever is cached — empty.

The fix is a small docx-js option (`cachedEntries`) that populates the field's cache at generation time, making the TOC self-rendering on open for every consumer.

**Bug 2 — `Bookmark` violates OOXML ID uniqueness.** docx-js's `Bookmark` convenience class emits `w:id="1"` for both `bookmarkStart` and `bookmarkEnd` on every bookmark in the document. `w:id` is a shared-namespace integer across bookmarks, tracked changes, comments, and move ranges (same namespace the validator fixes in #541 addressed for tracked changes). Following the current SKILL.md example end-to-end produces a malformed .docx:

- The skill's own `scripts/office/validate.py` correctly rejects it with `Duplicate id='1' in <bookmarkstart>` / `<bookmarkend>`.
- Word, Google Docs, and LibreOffice tolerate the malformed file in practice, but the spec violation is real and the validator path is broken for any user who follows SKILL.md step-by-step.

The fix is to use the library's lower-level `BookmarkStart(name, linkId)` and `BookmarkEnd(linkId)` constructors with a unique numeric `linkId` per pair. This generates spec-valid OOXML on first write — no unpack/repack workaround, and the skill's own validator passes.

Changes
-------

`skills/docx/SKILL.md` only. No script changes.

- Setup imports: replace `Bookmark` with `BookmarkStart, BookmarkEnd`
- `### Hyperlinks`: rewrite the internal-link example to construct `BookmarkStart(name, linkId)` + `TextRun` + `BookmarkEnd(linkId)` with a unique numeric `linkId`
- `### Table of Contents`: rewrite the example to include `cachedEntries` whose `href` values match the `BookmarkStart` `w:name` on each heading
- `### Critical Rules for docx-js`: append two bullets — one on `cachedEntries` (framed around self-rendering correctness, with consumer differences noted), one on preferring `BookmarkStart`/`BookmarkEnd` over `Bookmark` (framed around OOXML ID uniqueness)

Testing
-------

Verified on the same generated doc across multiple consumers:

- `scripts/office/validate.py`: passes on first generation (no unpack/repack needed).
- Unpacked XML: unique `w:id`s (1, 2, 3) on matched `bookmarkStart`/`bookmarkEnd` pairs; TOC SDT wraps one populated `w:hyperlink` per cached entry with `w:anchor` matching the bookmark `w:name`; the inline `InternalHyperlink` resolves to the right anchor.
- Microsoft Word: TOC renders on open (populated from `cachedEntries`); `F9` / "Update fields" is not required for the TOC to display; bookmarks navigate correctly.
- Google Drive → Google Docs conversion: TOC populated on open with no "refresh" prompt; each entry's click scrolls to the matching heading; Docs API confirms each TOC entry's `link.bookmarkId` matches the one the inline `InternalHyperlink` targets; Document Outline panel shows correct hierarchy.