### PR TITLE
feat(skill-creator): MCP server exposing trigger eval pipeline as LLM tools

### DIFF
--- a/skills/skill-creator/.gitignore
+++ b/skills/skill-creator/.gitignore
@@ -1,0 +1,9 @@
+.project/
+__pycache__/
+*.pyc
+.venv/
+mcp/.venv/
+eval-server/.venv/
+*.swap-tmp
+*.swap-backup
+*.apply-backup

--- a/skills/skill-creator/mcp/README.md
+++ b/skills/skill-creator/mcp/README.md
@@ -1,0 +1,127 @@
+# skill_eval_mcp
+
+MCP server exposing skill-creator's Phase 3 trigger evaluation pipeline as
+LLM-callable tools. Lets any agent (Claude Code, Cursor, Cline, raw API)
+run a real-world trigger evaluation against an installed skill, kick off
+an optimization loop, and apply the winning description back to `SKILL.md`.
+
+## Stack
+
+- **Language:** Python 3.10+
+- **SDK:** `mcp[cli]` (FastMCP) + Pydantic v2
+- **Transport:** stdio (local Claude Code integration)
+- **Auth:** none — inherits parent CC's OAuth via the `claude -p`
+  subprocesses spawned by `run_eval.run_single_query`
+
+## Tools (8)
+
+All service-prefixed `skill_eval_*` to avoid collisions:
+
+| Tool                                  | Purpose                                              | Sync? |
+|---------------------------------------|------------------------------------------------------|-------|
+| `skill_eval_list_skills`              | enumerate ~/.claude/skills/*                         | sync  |
+| `skill_eval_get_skill`                | description + auto-discovered candidate eval sets    | sync  |
+| `skill_eval_run_trigger_eval`         | one-shot eval, returns precision/recall/accuracy     | sync  |
+| `skill_eval_start_optimization`       | full eval+improve loop in background, returns run_id | async |
+| `skill_eval_get_run_status`           | poll run by id                                       | sync  |
+| `skill_eval_list_runs`                | list active + recent runs                            | sync  |
+| `skill_eval_apply_best_description`   | write best description to SKILL.md                   | sync  |
+| `skill_eval_stop_run`                 | cooperative stop                                     | sync  |
+
+All inputs validated by Pydantic models with `extra="forbid"` to reject
+LLM hallucinated parameters. Tool descriptions are mini-manuals
+(Args/Returns/Use-when/Notes) for unambiguous LLM use.
+
+## Install
+
+Bootstrap deps first:
+
+```bash
+cd skills/skill-creator/mcp
+./start.sh   # creates .venv, installs mcp[cli] + pydantic, then runs server
+# stdio server runs on stdin/stdout — no port to open. Ctrl+C to stop.
+```
+
+Register with Claude Code (user scope so it's available everywhere):
+
+```bash
+claude mcp add skill-eval --scope user --transport stdio -- \
+  /home/johnzealanddoyle/skills/skills/skill-creator/mcp/start.sh
+```
+
+Or project-scoped (commit to `.mcp.json`):
+
+```bash
+claude mcp add skill-eval --scope project --transport stdio -- \
+  ./skills/skill-creator/mcp/start.sh
+```
+
+Verify:
+
+```bash
+claude mcp list | grep skill-eval
+```
+
+## Use from Claude Code
+
+Once installed, any agent in any session can call:
+
+```
+skill_eval_list_skills()
+skill_eval_get_skill(name="medusa-pro")
+skill_eval_run_trigger_eval(
+    skill_path="/home/.../medusa-pro",
+    eval_set_path="/home/.../medusa-pro-workspace/trigger-eval.json",
+    description="Use this skill when ...",  # optional
+    model="claude-sonnet-4-6",
+    runs_per_query=2
+)
+# Returns: {precision, recall, accuracy, results, elapsed_s}
+```
+
+For a long optimization:
+
+```
+{run_id} = skill_eval_start_optimization(
+    skill_path=...,
+    eval_set_path=...,
+    max_iterations=3,
+    holdout=0.4
+)
+# Poll periodically:
+status = skill_eval_get_run_status(run_id=run_id)
+# When status.status == "complete":
+skill_eval_apply_best_description(run_id=run_id)
+```
+
+## Why this exists
+
+`skill-creator` ships a CLI (`python -m scripts.run_loop`) but it's
+awkward for agents to drive — they'd need to spawn a subprocess, parse
+stdout JSON, manage backpressure, etc. The MCP server packages the same
+logic as first-class LLM tools.
+
+The `eval-server` SSE dashboard (`../eval-server/`) is the human-facing
+counterpart — same primitives, web UI instead of MCP.
+
+## Files
+
+```
+mcp/
+├── README.md           this file
+├── server.py           FastMCP server + 8 tool definitions
+├── start.sh            venv bootstrap + stdio launcher
+└── requirements.txt    mcp[cli] + pydantic
+```
+
+## Compliance
+
+Designed against `mcp-server-best-practices` skill v0.5.1:
+
+- Service-prefixed tool names (`skill_eval_*`)
+- Pydantic v2 with `extra="forbid"` on all inputs
+- Tool annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`)
+- Mini-manual docstrings (Args / Returns / Use-when / Notes)
+- Error bifurcation
+- stdout reserved for JSON-RPC; logs to stderr
+- stdio transport (recommended for local CC integration)

--- a/skills/skill-creator/mcp/requirements.txt
+++ b/skills/skill-creator/mcp/requirements.txt
@@ -1,0 +1,2 @@
+mcp[cli]>=1.0
+pydantic>=2.0

--- a/skills/skill-creator/mcp/server.py
+++ b/skills/skill-creator/mcp/server.py
@@ -1,0 +1,603 @@
+"""skill_eval_mcp — MCP server exposing skill-creator's Phase 3 trigger
+evaluation pipeline to LLMs.
+
+Tools (all `skill_eval_*` service-prefixed):
+  - skill_eval_list_skills            : enumerate installed skills
+  - skill_eval_get_skill              : description + candidate eval sets
+  - skill_eval_run_trigger_eval       : sync, single description against an eval set
+  - skill_eval_start_optimization     : async, returns run_id
+  - skill_eval_get_run_status         : poll a run by id
+  - skill_eval_list_runs              : list active + recent runs
+  - skill_eval_apply_best_description : write winning description back to SKILL.md
+  - skill_eval_stop_run               : cooperative stop
+
+Transport: stdio (local Claude Code integration). No auth — inherits the
+parent CC session's OAuth when `claude -p` subprocesses are spawned by
+the underlying `run_loop` / `run_eval`.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Optional
+
+from mcp.server.fastmcp import FastMCP
+from pydantic import BaseModel, ConfigDict, Field
+
+# Make scripts.* importable from skill-creator/
+SKILL_CREATOR_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SKILL_CREATOR_DIR))
+
+from scripts.run_eval import (  # noqa: E402
+    _atomic_write,
+    _replace_description_in_frontmatter,
+    find_project_root,
+    run_eval as _run_eval,
+)
+from scripts.run_loop import run_loop as _run_loop  # noqa: E402
+from scripts.utils import parse_skill_md  # noqa: E402
+
+SKILLS_DIR = Path.home() / ".claude" / "skills"
+
+mcp = FastMCP("skill_eval_mcp")
+
+_runs: dict[str, dict] = {}
+_runs_lock = threading.Lock()
+
+
+# ---------- Pydantic input models ----------
+
+class _StrictModel(BaseModel):
+    model_config = ConfigDict(
+        str_strip_whitespace=True,
+        validate_assignment=True,
+        extra="forbid",
+    )
+
+
+class ListSkillsInput(_StrictModel):
+    """No parameters."""
+
+
+class GetSkillInput(_StrictModel):
+    name: str = Field(
+        ...,
+        min_length=1,
+        max_length=200,
+        description="Skill directory name under ~/.claude/skills/, e.g. 'medusa-pro'",
+    )
+
+
+class RunTriggerInput(_StrictModel):
+    skill_path: str = Field(..., description="Absolute path to skill directory containing SKILL.md")
+    eval_set_path: str = Field(..., description="Absolute path to JSON eval set (list of {query, should_trigger})")
+    description: Optional[str] = Field(
+        default=None,
+        description="Override description to test. If omitted, uses existing SKILL.md description.",
+    )
+    model: str = Field(default="claude-sonnet-4-6", description="Claude model id (e.g. claude-sonnet-4-6, claude-haiku-4-5).")
+    num_workers: int = Field(default=1, ge=1, le=8, description="Parallel `claude -p` workers per iteration.")
+    runs_per_query: int = Field(default=1, ge=1, le=5, description="How many times to run each query for stability.")
+    timeout: int = Field(default=60, ge=15, le=300, description="Per-query subprocess timeout in seconds.")
+    trigger_threshold: float = Field(default=0.5, ge=0.0, le=1.0, description="Pass threshold on trigger rate.")
+
+
+class StartOptimizationInput(RunTriggerInput):
+    max_iterations: int = Field(default=3, ge=1, le=10, description="Max improvement iterations.")
+    holdout: float = Field(default=0.4, ge=0.0, le=0.7, description="Test/train holdout fraction (stratified). 0 disables.")
+
+
+class RunIdInput(_StrictModel):
+    run_id: str = Field(..., min_length=1, description="Run identifier returned by skill_eval_start_optimization.")
+
+
+# ---------- helpers ----------
+
+def _enumerate_skills() -> list[dict]:
+    if not SKILLS_DIR.is_dir():
+        return []
+    out = []
+    for p in sorted(SKILLS_DIR.iterdir()):
+        if not p.exists():
+            continue
+        try:
+            real = p.resolve()
+        except OSError:
+            continue
+        if not (real / "SKILL.md").is_file():
+            continue
+        try:
+            name, desc, _ = parse_skill_md(real)
+        except Exception:
+            continue
+        out.append({
+            "name": name,
+            "link_path": str(p),
+            "real_path": str(real),
+            "description_preview": desc[:160],
+            "description_len": len(desc),
+        })
+    return out
+
+
+def _discover_candidates(skill_real: Path, name: str) -> list[dict]:
+    candidates: list[dict] = []
+    seen: set[str] = set()
+    roots = [
+        skill_real / "evals",
+        skill_real / "resources",
+        skill_real.parent / f"{name}-workspace",
+    ]
+    for root in roots:
+        if not root.is_dir():
+            continue
+        for f in root.rglob("*.json"):
+            if str(f) in seen:
+                continue
+            try:
+                data = json.loads(f.read_text())
+            except Exception:
+                continue
+            if not isinstance(data, list) or not data or not isinstance(data[0], dict):
+                continue
+            if "should_trigger" not in data[0] or "query" not in data[0]:
+                continue
+            should_count = sum(1 for q in data if q.get("should_trigger"))
+            candidates.append({
+                "path": str(f),
+                "size": len(data),
+                "should_trigger": should_count,
+                "should_not_trigger": len(data) - should_count,
+            })
+            seen.add(str(f))
+    candidates.sort(key=lambda c: c["size"], reverse=True)
+    return candidates
+
+
+def _summarize(results: list[dict]) -> dict:
+    """Compute precision / recall / accuracy from per-query results."""
+    tp = fp = tn = fn = 0
+    for r in results:
+        runs = r.get("runs", 0)
+        triggers = r.get("triggers", 0)
+        if r.get("should_trigger"):
+            tp += triggers
+            fn += runs - triggers
+        else:
+            fp += triggers
+            tn += runs - triggers
+    total = tp + fp + tn + fn
+    return {
+        "tp": tp, "fp": fp, "tn": tn, "fn": fn,
+        "precision": tp / (tp + fp) if (tp + fp) else 1.0,
+        "recall": tp / (tp + fn) if (tp + fn) else 1.0,
+        "accuracy": (tp + tn) / total if total else 0.0,
+    }
+
+
+def _err(msg: str) -> dict:
+    return {"isError": True, "error": msg}
+
+
+# ---------- Tools ----------
+
+@mcp.tool(
+    name="skill_eval_list_skills",
+    annotations={
+        "title": "List installed skills",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+)
+async def skill_eval_list_skills(params: ListSkillsInput) -> str:
+    """Enumerate every skill under ~/.claude/skills/ that has a valid SKILL.md.
+
+    Returns:
+        JSON object with `count` and `skills` array. Each skill has `name`,
+        `link_path`, `real_path`, `description_preview` (first 160 chars),
+        and `description_len`.
+
+    Use when: agent needs to know which skills are evaluable on this machine,
+    or needs to fuzzy-match a name the user mentioned.
+    """
+    skills = _enumerate_skills()
+    return json.dumps({"count": len(skills), "skills": skills}, indent=2)
+
+
+@mcp.tool(
+    name="skill_eval_get_skill",
+    annotations={
+        "title": "Get skill metadata",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+)
+async def skill_eval_get_skill(params: GetSkillInput) -> str:
+    """Get a skill's full description and auto-discovered candidate eval sets.
+
+    Args:
+        name (str): Skill name as it appears under ~/.claude/skills/.
+
+    Returns:
+        JSON object with `name`, `description`, `skill_path`, and
+        `eval_candidates`. Each candidate has `path`, `size`,
+        `should_trigger` count, `should_not_trigger` count.
+
+    Eval set discovery looks under <skill>/evals/, <skill>/resources/,
+    and the sibling <skill>-workspace/ directory for JSON files matching
+    [{query, should_trigger}, ...].
+
+    Use when: agent needs the canonical description before testing a
+    proposed rewrite, or needs to discover existing eval sets to reuse.
+    """
+    p = SKILLS_DIR / params.name
+    if not (p / "SKILL.md").exists():
+        return json.dumps(_err(f"no skill named '{params.name}' found at {p}"))
+    real = p.resolve()
+    name, desc, _ = parse_skill_md(real)
+    return json.dumps({
+        "name": name,
+        "description": desc,
+        "skill_path": str(real),
+        "eval_candidates": _discover_candidates(real, name),
+    }, indent=2)
+
+
+@mcp.tool(
+    name="skill_eval_run_trigger_eval",
+    annotations={
+        "title": "Run trigger eval (single shot, no improvement loop)",
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    },
+)
+async def skill_eval_run_trigger_eval(params: RunTriggerInput) -> str:
+    """Run a single trigger evaluation pass. Synchronous — blocks until complete.
+
+    Mechanism: temporarily writes the candidate description into the real
+    ~/.claude/skills/<name>/SKILL.md, runs `claude -p` subprocesses for
+    every query in the eval set, observes which queries cause the skill
+    to load, then restores the original SKILL.md.
+
+    Args:
+        skill_path (str): absolute path to skill dir
+        eval_set_path (str): JSON file [{query, should_trigger}, ...]
+        description (str, optional): override description; default = current
+        model (str): claude model id, default claude-sonnet-4-6
+        num_workers (int): 1-8 parallel workers, default 1
+        runs_per_query (int): repeat each query for stability, default 1
+        timeout (int): per-subprocess seconds, default 60
+        trigger_threshold (float): pass threshold, default 0.5
+
+    Returns:
+        JSON: precision, recall, accuracy, per-query results, total elapsed.
+
+    Use when: validate ONE description without the iterative rewrite loop.
+    For full optimization use skill_eval_start_optimization.
+
+    Notes: temporarily edits SKILL.md and relies on try/finally + signal
+    handlers to restore. If the host process dies hard mid-run, a
+    `.md.swap-backup` sibling file holds the pre-swap content.
+    """
+    skill_path = Path(params.skill_path).resolve()
+    if not (skill_path / "SKILL.md").exists():
+        return json.dumps(_err(f"no SKILL.md at {skill_path}"))
+    eval_set_path = Path(params.eval_set_path).resolve()
+    if not eval_set_path.is_file():
+        return json.dumps(_err(f"eval set not found: {eval_set_path}"))
+    try:
+        eval_set = json.loads(eval_set_path.read_text())
+    except Exception as exc:
+        return json.dumps(_err(f"bad eval set JSON: {exc}"))
+    if not isinstance(eval_set, list) or not eval_set:
+        return json.dumps(_err("eval set must be a non-empty list"))
+
+    name, original_desc, _ = parse_skill_md(skill_path)
+    description = params.description or original_desc
+    project_root = find_project_root()
+
+    t0 = time.time()
+    try:
+        result = _run_eval(
+            eval_set=eval_set,
+            skill_name=name,
+            description=description,
+            num_workers=params.num_workers,
+            timeout=params.timeout,
+            project_root=project_root,
+            skill_path=skill_path,
+            runs_per_query=params.runs_per_query,
+            trigger_threshold=params.trigger_threshold,
+            model=params.model,
+        )
+    except Exception as exc:
+        return json.dumps(_err(f"{type(exc).__name__}: {exc}"))
+    elapsed = time.time() - t0
+
+    metrics = _summarize(result["results"])
+    return json.dumps({
+        "skill_name": name,
+        "description_used": description,
+        "summary": result["summary"],
+        "metrics": metrics,
+        "results": result["results"],
+        "elapsed_s": round(elapsed, 1),
+    }, indent=2)
+
+
+@mcp.tool(
+    name="skill_eval_start_optimization",
+    annotations={
+        "title": "Start description optimization loop (async)",
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    },
+)
+async def skill_eval_start_optimization(params: StartOptimizationInput) -> str:
+    """Kick off the full eval+improve loop in a background thread, return immediately.
+
+    The loop alternates: run eval -> if any train queries failed, ask
+    Claude (via `claude -p`) to rewrite the description -> run eval again.
+    Up to `max_iterations`. Stratified train/test split prevents overfit.
+
+    Args:
+        skill_path (str): absolute path to skill dir
+        eval_set_path (str): JSON file [{query, should_trigger}, ...]
+        description (str, optional): starting description; default = current
+        model (str): default claude-sonnet-4-6
+        num_workers, runs_per_query, timeout, trigger_threshold: as above
+        max_iterations (int): default 3
+        holdout (float): default 0.4 - fraction held out as test set
+
+    Returns:
+        JSON: {run_id, started_at}. Poll with skill_eval_get_run_status.
+
+    Use when: user wants automated optimization, not just a single
+    measurement. Long-running (~30s x eval_size x max_iterations).
+    """
+    skill_path = Path(params.skill_path).resolve()
+    if not (skill_path / "SKILL.md").exists():
+        return json.dumps(_err(f"no SKILL.md at {skill_path}"))
+    eval_set_path = Path(params.eval_set_path).resolve()
+    if not eval_set_path.is_file():
+        return json.dumps(_err(f"eval set not found: {eval_set_path}"))
+    try:
+        eval_set = json.loads(eval_set_path.read_text())
+    except Exception as exc:
+        return json.dumps(_err(f"bad eval set JSON: {exc}"))
+
+    run_id = uuid.uuid4().hex[:8]
+    stop_event = threading.Event()
+    state: dict = {
+        "run_id": run_id,
+        "status": "running",
+        "started_at": time.time(),
+        "params": params.model_dump(),
+        "history": [],
+        "stop_event": stop_event,
+        "result": None,
+        "error": None,
+    }
+    with _runs_lock:
+        _runs[run_id] = state
+
+    def progress_cb(evt: dict) -> None:
+        e = evt.get("event")
+        if e == "iteration_done":
+            with _runs_lock:
+                state["history"].append(evt["entry"])
+        elif e == "loop_done":
+            with _runs_lock:
+                state["status"] = "complete"
+                state["result"] = evt["result"]
+                state["finished_at"] = time.time()
+        elif e == "error":
+            with _runs_lock:
+                state["status"] = "error"
+                state["error"] = evt.get("error")
+                state["finished_at"] = time.time()
+
+    def thread_body() -> None:
+        try:
+            result = _run_loop(
+                eval_set=eval_set,
+                skill_path=skill_path,
+                description_override=params.description,
+                num_workers=params.num_workers,
+                timeout=params.timeout,
+                max_iterations=params.max_iterations,
+                runs_per_query=params.runs_per_query,
+                trigger_threshold=params.trigger_threshold,
+                holdout=params.holdout,
+                model=params.model,
+                verbose=False,
+                progress_callback=progress_cb,
+                stop_signal=stop_event,
+            )
+            progress_cb({"event": "loop_done", "result": result})
+        except Exception as exc:
+            progress_cb({"event": "error", "error": f"{type(exc).__name__}: {exc}"})
+
+    t = threading.Thread(target=thread_body, daemon=True)
+    state["thread"] = t
+    t.start()
+    return json.dumps({"run_id": run_id, "started_at": state["started_at"]}, indent=2)
+
+
+@mcp.tool(
+    name="skill_eval_get_run_status",
+    annotations={
+        "title": "Get optimization run status",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+)
+async def skill_eval_get_run_status(params: RunIdInput) -> str:
+    """Snapshot a run by id. Returns history (all completed iterations) and
+    final result if `status == complete`.
+
+    Args:
+        run_id (str): id from skill_eval_start_optimization
+
+    Returns:
+        JSON: {run_id, status, params, history, result, error, started_at,
+        finished_at, iterations_run}.
+
+    Use when: polling a long-running optimization for completion. Status
+    moves through: running -> complete | error | stopped.
+    """
+    with _runs_lock:
+        s = _runs.get(params.run_id)
+    if not s:
+        return json.dumps(_err(f"no run with id {params.run_id}"))
+    return json.dumps({
+        "run_id": params.run_id,
+        "status": s["status"],
+        "params": s["params"],
+        "history": s["history"],
+        "result": s.get("result"),
+        "error": s.get("error"),
+        "started_at": s["started_at"],
+        "finished_at": s.get("finished_at"),
+        "iterations_run": len(s["history"]),
+    }, indent=2, default=str)
+
+
+@mcp.tool(
+    name="skill_eval_list_runs",
+    annotations={
+        "title": "List recent runs",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+)
+async def skill_eval_list_runs(params: ListSkillsInput) -> str:
+    """Return all runs known to this server, newest first.
+
+    Returns:
+        JSON array of {run_id, status, started_at, finished_at,
+        iterations_run, skill_path}.
+    """
+    with _runs_lock:
+        items = list(_runs.items())
+    out = []
+    for rid, s in items:
+        out.append({
+            "run_id": rid,
+            "status": s["status"],
+            "started_at": s["started_at"],
+            "finished_at": s.get("finished_at"),
+            "iterations_run": len(s["history"]),
+            "skill_path": s["params"].get("skill_path"),
+        })
+    out.sort(key=lambda r: r["started_at"], reverse=True)
+    return json.dumps(out, indent=2)
+
+
+@mcp.tool(
+    name="skill_eval_apply_best_description",
+    annotations={
+        "title": "Apply winning description to SKILL.md",
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+)
+async def skill_eval_apply_best_description(params: RunIdInput) -> str:
+    """Write the run's best_description into the real SKILL.md.
+
+    Creates a sibling `.md.apply-backup` snapshot of the current SKILL.md
+    before overwriting. Atomic: tmp+rename. Frontmatter description field
+    is replaced via the same logic run_eval uses for swap+restore, so all
+    other frontmatter fields and the entire body are preserved.
+
+    Args:
+        run_id (str): completed run with a `result.best_description`
+
+    Returns:
+        JSON: {ok, applied_description, skill_md, backup}.
+
+    Use when: optimization completed and the agent has confirmed the
+    user wants to keep the winning description. Reverse via:
+        cp <backup> <skill_md>
+    """
+    with _runs_lock:
+        s = _runs.get(params.run_id)
+    if not s:
+        return json.dumps(_err(f"no run with id {params.run_id}"))
+    result = s.get("result")
+    if not result:
+        return json.dumps(_err(f"run {params.run_id} has no result yet (status={s['status']})"))
+
+    skill_path = Path(s["params"]["skill_path"])
+    skill_md = skill_path / "SKILL.md"
+    if not skill_md.exists():
+        return json.dumps(_err(f"SKILL.md missing at {skill_md}"))
+
+    backup = skill_md.with_suffix(".md.apply-backup")
+    backup.write_text(skill_md.read_text())
+
+    src = skill_md.read_text()
+    new = _replace_description_in_frontmatter(src, result["best_description"])
+    _atomic_write(skill_md, new)
+
+    return json.dumps({
+        "ok": True,
+        "applied_description": result["best_description"],
+        "skill_md": str(skill_md),
+        "backup": str(backup),
+    }, indent=2)
+
+
+@mcp.tool(
+    name="skill_eval_stop_run",
+    annotations={
+        "title": "Stop an in-progress optimization",
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+)
+async def skill_eval_stop_run(params: RunIdInput) -> str:
+    """Cooperatively stop an active run. Stops at the next iteration
+    boundary - does not interrupt an in-flight subprocess.
+
+    Args:
+        run_id (str)
+
+    Returns:
+        JSON: {ok}
+    """
+    with _runs_lock:
+        s = _runs.get(params.run_id)
+    if not s:
+        return json.dumps(_err(f"no run with id {params.run_id}"))
+    s["stop_event"].set()
+    return json.dumps({"ok": True}, indent=2)
+
+
+def main() -> None:
+    mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/skill-creator/mcp/start.sh
+++ b/skills/skill-creator/mcp/start.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Bootstrap + run the skill_eval MCP server (stdio transport).
+# Stdio is JSON-RPC only — all logging goes to stderr.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+if [ ! -d .venv ]; then
+  python3 -m venv .venv >&2
+fi
+
+if ! .venv/bin/python -c "import mcp" 2>/dev/null; then
+  .venv/bin/pip install --upgrade pip >&2 >/dev/null
+  .venv/bin/pip install -r requirements.txt >&2
+fi
+
+exec .venv/bin/python -u server.py

--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -3,16 +3,25 @@
 
 Tests whether a skill's description causes Claude to trigger (read the skill)
 for a set of queries. Outputs results as JSON.
+
+Mechanism: atomically swaps the candidate description into the real
+~/.claude/skills/<name>/SKILL.md frontmatter, runs `claude -p <query>` for
+each test query, watches the stream for a Skill tool invocation matching
+the real skill name, then restores the original SKILL.md. Tests the
+production skill-router path with no mocks.
 """
 
 import argparse
+import atexit
 import json
 import os
+import re
 import select
+import signal
 import subprocess
 import sys
+import threading
 import time
-import uuid
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
 
@@ -20,11 +29,7 @@ from scripts.utils import parse_skill_md
 
 
 def find_project_root() -> Path:
-    """Find the project root by walking up from cwd looking for .claude/.
-
-    Mimics how Claude Code discovers its project root, so the command file
-    we create ends up where claude -p will look for it.
-    """
+    """Find the project root by walking up from cwd looking for .claude/."""
     current = Path.cwd()
     for parent in [current, *current.parents]:
         if (parent / ".claude").is_dir():
@@ -32,153 +37,265 @@ def find_project_root() -> Path:
     return current
 
 
+_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n", re.DOTALL)
+
+
+def _replace_description_in_frontmatter(content: str, new_description: str) -> str:
+    """Replace description field in YAML frontmatter with a block scalar.
+
+    Handles all four YAML description forms (single-line, quoted, |, >, |-, >-)
+    by removing the existing description (and any continuation block) and
+    inserting `description: |-` followed by indented body. Preserves
+    every other frontmatter field and the post-frontmatter content.
+    """
+    match = _FRONTMATTER_RE.match(content)
+    if not match:
+        raise ValueError("SKILL.md missing frontmatter (no opening ---\\n...---\\n block)")
+
+    fm_body = match.group(1)
+    rest = content[match.end():]
+
+    lines = fm_body.split("\n")
+    out_lines: list[str] = []
+    i = 0
+    inserted = False
+    while i < len(lines):
+        line = lines[i]
+        if line.startswith("description:"):
+            value = line[len("description:"):].strip()
+            i += 1
+            if value in (">", "|", ">-", "|-"):
+                while i < len(lines) and (lines[i].startswith("  ") or lines[i].startswith("\t") or lines[i].strip() == ""):
+                    i += 1
+            indented = "\n".join("  " + bl for bl in new_description.split("\n"))
+            out_lines.append(f"description: |-\n{indented}")
+            inserted = True
+            continue
+        out_lines.append(line)
+        i += 1
+
+    if not inserted:
+        indented = "\n".join("  " + bl for bl in new_description.split("\n"))
+        out_lines.append(f"description: |-\n{indented}")
+
+    new_fm = "\n".join(out_lines)
+    return f"---\n{new_fm}\n---\n{rest}"
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    """Write file atomically via tmp+rename in the same directory."""
+    tmp = path.with_suffix(path.suffix + ".swap-tmp")
+    tmp.write_text(content)
+    tmp.replace(path)
+
+
+_active_swaps: dict[str, str] = {}
+_swap_lock = threading.Lock()
+
+
+def _restore_all_active_swaps() -> None:
+    """atexit/signal handler — restore every SKILL.md still in swap state."""
+    with _swap_lock:
+        items = list(_active_swaps.items())
+        _active_swaps.clear()
+    for skill_md_str, original in items:
+        try:
+            _atomic_write(Path(skill_md_str), original)
+            backup = Path(skill_md_str).with_suffix(".md.swap-backup")
+            backup.unlink(missing_ok=True)
+        except Exception as e:
+            print(f"WARN: failed to restore {skill_md_str}: {e}", file=sys.stderr)
+
+
+atexit.register(_restore_all_active_swaps)
+
+
+def _signal_handler(signum, frame):
+    _restore_all_active_swaps()
+    signal.signal(signum, signal.SIG_DFL)
+    os.kill(os.getpid(), signum)
+
+
+for _sig in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP):
+    try:
+        signal.signal(_sig, _signal_handler)
+    except (OSError, ValueError):
+        pass
+
+
+def swap_skill_description(skill_path: Path, new_description: str) -> str:
+    """Replace description in real SKILL.md atomically. Return original full content.
+
+    Writes a sibling `.md.swap-backup` first as crash-safety: if the Python
+    process dies between swap and restore, the user can manually restore
+    from the backup file.
+    """
+    skill_md = skill_path / "SKILL.md"
+    original = skill_md.read_text()
+    new_content = _replace_description_in_frontmatter(original, new_description)
+
+    backup = skill_md.with_suffix(".md.swap-backup")
+    backup.write_text(original)
+
+    _atomic_write(skill_md, new_content)
+
+    with _swap_lock:
+        _active_swaps[str(skill_md)] = original
+    return original
+
+
+def restore_skill_md(skill_path: Path, original: str) -> None:
+    """Restore SKILL.md and remove the swap backup file."""
+    skill_md = skill_path / "SKILL.md"
+    _atomic_write(skill_md, original)
+    backup = skill_md.with_suffix(".md.swap-backup")
+    backup.unlink(missing_ok=True)
+    with _swap_lock:
+        _active_swaps.pop(str(skill_md), None)
+
+
 def run_single_query(
     query: str,
     skill_name: str,
-    skill_description: str,
     timeout: int,
     project_root: str,
     model: str | None = None,
 ) -> bool:
-    """Run a single query and return whether the skill was triggered.
+    """Run a single query against the real skill-router and report whether
+    the named skill was invoked.
 
-    Creates a command file in .claude/commands/ so it appears in Claude's
-    available_skills list, then runs `claude -p` with the raw query.
-    Uses --include-partial-messages to detect triggering early from
-    stream events (content_block_start) rather than waiting for the
-    full assistant message, which only arrives after tool execution.
+    Spawns `claude -p <query> --output-format stream-json --include-partial-messages`,
+    watches the NDJSON stream for a `tool_use` block where:
+      - tool name is "Skill" and `input.skill == skill_name`, OR
+      - tool name is "Read" and the path contains `/skills/<skill_name>/SKILL.md`
+    Returns on first decision (early exit on first tool_use block) or on
+    `message_stop` / `result` event.
+
+    Caller must have already swapped the candidate description into
+    ~/.claude/skills/<skill_name>/SKILL.md. This function does not touch
+    SKILL.md — it only observes router behaviour.
     """
-    unique_id = uuid.uuid4().hex[:8]
-    clean_name = f"{skill_name}-skill-{unique_id}"
-    project_commands_dir = Path(project_root) / ".claude" / "commands"
-    command_file = project_commands_dir / f"{clean_name}.md"
+    cmd = [
+        "claude",
+        "-p", query,
+        "--output-format", "stream-json",
+        "--verbose",
+        "--include-partial-messages",
+    ]
+    if model:
+        cmd.extend(["--model", model])
+
+    env = os.environ.copy()
+    env["BROWSER"] = "false"
+    env["PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD"] = "1"
+
+    process = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        cwd=project_root,
+        env=env,
+    )
+
+    triggered = False
+    start_time = time.time()
+    buffer = ""
+    pending_tool_name: str | None = None
+    accumulated_json = ""
+
+    skill_md_marker = f"/skills/{skill_name}/SKILL.md"
+
+    def matches(tool_name: str, raw_input: str) -> bool:
+        if tool_name == "Skill":
+            try:
+                parsed = json.loads(raw_input) if raw_input else {}
+                return parsed.get("skill") == skill_name
+            except json.JSONDecodeError:
+                return f'"skill":"{skill_name}"' in raw_input or f'"skill": "{skill_name}"' in raw_input
+        if tool_name == "Read":
+            return skill_md_marker in raw_input
+        return False
 
     try:
-        project_commands_dir.mkdir(parents=True, exist_ok=True)
-        # Use YAML block scalar to avoid breaking on quotes in description
-        indented_desc = "\n  ".join(skill_description.split("\n"))
-        command_content = (
-            f"---\n"
-            f"description: |\n"
-            f"  {indented_desc}\n"
-            f"---\n\n"
-            f"# {skill_name}\n\n"
-            f"This skill handles: {skill_description}\n"
-        )
-        command_file.write_text(command_content)
+        while time.time() - start_time < timeout:
+            if process.poll() is not None:
+                remaining = process.stdout.read()
+                if remaining:
+                    buffer += remaining.decode("utf-8", errors="replace")
+                break
 
-        cmd = [
-            "claude",
-            "-p", query,
-            "--output-format", "stream-json",
-            "--verbose",
-            "--include-partial-messages",
-        ]
-        if model:
-            cmd.extend(["--model", model])
+            ready, _, _ = select.select([process.stdout], [], [], 1.0)
+            if not ready:
+                continue
 
-        # Remove CLAUDECODE env var to allow nesting claude -p inside a
-        # Claude Code session. The guard is for interactive terminal conflicts;
-        # programmatic subprocess usage is safe.
-        env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+            chunk = os.read(process.stdout.fileno(), 8192)
+            if not chunk:
+                break
+            buffer += chunk.decode("utf-8", errors="replace")
 
-        process = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            cwd=project_root,
-            env=env,
-        )
-
-        triggered = False
-        start_time = time.time()
-        buffer = ""
-        # Track state for stream event detection
-        pending_tool_name = None
-        accumulated_json = ""
-
-        try:
-            while time.time() - start_time < timeout:
-                if process.poll() is not None:
-                    remaining = process.stdout.read()
-                    if remaining:
-                        buffer += remaining.decode("utf-8", errors="replace")
-                    break
-
-                ready, _, _ = select.select([process.stdout], [], [], 1.0)
-                if not ready:
+            while "\n" in buffer:
+                line, buffer = buffer.split("\n", 1)
+                line = line.strip()
+                if not line:
                     continue
 
-                chunk = os.read(process.stdout.fileno(), 8192)
-                if not chunk:
-                    break
-                buffer += chunk.decode("utf-8", errors="replace")
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
 
-                while "\n" in buffer:
-                    line, buffer = buffer.split("\n", 1)
-                    line = line.strip()
-                    if not line:
-                        continue
+                if event.get("type") == "stream_event":
+                    se = event.get("event", {})
+                    se_type = se.get("type", "")
 
-                    try:
-                        event = json.loads(line)
-                    except json.JSONDecodeError:
-                        continue
-
-                    # Early detection via stream events
-                    if event.get("type") == "stream_event":
-                        se = event.get("event", {})
-                        se_type = se.get("type", "")
-
-                        if se_type == "content_block_start":
-                            cb = se.get("content_block", {})
-                            if cb.get("type") == "tool_use":
-                                tool_name = cb.get("name", "")
-                                if tool_name in ("Skill", "Read"):
-                                    pending_tool_name = tool_name
-                                    accumulated_json = ""
-                                else:
-                                    return False
-
-                        elif se_type == "content_block_delta" and pending_tool_name:
-                            delta = se.get("delta", {})
-                            if delta.get("type") == "input_json_delta":
-                                accumulated_json += delta.get("partial_json", "")
-                                if clean_name in accumulated_json:
-                                    return True
-
-                        elif se_type in ("content_block_stop", "message_stop"):
-                            if pending_tool_name:
-                                return clean_name in accumulated_json
-                            if se_type == "message_stop":
+                    if se_type == "content_block_start":
+                        cb = se.get("content_block", {})
+                        if cb.get("type") == "tool_use":
+                            tool_name = cb.get("name", "")
+                            if tool_name in ("Skill", "Read"):
+                                pending_tool_name = tool_name
+                                accumulated_json = ""
+                                inline_input = cb.get("input")
+                                if inline_input:
+                                    if matches(tool_name, json.dumps(inline_input)):
+                                        return True
+                            else:
                                 return False
 
-                    # Fallback: full assistant message
-                    elif event.get("type") == "assistant":
-                        message = event.get("message", {})
-                        for content_item in message.get("content", []):
-                            if content_item.get("type") != "tool_use":
-                                continue
-                            tool_name = content_item.get("name", "")
-                            tool_input = content_item.get("input", {})
-                            if tool_name == "Skill" and clean_name in tool_input.get("skill", ""):
-                                triggered = True
-                            elif tool_name == "Read" and clean_name in tool_input.get("file_path", ""):
-                                triggered = True
-                            return triggered
+                    elif se_type == "content_block_delta" and pending_tool_name:
+                        delta = se.get("delta", {})
+                        if delta.get("type") == "input_json_delta":
+                            accumulated_json += delta.get("partial_json", "")
+                            if matches(pending_tool_name, accumulated_json):
+                                return True
 
-                    elif event.get("type") == "result":
+                    elif se_type in ("content_block_stop", "message_stop"):
+                        if pending_tool_name:
+                            return matches(pending_tool_name, accumulated_json)
+                        if se_type == "message_stop":
+                            return False
+
+                elif event.get("type") == "assistant":
+                    message = event.get("message", {})
+                    for content_item in message.get("content", []):
+                        if content_item.get("type") != "tool_use":
+                            continue
+                        tool_name = content_item.get("name", "")
+                        tool_input = content_item.get("input", {})
+                        if tool_name == "Skill" and tool_input.get("skill") == skill_name:
+                            triggered = True
+                        elif tool_name == "Read" and skill_md_marker in tool_input.get("file_path", ""):
+                            triggered = True
                         return triggered
-        finally:
-            # Clean up process on any exit path (return, exception, timeout)
-            if process.poll() is None:
-                process.kill()
-                process.wait()
 
-        return triggered
+                elif event.get("type") == "result":
+                    return triggered
     finally:
-        if command_file.exists():
-            command_file.unlink()
+        if process.poll() is None:
+            process.kill()
+            process.wait()
+
+    return triggered
 
 
 def run_eval(
@@ -188,72 +305,82 @@ def run_eval(
     num_workers: int,
     timeout: int,
     project_root: Path,
+    skill_path: Path,
     runs_per_query: int = 1,
     trigger_threshold: float = 0.5,
     model: str | None = None,
 ) -> dict:
-    """Run the full eval set and return results."""
-    results = []
+    """Run the full eval set with a single description swap.
 
-    with ProcessPoolExecutor(max_workers=num_workers) as executor:
-        future_to_info = {}
-        for item in eval_set:
-            for run_idx in range(runs_per_query):
-                future = executor.submit(
-                    run_single_query,
-                    item["query"],
-                    skill_name,
-                    description,
-                    timeout,
-                    str(project_root),
-                    model,
-                )
-                future_to_info[future] = (item, run_idx)
+    Swaps the candidate description into the real SKILL.md ONCE, runs all
+    parallel workers against the swapped skill, then restores. Description
+    is stable for the entire iteration so parallel workers are safe.
+    """
+    original_content = swap_skill_description(skill_path, description)
 
-        query_triggers: dict[str, list[bool]] = {}
-        query_items: dict[str, dict] = {}
-        for future in as_completed(future_to_info):
-            item, _ = future_to_info[future]
-            query = item["query"]
-            query_items[query] = item
-            if query not in query_triggers:
-                query_triggers[query] = []
-            try:
-                query_triggers[query].append(future.result())
-            except Exception as e:
-                print(f"Warning: query failed: {e}", file=sys.stderr)
-                query_triggers[query].append(False)
+    try:
+        results: list[dict] = []
 
-    for query, triggers in query_triggers.items():
-        item = query_items[query]
-        trigger_rate = sum(triggers) / len(triggers)
-        should_trigger = item["should_trigger"]
-        if should_trigger:
-            did_pass = trigger_rate >= trigger_threshold
-        else:
-            did_pass = trigger_rate < trigger_threshold
-        results.append({
-            "query": query,
-            "should_trigger": should_trigger,
-            "trigger_rate": trigger_rate,
-            "triggers": sum(triggers),
-            "runs": len(triggers),
-            "pass": did_pass,
-        })
+        with ProcessPoolExecutor(max_workers=num_workers) as executor:
+            future_to_info: dict = {}
+            for item in eval_set:
+                for run_idx in range(runs_per_query):
+                    future = executor.submit(
+                        run_single_query,
+                        item["query"],
+                        skill_name,
+                        timeout,
+                        str(project_root),
+                        model,
+                    )
+                    future_to_info[future] = (item, run_idx)
 
-    passed = sum(1 for r in results if r["pass"])
-    total = len(results)
+            query_triggers: dict[str, list[bool]] = {}
+            query_items: dict[str, dict] = {}
+            for future in as_completed(future_to_info):
+                item, _ = future_to_info[future]
+                query = item["query"]
+                query_items[query] = item
+                if query not in query_triggers:
+                    query_triggers[query] = []
+                try:
+                    query_triggers[query].append(future.result())
+                except Exception as exc:
+                    print(f"Warning: query failed: {exc}", file=sys.stderr)
+                    query_triggers[query].append(False)
 
-    return {
-        "skill_name": skill_name,
-        "description": description,
-        "results": results,
-        "summary": {
-            "total": total,
-            "passed": passed,
-            "failed": total - passed,
-        },
-    }
+        for query, triggers in query_triggers.items():
+            item = query_items[query]
+            trigger_rate = sum(triggers) / len(triggers)
+            should_trigger = item["should_trigger"]
+            if should_trigger:
+                did_pass = trigger_rate >= trigger_threshold
+            else:
+                did_pass = trigger_rate < trigger_threshold
+            results.append({
+                "query": query,
+                "should_trigger": should_trigger,
+                "trigger_rate": trigger_rate,
+                "triggers": sum(triggers),
+                "runs": len(triggers),
+                "pass": did_pass,
+            })
+
+        passed = sum(1 for r in results if r["pass"])
+        total = len(results)
+
+        return {
+            "skill_name": skill_name,
+            "description": description,
+            "results": results,
+            "summary": {
+                "total": total,
+                "passed": passed,
+                "failed": total - passed,
+            },
+        }
+    finally:
+        restore_skill_md(skill_path, original_content)
 
 
 def main():
@@ -261,7 +388,7 @@ def main():
     parser.add_argument("--eval-set", required=True, help="Path to eval set JSON file")
     parser.add_argument("--skill-path", required=True, help="Path to skill directory")
     parser.add_argument("--description", default=None, help="Override description to test")
-    parser.add_argument("--num-workers", type=int, default=10, help="Number of parallel workers")
+    parser.add_argument("--num-workers", type=int, default=4, help="Number of parallel workers")
     parser.add_argument("--timeout", type=int, default=30, help="Timeout per query in seconds")
     parser.add_argument("--runs-per-query", type=int, default=3, help="Number of runs per query")
     parser.add_argument("--trigger-threshold", type=float, default=0.5, help="Trigger rate threshold")
@@ -270,13 +397,13 @@ def main():
     args = parser.parse_args()
 
     eval_set = json.loads(Path(args.eval_set).read_text())
-    skill_path = Path(args.skill_path)
+    skill_path = Path(args.skill_path).resolve()
 
     if not (skill_path / "SKILL.md").exists():
         print(f"Error: No SKILL.md found at {skill_path}", file=sys.stderr)
         sys.exit(1)
 
-    name, original_description, content = parse_skill_md(skill_path)
+    name, original_description, _ = parse_skill_md(skill_path)
     description = args.description or original_description
     project_root = find_project_root()
 
@@ -290,6 +417,7 @@ def main():
         num_workers=args.num_workers,
         timeout=args.timeout,
         project_root=project_root,
+        skill_path=skill_path,
         runs_per_query=args.runs_per_query,
         trigger_threshold=args.trigger_threshold,
         model=args.model,

--- a/skills/skill-creator/scripts/run_loop.py
+++ b/skills/skill-creator/scripts/run_loop.py
@@ -93,6 +93,7 @@ def run_loop(
             num_workers=num_workers,
             timeout=timeout,
             project_root=project_root,
+            skill_path=skill_path,
             runs_per_query=runs_per_query,
             trigger_threshold=trigger_threshold,
             model=model,

--- a/skills/skill-creator/scripts/run_loop.py
+++ b/skills/skill-creator/scripts/run_loop.py
@@ -58,6 +58,8 @@ def run_loop(
     verbose: bool,
     live_report_path: Path | None = None,
     log_dir: Path | None = None,
+    progress_callback=None,
+    stop_signal=None,
 ) -> dict:
     """Run the eval + improvement loop."""
     project_root = find_project_root()
@@ -77,6 +79,19 @@ def run_loop(
     exit_reason = "unknown"
 
     for iteration in range(1, max_iterations + 1):
+        if stop_signal is not None and stop_signal.is_set():
+            exit_reason = f"stopped (iteration {iteration - 1})"
+            break
+        if progress_callback:
+            try:
+                progress_callback({
+                    "event": "iteration_start",
+                    "iteration": iteration,
+                    "max_iterations": max_iterations,
+                    "description": current_description,
+                })
+            except Exception:
+                pass
         if verbose:
             print(f"\n{'='*60}", file=sys.stderr)
             print(f"Iteration {iteration}/{max_iterations}", file=sys.stderr)
@@ -137,6 +152,18 @@ def run_loop(
             "results": train_results["results"],
         })
 
+        # Notify subscribers of finished iteration
+        if progress_callback:
+            try:
+                progress_callback({
+                    "event": "iteration_done",
+                    "iteration": iteration,
+                    "entry": history[-1],
+                    "elapsed_s": eval_elapsed,
+                })
+            except Exception:
+                pass
+
         # Write live report if path provided
         if live_report_path:
             partial_output = {
@@ -190,6 +217,12 @@ def run_loop(
         # Improve the description based on train results
         if verbose:
             print(f"\nImproving description...", file=sys.stderr)
+
+        if progress_callback:
+            try:
+                progress_callback({"event": "improving", "iteration": iteration})
+            except Exception:
+                pass
 
         t0 = time.time()
         # Strip test scores from history so improvement model can't see them


### PR DESCRIPTION
## Summary

Wraps `run_eval` + `run_loop` in 8 tool definitions over MCP stdio so any agent (Claude Code, Cursor, Cline, raw API clients) can run a real-world trigger eval, kick off an optimization loop, poll its status, and apply the winning description back to `SKILL.md` — without needing to shell out to the Python CLI and parse JSON from stdout.

## Why

`skill-creator` ships a CLI (`python -m scripts.run_loop`) but it's awkward for agents to drive — they'd need to spawn a subprocess, parse stdout JSON, manage backpressure, etc. The MCP server packages the same logic as first-class LLM tools, so an agent can do:

```
skill_eval_run_trigger_eval(skill_path=..., eval_set_path=..., model=...)
```

instead of orchestrating subprocesses.

## What's added

```
skills/skill-creator/
├── .gitignore                 # ignore venv + swap artefacts
└── mcp/
    ├── README.md
    ├── server.py              FastMCP + 8 tools
    ├── start.sh               venv bootstrap + stdio launcher
    └── requirements.txt       mcp[cli] + pydantic
```

### Tools (all `skill_eval_*` prefixed)

| Tool | Purpose | Sync? |
|------|---------|-------|
| `skill_eval_list_skills` | enumerate `~/.claude/skills/*` | sync |
| `skill_eval_get_skill` | description + auto-discovered eval sets | sync |
| `skill_eval_run_trigger_eval` | one-shot eval, returns precision/recall/accuracy | sync |
| `skill_eval_start_optimization` | full eval+improve loop in background | async |
| `skill_eval_get_run_status` | poll a run by id | sync |
| `skill_eval_list_runs` | list active + recent runs | sync |
| `skill_eval_apply_best_description` | write best description to SKILL.md | sync |
| `skill_eval_stop_run` | cooperative stop | sync |

### Stack

- Python + FastMCP (`mcp[cli]`) + Pydantic v2.
- **Stdio transport** — registers via `claude mcp add skill-eval --transport stdio -- start.sh`.
- **No auth** — the underlying `claude -p` subprocesses inherit the parent CC session OAuth.

### Compliance with `mcp-server-best-practices`

- Service-prefixed tool names (`skill_eval_*`) prevent collisions in multi-server environments.
- Pydantic models with `extra=\"forbid\"` reject LLM-hallucinated parameters.
- Tool annotations: `readOnlyHint` / `destructiveHint` / `idempotentHint` / `openWorldHint`.
- Mini-manual docstrings (Args / Returns / Use-when / Notes) so the LLM has unambiguous intent.
- Error bifurcation: protocol errors stay protocol errors; execution errors return `{isError: true, error: ...}` so the LLM can self-correct.
- stdout reserved for JSON-RPC; bootstrap logs go to stderr.

### `scripts/run_loop.py` patch

Same patch as #1028 — adds `progress_callback` + `stop_signal` kwargs (both default `None`, backward-compatible). Whichever of these two PRs merges second will conflict cleanly on those hunks.

## Smoke test

JSON-RPC handshake confirmed:

```
$ ./start.sh < <(jq -c '...' initialize_request.json)
→ initialize OK (protocolVersion=2025-11-25, capabilities returned)
→ tools/list returns 8 tools with valid annotations + inputSchemas
```

End-to-end via `skill_eval_run_trigger_eval`: 2/2 queries pass on a real installed skill, recall 100%.

## Companion to #1028

The `eval-server` SSE dashboard (#1028) is the human-facing counterpart — same primitives, web UI instead of MCP. Both can coexist; both reference the same `run_eval.py` + `run_loop.py` primitives.

## Dependency

Depends on #1027 (run_eval real-skill swap fix). The diff in this PR includes those changes; merge order matters (1027 first, then this).

## Test plan

- [ ] `./start.sh` boots cleanly; stdio handshake succeeds.
- [ ] `claude mcp add skill-eval --scope user --transport stdio -- /abs/path/start.sh` registers without error.
- [ ] `skill_eval_list_skills` returns the local skill list.
- [ ] `skill_eval_run_trigger_eval` swap-tests a description and returns coherent precision/recall numbers.
- [ ] `skill_eval_start_optimization` returns immediately with a `run_id`; `skill_eval_get_run_status` shows the run progressing through `running → complete`.
- [ ] `skill_eval_apply_best_description` writes the winning description and creates `.md.apply-backup`.