### PR TITLE
Add wp-healthcheck skill

### DIFF
--- a/skills/wp-healthcheck/LICENSE.txt
+++ b/skills/wp-healthcheck/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 npc (Azusa Yabune)
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/wp-healthcheck/SKILL.md
+++ b/skills/wp-healthcheck/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: wp-healthcheck
+description: Diagnoses WordPress site health from public information only. Detects WordPress version and active theme, validates SSL/TLS certificate expiry and issuer, checks recommended security headers (X-Frame-Options, HSTS, CSP, X-Content-Type-Options, Referrer-Policy), verifies robots.txt and sitemap.xml, measures top-page response time, probes xmlrpc.php / wp-json / wp-cron.php exposure, and flags installed plugins with historical CVEs. Produces a Markdown report graded OK / WARNING / CRITICAL / UNKNOWN. Use this skill whenever the user asks to check, audit, diagnose, scan, or review a WordPress site, mentions wp-healthcheck, asks why a WordPress site is slow or insecure, requests a maintenance report, or provides a URL and asks whether it looks healthy. Works on any public WordPress site without credentials. For internal audits requiring database, file integrity, or admin state, recommend a dedicated WordPress maintenance plugin instead.
+license: Complete terms in LICENSE
+---
+
+# wp-healthcheck
+
+## Overview
+
+`wp-healthcheck` runs an external, credential-less diagnostic against any WordPress site
+and produces a Markdown maintenance report. It probes only publicly accessible surfaces
+(HTML, headers, well-known endpoints, TLS certificate) and grades each finding on a
+four-tier scale: **OK / WARNING / CRITICAL / UNKNOWN**.
+
+This skill is intended for first-pass health checks before deeper internal audits.
+
+## When to use this skill
+
+Activate this skill when the user:
+
+- Asks to "check / audit / diagnose / scan / review" a WordPress site.
+- Mentions `wp-healthcheck`, "WP healthcheck", or "WordPress health check".
+- Provides a URL and asks whether it looks safe, secure, up to date, or healthy.
+- Reports that a WordPress site feels slow, insecure, or unmaintained and wants a quick
+  external assessment.
+- Wants a maintenance report they can share with a client without server access.
+
+Do **not** activate for: internal-only audits requiring database access, plugin code
+review, theme development, or general WordPress how-to questions.
+
+## Usage
+
+The user typically says one of:
+
+- "Run a healthcheck on https://example.com"
+- "Can you audit example.com? I think they're on an old WordPress."
+- "Use wp-healthcheck on https://example.com"
+
+Claude should:
+
+1. Confirm the target URL with the user (and confirm `https://` if they typed a bare
+   domain).
+2. Run `bash scripts/check_wp.sh <url>` (or pass `--output <file>` if the user wants the
+   report written to disk).
+3. Present the Markdown output to the user, then highlight the most important findings
+   (CRITICAL first, then WARNING) and suggest next steps.
+
+## Workflow
+
+```text
+User provides URL
+        |
+        v
+[ scripts/check_wp.sh <url> ]
+        |
+        +--> fetch_wp_meta.sh   (curl: HTML, /wp-json/, /readme.html, /xmlrpc.php,
+        |                        /wp-cron.php, /robots.txt, /sitemap.xml, TLS info)
+        |
+        +--> 8 diagnostic checks (version, theme, SSL, headers, robots/sitemap,
+        |                        response time, API surface, plugin fingerprints)
+        |
+        +--> format_report.sh   (renders findings as Markdown)
+        |
+        v
+Markdown report on stdout (or written to --output file)
+```
+
+### Command reference
+
+```bash
+# Print report to stdout
+bash scripts/check_wp.sh https://example.com
+
+# Write report to a file
+bash scripts/check_wp.sh https://example.com --output ./report.md
+```
+
+### Requirements
+
+- `bash`, `curl`, `jq`, `awk`, `sed`, `grep`, `mktemp`, `date` (all present on macOS and
+  most Linux distributions by default).
+- Network access to the target site.
+- No API keys or credentials.
+
+## Output format
+
+The report has three sections:
+
+1. **Header** — target URL, generation timestamp, overall verdict.
+2. **Summary table** — one row per diagnostic item with status and one-line summary.
+3. **Findings (detail)** — per-item explanation with raw evidence.
+
+Overall verdict is one of:
+
+- `Action required` — at least one CRITICAL finding.
+- `Attention recommended` — at least one WARNING (and no CRITICAL).
+- `Healthy on observable surfaces` — only OK / UNKNOWN.
+- `Could not assess (site unreachable or non-responsive)` — no OK results, only UNKNOWN.
+
+See `examples/sample-report.md` for a real run.
+
+## Limitations
+
+This skill examines **only publicly accessible information**. It cannot:
+
+- Determine the actual installed version of detected plugins.
+- See plugins that are active only in the WordPress admin (SEO, cache, backup, security
+  managers). Front-end-invisible plugins leave no fingerprint in public HTML, so the
+  detected plugin count is a **lower bound**, not a complete inventory.
+- Inspect the database, `wp-config.php`, file integrity, or admin-only state.
+- Detect compromised content not exposed on the front page.
+- Replace a WAF, vulnerability scanner, or full security audit.
+
+For deeper checks (file diffs, scheduled cron, user roles, transient state), use a
+dedicated WordPress maintenance plugin that runs inside the site.
+
+## References
+
+- `references/checklist.md` — full judgement criteria for each diagnostic item.
+- `examples/sample-report.md` — an example report produced by this skill.
+- `docs/skill-spec-research.md` — the Anthropic Agent Skills specification research that
+  informed this skill's design.

--- a/skills/wp-healthcheck/examples/sample-report.md
+++ b/skills/wp-healthcheck/examples/sample-report.md
@@ -1,0 +1,109 @@
+<!--
+This file is a real sample produced by:
+
+    bash scripts/check_wp.sh https://n-pc.jp --output examples/sample-report.md
+
+Re-run the same command to refresh it.
+-->
+
+# WordPress Healthcheck Report
+
+- Target: https://n-pc.jp
+- Generated: 2026-04-28 05:31:38 UTC
+- Skill: wp-healthcheck (Phase 1, standalone external probe)
+
+## Summary
+
+- Overall: **Action required**
+- OK: 6 / WARNING: 1 / CRITICAL: 1 / UNKNOWN: 0
+
+| Item | Status | Summary |
+|---|---|---|
+| WordPress version | OK | WordPress 6.9.4 appears reasonably current. |
+| Active theme | OK | Active theme: npc-abc-theme |
+| SSL / TLS certificate | OK | Certificate valid for 68 more days. |
+| Security headers | CRITICAL | 0 of 5 recommended security headers present. |
+| robots.txt and sitemap | OK | Both robots.txt and sitemap are present. |
+| Top page response time | OK | Top page time_total: 0.166054s |
+| Public API surface | OK | xmlrpc / wp-json / wp-cron probed. |
+| Plugin fingerprints | WARNING | Plugins with historical CVEs detected: contact-form-7  |
+
+## Findings (detail)
+
+### WordPress version — OK
+
+WordPress 6.9.4 appears reasonably current.
+
+- Detected version: 6.9.4
+
+### Active theme — OK
+
+Active theme: npc-abc-theme
+
+- Theme path detected from HTML.
+
+### SSL / TLS certificate — OK
+
+Certificate valid for 68 more days.
+
+- Subject: CN=www.n-pc.jp
+- Issuer: C=US; O=Let's Encrypt; CN=R13
+- Valid from: Apr  6 23:29:06 2026 GMT
+- Expires: Jul  5 23:29:05 2026 GMT
+- Days remaining: 68
+
+### Security headers — CRITICAL
+
+0 of 5 recommended security headers present.
+
+- Present: none
+- Missing: X-Frame-Options X-Content-Type-Options Strict-Transport-Security Content-Security-Policy Referrer-Policy 
+
+### robots.txt and sitemap — OK
+
+Both robots.txt and sitemap are present.
+
+- robots.txt status: 200
+- sitemap URL tried: https://n-pc.jp/sitemap.xml
+- sitemap status: 200
+
+### Top page response time — OK
+
+Top page time_total: 0.166054s
+
+- Single-sample measurement; treat as indicative only.
+
+### Public API surface — OK
+
+xmlrpc / wp-json / wp-cron probed.
+
+- xmlrpc.php: OK (disabled, status 404)
+- /wp-json/: OK (REST API reachable)
+- wp-cron.php: OK (status 404)
+
+### Plugin fingerprints — WARNING
+
+Plugins with historical CVEs detected: contact-form-7 
+
+- Front-end visible plugins (4): akismet cf7-google-analytics contact-form-7 google-site-kit 
+- Note: Plugins active only in the WordPress admin (SEO, cache, backup, security tools) typically leave no front-end fingerprint and cannot be detected from outside.
+- Action: verify each flagged plugin is up to date. Versions cannot be determined externally.
+
+## Limitations
+
+This report is built **only from publicly accessible information** (HTML, headers, well-known
+endpoints, TLS certificate). It cannot:
+
+- Determine actual installed plugin versions (only slugs visible in HTML).
+- See plugins that are active only in the WordPress admin (SEO, cache, backup, security
+  managers). Front-end-invisible plugins leave no fingerprint in public HTML, so the
+  detected plugin count is a **lower bound**, not a complete inventory.
+- Inspect database, wp-config.php, or admin-only state.
+- Detect exploited backdoors or compromised content not exposed on the front page.
+
+For an internal audit (file integrity, cron schedule, user roles, transient state, full
+plugin inventory), use a dedicated WordPress maintenance plugin that runs inside the site.
+
+## References
+
+See `references/checklist.md` in the skill directory for the full judgement criteria.

--- a/skills/wp-healthcheck/references/checklist.md
+++ b/skills/wp-healthcheck/references/checklist.md
@@ -1,0 +1,198 @@
+# WordPress Healthcheck Diagnostic Checklist
+
+This document defines the diagnostic items used by `scripts/check_wp.sh`.
+Each item is judged on a four-tier scale: **OK / WARNING / CRITICAL / UNKNOWN**.
+
+---
+
+## 1. WordPress version detection
+
+### Method
+- Extract `<meta name="generator" content="WordPress X.X.X">` from the HTML of the top page.
+- Probe `/readme.html` (HTTP HEAD).
+- Probe `/wp-json/` and parse the `name` field.
+
+### Judgement
+| Status | Condition |
+|---|---|
+| OK | Version detected and matches the latest stable major release (>= 6.4) |
+| WARNING | Version detected but is older than the latest stable major release |
+| CRITICAL | Version detected and is older than 6.0, or `/readme.html` is publicly accessible (typical sign of a long-unmaintained site) |
+| UNKNOWN | No version can be detected (generator meta removed, REST disabled) |
+
+### Notes
+- A missing generator meta is not necessarily bad (often a hardening choice). Combine with other signals.
+- `/readme.html` exposure is itself a soft fingerprinting risk and a maintenance smell.
+
+---
+
+## 2. Active theme detection
+
+### Method
+- Find the first occurrence of `/wp-content/themes/<theme-name>/` in the HTML and report `<theme-name>`.
+
+### Judgement
+| Status | Condition |
+|---|---|
+| OK | A theme name was detected |
+| UNKNOWN | No theme path appears in the HTML (rare, may indicate full caching layer or non-WP) |
+
+### Notes
+- This is informational. The skill does not flag specific themes as risky; detection alone is the goal.
+
+---
+
+## 3. SSL / TLS certificate
+
+### Method
+- Run `curl -vI --max-time 30 https://<host>/` and parse the certificate's notBefore / notAfter / issuer.
+- Compute days remaining until expiry.
+
+### Judgement
+| Status | Condition |
+|---|---|
+| OK | Valid certificate, more than 30 days until expiry |
+| WARNING | Less than 30 days until expiry |
+| CRITICAL | Already expired, hostname mismatch, or self-signed |
+| UNKNOWN | HTTPS not reachable / certificate chain could not be parsed |
+
+---
+
+## 4. Security headers
+
+### Method
+- `curl -sI --max-time 30 https://<host>/` and check presence of:
+  - `X-Frame-Options`
+  - `X-Content-Type-Options`
+  - `Strict-Transport-Security`
+  - `Content-Security-Policy`
+  - `Referrer-Policy`
+
+### Judgement
+| Status | Condition |
+|---|---|
+| OK | 4 or 5 headers present |
+| WARNING | 2 or 3 headers present |
+| CRITICAL | 0 or 1 headers present |
+| UNKNOWN | The site did not respond to a HEAD request |
+
+### Notes
+- HSTS (`Strict-Transport-Security`) is the most impactful for HTTPS sites.
+- CSP is hard to retrofit; its absence is common and not always critical, but worth flagging.
+
+---
+
+## 5. robots.txt and sitemap.xml
+
+### Method
+- HTTP GET `/robots.txt` and `/sitemap.xml` (and `/wp-sitemap.xml` as fallback).
+- Check status code 200 and basic content sanity (non-empty, contains expected keywords).
+
+### Judgement
+| Status | Condition |
+|---|---|
+| OK | Both robots.txt and a sitemap are present and look valid |
+| WARNING | One of them is missing or returns a non-200 status |
+| CRITICAL | Both missing |
+| UNKNOWN | Network errors prevented fetching |
+
+---
+
+## 6. Top-page response time
+
+### Method
+- `curl -o /dev/null -s -w '%{time_total}' https://<host>/` (single sample, HTTP/2 if available).
+
+### Judgement
+| Status | Condition |
+|---|---|
+| OK | time_total < 1.5 seconds |
+| WARNING | 1.5 to 3.0 seconds |
+| CRITICAL | > 3.0 seconds |
+| UNKNOWN | The request failed |
+
+### Notes
+- Single-sample timing is indicative only; for serious performance work, use a dedicated tool.
+
+---
+
+## 7. Public API surface
+
+### Method
+- `/xmlrpc.php`: HTTP HEAD or GET, check status code.
+  - 200 / 405 means xmlrpc is reachable (405 is what WordPress returns to GET; POST would be the real call).
+- `/wp-json/`: HTTP GET, check status and JSON parseability.
+- `/wp-cron.php`: HTTP HEAD, check status code.
+
+### Judgement
+| Item | OK | WARNING | CRITICAL |
+|---|---|---|---|
+| xmlrpc.php | Returns 403 / 404 / 410 (disabled) | Returns 405 (default WP) | Returns 200 with rsd link |
+| /wp-json/ | Reachable JSON | Reachable but partial | 500 errors |
+| wp-cron.php | Returns 200 / 404 | Returns 5xx | Times out |
+
+### Notes
+- `xmlrpc.php` being open is no longer "always critical" but it remains a brute-force and pingback amplification surface. We mark default state as WARNING.
+- Disabling `wp-cron.php` and using a real cron is best practice but cannot be detected externally; we only check reachability.
+
+---
+
+## 8. Known vulnerable plugin fingerprints
+
+### Method
+- Extract every `/wp-content/plugins/<plugin-name>/` path that appears in the HTML.
+- Compare each detected `<plugin-name>` against the known-issue list below (case-insensitive exact match on slug).
+
+### Known-issue plugin slugs (Phase 1 conservative list)
+The following slugs have had widely reported CVEs in recent years and warrant manual verification of installed version:
+
+- `wp-file-manager` — RCE in versions <= 6.8 (CVE-2020-25213)
+- `revslider` — Slider Revolution arbitrary file upload (older versions)
+- `wp-statistics` — historical SQLi
+- `duplicator` — historical arbitrary file download
+- `loginizer` — historical SQLi (versions < 1.6.4)
+- `elementor` — multiple historical XSS / auth bypass; verify latest
+- `all-in-one-seo-pack` — historical privilege escalation (older versions)
+- `wpforms-lite` — historical XSS
+- `contact-form-7` — historical unrestricted file upload (versions < 5.3.2)
+- `ninja-forms` — historical code injection
+- `updraftplus` — historical info disclosure
+- `wpbakery-page-builder` — historical XSS (formerly visual-composer)
+- `mailpoet` — historical SQLi (very old versions)
+- `wp-super-cache` — historical RCE
+- `social-warfare` — historical RCE (CVE-2019-9978)
+
+### Judgement
+| Status | Condition |
+|---|---|
+| OK | No fingerprints from the known-issue list were found |
+| WARNING | One or more known-issue plugins detected (version cannot be determined externally; manual check required) |
+| CRITICAL | (reserved — Phase 1 cannot reliably detect exploited versions externally) |
+| UNKNOWN | Plugin paths could not be enumerated (no plugins in HTML, or full-page caching strips them) |
+
+### Detection scope (important)
+
+This check detects **only plugins whose CSS/JS assets are enqueued on the front page** —
+roughly, plugins that visibly affect the public site. Plugins that operate only inside
+the WordPress admin (SEO meta managers like Yoast, caching plugins like WP Super Cache,
+backup plugins like UpdraftPlus, security plugins like SiteGuard, etc.) do not emit
+`/wp-content/plugins/<slug>/` paths into the front HTML and **cannot be detected from
+outside**.
+
+Treat the count as a **lower bound**. Many WordPress sites have 2–4× more plugins
+active than this check can see. For a complete plugin inventory, use a dedicated
+WordPress maintenance plugin (internal audit) or check the WP admin Plugins screen.
+
+### Notes
+- This list is intentionally short and high-signal. Phase 2 (with API access) can integrate with the WPScan vulnerability database for accurate version-aware checks.
+- "Detected" never means "exploitable". The skill flags candidates for the human reviewer.
+
+---
+
+## Severity summary mapping
+
+The final report aggregates per-item statuses:
+
+- **CRITICAL** count > 0 → overall "Action required"
+- **WARNING** count > 0 → overall "Attention recommended"
+- All OK / UNKNOWN → overall "Healthy on observable surfaces"

--- a/skills/wp-healthcheck/scripts/check_wp.sh
+++ b/skills/wp-healthcheck/scripts/check_wp.sh
@@ -1,0 +1,440 @@
+#!/usr/bin/env bash
+# check_wp.sh — WordPress site healthcheck (external / public-information only).
+#
+# 使い方:
+#   bash scripts/check_wp.sh <url> [--output <file>]
+#
+# 例:
+#   bash scripts/check_wp.sh https://n-pc.jp
+#   bash scripts/check_wp.sh https://example.com --output /tmp/report.md
+#
+# 依存: bash, curl, jq, awk, sed, grep, mktemp, date
+
+set -euo pipefail
+
+# ------------------------------------------------------------
+# 引数パース
+# ------------------------------------------------------------
+URL=""
+OUTPUT=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --output)
+      OUTPUT="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      sed -n '1,15p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    http://*|https://*)
+      URL="$1"
+      shift
+      ;;
+    *)
+      echo "Error: unknown argument or invalid URL: $1" >&2
+      echo "URL must start with http:// or https://" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$URL" ]; then
+  echo "Usage: $0 <url> [--output <file>]" >&2
+  exit 2
+fi
+
+# 末尾スラッシュ正規化
+URL="${URL%/}"
+
+# ------------------------------------------------------------
+# 依存チェック
+# ------------------------------------------------------------
+for cmd in curl jq awk sed grep mktemp date; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Error: required command '$cmd' is not installed." >&2
+    exit 1
+  fi
+done
+
+# ------------------------------------------------------------
+# 作業ディレクトリ準備（trap で必ず削除）
+# ------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WORK_DIR="$(mktemp -d -t wp-healthcheck.XXXXXX)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# ------------------------------------------------------------
+# 公開メタデータ取得
+# ------------------------------------------------------------
+bash "$SCRIPT_DIR/fetch_wp_meta.sh" "$URL" "$WORK_DIR"
+
+# ------------------------------------------------------------
+# 解析ユーティリティ
+# ------------------------------------------------------------
+
+# findings.tsv に1行追加
+add_finding() {
+  # $1 key, $2 status, $3 summary, $4 detail(pipe-separated)
+  printf '%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "${4:-}" >> "$WORK_DIR/findings.tsv"
+}
+
+# HTML本文存在チェック
+HTML="$WORK_DIR/index.html"
+HEADERS="$WORK_DIR/index.headers"
+
+if [ ! -s "$HTML" ]; then
+  add_finding "wp_version"     "UNKNOWN" "Top page could not be fetched." ""
+  add_finding "theme"          "UNKNOWN" "Top page could not be fetched." ""
+  add_finding "ssl_cert"       "UNKNOWN" "Site unreachable; TLS not evaluated." ""
+  add_finding "sec_headers"    "UNKNOWN" "No headers received." ""
+  add_finding "robots_sitemap" "UNKNOWN" "Site unreachable." ""
+  add_finding "response_time"  "UNKNOWN" "Site unreachable." ""
+  add_finding "api_surface"    "UNKNOWN" "Site unreachable." ""
+  add_finding "plugins"        "UNKNOWN" "Site unreachable." ""
+  bash "$SCRIPT_DIR/format_report.sh" "$WORK_DIR" "$URL" > "${OUTPUT:-/dev/stdout}"
+  if [ -n "$OUTPUT" ]; then
+    echo "Report written to: $OUTPUT" >&2
+  fi
+  exit 0
+fi
+
+# ------------------------------------------------------------
+# 1. WordPress version
+# ------------------------------------------------------------
+WP_VERSION=""
+WP_VERSION=$(grep -Eio '<meta[^>]*name=["'"'"']generator["'"'"'][^>]*content=["'"'"']WordPress[^"'"'"']*' "$HTML" \
+  | head -1 \
+  | sed -E 's/.*WordPress[[:space:]]+([0-9][0-9.]*).*/\1/' \
+  | head -1 || true)
+
+README_STATUS=$(cat "$WORK_DIR/readme.status" 2>/dev/null || echo "000")
+WPJSON_STATUS=$(cat "$WORK_DIR/wpjson.status" 2>/dev/null || echo "000")
+
+WPJSON_NAME=""
+if [ "$WPJSON_STATUS" = "200" ] && [ -s "$WORK_DIR/wpjson.body" ]; then
+  WPJSON_NAME=$(jq -r '.name // empty' "$WORK_DIR/wpjson.body" 2>/dev/null || echo "")
+fi
+
+# 判定
+WP_DETAIL=""
+if [ -n "$WP_VERSION" ]; then
+  MAJOR=$(echo "$WP_VERSION" | cut -d. -f1)
+  MINOR=$(echo "$WP_VERSION" | cut -d. -f2)
+  WP_DETAIL="Detected version: ${WP_VERSION}"
+  if [ "$README_STATUS" = "200" ]; then
+    WP_DETAIL="${WP_DETAIL}|/readme.html is publicly accessible (status 200) — typical of long-unmaintained installs."
+    WP_STATUS="CRITICAL"
+    WP_SUMMARY="WordPress ${WP_VERSION} detected; /readme.html is exposed."
+  elif [ "$MAJOR" -lt 6 ] 2>/dev/null; then
+    WP_STATUS="CRITICAL"
+    WP_SUMMARY="WordPress ${WP_VERSION} is significantly outdated (< 6.0)."
+  elif [ "$MAJOR" -eq 6 ] && [ "$MINOR" -lt 4 ] 2>/dev/null; then
+    WP_STATUS="WARNING"
+    WP_SUMMARY="WordPress ${WP_VERSION} is older than the recent stable line (>= 6.4)."
+  else
+    WP_STATUS="OK"
+    WP_SUMMARY="WordPress ${WP_VERSION} appears reasonably current."
+  fi
+else
+  WP_DETAIL="generator meta absent or stripped"
+  if [ "$README_STATUS" = "200" ]; then
+    WP_STATUS="WARNING"
+    WP_SUMMARY="Version not detected, but /readme.html is publicly accessible."
+    WP_DETAIL="${WP_DETAIL}|/readme.html status: 200"
+  elif [ "$WPJSON_STATUS" = "200" ] && [ -n "$WPJSON_NAME" ]; then
+    WP_STATUS="UNKNOWN"
+    WP_SUMMARY="Version unknown; REST API confirms WordPress (site name: ${WPJSON_NAME})."
+    WP_DETAIL="${WP_DETAIL}|/wp-json/ name: ${WPJSON_NAME}"
+  else
+    WP_STATUS="UNKNOWN"
+    WP_SUMMARY="No WordPress fingerprint detected on the front page."
+  fi
+fi
+add_finding "wp_version" "$WP_STATUS" "$WP_SUMMARY" "$WP_DETAIL"
+
+# ------------------------------------------------------------
+# 2. Active theme
+# ------------------------------------------------------------
+THEME=$(grep -Eo '/wp-content/themes/[a-zA-Z0-9_-]+/' "$HTML" \
+  | head -1 \
+  | sed -E 's|/wp-content/themes/([^/]+)/|\1|' || true)
+
+if [ -n "$THEME" ]; then
+  add_finding "theme" "OK" "Active theme: ${THEME}" "Theme path detected from HTML."
+else
+  add_finding "theme" "UNKNOWN" "Theme could not be detected from HTML." "Possible causes: full-page caching strips theme paths, or non-WordPress site."
+fi
+
+# ------------------------------------------------------------
+# 3. SSL / TLS
+# ------------------------------------------------------------
+SSL_VERBOSE="$WORK_DIR/ssl.verbose"
+SSL_STATUS="UNKNOWN"
+SSL_SUMMARY="HTTPS not used or certificate not parsed."
+SSL_DETAIL=""
+
+case "$URL" in
+  https://*)
+    if [ -s "$SSL_VERBOSE" ]; then
+      ISSUER=$(grep -E 'issuer:' "$SSL_VERBOSE" | head -1 | sed -E 's/.*issuer:[[:space:]]*//' || true)
+      EXPIRE_LINE=$(grep -E 'expire date:' "$SSL_VERBOSE" | head -1 | sed -E 's/.*expire date:[[:space:]]*//' || true)
+      START_LINE=$(grep -E 'start date:' "$SSL_VERBOSE" | head -1 | sed -E 's/.*start date:[[:space:]]*//' || true)
+      SUBJECT=$(grep -E 'subject:' "$SSL_VERBOSE" | head -1 | sed -E 's/.*subject:[[:space:]]*//' || true)
+      VERIFY_OK=$(grep -E 'SSL certificate verify ok' "$SSL_VERBOSE" || true)
+
+      if [ -n "$EXPIRE_LINE" ]; then
+        # 例: "Jul  5 23:29:05 2026 GMT" を "2026-07-05 23:29:05" に整形してから epoch化
+        # macOS の date -j は %Z や 1桁日のパースが弱いので前段で正規化する
+        EXPIRE_EPOCH=""
+        # GNU date が使える環境なら一発で済ませる
+        if date -d "$EXPIRE_LINE" '+%s' >/dev/null 2>&1; then
+          EXPIRE_EPOCH=$(date -d "$EXPIRE_LINE" '+%s')
+        else
+          # macOS BSD date 用の正規化: "Mon  D HH:MM:SS YYYY ZZZ" → "YYYY-MM-DD HH:MM:SS"
+          NORM=$(echo "$EXPIRE_LINE" | tr -s ' ')
+          MON_NAME=$(echo "$NORM" | awk '{print $1}')
+          DAY=$(echo "$NORM" | awk '{print $2}')
+          TIME_PART=$(echo "$NORM" | awk '{print $3}')
+          YEAR=$(echo "$NORM" | awk '{print $4}')
+          MON_NUM=""
+          case "$MON_NAME" in
+            Jan) MON_NUM="01" ;; Feb) MON_NUM="02" ;; Mar) MON_NUM="03" ;;
+            Apr) MON_NUM="04" ;; May) MON_NUM="05" ;; Jun) MON_NUM="06" ;;
+            Jul) MON_NUM="07" ;; Aug) MON_NUM="08" ;; Sep) MON_NUM="09" ;;
+            Oct) MON_NUM="10" ;; Nov) MON_NUM="11" ;; Dec) MON_NUM="12" ;;
+          esac
+          if [ -n "$MON_NUM" ] && [ -n "$DAY" ] && [ -n "$YEAR" ] && [ -n "$TIME_PART" ]; then
+            # 2桁ゼロパディング
+            DAY_PAD=$(printf '%02d' "$DAY" 2>/dev/null || echo "$DAY")
+            ISO="${YEAR}-${MON_NUM}-${DAY_PAD} ${TIME_PART}"
+            # 証明書時刻はUTCなので TZ=UTC で評価
+            if EPOCH_TRY=$(TZ=UTC date -j -f '%Y-%m-%d %H:%M:%S' "$ISO" '+%s' 2>/dev/null); then
+              EXPIRE_EPOCH="$EPOCH_TRY"
+            fi
+          fi
+        fi
+
+        NOW_EPOCH=$(date '+%s')
+        if [ -n "$EXPIRE_EPOCH" ]; then
+          DAYS_LEFT=$(( (EXPIRE_EPOCH - NOW_EPOCH) / 86400 ))
+          if [ "$DAYS_LEFT" -lt 0 ]; then
+            SSL_STATUS="CRITICAL"
+            SSL_SUMMARY="Certificate has expired (${DAYS_LEFT} days)."
+          elif [ "$DAYS_LEFT" -lt 30 ]; then
+            SSL_STATUS="WARNING"
+            SSL_SUMMARY="Certificate expires in ${DAYS_LEFT} days."
+          else
+            SSL_STATUS="OK"
+            SSL_SUMMARY="Certificate valid for ${DAYS_LEFT} more days."
+          fi
+          SSL_DETAIL="Subject: ${SUBJECT}|Issuer: ${ISSUER}|Valid from: ${START_LINE}|Expires: ${EXPIRE_LINE}|Days remaining: ${DAYS_LEFT}"
+        else
+          SSL_STATUS="UNKNOWN"
+          SSL_SUMMARY="Could not parse certificate expiry date."
+          SSL_DETAIL="Raw expire date string: ${EXPIRE_LINE}"
+        fi
+      fi
+
+      if [ -z "$VERIFY_OK" ] && [ "$SSL_STATUS" != "CRITICAL" ]; then
+        # verify ok 行が無く、かつ critical でないなら警告
+        if grep -qE 'self.signed|certificate verify failed|hostname.*does not match' "$SSL_VERBOSE"; then
+          SSL_STATUS="CRITICAL"
+          SSL_SUMMARY="Certificate verification failed."
+        fi
+      fi
+    fi
+    ;;
+  *)
+    SSL_STATUS="CRITICAL"
+    SSL_SUMMARY="Site is served over plain HTTP."
+    SSL_DETAIL="HTTPS is required for modern WordPress sites (SEO, login security, browser warnings)."
+    ;;
+esac
+
+add_finding "ssl_cert" "$SSL_STATUS" "$SSL_SUMMARY" "$SSL_DETAIL"
+
+# ------------------------------------------------------------
+# 4. Security headers
+# ------------------------------------------------------------
+header_present() {
+  # ヘッダ名（大小無視）が存在するか
+  grep -iE "^${1}:" "$HEADERS" >/dev/null 2>&1
+}
+
+PRESENT_HEADERS=""
+MISSING_HEADERS=""
+COUNT_PRESENT=0
+
+for h in "X-Frame-Options" "X-Content-Type-Options" "Strict-Transport-Security" "Content-Security-Policy" "Referrer-Policy"; do
+  if header_present "$h"; then
+    PRESENT_HEADERS="${PRESENT_HEADERS}${h} "
+    COUNT_PRESENT=$((COUNT_PRESENT + 1))
+  else
+    MISSING_HEADERS="${MISSING_HEADERS}${h} "
+  fi
+done
+
+if [ "$COUNT_PRESENT" -ge 4 ]; then
+  SEC_STATUS="OK"
+elif [ "$COUNT_PRESENT" -ge 2 ]; then
+  SEC_STATUS="WARNING"
+else
+  SEC_STATUS="CRITICAL"
+fi
+
+SEC_SUMMARY="${COUNT_PRESENT} of 5 recommended security headers present."
+SEC_DETAIL="Present: ${PRESENT_HEADERS:-none}|Missing: ${MISSING_HEADERS:-none}"
+add_finding "sec_headers" "$SEC_STATUS" "$SEC_SUMMARY" "$SEC_DETAIL"
+
+# ------------------------------------------------------------
+# 5. robots.txt and sitemap
+# ------------------------------------------------------------
+ROBOTS_STATUS=$(cat "$WORK_DIR/robots.status" 2>/dev/null || echo "000")
+SITEMAP_STATUS=$(cat "$WORK_DIR/sitemap.status" 2>/dev/null || echo "000")
+SITEMAP_URL=$(cat "$WORK_DIR/sitemap.url" 2>/dev/null || echo "")
+
+ROBOTS_OK=0
+SITEMAP_OK=0
+
+[ "$ROBOTS_STATUS" = "200" ] && [ -s "$WORK_DIR/robots.body" ] && ROBOTS_OK=1
+[ "$SITEMAP_STATUS" = "200" ] && SITEMAP_OK=1
+
+if [ "$ROBOTS_OK" = "1" ] && [ "$SITEMAP_OK" = "1" ]; then
+  RS_STATUS="OK"
+  RS_SUMMARY="Both robots.txt and sitemap are present."
+elif [ "$ROBOTS_OK" = "1" ] || [ "$SITEMAP_OK" = "1" ]; then
+  RS_STATUS="WARNING"
+  RS_SUMMARY="One of robots.txt / sitemap is missing or unreachable."
+else
+  RS_STATUS="CRITICAL"
+  RS_SUMMARY="Neither robots.txt nor sitemap is reachable."
+fi
+
+RS_DETAIL="robots.txt status: ${ROBOTS_STATUS}|sitemap URL tried: ${SITEMAP_URL}|sitemap status: ${SITEMAP_STATUS}"
+add_finding "robots_sitemap" "$RS_STATUS" "$RS_SUMMARY" "$RS_DETAIL"
+
+# ------------------------------------------------------------
+# 6. Response time
+# ------------------------------------------------------------
+TIME_TOTAL=$(cat "$WORK_DIR/time_total" 2>/dev/null || echo "0")
+# 小数比較は awk で
+TIME_STATUS=$(awk -v t="$TIME_TOTAL" 'BEGIN {
+  if (t+0 == 0) print "UNKNOWN";
+  else if (t+0 < 1.5) print "OK";
+  else if (t+0 < 3.0) print "WARNING";
+  else print "CRITICAL";
+}')
+TIME_SUMMARY="Top page time_total: ${TIME_TOTAL}s"
+add_finding "response_time" "$TIME_STATUS" "$TIME_SUMMARY" "Single-sample measurement; treat as indicative only."
+
+# ------------------------------------------------------------
+# 7. Public API surface
+# ------------------------------------------------------------
+XMLRPC_STATUS=$(cat "$WORK_DIR/xmlrpc.status" 2>/dev/null || echo "000")
+WPCRON_STATUS=$(cat "$WORK_DIR/wpcron.status" 2>/dev/null || echo "000")
+
+# xmlrpc 判定
+case "$XMLRPC_STATUS" in
+  403|404|410)  XMLRPC_VERDICT="OK (disabled, status ${XMLRPC_STATUS})"; XMLRPC_LEVEL=0 ;;
+  405)          XMLRPC_VERDICT="WARNING (default WordPress, GET returns 405)"; XMLRPC_LEVEL=1 ;;
+  200)          XMLRPC_VERDICT="CRITICAL (xmlrpc.php served on GET — verify it is intentional)"; XMLRPC_LEVEL=2 ;;
+  *)            XMLRPC_VERDICT="UNKNOWN (status ${XMLRPC_STATUS})"; XMLRPC_LEVEL=-1 ;;
+esac
+
+# wp-json 判定
+case "$WPJSON_STATUS" in
+  200) WPJSON_VERDICT="OK (REST API reachable)"; WPJSON_LEVEL=0 ;;
+  401|403) WPJSON_VERDICT="OK (REST API restricted, status ${WPJSON_STATUS})"; WPJSON_LEVEL=0 ;;
+  404) WPJSON_VERDICT="WARNING (REST API not found)"; WPJSON_LEVEL=1 ;;
+  5*) WPJSON_VERDICT="CRITICAL (REST API server error, status ${WPJSON_STATUS})"; WPJSON_LEVEL=2 ;;
+  *) WPJSON_VERDICT="UNKNOWN (status ${WPJSON_STATUS})"; WPJSON_LEVEL=-1 ;;
+esac
+
+# wp-cron 判定
+case "$WPCRON_STATUS" in
+  200|404) WPCRON_VERDICT="OK (status ${WPCRON_STATUS})"; WPCRON_LEVEL=0 ;;
+  5*) WPCRON_VERDICT="WARNING (server error, status ${WPCRON_STATUS})"; WPCRON_LEVEL=1 ;;
+  000) WPCRON_VERDICT="CRITICAL (timeout)"; WPCRON_LEVEL=2 ;;
+  *) WPCRON_VERDICT="OK (status ${WPCRON_STATUS})"; WPCRON_LEVEL=0 ;;
+esac
+
+# 最大レベルで集約
+MAX_LEVEL=$XMLRPC_LEVEL
+[ "$WPJSON_LEVEL" -gt "$MAX_LEVEL" ] && MAX_LEVEL=$WPJSON_LEVEL
+[ "$WPCRON_LEVEL" -gt "$MAX_LEVEL" ] && MAX_LEVEL=$WPCRON_LEVEL
+
+case "$MAX_LEVEL" in
+  2)  API_STATUS="CRITICAL" ;;
+  1)  API_STATUS="WARNING" ;;
+  0)  API_STATUS="OK" ;;
+  *)  API_STATUS="UNKNOWN" ;;
+esac
+
+API_SUMMARY="xmlrpc / wp-json / wp-cron probed."
+API_DETAIL="xmlrpc.php: ${XMLRPC_VERDICT}|/wp-json/: ${WPJSON_VERDICT}|wp-cron.php: ${WPCRON_VERDICT}"
+add_finding "api_surface" "$API_STATUS" "$API_SUMMARY" "$API_DETAIL"
+
+# ------------------------------------------------------------
+# 8. Plugin fingerprints + known-issue match
+# ------------------------------------------------------------
+# Limitation: detects only plugins that emit `/wp-content/plugins/<slug>/` paths
+# in the front-end HTML. Plugins active only in the WordPress admin (SEO meta
+# managers, caching plugins, backup plugins, security plugins, etc.) leave no
+# fingerprint on the public site and cannot be detected from outside. Treat the
+# resulting count as a lower bound, not a complete plugin inventory.
+#
+# HTML から plugin slug を全部抽出（重複排除）
+PLUGIN_SLUGS=$(grep -Eo '/wp-content/plugins/[a-zA-Z0-9_-]+/' "$HTML" \
+  | sed -E 's|/wp-content/plugins/([^/]+)/|\1|' \
+  | sort -u || true)
+
+# 既知脆弱性プラグインリスト（checklist.md に対応）
+KNOWN_VULN="wp-file-manager revslider wp-statistics duplicator loginizer elementor all-in-one-seo-pack wpforms-lite contact-form-7 ninja-forms updraftplus wpbakery-page-builder mailpoet wp-super-cache social-warfare"
+
+FOUND_VULN=""
+DETECTED_LIST=""
+PLUGIN_COUNT=0
+
+if [ -n "$PLUGIN_SLUGS" ]; then
+  while IFS= read -r slug; do
+    [ -z "$slug" ] && continue
+    PLUGIN_COUNT=$((PLUGIN_COUNT + 1))
+    DETECTED_LIST="${DETECTED_LIST}${slug} "
+    for vuln in $KNOWN_VULN; do
+      if [ "$slug" = "$vuln" ]; then
+        FOUND_VULN="${FOUND_VULN}${slug} "
+      fi
+    done
+  done <<EOF
+$PLUGIN_SLUGS
+EOF
+fi
+
+PLUGIN_NOTE="Note: Plugins active only in the WordPress admin (SEO, cache, backup, security tools) typically leave no front-end fingerprint and cannot be detected from outside."
+
+if [ "$PLUGIN_COUNT" -eq 0 ]; then
+  PLUGIN_STATUS="UNKNOWN"
+  PLUGIN_SUMMARY="No plugin paths detected in HTML."
+  PLUGIN_DETAIL="Possible causes: full-page caching, plugins with no front-end assets, or non-WordPress site.|${PLUGIN_NOTE}"
+elif [ -n "$FOUND_VULN" ]; then
+  PLUGIN_STATUS="WARNING"
+  PLUGIN_SUMMARY="Plugins with historical CVEs detected: ${FOUND_VULN}"
+  PLUGIN_DETAIL="Front-end visible plugins (${PLUGIN_COUNT}): ${DETECTED_LIST}|${PLUGIN_NOTE}|Action: verify each flagged plugin is up to date. Versions cannot be determined externally."
+else
+  PLUGIN_STATUS="OK"
+  PLUGIN_SUMMARY="${PLUGIN_COUNT} front-end visible plugin(s) detected; none on the known-issue list."
+  PLUGIN_DETAIL="Front-end visible plugins (${PLUGIN_COUNT}): ${DETECTED_LIST}|${PLUGIN_NOTE}"
+fi
+add_finding "plugins" "$PLUGIN_STATUS" "$PLUGIN_SUMMARY" "$PLUGIN_DETAIL"
+
+# ------------------------------------------------------------
+# レポート出力
+# ------------------------------------------------------------
+if [ -n "$OUTPUT" ]; then
+  bash "$SCRIPT_DIR/format_report.sh" "$WORK_DIR" "$URL" > "$OUTPUT"
+  echo "Report written to: $OUTPUT" >&2
+else
+  bash "$SCRIPT_DIR/format_report.sh" "$WORK_DIR" "$URL"
+fi

--- a/skills/wp-healthcheck/scripts/fetch_wp_meta.sh
+++ b/skills/wp-healthcheck/scripts/fetch_wp_meta.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# fetch_wp_meta.sh — fetch WordPress public metadata for a given site.
+# 使い方: fetch_wp_meta.sh <base_url> <work_dir>
+#
+# 取得物（work_dir 配下に保存）:
+#   index.html       トップページのHTML
+#   index.headers    トップページのレスポンスヘッダ
+#   readme.status    /readme.html のHTTPステータス
+#   wpjson.body      /wp-json/ のレスポンスボディ
+#   wpjson.status    /wp-json/ のHTTPステータス
+#   xmlrpc.status    /xmlrpc.php のHTTPステータス
+#   wpcron.status    /wp-cron.php のHTTPステータス
+#   robots.body      /robots.txt のレスポンスボディ
+#   robots.status    /robots.txt のHTTPステータス
+#   sitemap.status   /sitemap.xml or /wp-sitemap.xml のHTTPステータス
+#   sitemap.url      実際に200を返したサイトマップURL
+#   ssl.verbose      curl -vI の出力（証明書情報含む）
+#   time_total       トップページの応答秒数
+
+set -euo pipefail
+
+BASE_URL="${1:-}"
+WORK_DIR="${2:-}"
+
+if [ -z "$BASE_URL" ] || [ -z "$WORK_DIR" ]; then
+  echo "Usage: $0 <base_url> <work_dir>" >&2
+  exit 2
+fi
+
+# 末尾スラッシュを削る（正規化）
+BASE_URL="${BASE_URL%/}"
+
+CURL_OPTS_COMMON="--silent --show-error --connect-timeout 10 --max-time 30 --location --user-agent wp-healthcheck-skill/0.1"
+
+# 1. トップページ取得（HTML本文 + ヘッダ + 応答時間）
+curl $CURL_OPTS_COMMON \
+  -o "$WORK_DIR/index.html" \
+  -D "$WORK_DIR/index.headers" \
+  -w '%{time_total}' \
+  "$BASE_URL/" > "$WORK_DIR/time_total" 2>"$WORK_DIR/index.error" || true
+
+# 2. /readme.html ステータスのみ
+curl $CURL_OPTS_COMMON \
+  -o /dev/null \
+  -w '%{http_code}' \
+  -I "$BASE_URL/readme.html" > "$WORK_DIR/readme.status" 2>/dev/null || echo "000" > "$WORK_DIR/readme.status"
+
+# 3. /wp-json/ 本文+ステータス
+curl $CURL_OPTS_COMMON \
+  -o "$WORK_DIR/wpjson.body" \
+  -w '%{http_code}' \
+  "$BASE_URL/wp-json/" > "$WORK_DIR/wpjson.status" 2>/dev/null || echo "000" > "$WORK_DIR/wpjson.status"
+
+# 4. /xmlrpc.php ステータス（GETで判定）
+curl $CURL_OPTS_COMMON \
+  -o /dev/null \
+  -w '%{http_code}' \
+  "$BASE_URL/xmlrpc.php" > "$WORK_DIR/xmlrpc.status" 2>/dev/null || echo "000" > "$WORK_DIR/xmlrpc.status"
+
+# 5. /wp-cron.php ステータス（HEADで判定）
+curl $CURL_OPTS_COMMON \
+  -o /dev/null \
+  -w '%{http_code}' \
+  -I "$BASE_URL/wp-cron.php" > "$WORK_DIR/wpcron.status" 2>/dev/null || echo "000" > "$WORK_DIR/wpcron.status"
+
+# 6. robots.txt
+curl $CURL_OPTS_COMMON \
+  -o "$WORK_DIR/robots.body" \
+  -w '%{http_code}' \
+  "$BASE_URL/robots.txt" > "$WORK_DIR/robots.status" 2>/dev/null || echo "000" > "$WORK_DIR/robots.status"
+
+# 7. sitemap（/sitemap.xml → だめなら /wp-sitemap.xml）
+SITEMAP_URL="$BASE_URL/sitemap.xml"
+SITEMAP_STATUS=$(curl $CURL_OPTS_COMMON -o /dev/null -w '%{http_code}' -I "$SITEMAP_URL" 2>/dev/null || echo "000")
+if [ "$SITEMAP_STATUS" != "200" ]; then
+  SITEMAP_URL="$BASE_URL/wp-sitemap.xml"
+  SITEMAP_STATUS=$(curl $CURL_OPTS_COMMON -o /dev/null -w '%{http_code}' -I "$SITEMAP_URL" 2>/dev/null || echo "000")
+fi
+echo "$SITEMAP_STATUS" > "$WORK_DIR/sitemap.status"
+echo "$SITEMAP_URL" > "$WORK_DIR/sitemap.url"
+
+# 8. SSL/TLS情報（HTTPSの場合のみ意味がある。curl -vI で取得）
+case "$BASE_URL" in
+  https://*)
+    # curl -vI は標準エラーに証明書情報を出すので 2>&1 でキャプチャ
+    curl -vI --connect-timeout 10 --max-time 30 \
+      --user-agent wp-healthcheck-skill/0.1 \
+      "$BASE_URL/" > /dev/null 2> "$WORK_DIR/ssl.verbose" || true
+    ;;
+  *)
+    : > "$WORK_DIR/ssl.verbose"
+    ;;
+esac
+
+exit 0

--- a/skills/wp-healthcheck/scripts/format_report.sh
+++ b/skills/wp-healthcheck/scripts/format_report.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# format_report.sh — render the diagnostic findings as a Markdown report.
+# 使い方: format_report.sh <work_dir> <base_url>
+#
+# 期待入力: work_dir/findings.tsv （check_wp.sh が生成）
+#   1列目: 項目キー（例: wp_version, ssl_cert）
+#   2列目: ステータス（OK / WARNING / CRITICAL / UNKNOWN）
+#   3列目: 一行サマリ
+#   4列目: 詳細（パイプ `|` 区切りで複数行可）
+
+set -euo pipefail
+
+WORK_DIR="${1:-}"
+BASE_URL="${2:-}"
+
+if [ -z "$WORK_DIR" ] || [ -z "$BASE_URL" ]; then
+  echo "Usage: $0 <work_dir> <base_url>" >&2
+  exit 2
+fi
+
+FINDINGS="$WORK_DIR/findings.tsv"
+if [ ! -f "$FINDINGS" ]; then
+  echo "Error: $FINDINGS not found." >&2
+  exit 1
+fi
+
+# ステータス別カウント
+COUNT_OK=$(awk -F'\t' '$2=="OK"{c++} END{print c+0}' "$FINDINGS")
+COUNT_WARN=$(awk -F'\t' '$2=="WARNING"{c++} END{print c+0}' "$FINDINGS")
+COUNT_CRIT=$(awk -F'\t' '$2=="CRITICAL"{c++} END{print c+0}' "$FINDINGS")
+COUNT_UNK=$(awk -F'\t' '$2=="UNKNOWN"{c++} END{print c+0}' "$FINDINGS")
+
+# 全体評価
+if [ "$COUNT_CRIT" -gt 0 ]; then
+  OVERALL="Action required"
+elif [ "$COUNT_WARN" -gt 0 ]; then
+  OVERALL="Attention recommended"
+elif [ "$COUNT_OK" -eq 0 ] && [ "$COUNT_UNK" -gt 0 ]; then
+  # OK が0件で UNKNOWN ばかり = 観測自体ができていない
+  OVERALL="Could not assess (site unreachable or non-responsive)"
+else
+  OVERALL="Healthy on observable surfaces"
+fi
+
+NOW_UTC=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
+
+# 項目キー → 表示名のマッピング（bash 3.2 互換のため case で実装）
+label_for_key() {
+  case "$1" in
+    wp_version)       echo "WordPress version" ;;
+    theme)            echo "Active theme" ;;
+    ssl_cert)         echo "SSL / TLS certificate" ;;
+    sec_headers)      echo "Security headers" ;;
+    robots_sitemap)   echo "robots.txt and sitemap" ;;
+    response_time)    echo "Top page response time" ;;
+    api_surface)      echo "Public API surface" ;;
+    plugins)          echo "Plugin fingerprints" ;;
+    *)                echo "$1" ;;
+  esac
+}
+
+# レポート出力
+cat <<EOF
+# WordPress Healthcheck Report
+
+- Target: ${BASE_URL}
+- Generated: ${NOW_UTC}
+- Skill: wp-healthcheck (Phase 1, standalone external probe)
+
+## Summary
+
+- Overall: **${OVERALL}**
+- OK: ${COUNT_OK} / WARNING: ${COUNT_WARN} / CRITICAL: ${COUNT_CRIT} / UNKNOWN: ${COUNT_UNK}
+
+| Item | Status | Summary |
+|---|---|---|
+EOF
+
+# テーブル行
+while IFS=$'\t' read -r key status summary _detail; do
+  label=$(label_for_key "$key")
+  echo "| ${label} | ${status} | ${summary} |"
+done < "$FINDINGS"
+
+cat <<'EOF'
+
+## Findings (detail)
+
+EOF
+
+# 詳細セクション
+while IFS=$'\t' read -r key status summary detail; do
+  label=$(label_for_key "$key")
+  echo "### ${label} — ${status}"
+  echo ""
+  echo "${summary}"
+  echo ""
+  if [ -n "$detail" ]; then
+    # detail内は `|` を改行に変換
+    echo "$detail" | tr '|' '\n' | while IFS= read -r line; do
+      [ -n "$line" ] && echo "- ${line}"
+    done
+    echo ""
+  fi
+done < "$FINDINGS"
+
+cat <<'EOF'
+## Limitations
+
+This report is built **only from publicly accessible information** (HTML, headers, well-known
+endpoints, TLS certificate). It cannot:
+
+- Determine actual installed plugin versions (only slugs visible in HTML).
+- See plugins that are active only in the WordPress admin (SEO, cache, backup, security
+  managers). Front-end-invisible plugins leave no fingerprint in public HTML, so the
+  detected plugin count is a **lower bound**, not a complete inventory.
+- Inspect database, wp-config.php, or admin-only state.
+- Detect exploited backdoors or compromised content not exposed on the front page.
+
+For an internal audit (file integrity, cron schedule, user roles, transient state, full
+plugin inventory), use a dedicated WordPress maintenance plugin that runs inside the site.
+
+## References
+
+See `references/checklist.md` in the skill directory for the full judgement criteria.
+EOF


### PR DESCRIPTION
## Summary

Adds `wp-healthcheck`, a credential-less WordPress site diagnostic skill that
produces a graded Markdown maintenance report from publicly accessible
information only.

## What it does

- Detects WordPress version and active theme
- Validates SSL/TLS certificate (issuer + days remaining)
- Checks recommended security headers (X-Frame-Options, HSTS, CSP,
  X-Content-Type-Options, Referrer-Policy)
- Verifies robots.txt and sitemap.xml presence
- Measures top-page response time
- Probes xmlrpc.php / wp-json / wp-cron.php exposure
- Flags installed plugins with historical CVEs

Each finding is graded **OK / WARNING / CRITICAL / UNKNOWN**, and the report
ends with an explicit Limitations section so users understand what an
external probe cannot see.

## Why a skill

WordPress maintenance is a recurring task where the same first-pass checks
get repeated across many sites. Encapsulating the probe + grading + report
format as a skill lets Claude run a consistent assessment whenever a user
points it at a WordPress URL.

## Implementation

- `bash` + `curl` + `jq` only — no external API keys, no credentials.
- Three short scripts: `fetch_wp_meta.sh`, `check_wp.sh`, `format_report.sh`.
- Strict mode (`set -euo pipefail`) and conservative grading rules.
- Apache 2.0 licensed.

## Validation

Validated against production WordPress sites. A real sample report is
included at `skills/wp-healthcheck/examples/sample-report.md`.

## Notes

The skill is intentionally limited to public-information probes. Internal
audits (database, file integrity, admin-only state) are pointed to a
dedicated WordPress maintenance plugin in the Limitations section.