### PR TITLE
fix(skill-creator): correct package_skill.py invocation in docstring and usage

### DIFF
--- a/skills/skill-creator/scripts/package_skill.py
+++ b/skills/skill-creator/scripts/package_skill.py
@@ -3,11 +3,11 @@
 Skill Packager - Creates a distributable .skill file of a skill folder
 
 Usage:
-    python utils/package_skill.py <path/to/skill-folder> [output-directory]
+    python -m scripts.package_skill <path/to/skill-folder> [output-directory]
 
 Example:
-    python utils/package_skill.py skills/public/my-skill
-    python utils/package_skill.py skills/public/my-skill ./dist
+    python -m scripts.package_skill skills/public/my-skill
+    python -m scripts.package_skill skills/public/my-skill ./dist
 """
 
 import fnmatch
@@ -110,10 +110,10 @@ def package_skill(skill_path, output_dir=None):
 
 def main():
     if len(sys.argv) < 2:
-        print("Usage: python utils/package_skill.py <path/to/skill-folder> [output-directory]")
+        print("Usage: python -m scripts.package_skill <path/to/skill-folder> [output-directory]")
         print("\nExample:")
-        print("  python utils/package_skill.py skills/public/my-skill")
-        print("  python utils/package_skill.py skills/public/my-skill ./dist")
+        print("  python -m scripts.package_skill skills/public/my-skill")
+        print("  python -m scripts.package_skill skills/public/my-skill ./dist")
         sys.exit(1)
 
     skill_path = sys.argv[1]
@@ -134,3 +134,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Problem

\`package_skill.py\` imports from \`scripts.quick_validate\`, which means running it as \`python utils/package_skill.py\` (what the docstring and \`main()\` usage output instruct) fails immediately with \`ModuleNotFoundError\`. The correct form is \`python -m scripts.package_skill\`, which is what \`SKILL.md\` (line 413) already documents — the script just contradicts itself.

Closes #904.

## Fix

Updated the module-level docstring and the three \`print()\` lines in \`main()\` to say \`python -m scripts.package_skill\` so the script's own help output matches how it must actually be invoked.