### PR TITLE
skill-creator: fix Windows subprocess + encoding bugs

### DIFF
--- a/skills/skill-creator/scripts/generate_report.py
+++ b/skills/skill-creator/scripts/generate_report.py
@@ -316,7 +316,7 @@ def main():
     html_output = generate_html(data, skill_name=args.skill_name)
 
     if args.output:
-        Path(args.output).write_text(html_output)
+        Path(args.output).write_text(html_output, encoding="utf-8")
         print(f"Report written to {args.output}", file=sys.stderr)
     else:
         print(html_output)

--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -9,6 +9,7 @@ import argparse
 import json
 import os
 import select
+import shutil
 import subprocess
 import sys
 import time
@@ -65,10 +66,10 @@ def run_single_query(
             f"# {skill_name}\n\n"
             f"This skill handles: {skill_description}\n"
         )
-        command_file.write_text(command_content)
+        command_file.write_text(command_content, encoding="utf-8")
 
         cmd = [
-            "claude",
+            shutil.which("claude") or "claude.cmd",
             "-p", query,
             "--output-format", "stream-json",
             "--verbose",

--- a/skills/skill-creator/scripts/run_loop.py
+++ b/skills/skill-creator/scripts/run_loop.py
@@ -148,7 +148,7 @@ def run_loop(
                 "test_size": len(test_set),
                 "history": history,
             }
-            live_report_path.write_text(generate_html(partial_output, auto_refresh=True, skill_name=name))
+            live_report_path.write_text(generate_html(partial_output, auto_refresh=True, skill_name=name), encoding="utf-8")
 
         if verbose:
             def print_eval_stats(label, results, elapsed):
@@ -275,7 +275,7 @@ def main():
         else:
             live_report_path = Path(args.report)
         # Open the report immediately so the user can watch
-        live_report_path.write_text("<html><body><h1>Starting optimization loop...</h1><meta http-equiv='refresh' content='5'></body></html>")
+        live_report_path.write_text("<html><body><h1>Starting optimization loop...</h1><meta http-equiv='refresh' content='5'></body></html>", encoding="utf-8")
         webbrowser.open(str(live_report_path))
     else:
         live_report_path = None
@@ -310,15 +310,15 @@ def main():
     json_output = json.dumps(output, indent=2)
     print(json_output)
     if results_dir:
-        (results_dir / "results.json").write_text(json_output)
+        (results_dir / "results.json").write_text(json_output, encoding="utf-8")
 
     # Write final HTML report (without auto-refresh)
     if live_report_path:
-        live_report_path.write_text(generate_html(output, auto_refresh=False, skill_name=name))
+        live_report_path.write_text(generate_html(output, auto_refresh=False, skill_name=name), encoding="utf-8")
         print(f"\nReport: {live_report_path}", file=sys.stderr)
 
     if results_dir and live_report_path:
-        (results_dir / "report.html").write_text(generate_html(output, auto_refresh=False, skill_name=name))
+        (results_dir / "report.html").write_text(generate_html(output, auto_refresh=False, skill_name=name), encoding="utf-8")
 
     if results_dir:
         print(f"Results saved to: {results_dir}", file=sys.stderr)


### PR DESCRIPTION
## Two Windows compatibility fixes for skill-creator scripts

Found while running `run_loop.py` on Windows 11. Both fixes are 1-line changes.

**1. `subprocess.Popen(["claude", ...])` fails with `[WinError 2]`**
On Windows the CLI ships as `claude.cmd`. Python's subprocess doesn't honor `PATHEXT` for non-shell invocations, so it can't find the binary. Fix: use `shutil.which("claude") or "claude.cmd"` (or just `claude.cmd` if cross-platform isn't a concern — the script is Windows-or-bust without this fix anyway).

**2. `write_text()` fails with `UnicodeEncodeError` on cp1252**
`generate_report.py` and `run_loop.py` use `.write_text()` without specifying encoding. On Windows, `locale.getpreferredencoding()` returns cp1252 by default, which can't encode the ✗/✓ characters in the HTML report. Fix: add `encoding="utf-8"` to every `.write_text()` call (5 in run_loop.py, 1 in generate_report.py).

Tested locally — both fixes resolve the issues.