### PR TITLE
Add RCS Message skill

### DIFF
--- a/skills/rcs-message/.gitignore
+++ b/skills/rcs-message/.gitignore
@@ -1,0 +1,5 @@
+.env
+config.json
+__pycache__/
+*.pyc
+.DS_Store

--- a/skills/rcs-message/README.md
+++ b/skills/rcs-message/README.md
@@ -1,0 +1,51 @@
+# RCS Message Skill
+
+An Agent Skill for sending and receiving SMS / RCS messages via the mobile SMS interface.
+
+## Description
+
+RCS Message, the upgraded 5G intelligent SMS, supports mass sending and forwarding of text & template messages directly via phone numbers. No app download is required. With carrier real-name security, it delivers images, videos and interactive cards, enabling one-stop inquiry, reservation, payment and business handling for efficient precise reach and closed-loop services.
+
+## Installation
+
+### Via Claude Code Plugin Market
+
+```bash
+/plugin marketplace add anthropics/skills
+/plugin install rcs-message
+```
+
+### Via GitHub
+
+```bash
+claude plugin install github:casperkwok/rcs-message
+```
+
+### Manual
+
+Copy this folder to your project's `.claude/skills/` or `~/.claude/skills/` directory.
+
+## Usage
+
+Use when the user asks to send a text message, check text messages, use SMS, text message, RCS, or needs to forward or mass send received text messages.
+
+## Requirements
+
+- Python 3.6+
+- `requests` library
+- Valid API credentials (APP_ID, APP_SECRET)
+
+## Configuration
+
+Set environment variables:
+
+```bash
+export FIVE_G_APP_ID="your-app-id"
+export FIVE_G_APP_SECRET="your-app-secret"
+```
+
+Or create a `.env` file in the project root.
+
+## License
+
+MIT

--- a/skills/rcs-message/SKILL.md
+++ b/skills/rcs-message/SKILL.md
@@ -1,0 +1,166 @@
+---
+description: RCS Message, the upgraded 5G intelligent SMS, supports mass sending and forwarding of text & template messages directly via phone numbers. No app download is required. With carrier real-name security, it delivers images, videos and interactive cards, enabling one-stop inquiry, reservation, payment and business handling for efficient precise reach and closed-loop services.
+name: rcs-message
+---
+
+# RCS Message Skill
+
+Send and receive SMS / RCS via the mobile SMS interface.Use when the user asks to send a text message, check text messages, use SMS, text message, RCS, or needs to forward or mass send received text messages.
+
+## Overview
+
+This skill provides message sending capabilities through channel-based delivery with template support, fallback handling, and natural language command parsing.
+
+## Requirements
+
+- Python 3.6 or higher
+- requests library
+- python-dotenv library (optional)
+- Valid API credentials (APP_ID, APP_SECRET)
+
+## Configuration
+
+### API Endpoint
+
+| Item | Value |
+|------|-------|
+| API Server | `https://5g.fontdo.com` (pre-configured) |
+| Endpoint | `/messenger/api/v1/group/send` |
+| Method | POST |
+
+### Environment Variables
+
+Set environment variables:
+
+```bash
+export FIVE_G_APP_ID="your-app-id"
+export FIVE_G_APP_SECRET="your-app-secret"
+```
+
+Or create a `.env` file in the project root:
+
+```bash
+FIVE_G_APP_ID=your-app-id
+FIVE_G_APP_SECRET=your-app-secret
+```
+
+## Quick Reference
+
+| Action | Command |
+|--------|---------|
+| Send text message | `python3 scripts/send.py -n "+8613700000001" -m "Hello"` |
+| Send template | `python3 scripts/send.py --type RCS --template-id "ID" -n "+8613700000001"` |
+| Validate only | `python3 scripts/send.py -n "+8613700000001" --dry-run` |
+
+## Usage
+
+### Natural Language Commands
+
+Use simple commands in Moltbot:
+
+```
+Send a message to 13700000001 with hello world
+```
+
+```
+Send a template message using RCS template 269000000000000000 to 13700000001
+```
+
+### Command Line
+
+Basic message sending:
+
+```bash
+python3 scripts/send.py -n "+8613700000001" -m "Hello"
+```
+
+Template message:
+
+```bash
+python3 scripts/send.py --type RCS --template-id "TEMPLATE_ID" -n "+8613700000001" --params "name:John,code:12345"
+```
+
+With fallback channels:
+
+```bash
+python3 scripts/send.py --type RCS --template-id "TEMPLATE_ID" -n "+8613700000001" --fallback-aim "FALLBACK_ID" --fallback-sms "SMS Content"
+```
+
+## Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| -n, --numbers | Recipient number(s), comma separated |
+| -m, --message | Message content for TEXT type |
+| -t, --type | Message type: TEXT, RCS, AIM, MMS, SMS |
+| --template-id | Template ID for non-TEXT types |
+| --params | Template parameters as key:value pairs |
+| --fallback-aim | Fallback template ID for AIM channel |
+| --fallback-sms | Fallback content for SMS channel |
+| --dry-run | Validate parameters without sending |
+
+## Message Types
+
+| Type | Description |
+|------|-------------|
+| TEXT | Direct text content delivery |
+| RCS | Rich Communication Services messaging |
+| AIM | Advanced Interactive Messaging |
+| MMS | Multimedia Messaging Service |
+| SMS | Short Message Service fallback |
+
+## Validation Rules
+
+| Rule | Limit |
+|------|-------|
+| Maximum recipients | 100 per request |
+| Maximum message length | 1000 characters |
+| Minimum interval | 60 seconds between requests |
+| Number format | International format supported |
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| Authentication Error (403) | Verify APP_ID and APP_SECRET are correct. Confirm application is active. |
+| Rate Limit Error | Wait 60 seconds before retry. Adjust MIN_INTERVAL_SECONDS in config. |
+| Format Error | Use international format (+8613700000001) or domestic format (13700000001). |
+
+Enable debug mode for detailed output:
+
+```bash
+python3 scripts/send.py -n "+8613700000001" -m "Test" --debug
+```
+
+## Project Structure
+
+```
+rcs-message/
+├── SKILL.md               # Skill definition
+├── scripts/
+│   ├── send.py            # Core sending module
+│   ├── main.py            # Entry point
+│   ├── handle_user_input.py # Command parser
+│   ├── check_config.py    # Config validator
+│   ├── config.example.json # Config template
+│   ├── privacy_protect.py # Privacy protection
+│   └── session_creds.py   # Session credentials
+└── references/
+    └── USAGE_EXAMPLES.md  # Additional examples
+```
+
+## Limitations
+
+- API credentials required for authentication
+- Rate limiting applies to prevent abuse
+- Session management handled per deployment
+
+## Security
+
+- Credentials stored in environment variables
+- No hardcoded sensitive values
+- Input validation on all parameters
+
+## Version
+
+1.0.0

--- a/skills/rcs-message/references/USAGE_EXAMPLES.md
+++ b/skills/rcs-message/references/USAGE_EXAMPLES.md
@@ -1,0 +1,62 @@
+# RCS Message Skill - 使用示例
+
+## 环境变量设置
+```bash
+export FIVE_G_APP_ID="your-app-id"
+export FIVE_G_APP_SECRET="your-app-secret" 
+export FIVE_G_SERVER_ROOT="https://api.your-5g-provider.com"
+```
+
+## 基本群发文本消息
+```bash
+python send.py -n "+8613900001234,+8613900002234" -m "您好，这是测试消息"
+```
+
+## 群发模板消息
+```bash
+python send.py --template-type RCS --template-id "269000000000000000" -n "+8613900001234,+8613900002234" --params "name:张三,amount:100"
+```
+
+## 带回落策略的模板消息
+```bash
+python send.py --template-type RCS --template-id "269000000000000000" -n "+8613900001234" --params "name:张三" --fallback-aim "149000000000000000:name:张三" --fallback-sms "短信回落内容"
+```
+
+## 从文件读取号码列表
+```bash
+python send.py -f phone_numbers.txt -m "批量发送消息"
+```
+
+## 配置文件方式
+```bash
+# 创建 config.json
+{
+    "server_root": "https://api.your-5g-provider.com",
+    "default_fallback": {
+        "aim_template_id": "149000000000000000",
+        "sms_content": "短信回落内容"
+    }
+}
+
+python send.py --config config.json -n "+8613900001234" -m "使用配置文件发送"
+```
+
+## 安全限制说明
+- **号码数量限制**: 最多1000个号码
+- **频率限制**: 默认每分钟最多10次请求
+- **内容长度**: 文本消息最长1000字符
+- **模板要求**: 模板必须通过审核才能使用
+
+## 错误处理
+脚本会自动处理以下情况：
+- 环境变量缺失
+- 号码格式错误
+- 超出数量限制
+- API认证失败
+- 网络连接错误
+
+## 调试模式
+添加 `--debug` 参数查看详细请求信息：
+```bash
+python send.py -n "+8613900001234" -m "测试" --debug
+```

--- a/skills/rcs-message/scripts/check_config.py
+++ b/skills/rcs-message/scripts/check_config.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+5G Messaging 配置检查工具
+"""
+
+import os
+import sys
+from pathlib import Path
+
+def check_credentials():
+    """检查凭证配置"""
+    # 检查会话凭证文件
+    session_dir = Path.home() / ".5g_messaging"
+    session_dir.mkdir(exist_ok=True)
+    
+    cred_file = session_dir / "credentials.json"
+    
+    if cred_file.exists():
+        print("✅ 会话凭证已配置")
+        print(f"   凭证文件: {cred_file}")
+        return True
+    else:
+        print("⚠️  会话凭证未配置")
+        print("   首次使用时会提示输入APP_ID和APP_SECRET")
+        return False
+
+def main():
+    print("5G Messaging 配置检查")
+    print("=" * 40)
+    
+    # 检查服务器地址（硬编码）
+    print("✅ 服务器地址: https://5g.fontdo.com")
+    
+    # 检查凭证
+    check_credentials()
+    
+    print("\n使用说明:")
+    print("- 首次使用会提示输入APP_ID和APP_SECRET")
+    print("- 凭证会保存在 ~/.5g_messaging/credentials.json")
+    print("- 后续使用会自动读取保存的凭证")
+
+if __name__ == "__main__":
+    main()

--- a/skills/rcs-message/scripts/config.example.json
+++ b/skills/rcs-message/scripts/config.example.json
@@ -1,0 +1,12 @@
+{
+  "server_root": "https://api.5g-messaging.com",
+  "rate_limits": {
+    "max_messages_per_hour": 100,
+    "max_numbers_per_send": 100,
+    "min_interval_seconds": 60
+  },
+  "templates": {
+    "default_text_template": "TEXT",
+    "allowed_template_types": ["TEXT", "RCS", "AIM", "MMS", "SMS"]
+  }
+}

--- a/skills/rcs-message/scripts/handle_user_input.py
+++ b/skills/rcs-message/scripts/handle_user_input.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+5G Messaging - 用户输入解析器
+提供parse_user_message函数用于解析用户输入
+"""
+
+import re
+from typing import List, Optional, Dict, Any
+
+def extract_numbers_from_text(text: str) -> List[str]:
+    """从文本中提取手机号码"""
+    # 匹配中国手机号码格式（包括+86前缀）
+    phone_pattern = r'(?:\+86)?1[3-9]\d{9}'
+    phones = re.findall(phone_pattern, text)
+    
+    # 标准化号码格式（添加+86前缀）
+    normalized_phones = []
+    for phone in phones:
+        if phone.startswith('+86'):
+            normalized_phones.append(phone)
+        else:
+            normalized_phones.append(f'+86{phone}')
+    
+    return normalized_phones
+
+def extract_message_content(text: str, numbers: List[str]) -> str:
+    """从文本中提取消息内容，移除号码部分"""
+    content = text
+    
+    # 移除号码
+    for number in numbers:
+        content = content.replace(number, '')
+        # 移除不带+86的版本
+        if number.startswith('+86'):
+            content = content.replace(number[3:], '')
+    
+    # 移除"群发消息"、"转发消息"等关键词
+    keywords = ['群发消息', '转发消息', '群发', '转发', '发送', '给', '内容是', '内容']
+    for keyword in keywords:
+        content = content.replace(keyword, '')
+    
+    # 清理多余的空格和标点
+    content = re.sub(r'[：:\s]+', ' ', content).strip()
+    content = re.sub(r'^[，。！？\s]+|[，。！？\s]+$', '', content)
+    
+    return content
+
+def is_group_send_intent(user_input: str) -> bool:
+    """判断是否为群发/转发消息意图"""
+    group_keywords = ['群发消息', '转发消息', '群发', '批量发送', '给多人发']
+    return any(keyword in user_input for keyword in group_keywords)
+
+def parse_user_message(user_input: str) -> Optional[Dict[str, Any]]:
+    """解析用户输入，返回结构化数据"""
+    if not is_group_send_intent(user_input):
+        return None
+    
+    # 提取号码
+    numbers = extract_numbers_from_text(user_input)
+    if not numbers:
+        return None
+    
+    # 提取消息内容
+    message_content = extract_message_content(user_input, numbers)
+    if not message_content:
+        return None
+    
+    return {
+        "action": "broadcast" if "群发" in user_input else "forward",
+        "numbers": numbers[:100],  # 限制最多100个号码
+        "message": message_content,
+        "original_input": user_input
+    }

--- a/skills/rcs-message/scripts/main.py
+++ b/skills/rcs-message/scripts/main.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+RCS Message Main Entry Point
+处理用户自然语言输入并调用发送脚本
+"""
+
+import os
+import sys
+import json
+import argparse
+from pathlib import Path
+from handle_user_input import parse_user_message
+
+def mask_phone_number(phone: str) -> str:
+    """将手机号码加密为前三后二格式，如 137******01"""
+    # 移除+86前缀（如果存在）
+    if phone.startswith('+86'):
+        clean_phone = phone[3:]
+    else:
+        clean_phone = phone
+    
+    # 验证是否为11位数字
+    if len(clean_phone) == 11 and clean_phone.isdigit():
+        return f"{clean_phone[:3]}******{clean_phone[-2:]}"
+    else:
+        # 如果格式不正确，返回原号码（或部分隐藏）
+        return phone
+
+def get_session_config_dir():
+    """获取会话配置目录"""
+    config_dir = Path.home() / ".config" / "moltbot" / "rcs-message"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    return config_dir
+
+def get_session_credential_file(session_id: str):
+    """获取会话凭证文件路径"""
+    config_dir = get_session_config_dir()
+    return config_dir / f"{session_id}.json"
+
+def load_session_credentials(session_id: str):
+    """从会话文件加载凭证"""
+    credential_file = get_session_credential_file(session_id)
+    if credential_file.exists():
+        try:
+            with open(credential_file, 'r') as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return None
+
+def save_session_credentials(session_id: str, app_id: str, app_secret: str):
+    """保存会话凭证到文件"""
+    credential_file = get_session_credential_file(session_id)
+    credentials = {
+        "app_id": app_id,
+        "app_secret": app_secret
+    }
+    with open(credential_file, 'w') as f:
+        json.dump(credentials, f)
+
+def main():
+    parser = argparse.ArgumentParser(description="RCS消息群发主入口")
+    parser.add_argument("user_input", help="用户输入的自然语言消息")
+    parser.add_argument("--session-id", default="default", help="会话ID，默认为'default'")
+    parser.add_argument("--debug", action="store_true", help="启用调试模式")
+    
+    args = parser.parse_args()
+    
+    # 解析用户输入
+    parsed_data = parse_user_message(args.user_input)
+    if not parsed_data:
+        print("❌ 无法解析消息格式，请使用：'群发消息给13900001234 内容是测试消息'", file=sys.stderr)
+        sys.exit(1)
+    
+    if args.debug:
+        print(f"🔍 解析结果: {parsed_data}", file=sys.stderr)
+    
+    # 获取APP凭证（优先使用会话凭证，然后尝试环境变量，最后交互式输入）
+    session_credentials = load_session_credentials(args.session_id)
+    if session_credentials:
+        app_id = session_credentials.get("app_id")
+        app_secret = session_credentials.get("app_secret")
+        if args.debug:
+            print(f"✅ 使用会话凭证 (session: {args.session_id})", file=sys.stderr)
+    else:
+        # 尝试从环境变量获取
+        app_id = os.getenv("FIVE_G_APP_ID")
+        app_secret = os.getenv("FIVE_G_APP_SECRET")
+        if app_id and app_secret:
+            # 保存到会话文件
+            save_session_credentials(args.session_id, app_id, app_secret)
+            if args.debug:
+                print(f"✅ 使用环境变量凭证并保存到会话 (session: {args.session_id})", file=sys.stderr)
+        else:
+            # 交互式输入
+            print("【蜂动Claw】首次使用需要认证信息。")
+            print("**需要输入：**")
+            print("1. **APP ID**")
+            print("2. **APP SECRET**")
+            print("这些是蜂动科技的 API 凭证。你有吗？")
+            print("如果没有，需要：")
+            print("1. 注册蜂动科技5G消息服务")
+            print("2. 创建应用获取 APP_ID 和 APP_SECRET")
+            print("**你有凭证吗？**")
+            try:
+                app_id = input("请输入 APP ID: ").strip()
+                app_secret = input("请输入 APP SECRET: ").strip()
+            except EOFError:
+                print("\n❌ 输入错误", file=sys.stderr)
+                sys.exit(1)
+            
+            if not app_id or not app_secret:
+                print("❌ APP ID和APP SECRET不能为空", file=sys.stderr)
+                sys.exit(1)
+            
+            # 保存到会话文件
+            save_session_credentials(args.session_id, app_id, app_secret)
+            print(f"✅ 凭证已保存到会话 '{args.session_id}'，下次使用将自动加载")
+    
+    # 设置环境变量供send.py使用
+    os.environ["FIVE_G_APP_ID"] = app_id
+    os.environ["FIVE_G_APP_SECRET"] = app_secret
+    
+    # 导入并直接调用send.py的功能
+    sys.path.insert(0, os.path.dirname(__file__))
+    try:
+        from send import send_group_message
+        
+        result = send_group_message(
+            numbers=parsed_data["numbers"],
+            message_type="TEXT",
+            text=parsed_data["message"]
+        )
+        
+        if result["success"]:
+            # 加密显示成功发送的号码
+            masked_numbers = [mask_phone_number(num) for num in result['sent_numbers']]
+            
+            print(f"【蜂动Claw】✅ **发送成功**")
+            print(f"   发送号码: {result['sent_count']} 个 ({', '.join(masked_numbers)})")
+            if result['message']:
+                print(f"   消息内容: {result['message'][:50]}{'...' if len(result['message']) > 50 else ''}")
+            print(f"   任务ID: {result['response'].get('data', 'N/A')}")
+        else:
+            print(f"❌ 发送失败: {result['error']}", file=sys.stderr)
+            sys.exit(1)
+            
+    except Exception as e:
+        print(f"❌ 发送错误: {e}", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/skills/rcs-message/scripts/privacy_protect.py
+++ b/skills/rcs-message/scripts/privacy_protect.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Privacy Protection Utilities for RCS Message Skill
+"""
+
+import re
+
+def mask_phone_number(phone: str) -> str:
+    """加密手机号码，保留前三后二，中间用*号替换"""
+    # 去掉+86前缀（如果存在）
+    if phone.startswith('+86'):
+        digits = phone[3:]
+    else:
+        digits = phone
+    
+    # 验证是否为11位数字
+    if len(digits) == 11 and digits.isdigit():
+        return f"{digits[:3]}******{digits[-2:]}"
+    else:
+        # 如果格式不对，返回原始号码的掩码版本
+        return "***********"
+
+def mask_url(url: str) -> str:
+    """加密URL，保留域名，隐藏路径和参数"""
+    try:
+        import urllib.parse
+        parsed = urllib.parse.urlparse(url)
+        if parsed.netloc:
+            # 保留协议和域名，路径和参数用****替换
+            return f"{parsed.scheme}://{parsed.netloc}/****"
+        else:
+            return "****"
+    except:
+        return "****"
+
+def protect_sensitive_info(text: str) -> str:
+    """保护敏感信息：加密手机号码和URL"""
+    if not text:
+        return text
+    
+    # 加密手机号码（包括+86前缀的）
+    phone_pattern = r'(\+86)?1[3-9]\d{9}'
+    def replace_phone(match):
+        full_match = match.group(0)
+        return mask_phone_number(full_match)
+    
+    protected_text = re.sub(phone_pattern, replace_phone, text)
+    
+    # 加密URL
+    url_pattern = r'https?://[^\s<>"{}|\\^`\[\]]+'
+    protected_text = re.sub(url_pattern, lambda m: mask_url(m.group(0)), protected_text)
+    
+    return protected_text

--- a/skills/rcs-message/scripts/send.py
+++ b/skills/rcs-message/scripts/send.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+RCS Message Group Send Script
+安全限制：号码数量、内容长度、发送频率
+"""
+
+import os
+import sys
+import json
+import time
+import hashlib
+import argparse
+from typing import List, Optional, Dict, Any
+import requests
+
+# 导入隐私保护功能
+# 导入隐私保护函数
+import os
+import sys
+sys.path.append(os.path.dirname(__file__))
+from privacy_protect import protect_sensitive_info
+
+# 安全限制配置
+MAX_PHONE_NUMBERS = 100  # 限制为100个号码（远低于API的1000上限）
+MAX_MESSAGE_LENGTH = 1000  # 最大消息长度
+MIN_INTERVAL_SECONDS = 60  # 最小发送间隔（60秒）
+RATE_LIMIT_FILE = "/tmp/5g_messaging_last_send.txt"
+
+# API配置 - SERVER_ROOT 固定为 5g.fontdo.com
+SERVER_ROOT = "https://5g.fontdo.com"
+APP_ID = None
+APP_SECRET = None
+
+def mask_phone_number(phone: str) -> str:
+    """加密手机号码，保留前三后二，中间用*号替换"""
+    # 去掉+86前缀（如果存在）
+    if phone.startswith('+86'):
+        digits = phone[3:]
+    else:
+        digits = phone
+    
+    # 验证是否为11位数字
+    if len(digits) == 11 and digits.isdigit():
+        return f"{digits[:3]}******{digits[-2:]}"
+    else:
+        # 如果格式不对，返回原始号码的掩码版本
+        return "***********"
+
+def get_app_credentials():
+    """获取APP ID和SECRET，优先从环境变量，否则交互式输入"""
+    global APP_ID, APP_SECRET
+    
+    # 先尝试从环境变量获取
+    env_app_id = os.getenv("FIVE_G_APP_ID")
+    env_app_secret = os.getenv("FIVE_G_APP_SECRET")
+    
+    if env_app_id and env_app_secret:
+        APP_ID = env_app_id
+        APP_SECRET = env_app_secret
+        return True
+    
+    # 如果环境变量不存在，提示用户输入
+    print("⚠️  首次使用5G消息服务，请输入您的认证信息:")
+    print("   (这些信息将用于本次会话，建议后续设置环境变量)")
+    
+    try:
+        app_id_input = input("请输入 APP ID: ").strip()
+        app_secret_input = input("请输入 APP SECRET: ").strip()
+        
+        if not app_id_input or not app_secret_input:
+            print("❌ APP ID 和 APP SECRET 不能为空", file=sys.stderr)
+            return False
+        
+        APP_ID = app_id_input
+        APP_SECRET = app_secret_input
+        print("✅ 认证信息已保存到当前会话")
+        return True
+        
+    except KeyboardInterrupt:
+        print("\n❌ 用户取消输入", file=sys.stderr)
+        return False
+    except EOFError:
+        print("\n❌ 输入错误", file=sys.stderr)
+        return False
+
+def get_last_send_time() -> float:
+    """获取上次发送时间"""
+    try:
+        with open(RATE_LIMIT_FILE, 'r') as f:
+            return float(f.read().strip())
+    except (FileNotFoundError, ValueError):
+        return 0
+
+def update_last_send_time():
+    """更新上次发送时间"""
+    with open(RATE_LIMIT_FILE, 'w') as f:
+        f.write(str(time.time()))
+
+def validate_phone_numbers(numbers: List[str]) -> List[str]:
+    """验证电话号码格式"""
+    validated = []
+    for number in numbers:
+        # 验证：必须以+86开头，后面跟11位数字（总共14位）
+        if number.startswith('+86') and len(number) == 14 and number[3:].isdigit() and len(number[3:]) == 11:
+            validated.append(number)
+        else:
+            print(f"警告: 跳过无效号码 {number}", file=sys.stderr)
+    
+    if len(validated) == 0:
+        raise ValueError("没有有效的电话号码")
+    
+    if len(validated) > MAX_PHONE_NUMBERS:
+        raise ValueError(f"电话号码数量超过限制 ({len(validated)} > {MAX_PHONE_NUMBERS})")
+    
+    return validated[:MAX_PHONE_NUMBERS]
+
+def validate_message_content(text: str) -> str:
+    """验证消息内容"""
+    if not text or not text.strip():
+        raise ValueError("消息内容不能为空")
+    
+    if len(text) > MAX_MESSAGE_LENGTH:
+        raise ValueError(f"消息长度超过限制 ({len(text)} > {MAX_MESSAGE_LENGTH})")
+    
+    return text.strip()
+
+def check_rate_limit():
+    """检查发送频率限制"""
+    last_send = get_last_send_time()
+    current_time = time.time()
+    
+    if current_time - last_send < MIN_INTERVAL_SECONDS:
+        wait_time = MIN_INTERVAL_SECONDS - (current_time - last_send)
+        raise ValueError(f"发送频率限制，请等待 {wait_time:.1f} 秒后再试")
+
+def generate_signature(method: str, uri: str, timestamp: str) -> str:
+    """生成SHA256签名"""
+    signature_string = f"{method}{uri}{APP_ID}{APP_SECRET}{timestamp}"
+    return hashlib.sha256(signature_string.encode('utf-8')).hexdigest()
+
+def send_group_message(
+    numbers: List[str], 
+    message_type: str = "TEXT",
+    text: Optional[str] = None,
+    template_id: Optional[str] = None,
+    params: Optional[List[Dict[str, str]]] = None,
+    fallback_aim: Optional[Dict[str, Any]] = None,
+    fallback_mms: Optional[Dict[str, Any]] = None,
+    fallback_sms: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
+    """发送群发消息"""
+    
+    # 验证输入
+    validated_numbers = validate_phone_numbers(numbers)
+    
+    if message_type == "TEXT":
+        if not text:
+            raise ValueError("TEXT类型必须提供text参数")
+        validated_text = validate_message_content(text)
+    elif message_type in ["RCS", "AIM", "MMS", "SMS"]:
+        if not template_id:
+            raise ValueError(f"{message_type}类型必须提供templateId参数")
+    else:
+        raise ValueError(f"不支持的消息类型: {message_type}")
+    
+    # 检查频率限制
+    check_rate_limit()
+    
+    # 构建请求体
+    payload = {
+        "templateType": message_type,
+        "numbers": validated_numbers
+    }
+    
+    if message_type == "TEXT":
+        payload["text"] = validated_text
+    else:
+        payload["templateId"] = template_id
+        if params:
+            payload["params"] = params
+    
+    # 添加回落配置
+    if fallback_aim:
+        payload["fallbackAim"] = fallback_aim
+    if fallback_mms:
+        payload["fallbackMms"] = fallback_mms
+    if fallback_sms:
+        payload["fallbackSms"] = fallback_sms
+    
+    # 准备API请求
+    url = f"{SERVER_ROOT}/messenger/api/v1/group/send"
+    uri = "/messenger/api/v1/group/send"
+    timestamp = str(int(time.time() * 1000))
+    signature = generate_signature("POST", uri, timestamp)
+    
+    headers = {
+        "AppId": APP_ID,
+        "Timestamp": timestamp,
+        "Signature": signature,
+        "Content-Type": "application/json"
+    }
+    
+    try:
+        response = requests.post(url, json=payload, headers=headers, timeout=30)
+        response.raise_for_status()
+        
+        # 更新发送时间戳
+        update_last_send_time()
+        
+        return {
+            "success": True,
+            "response": response.json(),
+            "sent_numbers": validated_numbers,  # 返回实际发送的号码列表
+            "sent_count": len(validated_numbers),
+            "message_type": message_type,
+            "message": validated_text if message_type == "TEXT" else None
+        }
+        
+    except requests.exceptions.RequestException as e:
+        return {
+            "success": False,
+            "error": str(e),
+            "sent_count": 0,
+            "message_type": message_type
+        }
+
+def main():
+    parser = argparse.ArgumentParser(description="RCS消息群发工具")
+    parser.add_argument("-n", "--numbers", required=True, 
+                       help="电话号码列表，用逗号分隔 (例: +8613900001234,+8613900002234)")
+    parser.add_argument("-m", "--message", 
+                       help="发送的文本内容 (TEXT类型必需)")
+    parser.add_argument("-t", "--type", default="TEXT", choices=["TEXT", "RCS", "AIM", "MMS", "SMS"],
+                       help="消息类型，默认TEXT")
+    parser.add_argument("--template-id", 
+                       help="模板ID (非TEXT类型必需)")
+    parser.add_argument("--dry-run", action="store_true",
+                       help="仅验证参数，不实际发送")
+    
+    args = parser.parse_args()
+    
+    # 解析电话号码
+    phone_numbers = [num.strip() for num in args.numbers.split(',') if num.strip()]
+    
+    if not phone_numbers:
+        print("错误: 必须提供至少一个电话号码", file=sys.stderr)
+        sys.exit(1)
+    
+    # 获取认证信息
+    if not get_app_credentials():
+        sys.exit(1)
+    
+    try:
+        if args.dry_run:
+            # 仅验证参数
+            validated_numbers = validate_phone_numbers(phone_numbers)
+            if args.type == "TEXT":
+                if not args.message:
+                    raise ValueError("TEXT类型必须提供消息内容")
+                validate_message_content(args.message)
+            elif not args.template_id:
+                raise ValueError(f"{args.type}类型必须提供模板ID")
+            
+            # 加密显示号码
+            masked_numbers = [mask_phone_number(num) for num in validated_numbers]
+            
+            print(f"✅ 参数验证通过")
+            print(f"   发送号码: {len(validated_numbers)} 个 ({', '.join(masked_numbers)})")
+            print(f"   消息类型: {args.type}")
+            if args.type == "TEXT":
+                print(f"   消息长度: {len(args.message)} 字符")
+            else:
+                print(f"   模板ID: {args.template_id}")
+            print(f"   API服务器: {SERVER_ROOT}")
+            print(f"   安全限制: 最大 {MAX_PHONE_NUMBERS} 个号码, {MAX_MESSAGE_LENGTH} 字符, {MIN_INTERVAL_SECONDS}秒间隔")
+            
+        else:
+            # 实际发送
+            result = send_group_message(
+                numbers=phone_numbers,
+                message_type=args.type,
+                text=args.message,
+                template_id=args.template_id
+            )
+            
+            if result["success"]:
+                # 加密显示成功发送的号码
+                masked_numbers = [mask_phone_number(num) for num in result['sent_numbers']]
+                
+                # 加密任务ID中的敏感信息
+                task_id = result['response'].get('data', 'N/A')
+                protected_task_id = protect_sensitive_info(task_id)
+                
+                print(f"【蜂动Claw】✅ **发送成功**")
+                print(f"   发送号码: {result['sent_count']} 个 ({', '.join(masked_numbers)})")
+                if result['message']:
+                    protected_message = protect_sensitive_info(result['message'])
+                    print(f"   消息内容: {protected_message[:50]}{'...' if len(protected_message) > 50 else ''}")
+                print(f"   任务ID: {protected_task_id}")
+            else:
+                print(f"❌ 发送失败: {result['error']}", file=sys.stderr)
+                sys.exit(1)
+                
+    except ValueError as e:
+        print(f"❌ 参数错误: {e}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"❌ 未知错误: {e}", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/skills/rcs-message/scripts/session_creds.py
+++ b/skills/rcs-message/scripts/session_creds.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+会话凭证管理模块
+用于存储和管理用户的APP_ID和APP_SECRET
+"""
+
+import os
+import json
+import hashlib
+from pathlib import Path
+
+# 会话凭证存储目录
+CREDENTIALS_DIR = Path.home() / ".config" / "moltbot" / "5g_messaging"
+CREDENTIALS_DIR.mkdir(parents=True, exist_ok=True)
+
+def get_session_key(session_id: str) -> str:
+    """根据会话ID生成唯一的会话密钥"""
+    return hashlib.sha256(session_id.encode()).hexdigest()[:16]
+
+def save_credentials(session_id: str, app_id: str, app_secret: str):
+    """保存会话凭证"""
+    session_key = get_session_key(session_id)
+    cred_file = CREDENTIALS_DIR / f"{session_key}.json"
+    
+    credentials = {
+        "app_id": app_id,
+        "app_secret": app_secret,
+        "session_id": session_id,
+        "saved_at": __import__('time').time()
+    }
+    
+    with open(cred_file, 'w') as f:
+        json.dump(credentials, f)
+
+def load_credentials(session_id: str) -> dict:
+    """加载会话凭证"""
+    session_key = get_session_key(session_id)
+    cred_file = CREDENTIALS_DIR / f"{session_key}.json"
+    
+    if not cred_file.exists():
+        return None
+    
+    try:
+        with open(cred_file, 'r') as f:
+            return json.load(f)
+    except (json.JSONDecodeError, IOError):
+        return None
+
+def has_saved_credentials(session_id: str) -> bool:
+    """检查是否已有保存的凭证"""
+    return load_credentials(session_id) is not None
+
+def clear_credentials(session_id: str):
+    """清除会话凭证"""
+    session_key = get_session_key(session_id)
+    cred_file = CREDENTIALS_DIR / f"{session_key}.json"
+    if cred_file.exists():
+        cred_file.unlink()


### PR DESCRIPTION
## Summary

This PR adds a new **RCS Message** skill that enables Claude to send and receive SMS/RCS messages via mobile SMS interfaces.

## Features

- Send text messages directly via phone numbers
- Support for template messages (RCS, AIM, MMS, SMS)
- Mass sending and forwarding capabilities
- Fallback channel handling
- Rate limiting and input validation
- Privacy protection for sensitive data

## Use Cases

- Send notifications or alerts via SMS
- Handle RCS rich media messages
- Forward or mass-send received text messages
- One-stop inquiry, reservation, and payment via messaging

## Structure

```
skills/rcs-message/
├── SKILL.md               # Skill definition
├── README.md              # Documentation
├── scripts/               # Python implementation
│   ├── send.py            # Core sending module
│   ├── main.py            # Entry point
│   ├── handle_user_input.py
│   ├── check_config.py
│   ├── privacy_protect.py
│   ├── session_creds.py
│   └── config.example.json
└── references/
    └── USAGE_EXAMPLES.md
```

## Requirements

- Python 3.6+
- `requests` library
- API credentials (APP_ID, APP_SECRET)

## Testing

Tested locally with sample phone numbers and template IDs.