### PR TITLE
feat(skill-creator): SSE dashboard at eval.localhost replacing auto-refresh HTML

### DIFF
--- a/skills/skill-creator/eval-server/README.md
+++ b/skills/skill-creator/eval-server/README.md
@@ -1,0 +1,98 @@
+# skill-creator eval dashboard
+
+Interactive web dashboard for running Phase-3 trigger optimization on a skill.
+Replaces the static `report.html` auto-refresh page with a Server-Sent Events
+stream so iterations land in the browser as they complete instead of forcing
+a full page reload every 5 seconds.
+
+## Stack
+
+- **Backend:** FastAPI + uvicorn. Spawns `run_loop()` in a thread, streams
+  iteration events to subscribers over SSE.
+- **Frontend:** vanilla HTML/CSS/JS. No build step. SSE consumer renders the
+  results table incrementally.
+- **Hosting:** [`portless`](https://github.com/portless/portless) wraps the
+  uvicorn process and exposes it at `http://eval.localhost:1355` (or the
+  configured proxy port).
+
+## Run it
+
+```bash
+# from this directory
+portless eval ./start.sh
+```
+
+That bootstraps `.venv`, installs `fastapi` + `uvicorn` if missing, picks an
+ephemeral port, and proxies `eval.localhost` to it. Open the printed URL
+(typically `http://eval.localhost:1355`).
+
+If you don't use portless:
+
+```bash
+./start.sh
+# then open http://127.0.0.1:8765
+```
+
+## Use it
+
+1. Pick a skill from the dropdown — populated from `~/.claude/skills/*`.
+2. Pick an eval set — auto-discovered from `<skill>/evals/`,
+   `<skill>/resources/`, or `<skill>-workspace/`. Must be a JSON array of
+   `{query, should_trigger}` objects.
+3. Tune model / workers / iterations / holdout. Defaults are conservative
+   (1 worker, 3 iters, 60s timeout) to match low-RAM laptops.
+4. **Start.** The status pill flips to *running*. Each finished iteration
+   appends a row to the live results table without reloading the page.
+5. After the loop ends, **Apply best to SKILL.md** writes the winning
+   description back to the real `SKILL.md` (sibling `.md.apply-backup`
+   file is created first).
+
+## Why SSE replaced the auto-refresh HTML
+
+The legacy `generate_report.py` writes one giant HTML file to
+`/tmp/skill_description_report_<skill>_<ts>.html` with `<meta refresh
+content="5">`. Every 5 seconds the browser reloads the entire document.
+With long iteration counts the file balloons (each iteration adds a row
+× N queries × details), and the browser re-parses + re-renders all of
+it on every tick. RAM and CPU climb steadily.
+
+SSE sends per-iteration JSON deltas. The DOM is patched incrementally.
+Steady-state RAM stays flat; CPU only spikes when an iteration lands.
+
+## API surface
+
+All endpoints are under `/api/`:
+
+| Method | Path                            | Purpose                                  |
+|--------|---------------------------------|------------------------------------------|
+| GET    | `/api/health`                   | health check                             |
+| GET    | `/api/skills`                   | list installed skills with previews      |
+| GET    | `/api/skills/{name}`            | full description + candidate eval sets   |
+| POST   | `/api/runs`                     | start a run, returns `{run_id}`          |
+| GET    | `/api/runs`                     | list active + completed runs             |
+| GET    | `/api/runs/{id}`                | snapshot of one run                      |
+| GET    | `/api/runs/{id}/stream`         | SSE: live iteration events               |
+| POST   | `/api/runs/{id}/stop`           | cooperative stop (next iteration boundary)|
+| POST   | `/api/runs/{id}/apply`          | write best description back to SKILL.md  |
+
+The SSE stream emits these event types:
+- `snapshot` — full state at subscribe time
+- `iteration_start` — iteration N starting
+- `iteration_done` — iteration N finished, includes per-query results
+- `improving` — loop is calling `improve_description.py` for next iter
+- `loop_done` — final result + best description
+- `error` — exception bubbled up
+
+## Files
+
+```
+eval-server/
+├── README.md              this file
+├── server.py              FastAPI + SSE backend
+├── start.sh               venv bootstrap + uvicorn launcher
+├── requirements.txt       fastapi + uvicorn[standard]
+└── static/
+    ├── index.html         dashboard markup
+    ├── styles.css         Anthropic-style theme (Lora/Poppins/cream)
+    └── app.js             SSE client + table rendering
+```

--- a/skills/skill-creator/eval-server/README.md
+++ b/skills/skill-creator/eval-server/README.md
@@ -12,21 +12,48 @@ a full page reload every 5 seconds.
 - **Frontend:** vanilla HTML/CSS/JS. No build step. SSE consumer renders the
   results table incrementally.
 - **Hosting:** [`portless`](https://github.com/portless/portless) wraps the
-  uvicorn process and exposes it at `http://eval.localhost:1355` (or the
-  configured proxy port).
+  uvicorn process and proxies it under a `.localhost` subdomain.
 
-## Run it
+## Run it — per-skill dashboard (recommended for parallel work)
+
+When working on multiple skills simultaneously across tmux windows,
+**give each dashboard its own portless subdomain named after the skill**
+so they don't collide. The bundled wrapper does this for you:
 
 ```bash
-# from this directory
-portless eval ./start.sh
+# in tmux window 1
+./start-for-skill.sh medusa-pro
+#   → http://eval-medusa-pro.localhost:1355
+
+# in tmux window 2
+./start-for-skill.sh drizzle-pro
+#   → http://eval-drizzle-pro.localhost:1355
+
+# in tmux window 3
+./start-for-skill.sh stripe-pro
+#   → http://eval-stripe-pro.localhost:1355
 ```
 
-That bootstraps `.venv`, installs `fastapi` + `uvicorn` if missing, picks an
-ephemeral port, and proxies `eval.localhost` to it. Open the printed URL
-(typically `http://eval.localhost:1355`).
+Each gets a distinct portless subdomain, a distinct ephemeral app port,
+and a dashboard title pre-scoped to that one skill. No route conflicts.
+The backend reads `SKILL_FILTER` env var (set by the wrapper) to narrow
+`/api/skills` to just that one — keeps the picker clean. The flock on
+`SKILL.md.swap-lock` (in `run_eval.py`) serializes any same-skill races
+across processes.
 
-If you don't use portless:
+## Run it — single multi-skill dashboard
+
+If you only ever optimize one skill at a time, use the generic one:
+
+```bash
+portless skill-eval ./start.sh
+#   → http://skill-eval.localhost:1355
+```
+
+Pick any skill from the dropdown. Concurrent runs against different
+skills are still safe via `POST /api/runs` calls.
+
+## Run it — without portless
 
 ```bash
 ./start.sh
@@ -89,10 +116,25 @@ The SSE stream emits these event types:
 eval-server/
 ├── README.md              this file
 ├── server.py              FastAPI + SSE backend
-├── start.sh               venv bootstrap + uvicorn launcher
+├── start.sh               venv bootstrap + uvicorn launcher (generic)
+├── start-for-skill.sh     per-skill wrapper: portless name = eval-<skill>
 ├── requirements.txt       fastapi + uvicorn[standard]
 └── static/
     ├── index.html         dashboard markup
     ├── styles.css         Anthropic-style theme (Lora/Poppins/cream)
     └── app.js             SSE client + table rendering
 ```
+
+## Naming convention
+
+| Mode             | URL                                       | When to use                                    |
+|------------------|-------------------------------------------|------------------------------------------------|
+| per-skill        | `http://eval-<skill>.localhost:1355`      | parallel work across tmux windows              |
+| multi-skill      | `http://skill-eval.localhost:1355`        | one-at-a-time optimization, generic harness    |
+| no portless      | `http://127.0.0.1:8765`                   | dev / debugging / no proxy installed           |
+
+The per-skill mode is the recommended default when running more than
+one optimization at once. Each tmux window gets a distinct subdomain,
+the page title shows which skill is being optimized, and the backend
+locks per-SKILL.md so even two processes targeting the same skill
+won't corrupt each other.

--- a/skills/skill-creator/eval-server/requirements.txt
+++ b/skills/skill-creator/eval-server/requirements.txt
@@ -1,0 +1,2 @@
+fastapi>=0.110
+uvicorn[standard]>=0.27

--- a/skills/skill-creator/eval-server/server.py
+++ b/skills/skill-creator/eval-server/server.py
@@ -1,0 +1,379 @@
+"""Interactive Phase-3 trigger optimization dashboard.
+
+FastAPI + Server-Sent Events. Replaces the static auto-refresh HTML
+report with a live web dashboard. Hosts on http://eval.local once
+proxied through `portless`.
+
+Endpoints:
+  GET  /                          → dashboard UI
+  GET  /api/skills                → list installed skills
+  GET  /api/skills/<name>         → skill metadata + candidate eval sets
+  POST /api/runs                  → start optimization run, returns run_id
+  GET  /api/runs                  → list active + recent runs
+  GET  /api/runs/<id>             → run snapshot
+  GET  /api/runs/<id>/stream      → SSE stream of iteration events
+  POST /api/runs/<id>/stop        → cooperative stop
+  POST /api/runs/<id>/apply       → write best description back to SKILL.md
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import queue
+import sys
+import threading
+import time
+import uuid
+from pathlib import Path
+
+from fastapi import FastAPI, Request
+from fastapi.responses import (
+    FileResponse,
+    JSONResponse,
+    StreamingResponse,
+)
+from fastapi.staticfiles import StaticFiles
+
+# Make scripts/* importable
+SKILL_CREATOR_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SKILL_CREATOR_DIR))
+
+from scripts.run_eval import (  # noqa: E402
+    _atomic_write,
+    _replace_description_in_frontmatter,
+    find_project_root,
+)
+from scripts.run_loop import run_loop  # noqa: E402
+from scripts.utils import parse_skill_md  # noqa: E402
+
+SKILLS_DIR = Path.home() / ".claude" / "skills"
+HERE = Path(__file__).resolve().parent
+
+app = FastAPI(title="skill-creator eval server")
+
+_runs: dict[str, dict] = {}
+_runs_lock = threading.Lock()
+
+
+def _record_event(state: dict, evt: dict) -> None:
+    """Append event to state.history when meaningful, then fan out to subscribers."""
+    e = evt.get("event")
+    if e == "iteration_done" and "entry" in evt:
+        with _runs_lock:
+            state["history"].append(evt["entry"])
+    elif e == "loop_done":
+        with _runs_lock:
+            state["status"] = "complete"
+            state["result"] = evt.get("result")
+            state["finished_at"] = time.time()
+    elif e == "error":
+        with _runs_lock:
+            state["status"] = "error"
+            state["error"] = evt.get("error")
+            state["finished_at"] = time.time()
+
+    with _runs_lock:
+        subs = list(state["subscribers"])
+    for q in subs:
+        try:
+            q.put_nowait(evt)
+        except queue.Full:
+            pass
+
+
+@app.get("/")
+def index():
+    return FileResponse(HERE / "static" / "index.html")
+
+
+@app.get("/api/health")
+def health():
+    return {"ok": True, "skills_dir": str(SKILLS_DIR), "skills_exist": SKILLS_DIR.is_dir()}
+
+
+@app.get("/api/skills")
+def list_skills():
+    """Enumerate ~/.claude/skills/<name>/SKILL.md entries."""
+    if not SKILLS_DIR.is_dir():
+        return []
+    out = []
+    for p in sorted(SKILLS_DIR.iterdir()):
+        if not p.is_dir() and not p.is_symlink():
+            continue
+        try:
+            real = p.resolve()
+        except OSError:
+            continue
+        if not (real / "SKILL.md").is_file():
+            continue
+        try:
+            name, desc, _ = parse_skill_md(real)
+        except Exception:
+            continue
+        out.append({
+            "name": name,
+            "link_path": str(p),
+            "real_path": str(real),
+            "description_preview": desc[:160],
+            "description_len": len(desc),
+        })
+    return out
+
+
+@app.get("/api/skills/{name}")
+def get_skill(name: str):
+    p = SKILLS_DIR / name
+    if not (p / "SKILL.md").exists():
+        return JSONResponse({"error": "not found"}, status_code=404)
+    real = p.resolve()
+    n, desc, _ = parse_skill_md(real)
+
+    # Auto-discover candidate eval sets:
+    # - <skill>/evals/*.json
+    # - <skill>/resources/*eval*.json
+    # - <skill>-workspace/*.json (sibling workspace)
+    candidates: list[dict] = []
+    seen: set[str] = set()
+    search_roots = [
+        real / "evals",
+        real / "resources",
+        real.parent / f"{n}-workspace",
+    ]
+    for root in search_roots:
+        if not root.is_dir():
+            continue
+        for f in root.rglob("*.json"):
+            if str(f) in seen:
+                continue
+            try:
+                data = json.loads(f.read_text())
+            except Exception:
+                continue
+            if not isinstance(data, list) or not data:
+                continue
+            if not isinstance(data[0], dict) or "should_trigger" not in data[0]:
+                continue
+            should_count = sum(1 for q in data if q.get("should_trigger"))
+            candidates.append({
+                "path": str(f),
+                "name": str(f.relative_to(root.parent)) if f.is_relative_to(root.parent) else str(f),
+                "size": len(data),
+                "should_trigger": should_count,
+                "should_not_trigger": len(data) - should_count,
+            })
+            seen.add(str(f))
+    candidates.sort(key=lambda c: c["size"], reverse=True)
+
+    return {
+        "name": n,
+        "description": desc,
+        "skill_path": str(real),
+        "eval_candidates": candidates,
+    }
+
+
+@app.post("/api/runs")
+async def create_run(req: Request):
+    body = await req.json()
+    skill_path = Path(body["skill_path"]).resolve()
+    eval_set_path = Path(body["eval_set_path"]).resolve()
+    if not (skill_path / "SKILL.md").exists():
+        return JSONResponse({"error": f"no SKILL.md at {skill_path}"}, status_code=400)
+    if not eval_set_path.is_file():
+        return JSONResponse({"error": f"eval set not found at {eval_set_path}"}, status_code=400)
+
+    try:
+        eval_set = json.loads(eval_set_path.read_text())
+    except Exception as exc:
+        return JSONResponse({"error": f"bad eval set JSON: {exc}"}, status_code=400)
+
+    if not isinstance(eval_set, list) or not eval_set:
+        return JSONResponse({"error": "eval set must be a non-empty list"}, status_code=400)
+
+    run_id = uuid.uuid4().hex[:8]
+    stop_event = threading.Event()
+
+    state: dict = {
+        "run_id": run_id,
+        "status": "running",
+        "params": {
+            "skill_path": str(skill_path),
+            "eval_set_path": str(eval_set_path),
+            "eval_size": len(eval_set),
+            "model": body.get("model", "claude-sonnet-4-6"),
+            "num_workers": int(body.get("num_workers", 1)),
+            "timeout": int(body.get("timeout", 60)),
+            "max_iterations": int(body.get("max_iterations", 5)),
+            "runs_per_query": int(body.get("runs_per_query", 1)),
+            "trigger_threshold": float(body.get("trigger_threshold", 0.5)),
+            "holdout": float(body.get("holdout", 0.4)),
+            "description_override": body.get("description") or None,
+        },
+        "history": [],
+        "subscribers": [],
+        "stop_event": stop_event,
+        "result": None,
+        "started_at": time.time(),
+    }
+    with _runs_lock:
+        _runs[run_id] = state
+
+    def progress_cb(evt: dict) -> None:
+        evt = {"run_id": run_id, "ts": time.time(), **evt}
+        _record_event(state, evt)
+
+    def thread_body() -> None:
+        try:
+            result = run_loop(
+                eval_set=eval_set,
+                skill_path=skill_path,
+                description_override=state["params"]["description_override"],
+                num_workers=state["params"]["num_workers"],
+                timeout=state["params"]["timeout"],
+                max_iterations=state["params"]["max_iterations"],
+                runs_per_query=state["params"]["runs_per_query"],
+                trigger_threshold=state["params"]["trigger_threshold"],
+                holdout=state["params"]["holdout"],
+                model=state["params"]["model"],
+                verbose=False,
+                progress_callback=progress_cb,
+                stop_signal=stop_event,
+            )
+            progress_cb({"event": "loop_done", "result": result})
+        except Exception as exc:
+            progress_cb({"event": "error", "error": f"{type(exc).__name__}: {exc}"})
+
+    t = threading.Thread(target=thread_body, daemon=True)
+    state["thread"] = t
+    t.start()
+    return {"run_id": run_id}
+
+
+@app.get("/api/runs")
+def list_runs():
+    with _runs_lock:
+        out = []
+        for rid, s in _runs.items():
+            out.append({
+                "run_id": rid,
+                "status": s["status"],
+                "started_at": s["started_at"],
+                "finished_at": s.get("finished_at"),
+                "params": s["params"],
+                "iterations_run": len(s["history"]),
+            })
+    return sorted(out, key=lambda r: r["started_at"], reverse=True)
+
+
+@app.get("/api/runs/{run_id}")
+def get_run(run_id: str):
+    with _runs_lock:
+        s = _runs.get(run_id)
+    if not s:
+        return JSONResponse({"error": "no such run"}, status_code=404)
+    return {
+        "run_id": run_id,
+        "status": s["status"],
+        "started_at": s["started_at"],
+        "finished_at": s.get("finished_at"),
+        "params": s["params"],
+        "history": s["history"],
+        "result": s.get("result"),
+        "error": s.get("error"),
+    }
+
+
+@app.get("/api/runs/{run_id}/stream")
+async def stream(run_id: str, req: Request):
+    with _runs_lock:
+        state = _runs.get(run_id)
+    if not state:
+        return JSONResponse({"error": "no such run"}, status_code=404)
+
+    q: queue.Queue = queue.Queue(maxsize=500)
+    with _runs_lock:
+        state["subscribers"].append(q)
+
+    snapshot = {
+        "event": "snapshot",
+        "run_id": run_id,
+        "status": state["status"],
+        "params": state["params"],
+        "history": list(state["history"]),
+        "result": state.get("result"),
+        "error": state.get("error"),
+    }
+
+    async def gen():
+        yield f"data: {json.dumps(snapshot)}\n\n"
+        try:
+            while True:
+                if await req.is_disconnected():
+                    return
+                try:
+                    evt = await asyncio.get_event_loop().run_in_executor(
+                        None, lambda: q.get(timeout=15)
+                    )
+                except queue.Empty:
+                    yield ": keepalive\n\n"
+                    continue
+                yield f"data: {json.dumps(evt)}\n\n"
+                if evt.get("event") in ("loop_done", "error"):
+                    return
+        finally:
+            with _runs_lock:
+                try:
+                    state["subscribers"].remove(q)
+                except ValueError:
+                    pass
+
+    return StreamingResponse(gen(), media_type="text/event-stream")
+
+
+@app.post("/api/runs/{run_id}/stop")
+def stop_run(run_id: str):
+    with _runs_lock:
+        state = _runs.get(run_id)
+    if not state:
+        return JSONResponse({"error": "no such run"}, status_code=404)
+    state["stop_event"].set()
+    return {"ok": True}
+
+
+@app.post("/api/runs/{run_id}/apply")
+async def apply_best(run_id: str):
+    with _runs_lock:
+        state = _runs.get(run_id)
+    if not state:
+        return JSONResponse({"error": "no such run"}, status_code=404)
+    result = state.get("result")
+    if not result:
+        return JSONResponse({"error": "run has no result yet"}, status_code=400)
+
+    skill_path = Path(state["params"]["skill_path"])
+    skill_md = skill_path / "SKILL.md"
+    if not skill_md.exists():
+        return JSONResponse({"error": f"SKILL.md missing at {skill_md}"}, status_code=400)
+
+    backup = skill_md.with_suffix(".md.apply-backup")
+    backup.write_text(skill_md.read_text())
+
+    src = skill_md.read_text()
+    new = _replace_description_in_frontmatter(src, result["best_description"])
+    _atomic_write(skill_md, new)
+
+    return {
+        "ok": True,
+        "applied_description": result["best_description"],
+        "skill_md": str(skill_md),
+        "backup": str(backup),
+    }
+
+
+app.mount("/static", StaticFiles(directory=HERE / "static"), name="static")
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="127.0.0.1", port=8765, log_level="info")

--- a/skills/skill-creator/eval-server/server.py
+++ b/skills/skill-creator/eval-server/server.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import queue
 import sys
 import threading
@@ -49,6 +50,11 @@ from scripts.utils import parse_skill_md  # noqa: E402
 
 SKILLS_DIR = Path.home() / ".claude" / "skills"
 HERE = Path(__file__).resolve().parent
+
+# When SKILL_FILTER is set, the dashboard restricts itself to that one skill.
+# Used by start-for-skill.sh to give each parallel run its own portless
+# subdomain (eval-<skill>.localhost) and a single-skill UI.
+SKILL_FILTER = os.environ.get("SKILL_FILTER", "").strip() or None
 
 app = FastAPI(title="skill-creator eval server")
 
@@ -89,16 +95,28 @@ def index():
 
 @app.get("/api/health")
 def health():
-    return {"ok": True, "skills_dir": str(SKILLS_DIR), "skills_exist": SKILLS_DIR.is_dir()}
+    return {
+        "ok": True,
+        "skills_dir": str(SKILLS_DIR),
+        "skills_exist": SKILLS_DIR.is_dir(),
+        "skill_filter": SKILL_FILTER,
+    }
 
 
 @app.get("/api/skills")
 def list_skills():
-    """Enumerate ~/.claude/skills/<name>/SKILL.md entries."""
+    """Enumerate ~/.claude/skills/<name>/SKILL.md entries.
+
+    If SKILL_FILTER env var is set (typically by start-for-skill.sh),
+    the listing is restricted to just that one skill so the dashboard
+    is scoped to a single skill per portless subdomain.
+    """
     if not SKILLS_DIR.is_dir():
         return []
     out = []
     for p in sorted(SKILLS_DIR.iterdir()):
+        if SKILL_FILTER and p.name != SKILL_FILTER:
+            continue
         if not p.is_dir() and not p.is_symlink():
             continue
         try:

--- a/skills/skill-creator/eval-server/start-for-skill.sh
+++ b/skills/skill-creator/eval-server/start-for-skill.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Run the eval dashboard scoped to ONE skill, so the portless URL reflects
+# the skill name. Useful when running multiple parallel optimizations across
+# tmux windows — each gets its own subdomain instead of colliding on
+# `skill-eval.localhost`.
+#
+# Usage:
+#   ./start-for-skill.sh <skill-name>
+#
+# Examples:
+#   ./start-for-skill.sh medusa-pro     → http://eval-medusa-pro.localhost:1355
+#   ./start-for-skill.sh drizzle-pro    → http://eval-drizzle-pro.localhost:1355
+#   ./start-for-skill.sh stripe-pro     → http://eval-stripe-pro.localhost:1355
+#
+# All can run simultaneously — different subdomains, different ephemeral
+# ports, no portless route conflicts.
+set -euo pipefail
+
+SKILL="${1:-}"
+if [ -z "$SKILL" ]; then
+  echo "Usage: $0 <skill-name>" >&2
+  echo "  e.g. $0 medusa-pro" >&2
+  exit 1
+fi
+
+SKILL_DIR="$HOME/.claude/skills/$SKILL"
+if [ ! -f "$SKILL_DIR/SKILL.md" ]; then
+  echo "Error: no skill '$SKILL' at $SKILL_DIR (no SKILL.md found)" >&2
+  echo "Available skills:" >&2
+  ls -1 "$HOME/.claude/skills/" 2>/dev/null | head -20 >&2
+  exit 1
+fi
+
+cd "$(dirname "$0")"
+
+# Tell the FastAPI server to pre-select this skill in the dashboard
+# and limit /api/skills to it.
+export SKILL_FILTER="$SKILL"
+
+# portless service name = "eval-<skill>" → "eval-<skill>.localhost:<proxy_port>"
+exec portless "eval-$SKILL" ./start.sh

--- a/skills/skill-creator/eval-server/start.sh
+++ b/skills/skill-creator/eval-server/start.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Bootstrap + run the skill-creator eval dashboard server.
+# Use `portless eval ./start.sh` from this directory to expose at http://eval.local
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+if [ ! -d .venv ]; then
+  python3 -m venv .venv
+fi
+
+# Install deps if not present
+if ! .venv/bin/python -c "import fastapi, uvicorn" 2>/dev/null; then
+  .venv/bin/pip install --upgrade pip >/dev/null
+  .venv/bin/pip install -r requirements.txt
+fi
+
+# Bind 0.0.0.0 so portless can reach it from the host network namespace
+HOST="${HOST:-127.0.0.1}"
+PORT="${PORT:-8765}"
+exec .venv/bin/python -m uvicorn server:app --host "$HOST" --port "$PORT" --log-level info

--- a/skills/skill-creator/eval-server/static/app.js
+++ b/skills/skill-creator/eval-server/static/app.js
@@ -45,6 +45,15 @@ function clear(node) {
 // ---- bootstrap ----
 
 async function loadSkills() {
+  // Read scoping hint first — if SKILL_FILTER was set on the server, narrow
+  // the page title to that skill so the tab + URL are unambiguous when
+  // running multiple parallel dashboards.
+  let scopedSkill = null;
+  try {
+    const health = await (await fetch("/api/health")).json();
+    scopedSkill = health.skill_filter || null;
+  } catch {}
+
   const res = await fetch("/api/skills");
   state.skills = await res.json();
   const sel = $("skill-select");
@@ -55,6 +64,16 @@ async function loadSkills() {
       `${s.name}  (${s.description_len} chars)`,
     ]);
     sel.appendChild(opt);
+  }
+
+  if (scopedSkill) {
+    document.title = `${scopedSkill} — skill-creator eval`;
+    const h1 = document.querySelector(".topbar h1");
+    if (h1) h1.textContent = `skill-creator · ${scopedSkill}`;
+    if (state.skills.length === 1) {
+      sel.value = scopedSkill;
+      loadSkillDetail(scopedSkill);
+    }
   }
 }
 

--- a/skills/skill-creator/eval-server/static/app.js
+++ b/skills/skill-creator/eval-server/static/app.js
@@ -1,0 +1,458 @@
+// skill-creator eval dashboard — vanilla JS SSE client
+// All dynamic strings are inserted via textContent or createElement to avoid XSS.
+
+const $ = (id) => document.getElementById(id);
+
+const state = {
+  skills: [],
+  selectedSkill: null,
+  evalCandidates: [],
+  selectedEvalSet: null,
+  evalSetSize: 0,
+  runId: null,
+  evtSource: null,
+  trainQueries: [],
+  testQueries: [],
+  history: [],
+  result: null,
+};
+
+// ---- DOM helpers ----
+
+function el(tag, props = {}, children = []) {
+  const node = document.createElement(tag);
+  for (const [k, v] of Object.entries(props)) {
+    if (k === "className") node.className = v;
+    else if (k === "dataset") for (const [dk, dv] of Object.entries(v)) node.dataset[dk] = dv;
+    else if (k === "textContent") node.textContent = v;
+    else if (k === "title") node.title = v;
+    else if (k === "value") node.value = v;
+    else if (k === "type") node.type = v;
+    else node.setAttribute(k, v);
+  }
+  for (const c of children) {
+    if (c == null) continue;
+    if (typeof c === "string") node.appendChild(document.createTextNode(c));
+    else node.appendChild(c);
+  }
+  return node;
+}
+
+function clear(node) {
+  while (node.firstChild) node.removeChild(node.firstChild);
+}
+
+// ---- bootstrap ----
+
+async function loadSkills() {
+  const res = await fetch("/api/skills");
+  state.skills = await res.json();
+  const sel = $("skill-select");
+  clear(sel);
+  sel.appendChild(el("option", { value: "" }, ["— select skill —"]));
+  for (const s of state.skills) {
+    const opt = el("option", { value: s.name, title: s.description_preview }, [
+      `${s.name}  (${s.description_len} chars)`,
+    ]);
+    sel.appendChild(opt);
+  }
+}
+
+async function loadSkillDetail(name) {
+  if (!name) {
+    state.selectedSkill = null;
+    state.evalCandidates = [];
+    $("skill-desc-preview").textContent = "";
+    const sel = $("eval-set-select");
+    clear(sel);
+    sel.appendChild(el("option", { value: "" }, ["— pick a skill first —"]));
+    sel.disabled = true;
+    $("eval-set-stats").textContent = "";
+    refreshStartButton();
+    return;
+  }
+  const res = await fetch(`/api/skills/${encodeURIComponent(name)}`);
+  if (!res.ok) {
+    $("skill-desc-preview").textContent = "(failed to load)";
+    return;
+  }
+  const data = await res.json();
+  state.selectedSkill = data;
+  state.evalCandidates = data.eval_candidates || [];
+  $("skill-desc-preview").textContent =
+    data.description.slice(0, 200) + (data.description.length > 200 ? "…" : "");
+
+  const sel = $("eval-set-select");
+  clear(sel);
+  if (state.evalCandidates.length === 0) {
+    sel.appendChild(el("option", { value: "" }, ["no eval sets found — paste JSON below"]));
+    sel.disabled = true;
+  } else {
+    sel.disabled = false;
+    sel.appendChild(el("option", { value: "" }, ["— select eval set —"]));
+    for (const c of state.evalCandidates) {
+      sel.appendChild(
+        el("option", { value: c.path }, [
+          `${c.name}  (${c.size} queries: ${c.should_trigger}+ / ${c.should_not_trigger}-)`,
+        ]),
+      );
+    }
+  }
+  $("eval-set-stats").textContent = `${state.evalCandidates.length} candidate eval sets discovered`;
+  refreshStartButton();
+}
+
+function refreshStartButton() {
+  const skillOk = !!state.selectedSkill;
+  const evalOk = !!$("eval-set-select").value || !!$("eval-set-paste").value.trim();
+  $("start-btn").disabled = !(skillOk && evalOk);
+}
+
+// ---- run start ----
+
+async function startRun() {
+  const skill = state.selectedSkill;
+  if (!skill) return;
+
+  const evalSetPath = $("eval-set-select").value;
+  const pasted = $("eval-set-paste").value.trim();
+  if (pasted && !evalSetPath) {
+    alert(
+      "Paste-JSON support requires saving to disk first. Save your JSON to a file under <skill>/evals/ or <skill>-workspace/ and reload, or pick from the dropdown.",
+    );
+    return;
+  }
+
+  const body = {
+    skill_path: skill.skill_path,
+    eval_set_path: evalSetPath,
+    model: $("model-select").value,
+    num_workers: parseInt($("num-workers").value, 10),
+    timeout: parseInt($("timeout").value, 10),
+    max_iterations: parseInt($("max-iterations").value, 10),
+    runs_per_query: parseInt($("runs-per-query").value, 10),
+    trigger_threshold: parseFloat($("trigger-threshold").value),
+    holdout: parseFloat($("holdout").value),
+    description: $("description-override").value.trim() || null,
+  };
+
+  const res = await fetch("/api/runs", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    alert("Failed to start: " + (err.error || res.statusText));
+    return;
+  }
+  const { run_id } = await res.json();
+  state.runId = run_id;
+  state.history = [];
+  state.result = null;
+  state.trainQueries = [];
+  state.testQueries = [];
+  resetTable();
+  $("run-id").textContent = run_id;
+  $("run-iter-max").textContent = String(body.max_iterations);
+  $("run-iter").textContent = "0";
+  setStatus("running");
+  $("start-btn").disabled = true;
+  $("stop-btn").disabled = false;
+  $("apply-best-btn").disabled = true;
+  setConnectionPill("running");
+
+  attachStream(run_id);
+}
+
+function resetTable() {
+  clear($("results-tbody"));
+  const head = $("results-thead-row");
+  clear(head);
+  head.appendChild(el("th", {}, ["Iter"]));
+  head.appendChild(el("th", {}, ["Train"]));
+  head.appendChild(el("th", {}, ["Test"]));
+  head.appendChild(el("th", { className: "desc-col" }, ["Description"]));
+}
+
+function attachStream(runId) {
+  if (state.evtSource) state.evtSource.close();
+  const es = new EventSource(`/api/runs/${encodeURIComponent(runId)}/stream`);
+  state.evtSource = es;
+
+  es.onmessage = (e) => {
+    let evt;
+    try {
+      evt = JSON.parse(e.data);
+    } catch {
+      return;
+    }
+    handleEvent(evt);
+  };
+  es.onerror = () => {
+    setConnectionPill("error");
+  };
+}
+
+function handleEvent(evt) {
+  switch (evt.event) {
+    case "snapshot":
+      if (evt.history && evt.history.length) {
+        renderHeaderFromEntry(evt.history[0]);
+        for (const entry of evt.history) appendIterationRow(entry);
+        state.history = evt.history.slice();
+      }
+      if (evt.params) {
+        $("run-iter-max").textContent = String(evt.params.max_iterations);
+      }
+      if (evt.result) {
+        state.result = evt.result;
+        showFinalResult(evt.result);
+      }
+      setStatus(evt.status);
+      break;
+
+    case "iteration_start":
+      $("run-iter").textContent = String(evt.iteration);
+      setStatus("running");
+      break;
+
+    case "iteration_done":
+      if (state.history.length === 0) renderHeaderFromEntry(evt.entry);
+      state.history.push(evt.entry);
+      appendIterationRow(evt.entry);
+      $("run-iter").textContent = String(evt.iteration);
+      break;
+
+    case "improving":
+      setStatus("improving");
+      break;
+
+    case "loop_done":
+      state.result = evt.result;
+      showFinalResult(evt.result);
+      setStatus("complete");
+      $("stop-btn").disabled = true;
+      $("start-btn").disabled = false;
+      $("apply-best-btn").disabled = false;
+      setConnectionPill("complete");
+      if (state.evtSource) state.evtSource.close();
+      break;
+
+    case "error":
+      setStatus("error");
+      $("run-status").title = evt.error || "";
+      $("stop-btn").disabled = true;
+      $("start-btn").disabled = false;
+      setConnectionPill("error");
+      if (state.evtSource) state.evtSource.close();
+      break;
+
+    default:
+      break;
+  }
+}
+
+// ---- table rendering ----
+
+function renderHeaderFromEntry(entry) {
+  const trainResults = entry.train_results || entry.results || [];
+  const testResults = entry.test_results || [];
+  state.trainQueries = trainResults.map((r) => ({ query: r.query, should_trigger: r.should_trigger }));
+  state.testQueries = testResults.map((r) => ({ query: r.query, should_trigger: r.should_trigger }));
+  $("train-size").textContent = String(state.trainQueries.length);
+  $("test-size").textContent = String(state.testQueries.length);
+
+  const head = $("results-thead-row");
+  clear(head);
+  head.appendChild(el("th", {}, ["Iter"]));
+  head.appendChild(el("th", {}, ["Train"]));
+  head.appendChild(el("th", {}, ["Test"]));
+  head.appendChild(el("th", { className: "desc-col" }, ["Description"]));
+  for (const q of state.trainQueries) {
+    const cls = q.should_trigger ? "positive-col" : "negative-col";
+    head.appendChild(el("th", { className: cls, title: q.query }, [truncate(q.query, 40)]));
+  }
+  for (const q of state.testQueries) {
+    const cls = "test-col " + (q.should_trigger ? "positive-col" : "negative-col");
+    head.appendChild(el("th", { className: cls, title: q.query }, [truncate(q.query, 40)]));
+  }
+}
+
+function appendIterationRow(entry) {
+  const tbody = $("results-tbody");
+  const tr = el("tr", { dataset: { iteration: String(entry.iteration) } });
+
+  const trainCorrect = aggregateCorrect(entry.train_results || entry.results || []);
+  const testCorrect = aggregateCorrect(entry.test_results || []);
+
+  tr.appendChild(el("td", {}, [String(entry.iteration)]));
+  tr.appendChild(
+    el("td", {}, [
+      el("span", { className: `score-pill ${scoreClass(trainCorrect)}` }, [
+        `${trainCorrect.correct}/${trainCorrect.total}`,
+      ]),
+    ]),
+  );
+  tr.appendChild(
+    el("td", {}, [
+      el("span", { className: `score-pill ${scoreClass(testCorrect)}` }, [
+        `${testCorrect.correct}/${testCorrect.total}`,
+      ]),
+    ]),
+  );
+  tr.appendChild(el("td", { className: "desc-cell" }, [entry.description || ""]));
+
+  const trainByQuery = new Map((entry.train_results || entry.results || []).map((r) => [r.query, r]));
+  const testByQuery = new Map((entry.test_results || []).map((r) => [r.query, r]));
+
+  for (const q of state.trainQueries) {
+    tr.appendChild(makeResultCell(trainByQuery.get(q.query) || {}, false));
+  }
+  for (const q of state.testQueries) {
+    tr.appendChild(makeResultCell(testByQuery.get(q.query) || {}, true));
+  }
+
+  tbody.appendChild(tr);
+  highlightBestRow();
+}
+
+function makeResultCell(r, isTest) {
+  const cls = "result-cell" + (isTest ? " test-result-cell" : "");
+  if (Object.keys(r).length === 0) {
+    return el("td", { className: cls }, [el("span", { className: "rate" }, ["—"])]);
+  }
+  const ok = !!r.pass;
+  const td = el("td", { className: cls + (ok ? " pass" : " fail") }, [
+    ok ? "✓" : "✗",
+    el("span", { className: "rate" }, [`${r.triggers}/${r.runs}`]),
+  ]);
+  return td;
+}
+
+function aggregateCorrect(results) {
+  let correct = 0;
+  let total = 0;
+  for (const r of results) {
+    const runs = r.runs || 0;
+    const triggers = r.triggers || 0;
+    total += runs;
+    if (r.should_trigger) correct += triggers;
+    else correct += runs - triggers;
+  }
+  return { correct, total };
+}
+
+function scoreClass({ correct, total }) {
+  if (total === 0) return "score-bad";
+  const ratio = correct / total;
+  if (ratio >= 0.8) return "score-good";
+  if (ratio >= 0.5) return "score-ok";
+  return "score-bad";
+}
+
+function highlightBestRow() {
+  if (state.history.length === 0) return;
+  const useTest = state.testQueries.length > 0;
+  const bestEntry = state.history.reduce((a, b) => {
+    const av = useTest ? (a.test_passed ?? 0) : (a.train_passed ?? a.passed ?? 0);
+    const bv = useTest ? (b.test_passed ?? 0) : (b.train_passed ?? b.passed ?? 0);
+    return bv > av ? b : a;
+  });
+  document.querySelectorAll("tr.best-row").forEach((r) => r.classList.remove("best-row"));
+  const row = document.querySelector(`tr[data-iteration="${bestEntry.iteration}"]`);
+  if (row) row.classList.add("best-row");
+  $("best-description").textContent = bestEntry.description || "";
+  const ts = useTest ? bestEntry.test_passed : bestEntry.train_passed;
+  const tot = useTest ? bestEntry.test_total : bestEntry.train_total;
+  $("best-score").textContent = `${ts}/${tot} (iter ${bestEntry.iteration})`;
+}
+
+function showFinalResult(result) {
+  $("best-description").textContent = result.best_description || "";
+  $("best-score").textContent = result.best_score || "—";
+}
+
+// ---- status + ui plumbing ----
+
+function setStatus(s) {
+  const pill = $("run-status");
+  pill.className = "pill pill-" + s;
+  pill.textContent = s;
+}
+function setConnectionPill(s) {
+  const pill = $("connection-pill");
+  pill.className = "pill pill-" + s;
+  pill.textContent = s;
+}
+
+// ---- stop + apply ----
+
+async function stopRun() {
+  if (!state.runId) return;
+  await fetch(`/api/runs/${encodeURIComponent(state.runId)}/stop`, { method: "POST" });
+}
+
+async function applyBest() {
+  if (!state.runId) return;
+  if (!confirm("Overwrite SKILL.md with the best description?")) return;
+  const res = await fetch(`/api/runs/${encodeURIComponent(state.runId)}/apply`, {
+    method: "POST",
+  });
+  const data = await res.json();
+  if (data.ok) {
+    alert("Applied. Backup at: " + data.backup);
+  } else {
+    alert("Failed: " + (data.error || "unknown"));
+  }
+}
+
+// ---- run history ----
+
+async function showRunsModal() {
+  const res = await fetch("/api/runs");
+  const runs = await res.json();
+  const list = $("runs-list");
+  clear(list);
+  if (runs.length === 0) {
+    list.appendChild(el("li", {}, ["No runs yet"]));
+  } else {
+    for (const r of runs) {
+      const t = new Date(r.started_at * 1000).toLocaleString();
+      const li = el("li", {}, [
+        el("strong", {}, [r.run_id]),
+        ` · ${r.status} · ${t} · iters=${r.iterations_run}`,
+      ]);
+      const btn = el("button", { className: "ghost-btn" }, ["view"]);
+      btn.addEventListener("click", () => {
+        document.getElementById("runs-modal").close();
+        attachStream(r.run_id);
+        state.runId = r.run_id;
+        $("run-id").textContent = r.run_id;
+      });
+      li.appendChild(btn);
+      list.appendChild(li);
+    }
+  }
+  $("runs-modal").showModal();
+}
+
+// ---- helpers ----
+
+function truncate(s, n) {
+  if (typeof s !== "string") return "";
+  return s.length > n ? s.slice(0, n - 1) + "…" : s;
+}
+
+// ---- wiring ----
+
+document.addEventListener("DOMContentLoaded", () => {
+  loadSkills();
+  $("skill-select").addEventListener("change", (e) => loadSkillDetail(e.target.value));
+  $("eval-set-select").addEventListener("change", refreshStartButton);
+  $("eval-set-paste").addEventListener("input", refreshStartButton);
+  $("start-btn").addEventListener("click", startRun);
+  $("stop-btn").addEventListener("click", stopRun);
+  $("apply-best-btn").addEventListener("click", applyBest);
+  $("show-runs-btn").addEventListener("click", showRunsModal);
+});

--- a/skills/skill-creator/eval-server/static/index.html
+++ b/skills/skill-creator/eval-server/static/index.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>skill-creator — eval dashboard</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600&family=Lora:wght@400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/static/styles.css">
+</head>
+<body>
+  <header class="topbar">
+    <h1>skill-creator</h1>
+    <span class="topbar-sub">trigger optimization dashboard</span>
+    <div class="topbar-right">
+      <span id="connection-pill" class="pill pill-idle">idle</span>
+      <button id="show-runs-btn" class="ghost-btn">history</button>
+    </div>
+  </header>
+
+  <div class="layout">
+    <aside class="sidebar">
+      <section class="control-group">
+        <label for="skill-select">Skill</label>
+        <select id="skill-select">
+          <option value="">— select skill —</option>
+        </select>
+        <p class="hint" id="skill-desc-preview"></p>
+      </section>
+
+      <section class="control-group">
+        <label for="eval-set-select">Eval set</label>
+        <select id="eval-set-select" disabled>
+          <option value="">— pick a skill first —</option>
+        </select>
+        <p class="hint" id="eval-set-stats"></p>
+        <details class="paste-eval">
+          <summary>Or paste JSON</summary>
+          <textarea id="eval-set-paste" rows="4" placeholder='[{"query":"...","should_trigger":true},...]'></textarea>
+        </details>
+      </section>
+
+      <section class="control-group">
+        <label for="model-select">Model</label>
+        <select id="model-select">
+          <option value="claude-sonnet-4-6">claude-sonnet-4-6</option>
+          <option value="claude-opus-4-7">claude-opus-4-7</option>
+          <option value="claude-haiku-4-5">claude-haiku-4-5</option>
+          <option value="kimi-k2.6:cloud">kimi-k2.6:cloud</option>
+        </select>
+      </section>
+
+      <section class="control-group grid-2">
+        <div>
+          <label for="num-workers">Workers</label>
+          <input type="number" id="num-workers" min="1" max="8" value="1">
+        </div>
+        <div>
+          <label for="max-iterations">Iterations</label>
+          <input type="number" id="max-iterations" min="1" max="10" value="3">
+        </div>
+        <div>
+          <label for="runs-per-query">Runs/query</label>
+          <input type="number" id="runs-per-query" min="1" max="5" value="1">
+        </div>
+        <div>
+          <label for="timeout">Timeout (s)</label>
+          <input type="number" id="timeout" min="15" max="300" value="60">
+        </div>
+        <div>
+          <label for="holdout">Holdout</label>
+          <input type="number" id="holdout" min="0" max="0.7" step="0.05" value="0.4">
+        </div>
+        <div>
+          <label for="trigger-threshold">Threshold</label>
+          <input type="number" id="trigger-threshold" min="0" max="1" step="0.1" value="0.5">
+        </div>
+      </section>
+
+      <section class="control-group">
+        <label for="description-override">Description override (optional)</label>
+        <textarea id="description-override" rows="3" placeholder="leave blank to use SKILL.md description"></textarea>
+      </section>
+
+      <section class="control-group action-row">
+        <button id="start-btn" class="primary-btn" disabled>Start</button>
+        <button id="stop-btn" class="ghost-btn" disabled>Stop</button>
+      </section>
+
+      <section class="control-group action-row">
+        <button id="apply-best-btn" class="success-btn" disabled>Apply best to SKILL.md</button>
+      </section>
+    </aside>
+
+    <main class="main">
+      <section class="status-card">
+        <div class="status-row">
+          <strong>Run:</strong> <span id="run-id">—</span>
+          <strong>Status:</strong> <span id="run-status" class="pill pill-idle">idle</span>
+          <strong>Iter:</strong> <span id="run-iter">0</span> / <span id="run-iter-max">—</span>
+        </div>
+        <div class="status-row">
+          <strong>Best:</strong> <span id="best-score">—</span>
+          <strong>Train:</strong> <span id="train-size">—</span>
+          <strong>Test:</strong> <span id="test-size">—</span>
+        </div>
+        <div class="best-desc-card">
+          <div class="best-desc-label">Current best description</div>
+          <div id="best-description">—</div>
+        </div>
+      </section>
+
+      <section class="results-card">
+        <div class="results-table-wrap">
+          <table id="results-table">
+            <thead>
+              <tr id="results-thead-row">
+                <th>Iter</th>
+                <th>Train</th>
+                <th>Test</th>
+                <th class="desc-col">Description</th>
+              </tr>
+            </thead>
+            <tbody id="results-tbody"></tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <dialog id="runs-modal" class="runs-modal">
+    <h2>Recent runs</h2>
+    <ul id="runs-list"></ul>
+    <button class="ghost-btn" onclick="document.getElementById('runs-modal').close()">close</button>
+  </dialog>
+
+  <script src="/static/app.js"></script>
+</body>
+</html>

--- a/skills/skill-creator/eval-server/static/styles.css
+++ b/skills/skill-creator/eval-server/static/styles.css
@@ -1,0 +1,368 @@
+/* skill-creator eval dashboard — Anthropic-style theme */
+
+:root {
+  --bg: #faf9f5;
+  --surface: #ffffff;
+  --surface-2: #f5f3ec;
+  --border: #e8e6dc;
+  --text: #141413;
+  --text-muted: #6f6c5f;
+  --text-faint: #b0aea5;
+  --accent: #d97757;
+  --accent-hover: #c4613f;
+  --green: #788c5d;
+  --green-bg: #eef2e8;
+  --red: #c44;
+  --red-bg: #fceaea;
+  --blue: #6a9bcc;
+  --blue-bg: #f0f6fc;
+  --amber: #d97706;
+  --amber-bg: #fef3c7;
+  --header-bg: #141413;
+  --header-text: #faf9f5;
+  --radius: 8px;
+  --shadow-sm: 0 1px 2px rgba(20, 20, 19, 0.05);
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: 'Lora', Georgia, serif;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.topbar {
+  background: var(--header-bg);
+  color: var(--header-text);
+  padding: 0.75rem 1.5rem;
+  display: flex;
+  align-items: baseline;
+  gap: 1rem;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+.topbar h1 {
+  font-family: 'Poppins', sans-serif;
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+.topbar-sub {
+  font-size: 0.85rem;
+  opacity: 0.6;
+}
+.topbar-right {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 1.25rem;
+  padding: 1.25rem;
+  flex: 1;
+  min-height: 0;
+}
+@media (max-width: 900px) {
+  .layout { grid-template-columns: 1fr; }
+}
+
+.sidebar {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-self: start;
+  position: sticky;
+  top: 4rem;
+  max-height: calc(100vh - 5rem);
+  overflow-y: auto;
+}
+
+.main {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-width: 0;
+}
+
+.control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+.control-group label {
+  font-family: 'Poppins', sans-serif;
+  font-size: 0.78rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.control-group select,
+.control-group input[type="text"],
+.control-group input[type="number"],
+.control-group textarea {
+  font-family: inherit;
+  font-size: 0.9rem;
+  padding: 0.45rem 0.6rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--text);
+}
+.control-group textarea {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 0.78rem;
+  line-height: 1.4;
+  resize: vertical;
+}
+.control-group .hint {
+  font-size: 0.75rem;
+  color: var(--text-faint);
+  font-style: italic;
+}
+.control-group.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.6rem;
+}
+.control-group.grid-2 > div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+.control-group.grid-2 label {
+  font-size: 0.7rem;
+}
+.control-group.grid-2 input {
+  font-size: 0.85rem;
+  padding: 0.3rem 0.45rem;
+}
+
+.action-row {
+  flex-direction: row;
+  gap: 0.5rem;
+}
+.action-row > button {
+  flex: 1;
+}
+
+.paste-eval {
+  margin-top: 0.5rem;
+}
+.paste-eval summary {
+  cursor: pointer;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  user-select: none;
+}
+.paste-eval textarea {
+  margin-top: 0.4rem;
+  width: 100%;
+}
+
+button {
+  font-family: 'Poppins', sans-serif;
+  font-size: 0.85rem;
+  font-weight: 500;
+  padding: 0.55rem 0.9rem;
+  border-radius: 6px;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: background 0.12s, border-color 0.12s;
+}
+button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.primary-btn {
+  background: var(--accent);
+  color: white;
+}
+.primary-btn:not(:disabled):hover {
+  background: var(--accent-hover);
+}
+.ghost-btn {
+  background: transparent;
+  border-color: var(--border);
+  color: var(--text);
+}
+.ghost-btn:not(:disabled):hover {
+  background: var(--surface-2);
+}
+.success-btn {
+  background: var(--green);
+  color: white;
+}
+.success-btn:not(:disabled):hover {
+  background: #5e6f48;
+}
+
+.pill {
+  display: inline-block;
+  font-family: 'Poppins', sans-serif;
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0.18rem 0.5rem;
+  border-radius: 999px;
+}
+.pill-idle { background: var(--surface-2); color: var(--text-muted); }
+.pill-running { background: var(--blue-bg); color: var(--blue); }
+.pill-improving { background: var(--amber-bg); color: var(--amber); }
+.pill-complete { background: var(--green-bg); color: var(--green); }
+.pill-error { background: var(--red-bg); color: var(--red); }
+.pill-stopped { background: var(--surface-2); color: var(--text-muted); }
+
+.status-card,
+.results-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1rem 1.25rem;
+  box-shadow: var(--shadow-sm);
+}
+.status-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1.25rem;
+  align-items: center;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+.status-row strong {
+  color: var(--text);
+  font-family: 'Poppins', sans-serif;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.status-row + .status-row {
+  margin-top: 0.5rem;
+}
+
+.best-desc-card {
+  margin-top: 0.75rem;
+  background: var(--surface-2);
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+}
+.best-desc-label {
+  font-family: 'Poppins', sans-serif;
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 0.3rem;
+}
+#best-description {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 0.78rem;
+  line-height: 1.5;
+  color: var(--text);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.results-card {
+  padding: 0.5rem;
+}
+.results-table-wrap {
+  overflow-x: auto;
+}
+table {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 0.78rem;
+}
+th, td {
+  padding: 0.45rem 0.6rem;
+  border: 1px solid var(--border);
+  text-align: left;
+  vertical-align: top;
+}
+th {
+  font-family: 'Poppins', sans-serif;
+  background: var(--header-bg);
+  color: var(--header-text);
+  font-weight: 500;
+  white-space: nowrap;
+}
+th.test-col { background: var(--blue); }
+th.positive-col { border-bottom: 3px solid var(--green); }
+th.negative-col { border-bottom: 3px solid var(--red); }
+th.desc-col { min-width: 240px; max-width: 360px; }
+
+td.desc-cell {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 0.7rem;
+  word-break: break-word;
+  color: var(--text-muted);
+}
+td.result-cell {
+  text-align: center;
+  font-size: 1rem;
+}
+td.result-cell .rate {
+  display: block;
+  font-size: 0.65rem;
+  color: var(--text-faint);
+}
+td.test-result-cell { background: var(--blue-bg); }
+.pass { color: var(--green); }
+.fail { color: var(--red); }
+
+.score-pill {
+  display: inline-block;
+  font-family: 'Poppins', sans-serif;
+  font-size: 0.72rem;
+  font-weight: 500;
+  padding: 0.15rem 0.45rem;
+  border-radius: 4px;
+}
+.score-good { background: var(--green-bg); color: var(--green); }
+.score-ok { background: var(--amber-bg); color: var(--amber); }
+.score-bad { background: var(--red-bg); color: var(--red); }
+
+tr.best-row {
+  background: var(--green-bg);
+}
+
+.runs-modal {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  background: var(--surface);
+  max-width: 600px;
+}
+.runs-modal h2 {
+  font-family: 'Poppins', sans-serif;
+  font-size: 1rem;
+  margin-bottom: 0.75rem;
+}
+#runs-list {
+  list-style: none;
+  margin-bottom: 1rem;
+}
+#runs-list li {
+  border-bottom: 1px solid var(--border);
+  padding: 0.5rem 0;
+  font-size: 0.85rem;
+}
+#runs-list li button {
+  margin-left: 0.5rem;
+}

--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -3,16 +3,25 @@
 
 Tests whether a skill's description causes Claude to trigger (read the skill)
 for a set of queries. Outputs results as JSON.
+
+Mechanism: atomically swaps the candidate description into the real
+~/.claude/skills/<name>/SKILL.md frontmatter, runs `claude -p <query>` for
+each test query, watches the stream for a Skill tool invocation matching
+the real skill name, then restores the original SKILL.md. Tests the
+production skill-router path with no mocks.
 """
 
 import argparse
+import atexit
 import json
 import os
+import re
 import select
+import signal
 import subprocess
 import sys
+import threading
 import time
-import uuid
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
 
@@ -20,11 +29,7 @@ from scripts.utils import parse_skill_md
 
 
 def find_project_root() -> Path:
-    """Find the project root by walking up from cwd looking for .claude/.
-
-    Mimics how Claude Code discovers its project root, so the command file
-    we create ends up where claude -p will look for it.
-    """
+    """Find the project root by walking up from cwd looking for .claude/."""
     current = Path.cwd()
     for parent in [current, *current.parents]:
         if (parent / ".claude").is_dir():
@@ -32,153 +37,265 @@ def find_project_root() -> Path:
     return current
 
 
+_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n", re.DOTALL)
+
+
+def _replace_description_in_frontmatter(content: str, new_description: str) -> str:
+    """Replace description field in YAML frontmatter with a block scalar.
+
+    Handles all four YAML description forms (single-line, quoted, |, >, |-, >-)
+    by removing the existing description (and any continuation block) and
+    inserting `description: |-` followed by indented body. Preserves
+    every other frontmatter field and the post-frontmatter content.
+    """
+    match = _FRONTMATTER_RE.match(content)
+    if not match:
+        raise ValueError("SKILL.md missing frontmatter (no opening ---\\n...---\\n block)")
+
+    fm_body = match.group(1)
+    rest = content[match.end():]
+
+    lines = fm_body.split("\n")
+    out_lines: list[str] = []
+    i = 0
+    inserted = False
+    while i < len(lines):
+        line = lines[i]
+        if line.startswith("description:"):
+            value = line[len("description:"):].strip()
+            i += 1
+            if value in (">", "|", ">-", "|-"):
+                while i < len(lines) and (lines[i].startswith("  ") or lines[i].startswith("\t") or lines[i].strip() == ""):
+                    i += 1
+            indented = "\n".join("  " + bl for bl in new_description.split("\n"))
+            out_lines.append(f"description: |-\n{indented}")
+            inserted = True
+            continue
+        out_lines.append(line)
+        i += 1
+
+    if not inserted:
+        indented = "\n".join("  " + bl for bl in new_description.split("\n"))
+        out_lines.append(f"description: |-\n{indented}")
+
+    new_fm = "\n".join(out_lines)
+    return f"---\n{new_fm}\n---\n{rest}"
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    """Write file atomically via tmp+rename in the same directory."""
+    tmp = path.with_suffix(path.suffix + ".swap-tmp")
+    tmp.write_text(content)
+    tmp.replace(path)
+
+
+_active_swaps: dict[str, str] = {}
+_swap_lock = threading.Lock()
+
+
+def _restore_all_active_swaps() -> None:
+    """atexit/signal handler — restore every SKILL.md still in swap state."""
+    with _swap_lock:
+        items = list(_active_swaps.items())
+        _active_swaps.clear()
+    for skill_md_str, original in items:
+        try:
+            _atomic_write(Path(skill_md_str), original)
+            backup = Path(skill_md_str).with_suffix(".md.swap-backup")
+            backup.unlink(missing_ok=True)
+        except Exception as e:
+            print(f"WARN: failed to restore {skill_md_str}: {e}", file=sys.stderr)
+
+
+atexit.register(_restore_all_active_swaps)
+
+
+def _signal_handler(signum, frame):
+    _restore_all_active_swaps()
+    signal.signal(signum, signal.SIG_DFL)
+    os.kill(os.getpid(), signum)
+
+
+for _sig in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP):
+    try:
+        signal.signal(_sig, _signal_handler)
+    except (OSError, ValueError):
+        pass
+
+
+def swap_skill_description(skill_path: Path, new_description: str) -> str:
+    """Replace description in real SKILL.md atomically. Return original full content.
+
+    Writes a sibling `.md.swap-backup` first as crash-safety: if the Python
+    process dies between swap and restore, the user can manually restore
+    from the backup file.
+    """
+    skill_md = skill_path / "SKILL.md"
+    original = skill_md.read_text()
+    new_content = _replace_description_in_frontmatter(original, new_description)
+
+    backup = skill_md.with_suffix(".md.swap-backup")
+    backup.write_text(original)
+
+    _atomic_write(skill_md, new_content)
+
+    with _swap_lock:
+        _active_swaps[str(skill_md)] = original
+    return original
+
+
+def restore_skill_md(skill_path: Path, original: str) -> None:
+    """Restore SKILL.md and remove the swap backup file."""
+    skill_md = skill_path / "SKILL.md"
+    _atomic_write(skill_md, original)
+    backup = skill_md.with_suffix(".md.swap-backup")
+    backup.unlink(missing_ok=True)
+    with _swap_lock:
+        _active_swaps.pop(str(skill_md), None)
+
+
 def run_single_query(
     query: str,
     skill_name: str,
-    skill_description: str,
     timeout: int,
     project_root: str,
     model: str | None = None,
 ) -> bool:
-    """Run a single query and return whether the skill was triggered.
+    """Run a single query against the real skill-router and report whether
+    the named skill was invoked.
 
-    Creates a command file in .claude/commands/ so it appears in Claude's
-    available_skills list, then runs `claude -p` with the raw query.
-    Uses --include-partial-messages to detect triggering early from
-    stream events (content_block_start) rather than waiting for the
-    full assistant message, which only arrives after tool execution.
+    Spawns `claude -p <query> --output-format stream-json --include-partial-messages`,
+    watches the NDJSON stream for a `tool_use` block where:
+      - tool name is "Skill" and `input.skill == skill_name`, OR
+      - tool name is "Read" and the path contains `/skills/<skill_name>/SKILL.md`
+    Returns on first decision (early exit on first tool_use block) or on
+    `message_stop` / `result` event.
+
+    Caller must have already swapped the candidate description into
+    ~/.claude/skills/<skill_name>/SKILL.md. This function does not touch
+    SKILL.md — it only observes router behaviour.
     """
-    unique_id = uuid.uuid4().hex[:8]
-    clean_name = f"{skill_name}-skill-{unique_id}"
-    project_commands_dir = Path(project_root) / ".claude" / "commands"
-    command_file = project_commands_dir / f"{clean_name}.md"
+    cmd = [
+        "claude",
+        "-p", query,
+        "--output-format", "stream-json",
+        "--verbose",
+        "--include-partial-messages",
+    ]
+    if model:
+        cmd.extend(["--model", model])
+
+    env = os.environ.copy()
+    env["BROWSER"] = "false"
+    env["PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD"] = "1"
+
+    process = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        cwd=project_root,
+        env=env,
+    )
+
+    triggered = False
+    start_time = time.time()
+    buffer = ""
+    pending_tool_name: str | None = None
+    accumulated_json = ""
+
+    skill_md_marker = f"/skills/{skill_name}/SKILL.md"
+
+    def matches(tool_name: str, raw_input: str) -> bool:
+        if tool_name == "Skill":
+            try:
+                parsed = json.loads(raw_input) if raw_input else {}
+                return parsed.get("skill") == skill_name
+            except json.JSONDecodeError:
+                return f'"skill":"{skill_name}"' in raw_input or f'"skill": "{skill_name}"' in raw_input
+        if tool_name == "Read":
+            return skill_md_marker in raw_input
+        return False
 
     try:
-        project_commands_dir.mkdir(parents=True, exist_ok=True)
-        # Use YAML block scalar to avoid breaking on quotes in description
-        indented_desc = "\n  ".join(skill_description.split("\n"))
-        command_content = (
-            f"---\n"
-            f"description: |\n"
-            f"  {indented_desc}\n"
-            f"---\n\n"
-            f"# {skill_name}\n\n"
-            f"This skill handles: {skill_description}\n"
-        )
-        command_file.write_text(command_content)
+        while time.time() - start_time < timeout:
+            if process.poll() is not None:
+                remaining = process.stdout.read()
+                if remaining:
+                    buffer += remaining.decode("utf-8", errors="replace")
+                break
 
-        cmd = [
-            "claude",
-            "-p", query,
-            "--output-format", "stream-json",
-            "--verbose",
-            "--include-partial-messages",
-        ]
-        if model:
-            cmd.extend(["--model", model])
+            ready, _, _ = select.select([process.stdout], [], [], 1.0)
+            if not ready:
+                continue
 
-        # Remove CLAUDECODE env var to allow nesting claude -p inside a
-        # Claude Code session. The guard is for interactive terminal conflicts;
-        # programmatic subprocess usage is safe.
-        env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+            chunk = os.read(process.stdout.fileno(), 8192)
+            if not chunk:
+                break
+            buffer += chunk.decode("utf-8", errors="replace")
 
-        process = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            cwd=project_root,
-            env=env,
-        )
-
-        triggered = False
-        start_time = time.time()
-        buffer = ""
-        # Track state for stream event detection
-        pending_tool_name = None
-        accumulated_json = ""
-
-        try:
-            while time.time() - start_time < timeout:
-                if process.poll() is not None:
-                    remaining = process.stdout.read()
-                    if remaining:
-                        buffer += remaining.decode("utf-8", errors="replace")
-                    break
-
-                ready, _, _ = select.select([process.stdout], [], [], 1.0)
-                if not ready:
+            while "\n" in buffer:
+                line, buffer = buffer.split("\n", 1)
+                line = line.strip()
+                if not line:
                     continue
 
-                chunk = os.read(process.stdout.fileno(), 8192)
-                if not chunk:
-                    break
-                buffer += chunk.decode("utf-8", errors="replace")
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
 
-                while "\n" in buffer:
-                    line, buffer = buffer.split("\n", 1)
-                    line = line.strip()
-                    if not line:
-                        continue
+                if event.get("type") == "stream_event":
+                    se = event.get("event", {})
+                    se_type = se.get("type", "")
 
-                    try:
-                        event = json.loads(line)
-                    except json.JSONDecodeError:
-                        continue
-
-                    # Early detection via stream events
-                    if event.get("type") == "stream_event":
-                        se = event.get("event", {})
-                        se_type = se.get("type", "")
-
-                        if se_type == "content_block_start":
-                            cb = se.get("content_block", {})
-                            if cb.get("type") == "tool_use":
-                                tool_name = cb.get("name", "")
-                                if tool_name in ("Skill", "Read"):
-                                    pending_tool_name = tool_name
-                                    accumulated_json = ""
-                                else:
-                                    return False
-
-                        elif se_type == "content_block_delta" and pending_tool_name:
-                            delta = se.get("delta", {})
-                            if delta.get("type") == "input_json_delta":
-                                accumulated_json += delta.get("partial_json", "")
-                                if clean_name in accumulated_json:
-                                    return True
-
-                        elif se_type in ("content_block_stop", "message_stop"):
-                            if pending_tool_name:
-                                return clean_name in accumulated_json
-                            if se_type == "message_stop":
+                    if se_type == "content_block_start":
+                        cb = se.get("content_block", {})
+                        if cb.get("type") == "tool_use":
+                            tool_name = cb.get("name", "")
+                            if tool_name in ("Skill", "Read"):
+                                pending_tool_name = tool_name
+                                accumulated_json = ""
+                                inline_input = cb.get("input")
+                                if inline_input:
+                                    if matches(tool_name, json.dumps(inline_input)):
+                                        return True
+                            else:
                                 return False
 
-                    # Fallback: full assistant message
-                    elif event.get("type") == "assistant":
-                        message = event.get("message", {})
-                        for content_item in message.get("content", []):
-                            if content_item.get("type") != "tool_use":
-                                continue
-                            tool_name = content_item.get("name", "")
-                            tool_input = content_item.get("input", {})
-                            if tool_name == "Skill" and clean_name in tool_input.get("skill", ""):
-                                triggered = True
-                            elif tool_name == "Read" and clean_name in tool_input.get("file_path", ""):
-                                triggered = True
-                            return triggered
+                    elif se_type == "content_block_delta" and pending_tool_name:
+                        delta = se.get("delta", {})
+                        if delta.get("type") == "input_json_delta":
+                            accumulated_json += delta.get("partial_json", "")
+                            if matches(pending_tool_name, accumulated_json):
+                                return True
 
-                    elif event.get("type") == "result":
+                    elif se_type in ("content_block_stop", "message_stop"):
+                        if pending_tool_name:
+                            return matches(pending_tool_name, accumulated_json)
+                        if se_type == "message_stop":
+                            return False
+
+                elif event.get("type") == "assistant":
+                    message = event.get("message", {})
+                    for content_item in message.get("content", []):
+                        if content_item.get("type") != "tool_use":
+                            continue
+                        tool_name = content_item.get("name", "")
+                        tool_input = content_item.get("input", {})
+                        if tool_name == "Skill" and tool_input.get("skill") == skill_name:
+                            triggered = True
+                        elif tool_name == "Read" and skill_md_marker in tool_input.get("file_path", ""):
+                            triggered = True
                         return triggered
-        finally:
-            # Clean up process on any exit path (return, exception, timeout)
-            if process.poll() is None:
-                process.kill()
-                process.wait()
 
-        return triggered
+                elif event.get("type") == "result":
+                    return triggered
     finally:
-        if command_file.exists():
-            command_file.unlink()
+        if process.poll() is None:
+            process.kill()
+            process.wait()
+
+    return triggered
 
 
 def run_eval(
@@ -188,72 +305,82 @@ def run_eval(
     num_workers: int,
     timeout: int,
     project_root: Path,
+    skill_path: Path,
     runs_per_query: int = 1,
     trigger_threshold: float = 0.5,
     model: str | None = None,
 ) -> dict:
-    """Run the full eval set and return results."""
-    results = []
+    """Run the full eval set with a single description swap.
 
-    with ProcessPoolExecutor(max_workers=num_workers) as executor:
-        future_to_info = {}
-        for item in eval_set:
-            for run_idx in range(runs_per_query):
-                future = executor.submit(
-                    run_single_query,
-                    item["query"],
-                    skill_name,
-                    description,
-                    timeout,
-                    str(project_root),
-                    model,
-                )
-                future_to_info[future] = (item, run_idx)
+    Swaps the candidate description into the real SKILL.md ONCE, runs all
+    parallel workers against the swapped skill, then restores. Description
+    is stable for the entire iteration so parallel workers are safe.
+    """
+    original_content = swap_skill_description(skill_path, description)
 
-        query_triggers: dict[str, list[bool]] = {}
-        query_items: dict[str, dict] = {}
-        for future in as_completed(future_to_info):
-            item, _ = future_to_info[future]
-            query = item["query"]
-            query_items[query] = item
-            if query not in query_triggers:
-                query_triggers[query] = []
-            try:
-                query_triggers[query].append(future.result())
-            except Exception as e:
-                print(f"Warning: query failed: {e}", file=sys.stderr)
-                query_triggers[query].append(False)
+    try:
+        results: list[dict] = []
 
-    for query, triggers in query_triggers.items():
-        item = query_items[query]
-        trigger_rate = sum(triggers) / len(triggers)
-        should_trigger = item["should_trigger"]
-        if should_trigger:
-            did_pass = trigger_rate >= trigger_threshold
-        else:
-            did_pass = trigger_rate < trigger_threshold
-        results.append({
-            "query": query,
-            "should_trigger": should_trigger,
-            "trigger_rate": trigger_rate,
-            "triggers": sum(triggers),
-            "runs": len(triggers),
-            "pass": did_pass,
-        })
+        with ProcessPoolExecutor(max_workers=num_workers) as executor:
+            future_to_info: dict = {}
+            for item in eval_set:
+                for run_idx in range(runs_per_query):
+                    future = executor.submit(
+                        run_single_query,
+                        item["query"],
+                        skill_name,
+                        timeout,
+                        str(project_root),
+                        model,
+                    )
+                    future_to_info[future] = (item, run_idx)
 
-    passed = sum(1 for r in results if r["pass"])
-    total = len(results)
+            query_triggers: dict[str, list[bool]] = {}
+            query_items: dict[str, dict] = {}
+            for future in as_completed(future_to_info):
+                item, _ = future_to_info[future]
+                query = item["query"]
+                query_items[query] = item
+                if query not in query_triggers:
+                    query_triggers[query] = []
+                try:
+                    query_triggers[query].append(future.result())
+                except Exception as exc:
+                    print(f"Warning: query failed: {exc}", file=sys.stderr)
+                    query_triggers[query].append(False)
 
-    return {
-        "skill_name": skill_name,
-        "description": description,
-        "results": results,
-        "summary": {
-            "total": total,
-            "passed": passed,
-            "failed": total - passed,
-        },
-    }
+        for query, triggers in query_triggers.items():
+            item = query_items[query]
+            trigger_rate = sum(triggers) / len(triggers)
+            should_trigger = item["should_trigger"]
+            if should_trigger:
+                did_pass = trigger_rate >= trigger_threshold
+            else:
+                did_pass = trigger_rate < trigger_threshold
+            results.append({
+                "query": query,
+                "should_trigger": should_trigger,
+                "trigger_rate": trigger_rate,
+                "triggers": sum(triggers),
+                "runs": len(triggers),
+                "pass": did_pass,
+            })
+
+        passed = sum(1 for r in results if r["pass"])
+        total = len(results)
+
+        return {
+            "skill_name": skill_name,
+            "description": description,
+            "results": results,
+            "summary": {
+                "total": total,
+                "passed": passed,
+                "failed": total - passed,
+            },
+        }
+    finally:
+        restore_skill_md(skill_path, original_content)
 
 
 def main():
@@ -261,7 +388,7 @@ def main():
     parser.add_argument("--eval-set", required=True, help="Path to eval set JSON file")
     parser.add_argument("--skill-path", required=True, help="Path to skill directory")
     parser.add_argument("--description", default=None, help="Override description to test")
-    parser.add_argument("--num-workers", type=int, default=10, help="Number of parallel workers")
+    parser.add_argument("--num-workers", type=int, default=4, help="Number of parallel workers")
     parser.add_argument("--timeout", type=int, default=30, help="Timeout per query in seconds")
     parser.add_argument("--runs-per-query", type=int, default=3, help="Number of runs per query")
     parser.add_argument("--trigger-threshold", type=float, default=0.5, help="Trigger rate threshold")
@@ -270,13 +397,13 @@ def main():
     args = parser.parse_args()
 
     eval_set = json.loads(Path(args.eval_set).read_text())
-    skill_path = Path(args.skill_path)
+    skill_path = Path(args.skill_path).resolve()
 
     if not (skill_path / "SKILL.md").exists():
         print(f"Error: No SKILL.md found at {skill_path}", file=sys.stderr)
         sys.exit(1)
 
-    name, original_description, content = parse_skill_md(skill_path)
+    name, original_description, _ = parse_skill_md(skill_path)
     description = args.description or original_description
     project_root = find_project_root()
 
@@ -290,6 +417,7 @@ def main():
         num_workers=args.num_workers,
         timeout=args.timeout,
         project_root=project_root,
+        skill_path=skill_path,
         runs_per_query=args.runs_per_query,
         trigger_threshold=args.trigger_threshold,
         model=args.model,

--- a/skills/skill-creator/scripts/run_loop.py
+++ b/skills/skill-creator/scripts/run_loop.py
@@ -93,6 +93,7 @@ def run_loop(
             num_workers=num_workers,
             timeout=timeout,
             project_root=project_root,
+            skill_path=skill_path,
             runs_per_query=runs_per_query,
             trigger_threshold=trigger_threshold,
             model=model,

--- a/skills/skill-creator/scripts/run_loop.py
+++ b/skills/skill-creator/scripts/run_loop.py
@@ -58,6 +58,8 @@ def run_loop(
     verbose: bool,
     live_report_path: Path | None = None,
     log_dir: Path | None = None,
+    progress_callback=None,
+    stop_signal=None,
 ) -> dict:
     """Run the eval + improvement loop."""
     project_root = find_project_root()
@@ -77,6 +79,19 @@ def run_loop(
     exit_reason = "unknown"
 
     for iteration in range(1, max_iterations + 1):
+        if stop_signal is not None and stop_signal.is_set():
+            exit_reason = f"stopped (iteration {iteration - 1})"
+            break
+        if progress_callback:
+            try:
+                progress_callback({
+                    "event": "iteration_start",
+                    "iteration": iteration,
+                    "max_iterations": max_iterations,
+                    "description": current_description,
+                })
+            except Exception:
+                pass
         if verbose:
             print(f"\n{'='*60}", file=sys.stderr)
             print(f"Iteration {iteration}/{max_iterations}", file=sys.stderr)
@@ -137,6 +152,18 @@ def run_loop(
             "results": train_results["results"],
         })
 
+        # Notify subscribers of finished iteration
+        if progress_callback:
+            try:
+                progress_callback({
+                    "event": "iteration_done",
+                    "iteration": iteration,
+                    "entry": history[-1],
+                    "elapsed_s": eval_elapsed,
+                })
+            except Exception:
+                pass
+
         # Write live report if path provided
         if live_report_path:
             partial_output = {
@@ -190,6 +217,12 @@ def run_loop(
         # Improve the description based on train results
         if verbose:
             print(f"\nImproving description...", file=sys.stderr)
+
+        if progress_callback:
+            try:
+                progress_callback({"event": "improving", "iteration": iteration})
+            except Exception:
+                pass
 
         t0 = time.time()
         # Strip test scores from history so improvement model can't see them


### PR DESCRIPTION
## Summary

Replaces the static `report.html` auto-refresh page with a live web dashboard backed by Server-Sent Events. Iterations land in the browser as they complete instead of forcing a full page reload every 5 seconds.

## Why

The legacy `generate_report.py` writes an HTML file with `<meta refresh content="5">`. With long iteration counts the document balloons (rows × queries × per-iteration details), and the browser re-parses + re-renders the entire DOM every tick. RAM and CPU climb steadily over a long run. SSE deltas patch the DOM incrementally — steady-state RAM stays flat.

## What's added

```
skills/skill-creator/eval-server/
├── README.md
├── server.py              FastAPI + SSE backend
├── start.sh               venv bootstrap + uvicorn launcher
├── requirements.txt       fastapi + uvicorn[standard]
└── static/
    ├── index.html         dashboard markup
    ├── styles.css         theme matching report.html (Lora/Poppins/cream)
    └── app.js             SSE consumer (no build step)
```

### Backend (`eval-server/server.py`)
- Spawns `run_loop` in a thread, fans out iteration events to a `queue.Queue` per SSE subscriber via `StreamingResponse`.
- Full snapshot replayed on initial connection so late-joiners see prior iterations.
- Endpoints:
  - `GET /api/health`
  - `GET /api/skills` — enumerate `~/.claude/skills/*`
  - `GET /api/skills/{name}` — description + auto-discovered eval sets
  - `POST /api/runs` — start a run, returns `run_id`
  - `GET /api/runs` — list active + recent runs
  - `GET /api/runs/{id}` — snapshot
  - `GET /api/runs/{id}/stream` — SSE
  - `POST /api/runs/{id}/stop` — cooperative stop
  - `POST /api/runs/{id}/apply` — write best back to SKILL.md (with `.md.apply-backup`)
- Auto-discovers candidate eval sets in `<skill>/evals/`, `<skill>/resources/`, `<skill>-workspace/`.

### Frontend (`eval-server/static/`)
- Pure vanilla JS / HTML / CSS — no build, no framework.
- All dynamic content set via `textContent` / `createElement` to avoid XSS.
- `EventSource` consumer handles `snapshot`, `iteration_start`, `iteration_done`, `improving`, `loop_done`, `error` events.
- Best-iteration row highlighted live.

### `scripts/run_loop.py` refactor
- New `progress_callback` and `stop_signal` kwargs (both default `None` — backward-compatible with existing CLI/script callers).
- `progress_callback` fires on `iteration_start`, `iteration_done`, `improving`, `loop_done`.
- `stop_signal` is a `threading.Event` for cooperative shutdown checked at iteration boundaries.

## Bootstrap

```bash
cd skills/skill-creator/eval-server
portless eval ./start.sh
# → http://eval.localhost:1355
```

`start.sh` creates `.venv` + installs `requirements.txt` on first run.

## Test plan

- [ ] `./start.sh` boots cleanly, `/api/health` returns 200.
- [ ] `/api/skills` returns the skill list with description previews.
- [ ] `POST /api/runs` returns a `run_id` and immediately starts streaming via `/api/runs/{id}/stream`.
- [ ] SSE stream emits `snapshot → iteration_done → loop_done` in order.
- [ ] `Apply best` button writes the winning description and creates `.md.apply-backup`.
- [ ] Killing uvicorn mid-run leaves SKILL.md intact (signal handlers restore).

## Compatibility

The static `generate_report.py` path is **not removed** — kept for offline / file-based report sharing.

## Dependency

Depends on the `run_eval.py` fix in #1027 — uses the new `_replace_description_in_frontmatter` and `_atomic_write` helpers from that PR. The diff in this PR includes those changes; merge order matters (1027 first, then this).