### PR TITLE
fix(pdf): fix output dir creation and use LANCZOS resampling.

### DIFF
--- a/skills/pdf/scripts/convert_pdf_to_images.py
+++ b/skills/pdf/scripts/convert_pdf_to_images.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 
 from pdf2image import convert_from_path
+from PIL import Image
 
 
 def convert(pdf_path, output_dir, max_dim=1000):
@@ -17,10 +18,9 @@ def convert(pdf_path, output_dir, max_dim=1000):
     for i, image in enumerate(images):
         width, height = image.size
         if width > max_dim or height > max_dim:
-            scale_factor = min(max_dim / width, max_dim / height)
-            new_width = int(width * scale_factor)
-            new_height = int(height * scale_factor)
-            image = image.resize((new_width, new_height))
+            scale_factor = max_dim / max(width, height)
+            new_size = (int(width * scale_factor), int(height * scale_factor))
+            image = image.resize(new_size, Image.LANCZOS)
 
         image_path = output_dir / f"page_{i + 1}.png"
         image.save(image_path)

--- a/skills/pdf/scripts/convert_pdf_to_images.py
+++ b/skills/pdf/scripts/convert_pdf_to_images.py
@@ -1,12 +1,17 @@
-import os
 import sys
+from pathlib import Path
 
 from pdf2image import convert_from_path
 
 
-
-
 def convert(pdf_path, output_dir, max_dim=1000):
+    pdf_path = Path(pdf_path)
+    output_dir = Path(output_dir)
+
+    if not pdf_path.is_file():
+        raise FileNotFoundError(f"PDF not found: {pdf_path}")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
     images = convert_from_path(pdf_path, dpi=200)
 
     for i, image in enumerate(images):
@@ -16,10 +21,10 @@ def convert(pdf_path, output_dir, max_dim=1000):
             new_width = int(width * scale_factor)
             new_height = int(height * scale_factor)
             image = image.resize((new_width, new_height))
-        
-        image_path = os.path.join(output_dir, f"page_{i+1}.png")
+
+        image_path = output_dir / f"page_{i + 1}.png"
         image.save(image_path)
-        print(f"Saved page {i+1} as {image_path} (size: {image.size})")
+        print(f"Saved page {i + 1} as {image_path} (size: {image.size})")
 
     print(f"Converted {len(images)} pages to PNG images")
 

--- a/skills/pdf/scripts/convert_pdf_to_images.py
+++ b/skills/pdf/scripts/convert_pdf_to_images.py
@@ -12,8 +12,15 @@ def convert(pdf_path, output_dir, max_dim=1000):
     if not pdf_path.is_file():
         raise FileNotFoundError(f"PDF not found: {pdf_path}")
 
+    if max_dim <= 0:
+        raise ValueError(f"max_dim must be positive, got {max_dim}")
+
     output_dir.mkdir(parents=True, exist_ok=True)
-    images = convert_from_path(pdf_path, dpi=200)
+
+    try:
+        images = convert_from_path(pdf_path, dpi=200, thread_count=4)
+    except Exception as e:
+        raise RuntimeError(f"failed to convert PDF: {pdf_path}") from e
 
     for i, image in enumerate(images):
         width, height = image.size


### PR DESCRIPTION
## Summary

- create output directory if it doesn't exist, fixing `FileNotFoundError` (#1025) 
- switch to LANCZOS resampling for better quality on downscaled PDF pages
- add `thread_count=4` for parallel page conversion

## Why
Fixes #1025.

LANCZOS produces sharper results than the default filters (BICUBICAL or NEAREST) when downscaling pages with text and fine lines - noticeably better at small `max_dim` values.

## Changes
`skills/pdf/scripts/convert_pdf_to_images.py` only. no MD changes.
- replace `os.path` with `pathlib.Path` throughout for consistency
- add safeguards for missing PDF, `max_dim <= 0`, and corrupt PDF on conversion
- formatted with `ruff`