### PR TITLE
Add style-guide-enforcer skill for generation-time style enforcement for technical publications

### DIFF
--- a/skills/style-guide-enforcer/LICENSE.txt
+++ b/skills/style-guide-enforcer/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the
+      purposes of this License, Derivative Works shall not include works that
+      remain separable from, or merely link (or bind by name) to the
+      interfaces of the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to the Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute
+      the Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable by
+      such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only.
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing
+      the origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Anthropic, PBC.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/style-guide-enforcer/SKILL.md
+++ b/skills/style-guide-enforcer/SKILL.md
@@ -41,11 +41,15 @@ Apply style standards at the point of generation. Do not produce content first a
 
 ## Reference
 
-Authoritative style guides supported by this skill:
-- [Microsoft Writing Style Guide](https://learn.microsoft.com/en-us/style-guide/welcome/)
-- [Google Developer Documentation Style Guide](https://developers.google.com/style)
-- [ASD-STE100 Simplified Technical English](https://www.asd-ste100.org/)
-- [Plain Language Guidelines — plainlanguage.gov](https://www.plainlanguage.gov/guidelines/)
+Select one style guide based on your industry and domain. Applying multiple guides simultaneously will produce conflicting rules.
+
+| Style Guide | Domain |
+|---|---|
+| [Microsoft Writing Style Guide](https://learn.microsoft.com/en-us/style-guide/welcome/) | Software and UI documentation |
+| [Google Developer Documentation Style Guide](https://developers.google.com/style) | Developer and API documentation |
+| [ASD-STE100 Simplified Technical English](https://www.asd-ste100.org/) | Aerospace, defense, and safety-critical systems |
+| [Plain Language Guidelines — GSA](https://github.com/gsa/plainlanguage.gov) | U.S. federal and regulated-industry content |
+| [Apple Style Guide](https://developer.apple.com/documentation/styleguide) | iOS, macOS, and Apple platform documentation |
 
 ## What This Skill Does Not Do
 

--- a/skills/style-guide-enforcer/SKILL.md
+++ b/skills/style-guide-enforcer/SKILL.md
@@ -1,24 +1,36 @@
 ---
 name: style-guide-enforcer
 
-description: Apply documentation style standards to AI-generated content at creation time — not as a post-creation checklist. TRIGGER when: user wants to enforce style guide rules during content generation; user has a style guide or documentation standards document to apply; user wants consistent terminology, voice, and formatting across generated content. SKIP: user has no style guide or standards to apply; user wants freeform prose without style constraints.
+description: Apply documentation style standards to AI-generated content at creation time — not as a post-creation checklist. Use this skill when the user wants to enforce style guide rules during content generation, has a style guide or documentation standards document to apply, or wants consistent terminology, voice, and formatting across generated content.
 
-license: MIT
+license: Complete terms in LICENSE.txt
 ---
 
 # Style Guide Enforcer
 
-Apply documentation style standards during content creation — before validation, not after.
+Apply documentation style standards during content creation — not after.
+
+## When to Use This Skill
+
+Use this skill when the user has a style guide or documentation standards to apply during content generation, wants consistent terminology and formatting across generated content, or needs AI output to comply with a specific style standard.
+
+Do not use this skill when the user has no style guide or standards to apply, or wants freeform prose without style constraints.
 
 ## Inputs Required
 
-1. **Style guide or standards reference** — provide the document, rules, or key standards to apply. Examples: Microsoft Writing Style Guide (software/UI documentation); Google Developer Documentation Style Guide (developer and API documentation); ASD-STE100 Simplified Technical English (aerospace and defense technical documentation); Plain Language Guidelines — plainlanguage.gov (U.S. federal and regulated-industry content)
+1. **Style guide or standards reference** — the specific document, rules, or key standards to apply
 2. **Content to generate or review** — the documentation content in scope
 3. **Product terminology** — confirmed terms for UI elements, features, and workflows
 
-## Application Rules
+## Step-by-Step Workflow
 
-Apply style standards at the point of generation. Do not produce content first and apply style second — this produces inconsistency.
+1. **Identify the style guide** — Confirm which single style guide the user is applying. Do not apply multiple guides simultaneously — they produce conflicting rules. See the Reference table below for domain-matched options.
+2. **Load terminology** — Confirm the product terminology source. If none is provided, ask the user before proceeding.
+3. **Apply standards during generation** — Apply style rules at the point of content creation. Do not produce content first and apply style second — this produces inconsistency.
+4. **Flag unknown terms** — If any term appears in the content that is not in the confirmed terminology source, flag it explicitly. Do not invent synonyms.
+5. **Verify consistency** — After generation, confirm that parallel topics use the same structure, equivalent UI interactions follow the same pattern, and terminology is applied consistently across all content in scope.
+
+## Application Rules
 
 ### Terminology
 - Use only confirmed product terminology from the provided source
@@ -39,6 +51,47 @@ Apply style standards at the point of generation. Do not produce content first a
 - Maintain consistent structure across parallel topics
 - Apply the same pattern for equivalent UI interactions throughout
 
+## Examples
+
+### Before and After — Active Voice
+
+**Before (passive):**
+"The Export button can be selected to generate the report."
+
+**After (active):**
+"Select **Export** to generate the report."
+
+### Before and After — Terminology Enforcement
+
+**Before (inconsistent):**
+"To delete the route, click Remove. If you want to erase the flight plan, press Delete."
+
+**After (consistent terminology):**
+"To remove the route, select **Remove**. To remove the flight plan, select **Delete**."
+
+### Before and After — Heading Hierarchy
+
+**Before (inconsistent levels):**
+```
+# Configuration
+## Settings
+### Display Options
+## Configuring the Map
+```
+
+**After (correct hierarchy):**
+```
+# Configuration
+## Display Options
+## Map Configuration
+```
+
+## Common Edge Cases
+
+- **User provides multiple style guides** — Select one based on the user's domain. Ask which to apply if domain is ambiguous.
+- **Style guide conflicts with product terminology** — Product terminology takes precedence. Flag the conflict for the user.
+- **No product terminology source provided** — Do not proceed without one. Ask the user to supply confirmed terminology before generating content.
+
 ## Reference
 
 Select one style guide based on your industry and domain. Applying multiple guides simultaneously will produce conflicting rules.
@@ -51,6 +104,6 @@ Select one style guide based on your industry and domain. Applying multiple guid
 | [Plain Language Guidelines — GSA](https://github.com/gsa/plainlanguage.gov) | U.S. federal and regulated-industry content |
 | [Apple Style Guide](https://developer.apple.com/documentation/styleguide) | iOS, macOS, and Apple platform documentation |
 
-## What This Skill Does Not Do
+## Validation Requirement
 
-Style compliance does not substitute for behavioral validation. Stylistically correct content can still be operationally insufficient. Stage 3 validation is required regardless of style compliance.
+Style-compliant content must still be tested against actual application behavior before publication. Style compliance does not detect operationally insufficient content — procedures that use correct terminology and formatting but omit prerequisite conditions, misrepresent sequence dependencies, or fail to convey what the user needs to know. The person performing this validation must have direct knowledge of the end user's operational context.

--- a/skills/style-guide-enforcer/SKILL.md
+++ b/skills/style-guide-enforcer/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: style-guide-enforcer
+
+description: Apply documentation style standards to AI-generated content at creation time — not as a post-creation checklist. TRIGGER when: user wants to enforce style guide rules during content generation; user has a style guide or documentation standards document to apply; user wants consistent terminology, voice, and formatting across generated content. SKIP: user has no style guide or standards to apply; user wants freeform prose without style constraints.
+
+license: MIT
+---
+
+# Style Guide Enforcer
+
+Apply documentation style standards during content creation — before validation, not after.
+
+## Inputs Required
+
+1. **Style guide or standards reference** — provide the document, rules, or key standards to apply. Examples: Microsoft Writing Style Guide (software/UI documentation); Google Developer Documentation Style Guide (developer and API documentation); ASD-STE100 Simplified Technical English (aerospace and defense technical documentation); Plain Language Guidelines — plainlanguage.gov (U.S. federal and regulated-industry content)
+2. **Content to generate or review** — the documentation content in scope
+3. **Product terminology** — confirmed terms for UI elements, features, and workflows
+
+## Application Rules
+
+Apply style standards at the point of generation. Do not produce content first and apply style second — this produces inconsistency.
+
+### Terminology
+- Use only confirmed product terminology from the provided source
+- Flag any term not found in the source inputs — do not invent synonyms
+- Apply terminology consistently across all topics in scope
+
+### Voice and Tone
+- Apply the voice specified in the style guide
+- Default to active voice and direct address ("Select X" not "X can be selected")
+- Size sentences for users working under time pressure — short, unambiguous
+
+### Formatting
+- Apply heading hierarchy as specified
+- Apply list formatting rules as specified
+- Apply note, warning, and caution conventions as specified
+
+### Consistency
+- Maintain consistent structure across parallel topics
+- Apply the same pattern for equivalent UI interactions throughout
+
+## Reference
+
+Authoritative style guides supported by this skill:
+- [Microsoft Writing Style Guide](https://learn.microsoft.com/en-us/style-guide/welcome/)
+- [Google Developer Documentation Style Guide](https://developers.google.com/style)
+- [ASD-STE100 Simplified Technical English](https://www.asd-ste100.org/)
+- [Plain Language Guidelines — plainlanguage.gov](https://www.plainlanguage.gov/guidelines/)
+
+## What This Skill Does Not Do
+
+Style compliance does not substitute for behavioral validation. Stylistically correct content can still be operationally insufficient. Stage 3 validation is required regardless of style compliance.


### PR DESCRIPTION
## Summary

Adds a new skill that enforces documentation style standards.

## What This Skill Does

- Applies terminology, voice, tone, and formatting rules during content creation
- Restricts output to confirmed product terminology — flags undefined terms rather than inventing synonyms
- Defaults to active voice and direct address sized for users working under time pressure
- Maintains parallel structure across equivalent topics

## Supported Style Guides

- [Microsoft Writing Style Guide](https://learn.microsoft.com/en-us/style-guide/welcome/)
- [Google Developer Documentation Style Guide](https://developers.google.com/style)
- [ASD-STE100 Simplified Technical English](https://www.asd-ste100.org/)
- [Plain Language Guidelines — plainlanguage.gov](https://www.plainlanguage.gov/guidelines/)

## Origin

Originally developed as part of the [AI Documentation Validation Framework](https://github.com/kiaaw7/agenticai-docsvalidation-framework) (DOI: 10.5281/zenodo.19719493).