### PR TITLE
feat: add agent-architecture-audit skill

### DIFF
--- a/skills/agent-architecture-audit/LICENSE.txt
+++ b/skills/agent-architecture-audit/LICENSE.txt
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/skills/agent-architecture-audit/SKILL.md
+++ b/skills/agent-architecture-audit/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: agent-architecture-audit
+description: Audit the architecture and health of any AI agent system. Use when diagnosing why a wrapped agent behaves worse than the base model, investigating agent hallucinations, tool-use failures, memory contamination, or hidden prompt conflicts. Produces a structured JSON report with severity-ranked findings and a code-first fix plan.
+license: Apache-2.0
+---
+
+# Agent Architecture Audit
+
+Audit the architecture and health of any AI agent system.
+
+**The base model rarely fails. The wrapper architecture corrupts good answers into bad behavior.**
+
+When an AI agent (coding assistant, autonomous agent, chatbot with tools, or wrapped LLM) produces broken, hallucinated, or degraded output, the failure is almost never the model itself. It is the orchestration — the system prompt, memory layer, tool routing, hidden repair loops, and rendering pipeline — that corrupts good answers.
+
+## When to Use This Skill
+
+Use this skill when:
+
+- A wrapped agent behaves worse than the base model via direct API
+- The agent hallucinates, skips required tools, or reuses stale context
+- "Must use tool X" is in the prompt but the model answers without calling it
+- Old topics leak into new conversations across sessions
+- Internal logs show correct answers but users see broken output
+- Hidden retry/fallback agents silently mutate responses
+- Cost spikes with no visible output (runaway loops)
+
+## The 12-Layer Stack
+
+Every agent system has these layers. Any of them can corrupt the answer:
+
+| # | Layer | What Goes Wrong |
+|---|-------|----------------|
+| 1 | System prompt | Conflicting instructions, instruction bloat |
+| 2 | Session history | Stale context from previous turns |
+| 3 | Long-term memory | Pollution across sessions |
+| 4 | Distillation | Compressed artifacts re-entering as pseudo-facts |
+| 5 | Active recall | Redundant re-summary layers wasting context |
+| 6 | Tool selection | Wrong tool routing, model skips required tools |
+| 7 | Tool execution | Hallucinated execution — claims to call but doesn't |
+| 8 | Tool interpretation | Misread or ignored tool output |
+| 9 | Answer shaping | Format corruption in final response |
+| 10 | Platform rendering | UI/API/CLI mutates valid answers |
+| 11 | Hidden repair loops | Silent fallback/retry agents running second LLM pass |
+| 12 | Persistence | Expired state or cached artifacts reused as live evidence |
+
+## Audit Process
+
+### Phase 1: Intake — What Does the User Report?
+
+Capture symptoms in `agent_check_scope.json`:
+
+```json
+{
+  "target_name": "agent or system being audited",
+  "user_symptoms": ["what the user reports is wrong"],
+  "symptom_severity": "critical|high|medium|low",
+  "audit_scope": "what part of the stack to focus on"
+}
+```
+
+### Phase 2: Evidence Collection
+
+Gather whatever evidence is available from the system:
+
+- **System prompts** — all layers of instructions, from base to wrapper to fallback
+- **Tool definitions** — how tools are declared (prompt text vs code-enforced)
+- **Memory configuration** — what gets persisted, how it's retrieved, freshness rules
+- **Agent loop code** — the orchestration loop, tool routing, error handling, retry logic
+- **Output pipeline** — how answers are shaped, formatted, or transformed before delivery
+
+Collect into `evidence_pack.json`.
+
+### Phase 3: Code-Level Anti-Pattern Scan
+
+Run these grep-searchable patterns against any agent codebase or prompt collection:
+
+```bash
+# 1. Hardcoded secrets
+rg "sk-[A-Za-z0-9]{20,}|ghp_[A-Za-z0-9]{36}|AKIA[0-9A-Z]{16}" --type md --type json --type yaml
+
+# 2. Tool requirements in prompt only (no code gate)
+rg "must.*tool|required.*call|always.*use.*tool" --type md --type txt
+
+# 3. Hidden LLM calls outside main agent loop
+rg "completion|chat\.create|messages\.create|llm\.invoke" --type py --type ts
+
+# 4. Unrestricted code execution
+rg "exec\(|eval\(|subprocess\.(run|Popen)|os\.system\(" --type py -n
+
+# 5. Memory admission without user priority
+rg "memory.*admit|long.*term.*update|persist.*memory" --type py --type ts
+
+# 6. Missing error handling on agent paths
+rg "while.*agent|for.*turn|agent.*loop" --type py --type ts -A 3 | rg -v "max_|limit|break"
+
+# 7. Output mutation in delivery layer
+rg "mutate.*response|rewrite.*output|transform.*answer" --type py --type ts
+
+# 8. Unbounded memory/context growth
+rg "add.*memory|upsert.*vector|append.*context" --type py --type ts -A 3 | rg -v "max_|limit|ttl|trim"
+
+# 9. Missing observability (absence check)
+rg "langsmith|langfuse|opentelemetry|callback|tracer" --type py --type ts
+
+# 10. State mutators without upstream validation
+rg "file.*write|db.*insert|vector.*upsert" --type py --type ts -B 5 | rg -v "validate|guard|filter"
+```
+
+### Phase 4: Failure Mapping
+
+For each failure found, document in `failure_map.json`:
+
+```json
+{
+  "failures": [
+    {
+      "id": 1,
+      "severity": "critical|high|medium|low",
+      "layer": "which of the 12 layers",
+      "title": "what went wrong",
+      "mechanism": "how it happens",
+      "evidence": ["file:line or prompt excerpt"]
+    }
+  ]
+}
+```
+
+### Phase 5: Report Generation
+
+Produce `agent_check_report.json`:
+
+```json
+{
+  "schema_version": "oh-my-agent-check.report.v1",
+  "target_name": "agent name",
+  "overall_health": "critical_risk|high_risk|medium_risk|low_risk",
+  "findings": [
+    {
+      "severity": "critical|high|medium|low",
+      "title": "short description",
+      "layer": "which stack layer",
+      "mechanism": "how it corrupts the answer",
+      "evidence_refs": ["file:line or prompt"],
+      "recommended_fix": "what to change",
+      "fix_type": "code_enforced|prompt_only|architectural"
+    }
+  ],
+  "ordered_fix_plan": [
+    { "order": 1, "goal": "first thing to fix", "why_now": "why this comes first" }
+  ]
+}
+```
+
+## Audit Playbooks
+
+Choose the closest playbook based on symptoms:
+
+### wrapper-regression
+When the base model works fine but the wrapped agent is worse.
+Focus: system prompt conflicts, duplicated context, hidden formatting layers.
+
+### memory-contamination
+When old topics bleed into new conversations.
+Focus: same-session artifact reentry, stale session reuse, weak memory admission.
+
+### tool-discipline
+When the agent skips required tools or hallucinates execution.
+Focus: code-enforced vs prompt-enforced tool requirements, skip paths.
+
+### rendering-transport
+When internal answer is correct but delivery is broken.
+Focus: transport payload assumptions, platform-layer mutations.
+
+### hidden-agent-layers
+When silent repair/retry/summarize loops run without contracts.
+Focus: hidden repair agents, second-pass LLM calls, maintenance-worker synthesis.
+
+### code-execution-safety
+When the agent uses exec/eval/shell without sandboxing.
+Focus: resource limits, input validation, isolation.
+
+### memory-growth-hazard
+When memory/context grows without limits.
+Focus: size limits, TTL, retention policies.
+
+### observability-gap
+When there is no tracing or debugging capability.
+Focus: add logging, cost metrics, session replay.
+
+### state-mutator-safety
+When the agent writes to files/DBs without validation.
+Focus: upstream validation, guard nodes, rollback.
+
+## Severity Model
+
+| Level | Meaning |
+|-------|---------|
+| `critical` | Agent can confidently produce wrong operational behavior |
+| `high` | Agent frequently degrades correctness or stability |
+| `medium` | Correctness usually survives but output is fragile or wasteful |
+| `low` | Mostly cosmetic or maintainability issues |
+
+## Fix Strategy
+
+Default fix order (code-first, not prompt-first):
+
+1. **Code-gate tool requirements** — enforce in code, not just prompt text
+2. **Remove or narrow hidden repair agents** — make fallback explicit with contracts
+3. **Reduce context duplication** — same info through prompt + history + memory + distillation
+4. **Tighten memory admission** — user corrections > agent assertions
+5. **Tighten distillation triggers** — don't compress what shouldn't be compressed
+6. **Reduce rendering mutation** — pass-through, don't transform
+7. **Convert to typed JSON envelopes** — structured internal flow, not freeform prose
+
+## Anti-Patterns to Avoid
+
+- ❌ Saying "the model is weak" without falsifying the wrapper first
+- ❌ Saying "memory is bad" without showing the contamination path
+- ❌ Letting a clean current state erase a dirty historical incident
+- ❌ Treating markdown prose as a trustworthy internal protocol
+- ❌ Accepting "must use tool" in prompt text when code never enforces it


### PR DESCRIPTION
## What This Adds

A new skill at `skills/agent-architecture-audit/` — a comprehensive diagnostic framework for auditing the health of any AI agent system.

## Why It Belongs Here

This repository showcases production-grade skills for Claude. While existing skills cover frontend design, MCP servers, document processing, and creative work, none address the critical need to **diagnose why an agent system is broken**.

This skill fills that gap. It teaches Claude to systematically audit any AI agent architecture — from coding assistants to autonomous agents — and identify the exact layers corrupting good model answers into bad behavior.

## What's Inside

**10 Code-Level Anti-Patterns** — grep-searchable patterns with exact commands:
- Hardcoded secrets
- Tool requirements in prompt only (no code gate)
- Hidden LLM calls outside main agent loop
- Unrestricted code execution
- Missing error handling on agent paths
- Unbounded memory/context growth
- Missing observability
- State mutators without upstream validation
- Output mutation in delivery layer
- Memory admission without user priority

**12-Layer Stack Analysis** — from system prompt through persistence

**9 Audit Playbooks**:
- `wrapper-regression`, `memory-contamination`, `tool-discipline`
- `rendering-transport`, `hidden-agent-layers`
- `code-execution-safety`, `memory-growth-hazard`, `observability-gap`, `state-mutator-safety`

**Structured JSON Report Schema** — severity-ranked findings with code-first fix plan

## Who Needs This

Every developer building agent applications or using LLM APIs. Catches the failures that break agents in production:

- "Model works in playground but breaks in my agent"
- "Agent was fine yesterday, now it hallucinates"
- "Tool use is flaky"
- "Old topics keep appearing in new turns"
- "Internal answer correct, user sees broken output"

## Format

Follows the repository's skill conventions:
- `SKILL.md` with YAML frontmatter (name, description, license)
- Self-contained instructional content
- Apache-2.0 license (matching repo standard)

## Related

Full production-tested implementation: [oh-my-agent-check](https://github.com/huangrichao2020/oh-my-agent-check)

Integrated into: Langflow, GenericAgent, superpowers, Everything Claude Code, OpenCode