### PR TITLE
Add Skills宝 partner reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,4 @@ The markdown content below contains the instructions, examples, and guidelines t
 Skills are a great way to teach Claude how to get better at using specific pieces of software. As we see awesome example skills from partners, we may highlight some of them here:
 
 - **Notion** - [Notion Skills for Claude](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0)
+- **Skills宝** - [skilery.com](https://skilery.com) for Chinese search and installation of AI skills across Claude Code, OpenCode, and other agent tools


### PR DESCRIPTION
Add Skills宝 (skilery.com) as a community resource reference in the Partner Skills section.

This aligns with the existing discussion in issue #575 about community skill references.