### PR TITLE
Add dita-xml skill for structured DITA 1.3 XML generation

### DIFF
--- a/skills/dita-xml/LICENSE.txt
+++ b/skills/dita-xml/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the
+      purposes of this License, Derivative Works shall not include works that
+      remain separable from, or merely link (or bind by name) to the
+      interfaces of the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to the Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute
+      the Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable by
+      such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only.
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing
+      the origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Anthropic, PBC.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/dita-xml/SKILL.md
+++ b/skills/dita-xml/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: dita-xml
+
+description: Generate structured DITA XML documentation from source inputs — codebase, existing end-user documentation, and audience context. Produces concept, task, and reference topic types. TRIGGER when: user wants to generate DITA-structured documentation from product source files; user needs topic-typed XML output (concept/task/reference); user is documenting software procedures or UI workflows in DITA format. SKIP: user wants plain prose or Markdown output; user is not working with DITA or XML-based documentation systems.
+
+license: MIT
+---
+
+# DITA XML Documentation Generator
+
+Generate structured DITA XML documentation grounded in actual product behavior.
+
+## Inputs Required
+
+Before generating content, confirm these inputs are available in the session:
+
+1. **Application source** — codebase, UI specifications, or API definitions
+2. **Existing end-user documentation** — validated documentation for this product if available
+3. **Topic type** — concept, task, or reference
+4. **Audience** — who this documentation is for and their operational context
+
+## Topic Type Selection
+
+| Topic Type | Use When |
+|---|---|
+| `<concept>` | Explaining what something is or how it works |
+| `<task>` | Documenting a procedure the user performs |
+| `<reference>` | Documenting UI elements, fields, options, or parameters |
+
+## Generation Rules
+
+- Ground all content in the provided source inputs — do not generate from general knowledge
+- For task topics: each step must correspond to a verifiable action in the application
+- For concept topics: descriptions must reflect actual system behavior, not general software patterns
+- For reference topics: field names, values, and defaults must match the source exactly
+- Apply short-form steps sized for users working under operational pressure
+- Do not include prerequisites, warnings, or conditions that are not verifiable from the source inputs — flag gaps for the domain expert to resolve
+
+## Output Format
+
+Produce valid DITA 1.3 XML topics. Use standard DITA 1.3 element structure. Do not invent custom elements or attributes.
+
+## Reference
+
+This skill applies the DITA 1.3 standard as defined by OASIS:
+- [DITA 1.3 Specification](https://docs.oasis-open.org/dita/dita/v1.3/dita-v1.3-part0-overview.html)
+- [DITA 1.3 Element Reference](https://docs.oasis-open.org/dita/dita/v1.3/errata02/os/complete/part3-all-inclusive/langRef/containers/concept-elements.html)
+
+## Validation Reminder
+
+Output from this skill requires Stage 3 behavioral validation by the domain-expert technical communicator before publication. Generated content is a starting point, not a finished deliverable.

--- a/skills/dita-xml/SKILL.md
+++ b/skills/dita-xml/SKILL.md
@@ -1,14 +1,20 @@
 ---
 name: dita-xml
 
-description: Generate structured DITA XML documentation from source inputs — codebase, existing end-user documentation, and audience context. Produces concept, task, and reference topic types. TRIGGER when: user wants to generate DITA-structured documentation from product source files; user needs topic-typed XML output (concept/task/reference); user is documenting software procedures or UI workflows in DITA format. SKIP: user wants plain prose or Markdown output; user is not working with DITA or XML-based documentation systems.
+description: Generate structured DITA 1.3 XML documentation from source inputs — codebase, existing end-user documentation, and audience context. Produces concept, task, and reference topic types. Use this skill when the user wants to generate DITA-structured documentation from product source files, needs topic-typed XML output, or is documenting software procedures or UI workflows in DITA format.
 
-license: MIT
+license: Complete terms in LICENSE.txt
 ---
 
 # DITA XML Documentation Generator
 
 Generate structured DITA XML documentation grounded in actual product behavior.
+
+## When to Use This Skill
+
+Use this skill when the user wants to generate DITA-structured documentation from product source files, needs topic-typed XML output (concept/task/reference), or is documenting software procedures or UI workflows in DITA format.
+
+Do not use this skill for plain prose or Markdown output, or when the user is not working with DITA or XML-based documentation systems.
 
 ## Inputs Required
 
@@ -19,33 +25,91 @@ Before generating content, confirm these inputs are available in the session:
 3. **Topic type** — concept, task, or reference
 4. **Audience** — who this documentation is for and their operational context
 
-## Topic Type Selection
+## Step-by-Step Workflow
 
-| Topic Type | Use When |
-|---|---|
-| `<concept>` | Explaining what something is or how it works |
-| `<task>` | Documenting a procedure the user performs |
-| `<reference>` | Documenting UI elements, fields, options, or parameters |
+1. **Confirm inputs** — Verify all required inputs are available. If any are missing, ask the user before proceeding.
+2. **Select topic type** — Choose the appropriate DITA topic type based on the content purpose:
+   - `<concept>` — explaining what something is or how it works
+   - `<task>` — documenting a procedure the user performs
+   - `<reference>` — documenting UI elements, fields, options, or parameters
+3. **Extract from source** — Ground all content in the provided source inputs. Do not generate from general knowledge.
+4. **Generate XML** — Produce valid DITA 1.3 XML using standard element structure. Do not invent custom elements or attributes.
+5. **Verify against source** — For task topics, confirm each step corresponds to a verifiable action. For concept topics, confirm descriptions reflect actual system behavior. For reference topics, confirm field names, values, and defaults match the source exactly.
+6. **Behavioral validation required** — The user must test generated procedures against actual application behavior before publication. This step is not optional. AI-generated content can be technically accurate against source inputs but operationally insufficient — correct descriptions that fail to convey what users need to know, omit prerequisite conditions, or misrepresent sequence dependencies. These errors are invisible without hands-on testing by someone with direct knowledge of the user's operational context.
 
 ## Generation Rules
 
-- Ground all content in the provided source inputs — do not generate from general knowledge
 - For task topics: each step must correspond to a verifiable action in the application
 - For concept topics: descriptions must reflect actual system behavior, not general software patterns
 - For reference topics: field names, values, and defaults must match the source exactly
 - Apply short-form steps sized for users working under operational pressure
-- Do not include prerequisites, warnings, or conditions that are not verifiable from the source inputs — flag gaps for the domain expert to resolve
+- Do not include prerequisites, warnings, or conditions not verifiable from source inputs — flag gaps for the domain expert to resolve
 
-## Output Format
+## Examples
 
-Produce valid DITA 1.3 XML topics. Use standard DITA 1.3 element structure. Do not invent custom elements or attributes.
+### Task Topic
+
+**Input:** User provides API endpoint documentation and asks for a task topic on authenticating API requests.
+
+**Output:**
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE task PUBLIC "-//OASIS//DTD DITA 1.3 Task//EN" "task.dtd">
+<task id="api-authentication">
+  <title>Authenticate API Requests</title>
+  <taskbody>
+    <context>Before calling any API endpoint, you must authenticate your request with a valid API key.</context>
+    <steps>
+      <step>
+        <cmd>Open your API dashboard and copy your API key.</cmd>
+      </step>
+      <step>
+        <cmd>Add an <codeph>Authorization</codeph> header to your request with the value <codeph>Bearer {your-api-key}</codeph>.</cmd>
+      </step>
+      <step>
+        <cmd>Send the request to the API endpoint.</cmd>
+      </step>
+    </steps>
+    <result>The API validates your key and processes the request.</result>
+  </taskbody>
+</task>
+```
+
+### Concept Topic
+
+**Input:** User provides system architecture docs and asks for a concept topic on multi-tenant data isolation.
+
+**Output:**
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA 1.3 Concept//EN" "concept.dtd">
+<concept id="multi-tenant-isolation">
+  <title>Multi-Tenant Data Isolation</title>
+  <conbody>
+    <p>Each tenant's data is stored in a logically separated database schema. Queries are scoped to the authenticated tenant, preventing cross-tenant data access.</p>
+  </conbody>
+</concept>
+```
+
+## Common Edge Cases
+
+- **Source inputs are incomplete** — Generate what is verifiable and flag gaps explicitly with comments in the XML.
+- **Multiple topic types could apply** — When content could be a concept or a task, prefer task if the user needs to perform an action, concept if they need to understand the system.
+- **Source contradicts existing documentation** — Trust the source (code/spec) over existing docs. Flag the contradiction for the domain expert.
 
 ## Reference
 
-This skill applies the DITA 1.3 standard as defined by OASIS:
 - [DITA 1.3 Specification](https://docs.oasis-open.org/dita/dita/v1.3/dita-v1.3-part0-overview.html)
 - [DITA 1.3 Element Reference](https://docs.oasis-open.org/dita/dita/v1.3/errata02/os/complete/part3-all-inclusive/langRef/containers/concept-elements.html)
 
-## Validation Reminder
+## Validation Requirement
 
-Output from this skill requires Stage 3 behavioral validation by the domain-expert technical communicator before publication. Generated content is a starting point, not a finished deliverable.
+Generated content must be tested against actual application behavior before publication. This is not editorial review — it is behavioral validation:
+
+- For task topics: perform each documented step in the live application and confirm the documented sequence matches actual behavior
+- For concept topics: verify descriptions against the running system, not just the source code
+- For reference topics: confirm every field name, value, default, and option against the live UI
+
+The person performing this validation must have direct knowledge of the end user's operational context — what the user is doing, under what conditions, and with what consequences for error.

--- a/skills/dita-xml/SKILL.md
+++ b/skills/dita-xml/SKILL.md
@@ -49,48 +49,104 @@ Before generating content, confirm these inputs are available in the session:
 
 ### Task Topic
 
-**Input:** User provides API endpoint documentation and asks for a task topic on authenticating API requests.
+**Input:** User provides airline operations platform UI specs and asks for a task topic on submitting a delay report.
 
 **Output:**
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE task PUBLIC "-//OASIS//DTD DITA 1.3 Task//EN" "task.dtd">
-<task id="api-authentication">
-  <title>Authenticate API Requests</title>
+<task id="submit-delay-report">
+  <title>Submit a Delay Report</title>
   <taskbody>
-    <context>Before calling any API endpoint, you must authenticate your request with a valid API key.</context>
+    <context>When a flight departs late, submit a delay report to record the cause and duration for compliance tracking.</context>
     <steps>
       <step>
-        <cmd>Open your API dashboard and copy your API key.</cmd>
+        <cmd>From the flight list, select the delayed flight.</cmd>
       </step>
       <step>
-        <cmd>Add an <codeph>Authorization</codeph> header to your request with the value <codeph>Bearer {your-api-key}</codeph>.</cmd>
+        <cmd>Select <cmdname>Report Delay</cmdname>.</cmd>
       </step>
       <step>
-        <cmd>Send the request to the API endpoint.</cmd>
+        <cmd>Select the primary delay cause from the drop-down list.</cmd>
+      </step>
+      <step>
+        <cmd>Enter the delay duration in minutes.</cmd>
+      </step>
+      <step>
+        <cmd>Select <cmdname>Submit</cmdname>.</cmd>
       </step>
     </steps>
-    <result>The API validates your key and processes the request.</result>
+    <result>The delay is recorded against the flight and reflected in the daily compliance summary.</result>
   </taskbody>
 </task>
 ```
 
 ### Concept Topic
 
-**Input:** User provides system architecture docs and asks for a concept topic on multi-tenant data isolation.
+**Input:** User provides crew management documentation and asks for a concept topic on flight duty period.
 
 **Output:**
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA 1.3 Concept//EN" "concept.dtd">
-<concept id="multi-tenant-isolation">
-  <title>Multi-Tenant Data Isolation</title>
+<concept id="flight-duty-period">
+  <title>Flight Duty Period</title>
   <conbody>
-    <p>Each tenant's data is stored in a logically separated database schema. Queries are scoped to the authenticated tenant, preventing cross-tenant data access.</p>
+    <p>A flight duty period (FDP) is the time from when a crew member reports for duty until the last flight lands and the aircraft is parked. FDP limits vary by regulatory authority and depend on the number of flight segments, departure time, and crew complement.</p>
+    <p>The platform calculates FDP automatically based on the assigned schedule and flags any segment that would exceed the applicable limit.</p>
   </conbody>
 </concept>
+```
+
+### Reference Topic
+
+**Input:** User provides alert configuration specs and asks for a reference topic on alert settings.
+
+**Output:**
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA 1.3 Reference//EN" "reference.dtd">
+<reference id="alert-settings">
+  <title>Alert Configuration Settings</title>
+  <refbody>
+    <table>
+      <tgroup cols="3">
+        <thead>
+          <row>
+            <entry>Field</entry>
+            <entry>Type</entry>
+            <entry>Default</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry>Alert Name</entry>
+            <entry>Text (required)</entry>
+            <entry>—</entry>
+          </row>
+          <row>
+            <entry>Severity</entry>
+            <entry>Drop-down: Low, Medium, High, Critical</entry>
+            <entry>Medium</entry>
+          </row>
+          <row>
+            <entry>Threshold (minutes)</entry>
+            <entry>Integer</entry>
+            <entry>15</entry>
+          </row>
+          <row>
+            <entry>Notification Channel</entry>
+            <entry>Drop-down: Email, SMS, Dashboard</entry>
+            <entry>Dashboard</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+  </refbody>
+</reference>
 ```
 
 ## Common Edge Cases


### PR DESCRIPTION
## Summary

Adds a new skill for generating structured DITA 1.3 XML documentation grounded in actual product source inputs.

Technical writers working with DITA-based documentation systems have no existing agent skill for producing topic-typed XML output. This skill fills that gap.

## What This Skill Does

- Generates concept, task, and reference topics typed to DITA 1.3
- Grounds all output in user-provided source inputs — codebase, UI specs, or API definitions
- Enforces strict source fidelity: no content generated from general knowledge
- Flags gaps where source inputs are insufficient rather than inventing content
- Reminds users that Stage 3 behavioral validation is required before publication

## References

- [DITA 1.3 Specification — OASIS](https://docs.oasis-open.org/dita/dita/v1.3/dita-v1.3-part0-overview.html)
- [DITA 1.3 Element Reference — OASIS](https://docs.oasis-open.org/dita/dita/v1.3/errata02/os/complete/part3-all-inclusive/langRef/containers/concept-elements.html)

## Related

Part of the [AI Documentation Validation Framework](https://github.com/kiaaw7/agenticai-docsvalidation-framework) (DOI: 10.5281/zenodo.19719493) — an open, cross-platform methodology for human-led AI documentation production.