### PR TITLE
Add: designlang skill

### DIFF
--- a/skills/skills/designlang/LICENSE.txt
+++ b/skills/skills/designlang/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Manavarya Singh
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/skills/designlang/SKILL.md
+++ b/skills/skills/designlang/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: designlang
+description: Reverse-engineer any website into a complete design system. Use this skill when the user wants to extract design tokens, palette, typography, shadows, motion, or component anatomy from a public URL; generate an agent-native DESIGN.md; clone a site's design as a runnable Next.js starter; or compare local tokens against a deployed site (drift detection). Outputs DTCG W3C tokens plus emitters for Tailwind, CSS variables, Figma variables, shadcn/ui, React, Vue, Svelte, iOS SwiftUI, Android Compose, Flutter, and WordPress.
+license: MIT — see LICENSE.txt
+---
+
+# designlang
+
+`designlang` is an open-source CLI + MCP server that reverse-engineers any
+public website into a complete design system. It runs Playwright against the
+target URL, classifies the page (intent, material, library), extracts every
+token (colors, typography, spacing, radii, shadows, motion, anatomy, voice),
+and emits ~25 files including a single agent-native `DESIGN.md`.
+
+## When to use
+
+Use this skill when the user asks to:
+- **Extract design tokens** from a website (`"give me Stripe's design tokens"`).
+- **Generate a `DESIGN.md`** for an existing site so an AI agent can faithfully
+  rebuild it (`"create an AGENTS.md-style design doc for vercel.com"`).
+- **Clone a site's design** as a working Next.js starter
+  (`"give me a Next.js app that looks like linear.app"`).
+- **Detect drift** between local tokens and production
+  (`"is my Tailwind config still in sync with my deploy?"`).
+- **Iterate on tokens** conversationally
+  (`"sharpen the radii"` / `"make it brutalist"` / `"swap primary to #ff4800"`).
+
+## How to invoke
+
+The CLI works without install via `npx`:
+
+```bash
+npx designlang <url>                           # extract everything
+npx designlang clone <url>                     # generate a working Next.js repo
+npx designlang ci <url> --tokens ./tokens.json # PR-comment drift bot
+npx designlang chat <url>                      # REPL over the extraction
+npx designlang studio                          # local web studio
+npx designlang mcp                             # stdio MCP server
+```
+
+Outputs land in `./design-extract-output/` by default.
+
+## Output formats
+
+| File | Purpose |
+|---|---|
+| `*-DESIGN.md` | Single-file, 8-section, YAML front-matter agent-native artifact |
+| `*-design-tokens.json` | DTCG W3C primitive + semantic + composite |
+| `*-tailwind.config.js` | Tailwind v4-ready preset |
+| `*-variables.css` | CSS custom properties |
+| `*-figma-variables.json` | Figma Variable collection import |
+| `*-shadcn-theme.css` / `*-theme.js` | shadcn / React themes |
+| `ios/DesignTokens.swift` / `android/Theme.kt` / `flutter/design_tokens.dart` | Native platform tokens |
+| `*-anatomy.tsx` | Typed React stubs from variant × size × state matrices |
+| `*-motion-tokens.json` | Easing families, duration scale, springs |
+| `*-voice.json` | Tone, pronoun posture, CTA verbs, heading style |
+
+## MCP server
+
+Add to `~/.cursor/mcp.json` or `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "designlang": {
+      "command": "npx",
+      "args": ["-y", "designlang", "mcp"]
+    }
+  }
+}
+```
+
+The MCP server exposes the most recent extraction as live resources
+(`designlang://latest/tokens`, `designlang://latest/regions`,
+`designlang://latest/components`, `designlang://latest/css-health`,
+`designlang://latest/design-md`).
+
+## Spec
+
+The `DESIGN.md` format is published as an open spec at
+<https://designlang.app/spec> (CC BY 4.0).
+
+## Source
+
+- Repository: <https://github.com/Manavarya09/design-extract>
+- npm: <https://www.npmjs.com/package/designlang>
+- Web: <https://designlang.app>


### PR DESCRIPTION
## What

Adds a [`designlang`](https://github.com/Manavarya09/design-extract) skill — an open-source tool that reverse-engineers any website into a complete design system.

## Why

Agents that build UIs need accurate design context. designlang reads a live URL and produces:
- A single agent-native \`DESIGN.md\` (8-section, YAML front matter — based on the [DESIGN.md spec](https://designlang.app/spec))
- DTCG W3C tokens, Tailwind config, CSS variables, Figma variables
- iOS / Android / Flutter / WordPress emitters
- Component anatomy stubs, motion tokens, brand voice JSON
- A chat REPL with mutation operations (\`make it brutalist\`, \`sharpen radii\`, \`swap primary #ff4800\`)
- A \`clone\` command that generates a working Next.js starter from any URL

Adoption signal:
- **1.6k GitHub stars** and **5K+ npm downloads**
- ~500 daily visits at <https://designlang.app>
- Used in production via the bundled [MCP server](https://github.com/Manavarya09/design-extract#mcp), Cursor / Claude Desktop / Windsurf integrations, Figma plugin, Chrome / VS Code / Raycast extensions

## Skill content

\`skills/designlang/SKILL.md\` — invocable via:
- \`npx designlang <url>\` (extract)
- \`npx designlang clone <url>\` (Next.js starter)
- \`npx designlang ci <url> --tokens ./tokens.json\` (drift bot)
- \`npx designlang chat <url>\` (REPL)
- \`npx designlang mcp\` (stdio MCP server)

\`skills/designlang/LICENSE.txt\` — MIT.

## Compatibility

The skill follows the format used by existing skills in this repo (\`canvas-design\`, \`web-artifacts-builder\`, \`frontend-design\`). Front matter has \`name\`, \`description\`, \`license\`. Body documents \`when to use\`, invocation surface, and outputs.

Happy to iterate on the SKILL.md prose if you want it tighter or want different framing.