### PR TITLE
Add product-ready skill — AI-native Spec-Driven Development for Product Owners

### DIFF
--- a/skills/product-ready/LICENSE.txt
+++ b/skills/product-ready/LICENSE.txt
@@ -1,0 +1,200 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based upon (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and derivative works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to use, reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, trademark, patent,
+          attribution and other notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright notice to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Support, Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "page" as the copyright notice for easier identification within
+      third-party archives.
+
+   Copyright 2026 Product Ready
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/product-ready/SKILL.md
+++ b/skills/product-ready/SKILL.md
@@ -1,0 +1,465 @@
+---
+name: product-ready
+version: 1.2.0
+description: Use this skill when working on product ideas, PRDs, requirements, user stories, acceptance criteria, backlog items, behavior specs, test plans, readiness reviews, spec-driven development, or generating tests and code from a BDD Spec. Helps Product Owners clarify ideas, write PRDs, define AI-ready BDD Specs, score spec quality, generate AI prompts from scenarios, detect missing decisions, and prepare work for engineering.
+---
+
+# Product Ready Core
+
+## Purpose
+
+Product Ready ensures that all product work is:
+- clear
+- testable
+- measurable
+- non-duplicative
+- secure and compliant
+- usable (UI/UX included)
+- ready for engineering and acceptance
+
+If it is not testable and measurable, it is not Product Ready.
+
+## Core Principle
+
+Do not move forward until the work is:
+- understood
+- decision-complete
+- testable
+- aligned to a product goal
+
+## Adaptive Workflow Model
+
+Product Ready uses **one workflow with adaptive depth**, not multiple workflows.
+
+### Depth Levels
+
+- **Lightweight** → small changes, bugs, simple features
+- **Standard** → most product work
+- **Full** → high-risk, compliance-heavy, AI, financial, or complex systems
+
+### Escalation Rules
+
+Increase rigor if:
+- ambiguity increases
+- risk increases
+- compliance/security applies
+- multiple systems or workflows are involved
+- user impact is high
+
+## Spec-Driven Development Model
+
+Product Ready is AI-native Spec-Driven Development, built on BDD.
+
+The development chain:
+
+```
+PRD → BDD Spec (THE SPEC) → [AI: Tests + Code] → Acceptance
+```
+
+The BDD Spec is the canonical source of truth for all downstream work:
+- Test cases are **derived** from the BDD Spec, not invented separately
+- Code is **generated** from the BDD Spec, not guessed at
+- Acceptance is **validated** against the BDD Spec, not developer assumptions
+
+**Do not generate tests or code without a complete, unambiguous, decision-resolved BDD Spec.**
+
+The BDD Spec is earned — it is produced by validated discovery (Step 2), challenged assumptions (Step 3), and a complete PRD (Step 4). It is never written first.
+
+## Workflow (Canonical)
+
+### 1. Product Strategy / Goal
+
+Define:
+- business objective
+- customer problem
+- success metric (SMART)
+- priority vs other work
+
+If unclear → ask questions.
+
+### 2. Discovery / Validation
+
+Clarify:
+- problem
+- user
+- current workflow
+- desired outcome
+
+Validate:
+- assumptions
+- cheapest test
+- success/failure criteria
+
+### 3. Challenge (Drill-Me)
+
+Critically evaluate:
+- assumptions
+- risks (value, usability, feasibility, viability)
+- missing decisions
+- simpler alternatives
+
+### 4. PRD
+
+Produce structured product definition:
+- requirements (REQ-*)
+- business rules (BR-*)
+- goals and non-goals
+- metrics (SMART + integrity)
+- dependencies
+
+### 5. BDD Spec (THE SPEC)
+
+Define:
+- scenarios (BS-*)
+- Given / When / Then
+- edge cases
+- failure cases
+- UI states
+- observable outputs
+
+All scenarios must be testable.
+
+Before proceeding to Step 6, apply Spec Integrity guardrail:
+every scenario must be complete, unambiguous, decision-resolved, and linked to a REQ-*.
+If any condition is unmet → STOP. Do not proceed to test or code generation.
+
+### 5b. Generate from Spec (optional)
+
+Activates when the user asks to generate tests or code from the BDD Spec.
+
+Steps:
+1. Run Spec Quality Score (Guardrail #8)
+2. If score is **Incomplete** or **Partial** → list every failing dimension, STOP
+3. If score is **Complete** → format each BS-* scenario as an AI generation prompt
+
+For each scenario, produce one self-contained prompt block:
+
+    Scenario [BS-NNN]: [title]
+    Type: [Happy path / Edge case / Failure / Security / UI]
+
+    Given [preconditions — specific, named entities and values]
+    When [one action or event]
+    Then [exact, observable assertion]
+
+    Requirements: [REQ-NNN] — [brief text]
+    Business Rules: [BR-NNN] — [brief text]
+    Automation: [Unit / Integration / E2E / Manual]
+    Context: [API endpoints, data types, constraints the AI needs]
+
+    Generate: [test function / implementation stub / both]
+
+Output one prompt block per scenario. Do not bundle multiple scenarios in one block.
+
+### 6. Test Spec
+
+Convert behavior into:
+- test cases (TS-*) derived from BDD Spec scenarios
+- steps
+- assertions
+- automation level
+
+Do not invent missing rules.
+
+### 7. Prioritization
+
+Evaluate:
+- impact
+- effort
+- risk
+- confidence
+
+Produce ranked backlog.
+
+### 8. Issues
+
+Break into:
+- independent, testable stories
+- linked to REQ / BS / TS
+
+### 9. Build
+
+Ensure:
+- implementation follows BDD Spec
+- questions resolved before coding
+
+### 10. Acceptance
+
+A feature is acceptable only when:
+- all Must scenarios pass
+- tests pass
+- no critical defects
+- behavior matches intent
+- UI/UX is acceptable
+
+### 11. Release
+
+Ensure:
+- readiness criteria met
+- stakeholders aligned
+- rollback plan exists
+
+### 12. Measure
+
+Track:
+- success metrics
+- guardrail metrics
+- adoption
+- quality
+
+### 13. Learn / Iterate
+
+Evaluate:
+- what worked
+- what failed
+- next iteration
+
+Feed back into discovery.
+
+## BDD Spec → AI Prompt Mapping
+
+A BDD scenario is a complete AI generation prompt — no reformatting required when written correctly.
+
+### Rules for AI-ready Then clauses
+
+Then clauses must be **exact and observable**. Vague language breaks AI generation:
+
+- ❌ "the system should process the request" — untestable
+- ❌ "the user may see a confirmation" — ambiguous
+- ❌ "the page typically loads within a few seconds" — non-deterministic
+- ✅ "the API returns HTTP 200 with body `{"status": "created", "id": "<uuid>"}`"
+- ✅ "the user sees the message 'Your order has been placed (Order #12345)'"
+- ✅ "a record is inserted in the orders table with status='pending' and user_id matching the session"
+
+### One behaviour per scenario
+
+Do not combine multiple assertions in a single scenario. Split them:
+
+- ❌ `Given X, When Y, Then A and B and C`
+- ✅ `BS-001: Then A` | `BS-002: Then B` | `BS-003: Then C`
+
+### State all preconditions explicitly
+
+AI tools have no knowledge of your system. Given clauses must be self-contained:
+
+- ❌ "Given the user is logged in"
+- ✅ "Given a registered user with role=admin, account_status=active, and a valid session token"
+
+### Standard AI prompt format
+
+    Scenario [BS-NNN]: [title]
+    Type: [Happy path / Edge case / Failure / Security / UI]
+
+    Given [preconditions]
+    When [action]
+    Then [exact assertion]
+
+    Requirements: [REQ-NNN] — [brief text]
+    Business Rules: [BR-NNN] — [brief text]
+    Automation: [Unit / Integration / E2E / Manual]
+    Context: [technical constraints]
+
+    Generate: [test function / implementation / both]
+
+## Default Behavior
+
+If input is vague:
+→ start with Discovery
+
+If risky or complex:
+→ escalate to full workflow
+
+If small/simple:
+→ stay lightweight
+
+## First Interaction
+
+Three tiers — pick the first that matches:
+
+**1. Intent clear** (user named a task: "write a PRD", "review my backlog", "add export to CSV"):
+→ Skip any intro. Proceed directly to the appropriate workflow step.
+
+**2. Domain known, task unclear** (user named an area — UX, performance, onboarding, search — but not what they want to do):
+→ Skip the process menu. Ask what specific problem they're trying to solve.
+→ Example: "What's the specific UX problem you're seeing — is it a flow, a friction point, or something users are failing to do?"
+
+**3. No signal** (no domain, no task — e.g., "I have an idea", "I need help"):
+→ One sentence: "Product Ready helps you define, spec, and validate product work before it reaches engineering."
+→ One question: "What are you working on — an idea, a PRD, acceptance criteria, or a backlog review?"
+
+# Product Ready Guardrails
+
+## Purpose
+
+Guardrails ensure quality, prevent common pitfalls, and enforce standards throughout the product development process.
+
+## Core Guardrails
+
+### 1. No Missing Decisions
+If a decision is required but not made:
+→ Mark as **Missing Product Decision**
+→ Do not proceed until resolved
+
+### 2. Testability Rule
+If work cannot be tested:
+→ It is not ready
+→ Must have acceptance criteria and test cases
+
+### 3. No Duplicates or Conflicts
+- Detect duplicate requirements
+- Detect contradictions between rules
+- Normalize conflicting items into BR-* business rules
+- Resolve before finalizing
+
+### 4. Metric Integrity
+Every success metric must include:
+- **Baseline**: Current value
+- **Target**: Desired value
+- **Timeframe**: When to achieve
+- **Decision Rule**: How to evaluate success/failure
+
+### 5. Security & Compliance
+- Identify applicable frameworks (SOC2, NIST, PCI, etc.)
+- Map controls to requirements
+- Include security scenarios in BDD Spec
+- Generate compliance test cases
+
+### 6. UI is First-Class
+- Define all UI states and transitions
+- Ensure usability and accessibility standards
+- Include UI scenarios in BDD Spec
+- Validate with user testing criteria
+
+### 7. Evidence Over Assumption
+For all claims and assumptions:
+- Label evidence strength: Strong / Medium / Weak
+- Prefer data-driven decisions
+- Validate assumptions with cheapest tests
+
+### 8. Spec Integrity
+
+Before proceeding to test or code generation, run the **Spec Quality Score**:
+
+| Dimension | Check | Level |
+|-----------|-------|-------|
+| **Coverage** | Happy paths, edge cases, and failure paths all present | Critical |
+| **Clarity** | No "should", "may", "typically" in Then clauses — all assertions are exact and observable | Critical |
+| **Linkage** | Every BS-* scenario linked to at least one REQ-* | Required |
+| **Decisions** | No open [MPD] markers remaining | Required |
+| **UI** | All UI states defined (conditional — only if UI is involved) | Conditional |
+
+**Score:**
+- **Complete** → all Critical pass + all Required pass → proceed to generation
+- **Partial** → one or more Required dimensions fail → list what must be fixed, re-score before continuing
+- **Incomplete** → one or more Critical dimensions fail → STOP immediately. Do not generate tests or code.
+
+Report the score and list every failing dimension before stopping.
+
+## Execution Modes
+
+### Fast Mode (Default)
+- Minimal questions asked
+- Quick readiness check
+- Lightweight acceptance criteria
+- For small changes and simple features
+
+### Full Mode
+- Complete workflow execution
+- PRD + Behavior Spec + Test Spec
+- Compliance, UI, security included
+- For high-risk, complex, or regulated work
+
+### Escalation Triggers
+Automatically escalate to Full Mode when:
+- Risk level increases
+- Compliance requirements apply
+- Multiple systems involved
+- High user impact
+- Ambiguity detected
+
+# Output Rules
+
+- Be concise unless full mode is required
+- Do not generate long PRDs unless explicitly needed
+- Prefer structured output over essays
+- Ask questions before generating if unclear
+
+---
+
+# Skill Activation Behavior
+
+When invoked:
+
+1. Identify intent:
+   - clarify idea
+   - write PRD
+   - define behavior/tests
+   - review work
+
+2. Choose appropriate depth:
+   - fast
+   - standard
+   - full
+
+3. Proceed with minimal necessary steps
+
+---
+
+# Trigger Phrases
+
+This skill should activate when the user mentions or implies:
+- PRD
+- product requirements
+- user stories
+- acceptance criteria
+- backlog
+- feature design
+- product idea
+- feature request
+- behavior spec
+- test cases
+- readiness
+- review requirements
+- define workflow
+- improve feature
+- clarify idea
+- spec-driven development
+- BDD spec
+- generate from spec
+- generate tests
+- generate code from spec
+- score my spec
+- spec quality
+
+Even if the user does not explicitly say "Product Ready"
+
+---
+
+# Intent Detection
+
+Map user requests to workflow steps:
+- vague idea → Discovery
+- critique request → Challenge
+- PRD request → PRD (with questions first)
+- acceptance criteria → BDD Spec
+- test request → Test Spec
+- backlog → Issues / Prioritization
+- review → Guardrails / Anti-pattern detection
+- generate tests / generate code → run Spec Quality Score first (Guardrail #8), then Generate from Spec (Step 5b)
+- score my spec / check spec quality → run Spec Quality Score and report dimensions
+
+---
+
+# Minimal First Response Rule
+
+Do not overwhelm the user.
+- Ask only the minimum questions needed
+- Do not generate full artifacts unless asked
+- Start small, expand only when needed
+
+---
+
+# When NOT to use
+
+- Simple factual questions
+- Pure coding tasks without product context
+- General brainstorming unrelated to product definition


### PR DESCRIPTION
## Summary

**Product Ready** is an AI-native Spec-Driven Development skill for Product Owners. It guides users from a vague idea to a complete, AI-ready BDD Spec — then scores spec quality and generates AI prompts from each scenario.

The development chain:
```
PRD → BDD Spec (THE SPEC) → [AI: Tests + Code] → Acceptance
```

## Key features

- **13-step adaptive workflow** — Lightweight / Standard / Full, auto-escalates on risk/compliance signals
- **8 enforced guardrails** — including Spec Integrity (scores BDD Spec before any AI generation)
- **Spec Quality Score** — 5 dimensions: Coverage, Clarity, Linkage, Decisions, UI states → Complete / Partial / Incomplete
- **Step 5b: Generate from Spec** — formats each BDD scenario as a self-contained AI generation prompt
- **Three-tier First Interaction** — no menus, no intros unless the user gives no signal
- **Artifact numbering** — REQ-*, BR-*, BS-*, TS-*, [MPD] conventions throughout

## Trigger phrases

Activates automatically on: PRD, requirements, user stories, acceptance criteria, BDD spec, backlog, readiness review, spec-driven development, generate tests, generate code from spec, score my spec

## Testing

- 135 tests passing (52 structural integrity + 83 Slack bot unit tests)
- CI-validated on every commit

## License

Apache 2.0

## Source

https://github.com/cellango/product-ready — v1.2.0