### PR TITLE
Add content-architect skill for topic hierarchy and information architecture

### DIFF
--- a/skills/content-architect/LICENSE.txt
+++ b/skills/content-architect/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the
+      purposes of this License, Derivative Works shall not include works that
+      remain separable from, or merely link (or bind by name) to the
+      interfaces of the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to the Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute
+      the Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable by
+      such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only.
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing
+      the origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Anthropic, PBC.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/content-architect/SKILL.md
+++ b/skills/content-architect/SKILL.md
@@ -46,49 +46,58 @@ Do not use this skill when the user already has a content structure and needs co
 
 ### Topic Map Output
 
-**Input:** User provides scope for a navigation data distribution product serving EFB administrators and flight dispatchers.
+**Input:** User provides scope for an airline operations control platform serving operations controllers and crew schedulers.
 
 **Output:**
 
 ```
-Navigation Data Distribution — Topic Map
+Airline Operations Platform — Help Documentation Map
 
-EFB Administrator Topics
-├── CONCEPT: Navigation Data Overview
-│   └── What navigation data is distributed and how update cycles work
-├── TASK: Configure Navigation Data Sources
-│   └── Add, modify, and remove navigation data providers
-├── TASK: Schedule Data Updates
-│   └── Set automated update schedules for fleet-wide distribution
-└── REFERENCE: Data Source Settings
-    └── Fields, options, and defaults for source configuration
+Operations Controller Topics
+├── CONCEPT: Disruption Management Overview
+│   └── How the platform detects schedule conflicts and proposes recovery options
+│   └── PREREQUISITE: Flight Status Workflow (cross-audience)
+├── TASK: Recover a Disrupted Schedule
+│   └── Review alerts, evaluate re-routing and aircraft swap options, apply recovery
+│   └── RELATED: Modify a Crew Assignment (scheduler) — disruption recovery may require crew changes
+├── TASK: Monitor Operational Compliance
+│   └── Track delay codes, crew duty limits, and maintenance windows across the fleet
+│   └── SEE ALSO: Duty Time Fields (scheduler reference) — crew duty limits are defined there
+└── REFERENCE: Alert Types and Severity
+    └── Delay threshold alerts, crew timeout warnings, maintenance due flags — definitions and required actions
 
-Flight Dispatcher Topics
-├── CONCEPT: Navigation Data in Flight Planning
-│   └── How navigation data affects route calculation and NOTAM processing
-├── TASK: Verify Data Currency
-│   └── Confirm navigation data is current before authorizing a flight release
-└── REFERENCE: Data Cycle Indicators
-    └── Status fields and validity periods for navigation data cycles
+Crew Scheduler Topics
+├── CONCEPT: Crew Assignment Logic
+│   └── How the platform matches crew to flights based on qualifications, duty time, and rest requirements
+│   └── PREREQUISITE: Flight Status Workflow (cross-audience)
+├── TASK: Modify a Crew Assignment
+│   └── Replace a crew member, verify qualification and legality, publish the update
+│   └── RELATED: Recover a Disrupted Schedule (controller) — crew changes may trigger schedule alerts
+├── TASK: Build a Monthly Crew Plan
+│   └── Generate assignments from the schedule, resolve conflicts, and submit for approval
+│   └── PREREQUISITE: Crew Assignment Logic
+└── REFERENCE: Duty Time Fields
+    └── Flight duty period, rest period, cumulative hours — definitions and regulatory limits
+    └── REUSED BY: Monitor Operational Compliance (controller) — same field definitions
 
 Cross-Audience
-├── CONCEPT: Data Update Process
-│   └── Shared topic — covers the update pipeline end to end
-│   └── GAP: operational context differs per audience — needs separate framing
+├── CONCEPT: Flight Status Workflow
+│   └── Shared topic — covers how a flight moves from scheduled to dispatched
+│   └── GAP: controllers need guidance on crew-impact assessment during disruption — scheduler version does not cover this
 ```
 
 ### Coverage Gap Identification
 
-**Input:** User provides existing documentation structure that lists only system-architecture topics.
+**Input:** User provides existing documentation that covers only installation and system configuration.
 
 **Output:**
 
 ```
 Coverage gaps identified:
-- No task topics: existing structure describes system components but not user procedures
-- No audience separation: single topic set for all user groups
-- Missing: data currency verification procedures for dispatchers
-- Missing: source configuration tasks for administrators
+- No task topics: existing docs cover setup but not daily user procedures
+- No audience separation: single topic set for both controllers and schedulers
+- Missing: schedule recovery and compliance monitoring procedures for operations controllers
+- Missing: crew assignment modification and monthly planning procedures for crew schedulers
 ```
 
 ## Common Edge Cases

--- a/skills/content-architect/SKILL.md
+++ b/skills/content-architect/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: content-architect
+
+description: Design topic hierarchy, content relationships, and information architecture for product documentation. TRIGGER when: user needs to structure documentation for a new product or feature; user needs a topic map or content plan before writing begins; user needs to organize existing content into a coherent structure. SKIP: user already has a content structure and needs content generation; user needs editorial review of existing structure.
+
+license: MIT
+---
+
+# Content Architect
+
+Design documentation structure before content generation begins.
+
+## Inputs Required
+
+1. **Product scope** — what the product does and who uses it
+2. **User goals** — what tasks users need to accomplish
+3. **Audience** — user groups and their operational contexts
+4. **Existing documentation** — current structure if reorganizing
+
+## Deliverables
+
+### Topic Map
+Hierarchical list of all topics required, typed by content type (concept/task/reference) and organized by user goal — not by system architecture.
+
+### Content Relationships
+- Parent-child topic relationships
+- Cross-references between related topics
+- Reuse opportunities across user groups
+
+### Coverage Gaps
+Topics required that do not yet exist in current documentation.
+
+## Architecture Principles
+
+- Organize by what the user is doing — not how the system is built
+- One topic per user goal or concept — avoid combining unrelated information
+- Parallel structure for equivalent topics across user groups
+- Minimize prerequisite chains — users should reach any topic with minimal navigation
+
+## Output Format
+
+Produce a structured topic map as a hierarchical list with topic titles, types, and brief descriptions. Flag any gaps where source inputs are insufficient to define scope.
+
+## Reference
+
+- [DITA 1.3 Topic Types — OASIS](https://docs.oasis-open.org/dita/dita/v1.3/dita-v1.3-part0-overview.html)
+- [Every Page is Page One — Mark Baker](https://everypageispageone.com/) — topic-based authoring principles
+- [Diátaxis Framework](https://diataxis.fr/) — systematic approach to technical documentation structure

--- a/skills/content-architect/SKILL.md
+++ b/skills/content-architect/SKILL.md
@@ -1,14 +1,20 @@
 ---
 name: content-architect
 
-description: Design topic hierarchy, content relationships, and information architecture for product documentation. TRIGGER when: user needs to structure documentation for a new product or feature; user needs a topic map or content plan before writing begins; user needs to organize existing content into a coherent structure. SKIP: user already has a content structure and needs content generation; user needs editorial review of existing structure.
+description: Design topic hierarchy, content relationships, and information architecture for product documentation. Use this skill when the user needs to structure documentation for a new product or feature, needs a topic map or content plan before writing begins, or needs to organize existing content into a coherent structure.
 
-license: MIT
+license: Complete terms in LICENSE.txt
 ---
 
 # Content Architect
 
 Design documentation structure before content generation begins.
+
+## When to Use This Skill
+
+Use this skill when the user needs to structure documentation for a new product or feature, needs a topic map or content plan before writing begins, or needs to organize existing content into a coherent structure.
+
+Do not use this skill when the user already has a content structure and needs content generation, or when the user needs editorial review of an existing structure.
 
 ## Inputs Required
 
@@ -17,18 +23,17 @@ Design documentation structure before content generation begins.
 3. **Audience** — user groups and their operational contexts
 4. **Existing documentation** — current structure if reorganizing
 
-## Deliverables
+## Step-by-Step Workflow
 
-### Topic Map
-Hierarchical list of all topics required, typed by content type (concept/task/reference) and organized by user goal — not by system architecture.
-
-### Content Relationships
-- Parent-child topic relationships
-- Cross-references between related topics
-- Reuse opportunities across user groups
-
-### Coverage Gaps
-Topics required that do not yet exist in current documentation.
+1. **Gather inputs** — Confirm product scope, user goals, audience groups, and existing documentation. If any are missing, ask the user before proceeding.
+2. **Identify user goals** — List every distinct task users need to accomplish with the product. Group by audience if multiple user groups exist.
+3. **Assign topic types** — For each user goal, assign a content type:
+   - **Concept** — explaining what something is or how it works
+   - **Task** — documenting a procedure the user performs
+   - **Reference** — documenting UI elements, fields, options, or parameters
+4. **Build the topic map** — Organize topics hierarchically by user goal, not by system architecture. Apply parallel structure for equivalent topics across user groups.
+5. **Identify relationships** — Map parent-child relationships, cross-references, and reuse opportunities across user groups.
+6. **Flag coverage gaps** — Identify topics required that do not yet exist in current documentation.
 
 ## Architecture Principles
 
@@ -37,9 +42,68 @@ Topics required that do not yet exist in current documentation.
 - Parallel structure for equivalent topics across user groups
 - Minimize prerequisite chains — users should reach any topic with minimal navigation
 
+## Examples
+
+### Topic Map Output
+
+**Input:** User provides scope for a navigation data distribution product serving EFB administrators and flight dispatchers.
+
+**Output:**
+
+```
+Navigation Data Distribution — Topic Map
+
+EFB Administrator Topics
+├── CONCEPT: Navigation Data Overview
+│   └── What navigation data is distributed and how update cycles work
+├── TASK: Configure Navigation Data Sources
+│   └── Add, modify, and remove navigation data providers
+├── TASK: Schedule Data Updates
+│   └── Set automated update schedules for fleet-wide distribution
+└── REFERENCE: Data Source Settings
+    └── Fields, options, and defaults for source configuration
+
+Flight Dispatcher Topics
+├── CONCEPT: Navigation Data in Flight Planning
+│   └── How navigation data affects route calculation and NOTAM processing
+├── TASK: Verify Data Currency
+│   └── Confirm navigation data is current before authorizing a flight release
+└── REFERENCE: Data Cycle Indicators
+    └── Status fields and validity periods for navigation data cycles
+
+Cross-Audience
+├── CONCEPT: Data Update Process
+│   └── Shared topic — covers the update pipeline end to end
+│   └── GAP: operational context differs per audience — needs separate framing
+```
+
+### Coverage Gap Identification
+
+**Input:** User provides existing documentation structure that lists only system-architecture topics.
+
+**Output:**
+
+```
+Coverage gaps identified:
+- No task topics: existing structure describes system components but not user procedures
+- No audience separation: single topic set for all user groups
+- Missing: data currency verification procedures for dispatchers
+- Missing: source configuration tasks for administrators
+```
+
+## Common Edge Cases
+
+- **User provides system architecture instead of user goals** — Restructure around what users do, not how the system is built. Ask the user to confirm the restructured goals.
+- **Multiple audiences with overlapping tasks** — Create shared topics for overlap, audience-specific topics for divergence. Flag where operational context requires separate framing despite shared content.
+- **Existing documentation is unstructured** — Map existing content to the new topic types before identifying gaps. Do not discard existing content.
+
 ## Output Format
 
 Produce a structured topic map as a hierarchical list with topic titles, types, and brief descriptions. Flag any gaps where source inputs are insufficient to define scope.
+
+## Validation Requirement
+
+The topic map must be reviewed by someone with direct knowledge of the end users' operational contexts before content generation begins. A structurally correct topic map can still miss critical user goals, conflate distinct operator workflows, or organize content around system architecture rather than user tasks. The person performing this review must be able to answer: does each topic map to something a user actually needs to do, under conditions they actually face?
 
 ## Reference
 


### PR DESCRIPTION
## Summary

Adds a new skill for designing documentation structure

## What This Skill Does

- Produces a topic map organized around user goals — not system architecture
- Identifies parent-child relationships, cross-references, and content reuse opportunities
- Flags coverage gaps where source inputs are insufficient to define scope
- Enforces one topic per user goal — avoids combining unrelated information

## References

- [DITA 1.3 Topic Types — OASIS](https://docs.oasis-open.org/dita/dita/v1.3/dita-v1.3-part0-overview.html)
- [Every Page is Page One — Mark Baker](https://everypageispageone.com/)
- [Diátaxis Framework](https://diataxis.fr/)

## Origin

Originally developed as part of the [AI Documentation Validation Framework](https://github.com/kiaaw7/agenticai-docsvalidation-framework) (DOI: 10.5281/zenodo.19719493)