### PR TITLE
fix(skill-creator): use ensure_ascii=False in eval-viewer JSON embed

### DIFF
--- a/skills/skill-creator/eval-viewer/generate_review.py
+++ b/skills/skill-creator/eval-viewer/generate_review.py
@@ -276,7 +276,7 @@ def generate_html(
     if benchmark:
         embedded["benchmark"] = benchmark
 
-    data_json = json.dumps(embedded)
+    data_json = json.dumps(embedded, ensure_ascii=False)
 
     return template.replace("/*__EMBEDDED_DATA__*/", f"const EMBEDDED_DATA = {data_json};")
 
@@ -469,3 +469,4 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Problem

`generate_review.py` calls `json.dumps(embedded)` with the default `ensure_ascii=True`, which escapes every non-ASCII character as `\uXXXX`. The browser receives these as literal backslash-u sequences and displays them verbatim — making prompts, agent outputs, and grading evidence unreadable for any project whose content contains non-Latin characters (Cyrillic, CJK, Arabic, etc.).

Closes #1034.

## Fix

```python
# before
data_json = json.dumps(embedded)

# after
data_json = json.dumps(embedded, ensure_ascii=False)
```

This is safe: `generate_review.py` already reads/writes files as UTF-8 and `viewer.html` declares `<meta charset="UTF-8">`. The two other `json.dumps` calls in the file (lines 369, 373) go through the HTTP feedback pipe and are unaffected.