### PR TITLE
fix(pack): exclude OS metadata files from Office archives

### DIFF
--- a/skills/docx/scripts/office/pack.py
+++ b/skills/docx/scripts/office/pack.py
@@ -57,10 +57,11 @@ def pack(
             for xml_file in temp_content_dir.rglob(pattern):
                 _condense_xml(xml_file)
 
+        _OS_METADATA = {".DS_Store", "Thumbs.db"}
         output_path.parent.mkdir(parents=True, exist_ok=True)
         with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as zf:
             for f in temp_content_dir.rglob("*"):
-                if f.is_file():
+                if f.is_file() and f.name not in _OS_METADATA:
                     zf.write(f, f.relative_to(temp_content_dir))
 
     return None, f"Successfully packed {input_dir} to {output_file}"

--- a/skills/pptx/scripts/office/pack.py
+++ b/skills/pptx/scripts/office/pack.py
@@ -57,10 +57,11 @@ def pack(
             for xml_file in temp_content_dir.rglob(pattern):
                 _condense_xml(xml_file)
 
+        _OS_METADATA = {".DS_Store", "Thumbs.db"}
         output_path.parent.mkdir(parents=True, exist_ok=True)
         with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as zf:
             for f in temp_content_dir.rglob("*"):
-                if f.is_file():
+                if f.is_file() and f.name not in _OS_METADATA:
                     zf.write(f, f.relative_to(temp_content_dir))
 
     return None, f"Successfully packed {input_dir} to {output_file}"

--- a/skills/xlsx/scripts/office/pack.py
+++ b/skills/xlsx/scripts/office/pack.py
@@ -57,10 +57,11 @@ def pack(
             for xml_file in temp_content_dir.rglob(pattern):
                 _condense_xml(xml_file)
 
+        _OS_METADATA = {".DS_Store", "Thumbs.db"}
         output_path.parent.mkdir(parents=True, exist_ok=True)
         with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as zf:
             for f in temp_content_dir.rglob("*"):
-                if f.is_file():
+                if f.is_file() and f.name not in _OS_METADATA:
                     zf.write(f, f.relative_to(temp_content_dir))
 
     return None, f"Successfully packed {input_dir} to {output_file}"


### PR DESCRIPTION
## Problem

`pack.py` (shared across `docx`, `pptx`, `xlsx`) bundles every file from the unpacked directory, including OS metadata files like `.DS_Store` (macOS Finder) and `Thumbs.db` (Windows File Explorer).

Microsoft Office follows ECMA-376 strictly and rejects any archive entry not declared in `[Content_Types].xml`, so the repacked file triggers a "found a problem with content" repair dialog — or fails to open entirely. LibreOffice is lenient, which is likely why this hasn't shown up in CI.

Closes #1012.

## Fix

Add a small exclusion set checked in the zip loop, before each `zf.write()`:

```python
_OS_METADATA = {".DS_Store", "Thumbs.db"}
...
if f.is_file() and f.name not in _OS_METADATA:
    zf.write(f, f.relative_to(temp_content_dir))
```

Applied identically to all three skills — `docx`, `pptx`, `xlsx` — which share the same `pack.py`.

## Testing

Verified on macOS (Microsoft 365 for Mac):
- Before: unpack → browse in Finder → repack → PowerPoint shows repair dialog
- After: same flow → PowerPoint opens clean