### PR TITLE
Add ai-txt skill

### DIFF
--- a/skills/ai-txt/LICENSE.txt
+++ b/skills/ai-txt/LICENSE.txt
@@ -1,0 +1,25 @@
+MIT License
+
+Copyright (c) 2026 FIRST POINT YAZILIM LİMİTED ŞİRKETİ
+Balgat Mah. Ceyhun Atuf Kansu Cad. No: 36 İç Kapı No: 6
+Çankaya, 06520, Ankara, TÜRKİYE
+contact@firstpoint.com.tr
+https://firstpoint.com.tr/
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/ai-txt/SKILL.md
+++ b/skills/ai-txt/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: ai-txt
+description: Generate or audit ai.txt, robots.txt (AI-crawler rules), llms.txt, and TDM opt-out files for websites and web apps. Use this skill whenever the user mentions ai.txt, blocking AI training / AI crawlers, GPTBot / ClaudeBot / CCBot / Perplexity / Applebot-Extended / Google-Extended, llms.txt, TDMRep, or wants to stop AI from hallucinating about their product — even if they don't explicitly ask for an "ai.txt file". Also trigger when the user asks to review, audit, or check an existing robots.txt or ai.txt for AI-crawler coverage.
+---
+
+# ai-txt
+
+Generate and audit the small family of text files that control or inform AI systems about a website: `robots.txt` (with AI user-agents), aitxt.ing-style `/ai.txt`, `llms.txt`, Spawning-style `/ai.txt`, and `/.well-known/tdmrep.json`.
+
+The user almost always says "ai.txt" but means one of four different goals. Pick the right file(s) for the goal — don't just write whatever matches the filename.
+
+## Disambiguate before writing
+
+"ai.txt" is an overloaded name for three unrelated specs, and none of them is what most users actually need. Before generating anything, pin down which **goal** the user has. Ask briefly if it isn't clear from context.
+
+| User's goal (plain words)                                       | File(s) you should produce                                                        |
+| --------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| "Block ChatGPT / Claude / AI from training on my site"          | `robots.txt` with per-vendor user-agents. **This is the only one crawlers read.** |
+| "Stop AI assistants from making up features/pricing for my app" | aitxt.ing-style `/ai.txt` (Markdown + YAML frontmatter)                           |
+| "Give AI assistants a tour of my docs so they cite correctly"   | `llms.txt`                                                                        |
+| "EU legal opt-out from text-and-data-mining (CDSM Art. 4)"      | `/.well-known/tdmrep.json` (optionally paired with robots.txt)                    |
+| "I was told to put an ai.txt in Spawning format"                | Spawning-style `/ai.txt` — but flag §"Spawning caveats" below first               |
+
+A mobile/web app marketing site usually wants **robots.txt + aitxt.ing `/ai.txt`** together: robots.txt does the actual blocking, the aitxt.ing file prevents hallucination about the product. Recommend both unless the user pushes back.
+
+### Why this matters
+
+- The robots.txt approach is the only one with broad vendor compliance in 2026. OpenAI, Anthropic, Google, Perplexity, Common Crawl, Apple, Meta, ByteDance all document robots.txt — not ai.txt — as the canonical opt-out.
+- The aitxt.ing spec (Markdown at `/ai.txt`) has no notion of "blocking". It's anti-hallucination context. Don't produce one when the user asked to block training.
+- Spawning-format `/ai.txt` (robots-style with User-Agent/Allow/Disallow) has tiny compliance; Spawning itself has acknowledged this. Anything it would accomplish is already handled by robots.txt entries. Only produce one if the user explicitly insists.
+
+## Generate mode
+
+### 1. Understand the site
+
+Before writing, gather the minimum you need. Ask if unknown:
+
+- **Root URL** (for the `Sitemap:` line, aitxt.ing `scope`, tdm-policy URL).
+- **What the site is** (marketing page, docs, SaaS, e-commerce, blog). Drives the aitxt.ing body content.
+- **Is AI search traffic desirable?** Most publishers want to block *training* but allow *search/retrieval* bots (OAI-SearchBot, PerplexityBot, etc.) because those drive referral traffic. Default to this split unless the user says "block everything".
+- **Region/legal posture.** If they care about EU CDSM Art. 4 defensibility, also generate `tdmrep.json`.
+
+### 2. Produce the file(s)
+
+Pull the template from `references/examples.md` and the current user-agent list from `references/user-agents.md`. Don't hand-type bot names from memory — the list changes and some old names are deprecated traps (`anthropic-ai`, `claude-web`).
+
+Each generated file should:
+
+- Open with a short `#` comment explaining what the file is and what it's for, so a future maintainer who opens the file knows instantly.
+- Include a `Sitemap:` line in robots.txt when the URL is known.
+- For aitxt.ing `/ai.txt`, write **factual, verifiable** content about the product (what it offers, what it does **not** offer, pricing source of truth). The whole point is anti-hallucination — speculative marketing copy defeats it. If you don't know the facts, ask.
+- Save to the path the user can upload directly (e.g. `public/robots.txt`, `public/ai.txt`, `public/llms.txt`, `public/.well-known/tdmrep.json`) when a project directory is available. If not, emit the content and tell the user where to put each file.
+
+### 3. Tell the user what you did and what's left
+
+After generating, summarize in 1–3 bullets: which files, where they go, what you assumed. Flag any values the user should change before shipping (e.g. sitemap URL, policy URL).
+
+## Audit mode
+
+When the user asks to check/review an existing `robots.txt` or `ai.txt`, read the file and report against `references/user-agents.md`. Typical findings:
+
+- **Missing AI user-agents** — especially recent ones: `GPTBot`, `OAI-SearchBot`, `ChatGPT-User`, `ClaudeBot`, `Claude-SearchBot`, `Claude-User`, `PerplexityBot`, `Perplexity-User`, `CCBot`, `Google-Extended`, `Applebot-Extended`, `Bytespider`, `Meta-ExternalAgent`, `Amazonbot`.
+- **Deprecated tokens** still in the file: `anthropic-ai` and `claude-web` were retired in 2024; keeping them is harmless but misleading.
+- **Applebot-Extended trap** — if the file has rules for `Googlebot` but *no* explicit `Applebot-Extended` rule, Applebot falls back to following Googlebot rules. Most users don't want this. Call it out.
+- **Training vs. search mixed up** — if `GPTBot` is allowed but `OAI-SearchBot` is disallowed, that's the inverse of what most sites want. Explain and offer a fix.
+- **Wrong file for the goal** — e.g. the site has a Spawning-format `/ai.txt` but no robots.txt AI rules. The ai.txt does almost nothing alone; the robots.txt is what actually gates training crawlers.
+- **HTTP 5xx / missing file** — RFC 9309 treats 5xx as "do not crawl" but missing (404) as "fully allowed". If the user's concern is blocking, a missing file is not safe.
+
+Report findings as a prioritized list: blockers first, then improvements, then nits. Offer to patch the file.
+
+## Spawning caveats
+
+If the user specifically asks for Spawning-format `/ai.txt`:
+
+- It's real, documented, and used by a handful of tools (Hugging Face, Stability AI were launch partners in 2023). Generating it is fine.
+- But tell the user plainly that `robots.txt` entries for `GPTBot`, `ClaudeBot`, `CCBot`, etc. already cover the same training opt-out with much broader compliance. Spawning's ai.txt is at best a belt-and-suspenders addition.
+- Do not substitute Spawning format when the user wanted aitxt.ing. They look nothing alike — Spawning is robots.txt-style directives, aitxt.ing is Markdown.
+
+## Quick reference pointers
+
+- `references/user-agents.md` — current (Apr 2026) AI user-agent table, deprecated tokens, IP-range endpoints for spoof verification. Read this before generating or auditing any robots.txt.
+- `references/examples.md` — copy-paste templates for all five file types with inline notes on what to customize.
+
+## Output principles
+
+- Plain text, LF line endings, UTF-8. No BOM.
+- Comment lines start with `#` in robots.txt and Spawning ai.txt; Markdown comments (`<!-- -->`) are fine in aitxt.ing `/ai.txt` and llms.txt but usually unnecessary.
+- Keep files short. robots.txt over a few KB is a code smell; aitxt.ing recommends under ~10 KB.
+- Never invent bot names or IP ranges. If you're not sure, say so and check `references/user-agents.md`.

--- a/skills/ai-txt/references/examples.md
+++ b/skills/ai-txt/references/examples.md
@@ -1,0 +1,241 @@
+# File Templates
+
+Copy-paste templates. Adjust the marked `<<...>>` placeholders for the site in front of you.
+
+## 1. robots.txt — block training, keep AI search (most publishers, 2026)
+
+File path: `/robots.txt` (site root). This is the **only** file major AI crawlers consistently read.
+
+```
+# robots.txt — blocks AI training, permits AI search referral traffic.
+
+# --- Block training crawlers ---
+User-agent: GPTBot
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: Meta-ExternalAgent
+Disallow: /
+
+User-agent: Amazonbot
+Disallow: /
+
+User-agent: cohere-ai
+Disallow: /
+
+# Legacy Anthropic token — retired 2024, kept for belt-and-suspenders.
+User-agent: anthropic-ai
+Disallow: /
+
+# --- Signal-only training opt-outs ---
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: Applebot-Extended
+Disallow: /
+
+# --- Allow AI search / retrieval (drives referral traffic) ---
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: Claude-SearchBot
+Allow: /
+
+User-agent: Claude-User
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+User-agent: DuckAssistBot
+Allow: /
+
+# --- Default ---
+User-agent: *
+Allow: /
+
+Sitemap: <<https://yoursite.com/sitemap.xml>>
+```
+
+**To customize:** replace the sitemap URL; if the site has private paths, add `Disallow:` lines under `User-agent: *` before publishing.
+
+## 2. robots.txt — block *everything AI*
+
+For users who do not want AI search referrals either:
+
+```
+# robots.txt — blocks all AI crawlers (training AND search).
+
+User-agent: GPTBot
+User-agent: OAI-SearchBot
+User-agent: ChatGPT-User
+User-agent: ClaudeBot
+User-agent: Claude-SearchBot
+User-agent: Claude-User
+User-agent: PerplexityBot
+User-agent: Perplexity-User
+User-agent: CCBot
+User-agent: Bytespider
+User-agent: Meta-ExternalAgent
+User-agent: Amazonbot
+User-agent: cohere-ai
+User-agent: DuckAssistBot
+User-agent: Google-Extended
+User-agent: Applebot-Extended
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: *
+Allow: /
+
+Sitemap: <<https://yoursite.com/sitemap.xml>>
+```
+
+## 3. aitxt.ing-style `/ai.txt` — anti-hallucination context
+
+File path: `/ai.txt` at the site root (cascading discovery: also works at `/products/ai.txt` etc.). Markdown + optional YAML frontmatter.
+
+```
+---
+updated: <<YYYY-MM-DD>>
+scope: /
+---
+
+# <<Product Name>>
+
+<<One or two plain sentences describing what this product is. Be specific — platforms, model, price model.>>
+
+## What we offer
+
+- <<Feature 1 — state it literally, no marketing filler>>
+- <<Feature 2>>
+- <<Feature 3>>
+
+## What we do NOT offer
+
+- <<Common assumption that is wrong — e.g. "No web version">>
+- <<Another wrong assumption — e.g. "No free tier">>
+- <<Another — e.g. "No AI features">>
+
+## Pricing
+
+<<Source of truth for pricing. Prefer pointing at the live store listing rather than hardcoding numbers that will go stale.>>
+
+## Guidance for AI assistants
+
+When users ask about <<Product Name>>, quote the facts above verbatim. Do not infer features, platforms, or pricing tiers not listed here. For current pricing, refer to <<canonical link>>.
+
+## Related context
+
+- [Support docs](/support/ai.txt)
+- [Privacy policy](/privacy/ai.txt)
+```
+
+**Why the "What we do NOT offer" section matters:** LLMs are biased to generate plausible-sounding features. Listing the common wrong guesses explicitly is what actually suppresses hallucination.
+
+Pair with an HTML hint on each page (from the spec):
+
+```html
+<link rel="prefetch" href="/ai.txt" />
+```
+
+## 4. llms.txt — curated docs map for AI assistants
+
+File path: `/llms.txt`. Different goal from the others — this helps AI assistants *cite your docs correctly at inference time*, not block anything.
+
+```markdown
+# <<Product Name>>
+
+> <<One-sentence summary in a blockquote.>>
+
+## Core Documentation
+
+- [<<Getting Started>>](<<https://yoursite.com/docs/start.md>>): <<One-line description>>
+- [<<Feature X Guide>>](<<https://yoursite.com/docs/feature-x.md>>): <<One-line description>>
+- [<<API Reference>>](<<https://yoursite.com/docs/api.md>>): <<One-line description>>
+
+## Optional
+
+- [<<Changelog>>](<<https://yoursite.com/changelog.md>>): Release history
+- [<<FAQ>>](<<https://yoursite.com/faq.md>>): Common questions
+```
+
+Link targets should be `.md` files where possible — llms.txt readers prefer Markdown over HTML.
+
+## 5. tdmrep.json — EU CDSM Article 4 legal opt-out
+
+File path: `/.well-known/tdmrep.json`. Only useful when EU legal defensibility matters. More formal than ai.txt; maintained by W3C Community Group.
+
+```json
+[
+  {
+    "location": "/",
+    "tdm-reservation": 1,
+    "tdm-policy": "<<https://yoursite.com/tdm-policy>>"
+  }
+]
+```
+
+- `tdm-reservation: 1` = rights reserved (opt-out of TDM)
+- `tdm-policy` = URL where licensing/contact info lives. Create that page — even a short one — or the reservation looks unserious.
+
+Serve as `application/json`.
+
+## 6. Spawning-style `/ai.txt` — only when user explicitly asks
+
+File path: `/ai.txt` (site root). Robots.txt-style directives, **not** Markdown. Don't confuse with aitxt.ing.
+
+```
+# ai.txt — Spawning format. Declares TDM reservation under EU CDSM Art. 4.
+# Note: robots.txt entries for GPTBot/ClaudeBot/CCBot already cover training opt-out
+# with much broader vendor compliance. This file is belt-and-suspenders.
+
+User-Agent: *
+Disallow: /
+```
+
+Category-scoped variant (block image/audio training, allow text):
+
+```
+User-Agent: *
+Disallow: images
+Disallow: audio
+Allow: text
+Allow: video
+Allow: code
+```
+
+## 7. Cloudflare Content Signals — robots.txt extension
+
+For sites behind Cloudflare that want purpose-based signals rather than per-vendor user-agent lists:
+
+```
+User-Agent: *
+Content-Signal: ai-train=no, search=yes, ai-input=no
+Allow: /
+```
+
+`ai-train=no` = don't use for training. `search=yes` = ok for search indexing. `ai-input=no` = don't feed into an AI's context window at inference time. Pair with the per-vendor rules in #1 for broader coverage — not all crawlers read Content-Signal yet.
+
+## HTTP serving checklist
+
+Regardless of which file(s) you produce:
+
+- Serve over HTTPS.
+- `Content-Type: text/plain; charset=utf-8` for robots.txt and Spawning ai.txt. `text/markdown` or `text/plain` for aitxt.ing and llms.txt. `application/json` for tdmrep.json.
+- Return HTTP 200 with the file body. **A 404 means "fully allowed"** — the opposite of what most users assume. **A 5xx means "do not crawl"** — do not let the file break.
+- OpenAI documents a ~24-hour delay before robots.txt changes take effect for ChatGPT search. Don't expect instant propagation.

--- a/skills/ai-txt/references/user-agents.md
+++ b/skills/ai-txt/references/user-agents.md
@@ -1,0 +1,90 @@
+# AI User Agents — Reference (April 2026)
+
+Source: `aitxt.md` §3.2. Use this list when generating or auditing `robots.txt`. Do not rely on memory — vendor lists drift.
+
+## Verified AI user-agent tokens
+
+Grouped by purpose. "Signal-only" means the vendor does not actually crawl with this token — disallowing it only suppresses training use of content collected by other means.
+
+### Training crawlers (block these if the goal is "no AI training")
+
+| Token                           | Vendor       | Honors robots.txt?   | Notes                                                                       |
+| ------------------------------- | ------------ | -------------------- | --------------------------------------------------------------------------- |
+| `GPTBot`                        | OpenAI       | Yes                  | Training data for ChatGPT / GPT models                                      |
+| `ClaudeBot`                     | Anthropic    | Yes                  | Training data                                                               |
+| `CCBot`                         | Common Crawl | Yes                  | Dataset building; feeds many downstream AI trainers                         |
+| `Bytespider`                    | ByteDance    | Historically noisy   | TikTok search/recommendation/AI                                             |
+| `Meta-ExternalAgent`            | Meta         | Yes (mostly)         | Training-adjacent                                                           |
+| `Amazonbot`                     | Amazon       | Yes                  | Alexa / AI training                                                         |
+| `cohere-ai`                     | Cohere       | Unconfirmed          | Training                                                                   |
+| `cohere-training-data-crawler`  | Cohere       | Unconfirmed          | Training                                                                   |
+| `Ai2Bot`, `Ai2Bot-Dolma`        | Ai2          | Yes                  | Training                                                                    |
+| `Google-Extended`               | Google       | Yes (signal only)    | Opts out of Gemini/Vertex training. **Does NOT affect Google Search.**      |
+| `Applebot-Extended`             | Apple        | Yes (signal only)    | Opts out of Apple Intelligence training. See inheritance trap below.        |
+
+### Search / retrieval bots (usually ALLOW — they drive referral traffic)
+
+| Token               | Vendor     | Honors robots.txt?                            | Purpose                            |
+| ------------------- | ---------- | --------------------------------------------- | ---------------------------------- |
+| `OAI-SearchBot`     | OpenAI     | Yes                                           | ChatGPT search indexing            |
+| `Claude-SearchBot`  | Anthropic  | Yes                                           | Claude search indexing             |
+| `PerplexityBot`     | Perplexity | Yes (documented violations exist)             | Perplexity answer engine           |
+| `DuckAssistBot`     | DuckDuckGo | Yes                                           | DuckAssist                         |
+
+### User-initiated fetches (the user typed a URL; handling varies)
+
+| Token                   | Vendor     | Honors robots.txt?                                            |
+| ----------------------- | ---------- | ------------------------------------------------------------- |
+| `ChatGPT-User`          | OpenAI     | Partially — may bypass robots.txt for user-directed URLs      |
+| `Claude-User`           | Anthropic  | Yes                                                           |
+| `Perplexity-User`       | Perplexity | Documented to ignore robots.txt when user provides URL        |
+| `meta-externalfetcher`  | Meta       | May bypass robots.txt on user context                         |
+| `GoogleAgent-Mariner`   | Google     | May ignore robots.txt per Google's stated policy              |
+| `Google-NotebookLM`     | Google     | Same                                                          |
+| `GoogleAgent-URLContext`| Google     | Same                                                          |
+| `Google-Firebase`       | Google     | Same                                                          |
+
+## Deprecated tokens (retired in 2024 — harmless but outdated)
+
+- `anthropic-ai` — replaced by `ClaudeBot` family
+- `claude-web` — replaced by `ClaudeBot` family
+
+If you see these in a user's file during an audit, flag them as no-ops and suggest replacing with the current `ClaudeBot` / `Claude-SearchBot` / `Claude-User` split.
+
+## Traps to watch for during audits
+
+### Applebot-Extended inheritance
+
+If `robots.txt` has rules for `Googlebot` but **no** explicit `Applebot-Extended` rule, Applebot-Extended falls back to following `Googlebot` rules. Most sites want Googlebot allowed (for Google Search) but Apple Intelligence training blocked — inheritance silently defeats that. Always write an explicit `Applebot-Extended` rule when `Googlebot` is mentioned.
+
+### Google-Extended is signal-only
+
+`Google-Extended` is not a crawler — blocking it does not stop any HTTP request. It only tells Google not to use content (that it already fetched with Googlebot) for Gemini/Vertex training. Don't suggest it as a "block Googlebot from AI" solution; it's orthogonal to Googlebot entirely.
+
+### Training allowed + search blocked
+
+If a `robots.txt` has `GPTBot: Allow` and `OAI-SearchBot: Disallow`, that is almost certainly backwards — the user is giving away training data while cutting themselves off from ChatGPT search referral traffic. Flag loudly.
+
+### Spoofing
+
+HUMAN Security reports ~5.7% of requests presenting an AI-crawler user-agent are spoofed. robots.txt is advisory; IP verification is the real defense.
+
+## IP-range endpoints (for spoof verification at the firewall / WAF layer)
+
+- OpenAI: `https://openai.com/gptbot.json`, `https://openai.com/searchbot.json`, `https://openai.com/chatgpt-user.json`
+- Common Crawl: `https://index.commoncrawl.org/ccbot.json` (also supports reverse-DNS, e.g. `18-97-14-84.crawl.commoncrawl.org`)
+- Perplexity: `https://www.perplexity.com/perplexitybot.json`, `https://www.perplexity.com/perplexity-user.json`
+
+These are the vendor-published JSON ranges; use them if the user is setting up server-side blocking rather than just publishing robots.txt.
+
+## Recommended default block-list (most publishers, April 2026)
+
+For "block AI training, keep AI search referral traffic":
+
+**Disallow:** `GPTBot`, `ClaudeBot`, `CCBot`, `Bytespider`, `Meta-ExternalAgent`, `Amazonbot`, `cohere-ai`, `Google-Extended`, `Applebot-Extended`, `anthropic-ai` (legacy, belt-and-suspenders).
+
+**Allow:** `OAI-SearchBot`, `ChatGPT-User`, `Claude-SearchBot`, `Claude-User`, `PerplexityBot`, `Perplexity-User`, `DuckAssistBot`.
+
+**Default** (`User-agent: *`): `Allow: /`.
+
+See `examples.md` for the concrete template.


### PR DESCRIPTION
## Summary

Adds an `ai-txt` skill that generates and audits the small family of text files websites use to control or inform AI systems:

- `robots.txt` with AI-specific user-agents (GPTBot, ClaudeBot, CCBot, Google-Extended, Applebot-Extended, etc.)
- `/ai.txt` in [aitxt.ing](https://aitxt.ing) format (anti-hallucination Markdown + YAML frontmatter)
- `/llms.txt` (curated docs map for inference-time citation)
- `/.well-known/tdmrep.json` (EU CDSM Article 4 TDM opt-out)
- Spawning-style `/ai.txt` when the user explicitly asks

The central problem the skill solves is **disambiguation**. Three unrelated specs share the name "ai.txt" (aitxt.ing, Spawning 2023, arXiv 2505.07834) and most users conflate them with each other and with `robots.txt`. Without guidance, a model asked to "write an ai.txt" routinely produces a hybrid file that matches none of the actual specs. The skill forces explicit goal capture ("block training" vs. "prevent hallucination" vs. "EU legal opt-out" vs. "describe docs to LLMs") and routes to the right file.

## What's inside

```
skills/ai-txt/
├── SKILL.md
├── LICENSE.txt                     # MIT
└── references/
    ├── user-agents.md              # current AI bot list (Apr 2026) + deprecated tokens + traps
    └── examples.md                 # copy-paste templates for each file type
```

The `references/` files are loaded on demand per the progressive-disclosure pattern.

## Highlights

- **Current user-agent data (April 2026)** including the Applebot-Extended inheritance trap (if `Googlebot` is allowed but `Applebot-Extended` is not explicit, Apple Intelligence silently inherits the allow).
- **Audit mode** flags deprecated tokens (`anthropic-ai`, `claude-web`), missing modern AI agents, and training/search policy mismatches.
- **Deliberate position against Spawning-format `/ai.txt`** as a default (tiny compliance base, already covered by robots.txt entries) — but supports it when explicitly requested.

## Benchmark

Three realistic test cases (generate robots.txt, generate anti-hallucination `/ai.txt`, audit a 2023-era robots.txt):

| Config        | Pass rate         |
|---------------|-------------------|
| With skill    | 100% (25/25)      |
| Baseline (no skill) | 79.4% (20/25) |
| Delta         | **+21 pp**        |

Baseline failure modes include: blocking `PerplexityBot` when the user wanted Perplexity citations, inventing a hybrid `/ai.txt` schema with made-up key-value directives, and listing Applebot-Extended as "missing" without identifying the silent inheritance.

## License

MIT © FIRST POINT YAZILIM LİMİTED ŞİRKETİ. Also mirrored at https://github.com/First-Point/ai-txt-skill with a `v1.0.0` release.

## Test plan

- [x] `quick_validate` passes
- [x] `package_skill` produces a valid `.skill` archive
- [x] 3-test benchmark via skill-creator's runner: +21pp over no-skill baseline
- [ ] Reviewers can re-run the benchmark at https://github.com/First-Point/ai-txt-skill (iteration-1 workspace is preserved in the source repo)