### PR TITLE
Add screenshot-to-html skill

### DIFF
--- a/skills/screenshot-to-html/README.md
+++ b/skills/screenshot-to-html/README.md
@@ -1,0 +1,16 @@
+# screenshot-to-html
+
+Converts a product UI screenshot into a pixel-faithful, fully editable HTML file, then renders it as a PNG asset for websites or marketing materials.
+
+Colors, spacing, and all UI values are sampled directly from the source screenshot pixels — never guessed. Output includes a self-contained HTML file with CSS variables for easy editing, plus 1x and 2x/retina PNGs rendered via headless Chromium.
+
+**Triggers on:** uploading a product screenshot, "stylise this UI", "marketing asset from screenshot", "recreate this dashboard".
+
+See [SKILL.md](SKILL.md) for full instructions. Helper scripts live in [`scripts/`](scripts/):
+- `analyse.py` — sample colors and structure from the source image
+- `render.py` — render the HTML to PNG via headless Chromium
+
+## Requirements
+
+- Python 3
+- Playwright with Chromium (`pip install playwright && playwright install chromium`)

--- a/skills/screenshot-to-html/SKILL.md
+++ b/skills/screenshot-to-html/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: screenshot-to-html
+description: >
+  Converts a product UI screenshot into a pixel-faithful, fully editable HTML file,
+  then renders it as a PNG image asset ready for use on a website or in marketing materials.
+
+  Use this skill whenever the user:
+  - Uploads a product screenshot and wants to recreate it in HTML
+  - Wants a "marketable" or "polished" version of a product UI
+  - Asks to turn a screenshot into an editable file
+  - Wants to generate a PNG/image from a product UI for use on a website
+  - Asks to "stylise", "rerender", "recreate" or "clean up" a screenshot
+  - Mentions phrases like "product screenshot", "dashboard asset", "marketing asset", "UI mockup"
+
+  Output: a self-contained HTML file with CSS variables for easy editing, plus a PNG rendered
+  via headless Chromium (1x and 2x/retina). Colors, spacing, and all UI values are sampled
+  directly from the source screenshot pixels — never guessed.
+---
+
+# Screenshot → HTML → PNG
+
+Converts a product UI screenshot into a pixel-faithful, editable HTML file and renders it
+as a polished marketing asset PNG. All colors are sampled from the actual image.
+
+---
+
+## Step 1 — Understand the screenshot
+
+When the user uploads a screenshot, first ask (if not already clear):
+
+1. **Which section to feature?** (e.g. "the full dashboard", "just the top stats row", "the policy panel")
+2. **Background context** — dark surroundings or light? (determines the presentation frame glow color)
+3. **Crop** — remove chrome like sidebars, top navigation, scrollbars? (almost always yes for marketing use)
+
+Do not proceed until you know which section to feature. One question at a time if ambiguous.
+
+---
+
+## Step 2 — Analyse the screenshot
+
+Run `scripts/analyse.py` with the uploaded image path to:
+- Detect overall image dimensions
+- Sample key UI colors at strategic coordinates
+- Find bright/colored pixels (accents, tags, icons, progress bars)
+- Identify the crop boundaries (sidebar width, topbar height, scrollbar)
+
+```bash
+python3 scripts/analyse.py <image_path>
+```
+
+Read the output carefully. The color values it returns are ground truth — use them verbatim
+in the HTML CSS variables. Do not substitute with assumed brand colors.
+
+---
+
+## Step 3 — Crop the image (if requested)
+
+If the user wants the sidebar/topbar removed, use the crop values from Step 2:
+
+```python
+from PIL import Image
+img = Image.open(path)
+cropped = img.crop((left, top, right, bottom))
+cropped.save("/tmp/cropped.jpg", quality=92)
+```
+
+---
+
+## Step 4 — Build the HTML
+
+Build a **single self-contained HTML file** with:
+
+### Structure
+```
+<html>
+  <head>
+    <style> :root { --tokens } ... all CSS ... </style>
+  </head>
+  <body>
+    <div class="wrap">          ← outer glow + max-width
+      <div class="chrome">      ← rounded border + shadow
+        <div class="browser-bar"> ← 3 dots
+        <div class="dashboard"> ← the actual UI recreation
+```
+
+### CSS tokens (`:root`)
+All colors go here as named variables — never hardcode hex values in component CSS.
+Pull these directly from the analyser output:
+- `--bg` — main background
+- `--bg-panel` — card/panel surface
+- `--border` — panel border (rgba)
+- `--text-primary` — main text
+- `--text-secondary` — muted labels
+- `--text-muted` — very faint labels
+- One variable per accent color: `--blue`, `--amber`, `--green`, `--red`, etc.
+- Semantic tag backgrounds: `--tag-amber-bg`, etc.
+
+### Presentation frame
+Wrap the dashboard in a dark outer container with:
+- Radial gradient glow behind (color matches the dominant UI accent)
+- `border-radius: 10px` chrome border
+- `box-shadow` for depth
+- 3-dot browser bar at top
+
+### UI components
+Recreate each section faithfully:
+- **Stat cards**: 4-column grid, value in large bold type, label + icon
+- **Bar charts**: fixed-height container (`overflow: hidden`), labels in a separate row *outside* the height-constrained area (prevents bars exceeding the ceiling)
+- **Lists** (policies, audits, frameworks): border-bottom rows, tag badges, progress bars
+- **Tags/badges**: correct background + text color per state (Draft, Approved, Pending, In Progress)
+- **Progress bars**: track color from `--grey-track`, fill from `--blue`
+- **Icons**: inline SVG, stroke color matches the stat's accent
+
+### Realism rules
+- Replace any test/dev/placeholder usernames with realistic generic names (e.g. "M. Okafor", "S. Dhillon")
+- Keep all real data values (counts, dates, percentages, framework names)
+- Truncate long descriptions with `...` as in the original
+
+### Bar chart ceiling fix
+This is a known gotcha — always implement it:
+```html
+<!-- labels OUTSIDE the height-constrained bars container -->
+<div class="chart-inner" style="height:128px; overflow:hidden;">
+  <div class="chart-y">...</div>
+  <div class="bars">
+    <div class="bar-group"><div class="bar-cols">...</div></div>
+  </div>
+</div>
+<div class="bar-labels">  ← outside chart-inner
+  <div class="bar-lbl">Operational Tasks</div>
+  ...
+</div>
+```
+
+Bar heights must be calculated as: `value / max_value * chart_height_px`
+
+---
+
+## Step 5 — Render to PNG
+
+Use Playwright headless Chromium to render the HTML. Always generate both 1x and 2x:
+
+```bash
+python3 scripts/render.py <html_path> <output_dir>
+```
+
+This produces:
+- `dashboard.png` — standard resolution
+- `dashboard@2x.png` — retina (device_scale_factor=2)
+
+Recommend the `@2x` version for website use.
+
+---
+
+## Step 6 — Deliver
+
+Present both PNG files with `present_files`. Brief summary only — the user can see the files.
+
+If the user asks for adjustments (wrong bar height, wrong color, different crop), edit the HTML
+directly and re-run the renderer. No need to redo the full analysis.
+
+---
+
+## Common adjustments
+
+| Issue | Fix |
+|-------|-----|
+| Bar exceeds gridline | Reduce bar `height` value in HTML; verify chart-inner has `overflow:hidden` |
+| Wrong accent color | Re-sample that pixel region; update the CSS variable |
+| Sidebar still visible | Tighten left crop value by 5–10px increments |
+| Text too small | Increase font-size on `.stat-value` or `.item-name` |
+| Glow wrong color | Change the radial-gradient color in `.wrap::before` |
+
+---
+
+## Quality checklist
+
+Before delivering:
+- [ ] All colors traced to sampled pixels, not assumed
+- [ ] No test/dev usernames in the output
+- [ ] Bar chart labels are outside the overflow-hidden container
+- [ ] Tallest bar is visibly below its gridline ceiling (not touching or exceeding)
+- [ ] Both 1x and 2x PNGs generated
+- [ ] HTML opens in browser without errors

--- a/skills/screenshot-to-html/scripts/analyse.py
+++ b/skills/screenshot-to-html/scripts/analyse.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""
+analyse.py — Sample UI colors and detect layout bounds from a product screenshot.
+
+Usage:
+    python3 analyse.py <image_path>
+
+Output:
+    JSON with sampled colors, suggested crop bounds, and detected accent colors.
+"""
+
+import sys
+import json
+import numpy as np
+from PIL import Image, ImageEnhance
+from collections import defaultdict
+
+
+def hex_color(px):
+    return "#{:02x}{:02x}{:02x}".format(int(px[0]), int(px[1]), int(px[2]))
+
+
+def brightness(px):
+    return int(px[0]) + int(px[1]) + int(px[2])
+
+
+def is_blue(px):
+    r, g, b = int(px[0]), int(px[1]), int(px[2])
+    return b > 80 and b > r + 20 and b > g + 10
+
+def is_amber(px):
+    r, g, b = int(px[0]), int(px[1]), int(px[2])
+    return r > 160 and g > 120 and b < 60
+
+def is_green(px):
+    r, g, b = int(px[0]), int(px[1]), int(px[2])
+    return g > 150 and g > r + 40 and b < 100
+
+def is_red(px):
+    r, g, b = int(px[0]), int(px[1]), int(px[2])
+    return r > 140 and g < 80 and b < 80
+
+
+def detect_sidebar_width(arr):
+    """Detect sidebar by finding where the main content background starts."""
+    h, w = arr.shape[:2]
+    # Sample a vertical strip and look for a color shift
+    mid_y = h // 2
+    bg = arr[mid_y, w // 2]
+    for x in range(0, min(300, w)):
+        px = arr[mid_y, x]
+        if abs(int(px[0]) - int(bg[0])) > 15:
+            continue
+        # Check if it's been consistent for 10px
+        if x > 10:
+            strip = arr[mid_y, max(0,x-10):x]
+            diffs = [abs(int(p[0]) - int(bg[0])) for p in strip]
+            if all(d < 15 for d in diffs):
+                return x
+    return 0
+
+
+def detect_topbar_height(arr):
+    """Detect top bar height by finding where it ends."""
+    h, w = arr.shape[:2]
+    mid_x = w // 2
+    bg = arr[h // 2, mid_x]
+    for y in range(0, min(100, h)):
+        px = arr[y, mid_x]
+        if brightness(px) > 200:  # bright pixel = likely topbar text/icon
+            continue
+        if y > 10:
+            return y
+    return 44  # sensible default
+
+
+def sample_region_colors(arr, y1, y2, x1, x2, step=8):
+    """Find all non-trivially-dark colors in a region."""
+    colors = defaultdict(int)
+    for y in range(y1, y2, step):
+        for x in range(x1, x2, step):
+            px = arr[y, x]
+            b = brightness(px)
+            if b > 120:
+                colors[hex_color(px)] += 1
+    return sorted(colors.items(), key=lambda kv: -kv[1])
+
+
+def find_accent_colors(arr, y1, y2, x1, x2):
+    """Scan region for blue, amber, green, red accent pixels."""
+    accents = {"blue": None, "amber": None, "green": None, "red": None}
+    for y in range(y1, y2, 2):
+        for x in range(x1, x2, 2):
+            px = arr[y, x]
+            if accents["blue"] is None and is_blue(px):
+                accents["blue"] = hex_color(px)
+            if accents["amber"] is None and is_amber(px):
+                accents["amber"] = hex_color(px)
+            if accents["green"] is None and is_green(px):
+                accents["green"] = hex_color(px)
+            if accents["red"] is None and is_red(px):
+                accents["red"] = hex_color(px)
+        if all(v is not None for v in accents.values()):
+            break
+    return accents
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python3 analyse.py <image_path>", file=sys.stderr)
+        sys.exit(1)
+
+    path = sys.argv[1]
+    img = Image.open(path)
+    arr = np.array(img).astype(int)
+    h, w = arr.shape[:2]
+
+    result = {}
+
+    # Image dimensions
+    result["dimensions"] = {"width": w, "height": h}
+
+    # Detect chrome (sidebar + topbar)
+    sidebar_w = detect_sidebar_width(arr)
+    topbar_h = detect_topbar_height(arr)
+    result["suggested_crop"] = {
+        "left": sidebar_w,
+        "top": topbar_h,
+        "right": w - 18,   # trim scrollbar
+        "bottom": h - 10,
+        "note": "Adjust right/bottom if scrollbar or footer chrome is visible"
+    }
+
+    # Sample main background color
+    # Use a point well inside the content area
+    cx, cy = (sidebar_w + w) // 2, (topbar_h + h) // 2
+    bg_px = arr[cy, cx]
+    result["colors"] = {}
+    result["colors"]["bg"] = hex_color(bg_px)
+
+    # Panel color — slightly different from bg, scan for subtle variation
+    # Sample at 20% in from sidebar
+    panel_x = sidebar_w + (w - sidebar_w) // 5
+    panel_y = topbar_h + 60
+    result["colors"]["bg_panel"] = hex_color(arr[panel_y, panel_x])
+
+    # Text — find near-white pixels (headings)
+    bright_cols = sample_region_colors(arr, topbar_h, topbar_h + 200, sidebar_w, w, step=4)
+    text_candidates = [c for c, n in bright_cols if all(int(c[i:i+2], 16) > 200 for i in (1,3,5))]
+    result["colors"]["text_primary"] = text_candidates[0] if text_candidates else "#e2e0eb"
+
+    # Secondary text — medium brightness
+    mid_candidates = [c for c, n in bright_cols if 100 < max(int(c[i:i+2],16) for i in (1,3,5)) < 180]
+    result["colors"]["text_secondary"] = mid_candidates[0] if mid_candidates else "#9090a0"
+
+    # Accent colors — scan full content area
+    accents = find_accent_colors(arr, topbar_h, h, sidebar_w, w)
+    result["colors"].update(accents)
+
+    # Border color (estimate from bg)
+    bg_r = int(bg_px[0])
+    border_r = min(255, bg_r + 20)
+    result["colors"]["border"] = f"rgba({border_r},{border_r},{border_r+4},0.08)"
+    result["colors"]["grey_track"] = f"#{max(0,bg_r+25):02x}{max(0,bg_r+25):02x}{max(0,bg_r+28):02x}"
+
+    # Tag background estimates (based on accent colors)
+    def accent_bg(hex_col, alpha=0.15):
+        if hex_col is None:
+            return None
+        r = int(hex_col[1:3], 16)
+        g = int(hex_col[3:5], 16)
+        b = int(hex_col[5:7], 16)
+        return f"rgba({r},{g},{b},{alpha})"
+
+    result["colors"]["tag_blue_bg"]  = accent_bg(accents.get("blue"),  0.20)
+    result["colors"]["tag_amber_bg"] = accent_bg(accents.get("amber"), 0.14)
+    result["colors"]["tag_green_bg"] = accent_bg(accents.get("green"), 0.14)
+    result["colors"]["tag_red_bg"]   = accent_bg(accents.get("red"),   0.14)
+
+    # Summary guidance
+    result["guidance"] = {
+        "css_variables": "Use result['colors'] values directly in :root CSS variables.",
+        "bar_chart": "Calculate bar height as: value / max_value * chart_height_px. Keep labels outside overflow:hidden container.",
+        "presentation_frame": f"Use accent color '{accents.get('blue', '#375788')}' for the radial glow behind the dashboard.",
+        "crop": f"Remove sidebar (~{sidebar_w}px) and topbar (~{topbar_h}px) for clean marketing crop."
+    }
+
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/screenshot-to-html/scripts/render.py
+++ b/skills/screenshot-to-html/scripts/render.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""
+render.py — Render an HTML file to PNG using headless Chromium via Playwright.
+
+Usage:
+    python3 render.py <html_path> <output_dir> [selector]
+
+Arguments:
+    html_path   — path to the self-contained HTML file
+    output_dir  — directory to write PNGs into
+    selector    — CSS selector of element to screenshot (default: .wrap)
+
+Output:
+    <output_dir>/dashboard.png       — 1x standard
+    <output_dir>/dashboard@2x.png   — 2x retina
+"""
+
+import sys
+import os
+
+def render(html_path, output_dir, selector=".wrap"):
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        print("Playwright not installed. Run: pip install playwright --break-system-packages && python3 -m playwright install chromium")
+        sys.exit(1)
+
+    os.makedirs(output_dir, exist_ok=True)
+    abs_path = os.path.abspath(html_path)
+    out_1x = os.path.join(output_dir, "dashboard.png")
+    out_2x = os.path.join(output_dir, "dashboard@2x.png")
+
+    with sync_playwright() as p:
+        # 1x render
+        browser = p.chromium.launch()
+        page = browser.new_page(viewport={"width": 1200, "height": 1000})
+        page.goto(f"file://{abs_path}")
+        page.wait_for_timeout(800)
+        el = page.query_selector(selector)
+        if el is None:
+            print(f"Warning: selector '{selector}' not found, falling back to full page")
+            page.screenshot(path=out_1x, type="png", full_page=True)
+        else:
+            el.screenshot(path=out_1x, type="png")
+        browser.close()
+
+        # 2x render (retina)
+        browser = p.chromium.launch()
+        page = browser.new_page(viewport={"width": 1200, "height": 1000}, device_scale_factor=2)
+        page.goto(f"file://{abs_path}")
+        page.wait_for_timeout(800)
+        el = page.query_selector(selector)
+        if el is None:
+            page.screenshot(path=out_2x, type="png", full_page=True)
+        else:
+            el.screenshot(path=out_2x, type="png")
+        browser.close()
+
+    print(f"Rendered:")
+    print(f"  1x: {out_1x}  ({os.path.getsize(out_1x):,} bytes)")
+    print(f"  2x: {out_2x}  ({os.path.getsize(out_2x):,} bytes)")
+    return out_1x, out_2x
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print(__doc__)
+        sys.exit(1)
+
+    html_path = sys.argv[1]
+    output_dir = sys.argv[2]
+    selector = sys.argv[3] if len(sys.argv) > 3 else ".wrap"
+
+    render(html_path, output_dir, selector)


### PR DESCRIPTION
## Summary

Adds a new skill, **screenshot-to-html**, under `skills/screenshot-to-html/`.

It converts a product UI screenshot into a pixel-faithful, fully editable HTML file plus a 1x/2x PNG render via headless Chromium. All colors and spacing are sampled directly from the source pixels — never guessed — so the output is suitable for marketing assets that need to look like the real product.

## Why this is useful

Designers and marketers regularly need polished versions of in-product screenshots for landing pages, case studies, and decks. Today this means rebuilding the UI by hand in Figma. This skill takes a screenshot in and gives back an editable HTML file plus a PNG, with CSS variables for easy theming.

## Contents

- `SKILL.md` — instructions and trigger phrases
- `scripts/analyse.py` — samples colors and structure from the source image
- `scripts/render.py` — renders the final HTML to 1x/2x PNG via Playwright/Chromium
- `README.md` — quick reference and requirements

## Requirements

- Python 3
- Playwright with Chromium (`pip install playwright && playwright install chromium`)

## Origin

Part of a small skills collection I maintain at https://github.com/toppb/claude-skills (case study: https://www.toppbrocales.com/work/autokrator). Happy to adjust naming, structure, or scope to match conventions here.