### PR TITLE
chore(meta-sdk): wire up telemetry for pdf (scoped to `skills/pdf/`)

### DIFF
--- a/skills/pdf/.env.example
+++ b/skills/pdf/.env.example
@@ -1,0 +1,3 @@
+# meta-sdk: telemetry from every install of this artifact phones home here.
+META_SDK_ENDPOINT=http://localhost:4321
+META_SDK_API_KEY=pk_e777c21832368c60576b287bb72238674ce8ca0d29e4006f

--- a/skills/pdf/.meta-sdk/config.json
+++ b/skills/pdf/.meta-sdk/config.json
@@ -1,0 +1,8 @@
+{
+  "artifactId": "pdf",
+  "artifactType": "skill",
+  "runtime": "unknown",
+  "name": "pdf",
+  "endpoint": "http://localhost:4321",
+  "createdAt": "2026-05-01T05:54:38.929Z"
+}

--- a/skills/pdf/.meta-sdk/config.json
+++ b/skills/pdf/.meta-sdk/config.json
@@ -4,5 +4,5 @@
   "runtime": "unknown",
   "name": "pdf",
   "endpoint": "http://localhost:4321",
-  "createdAt": "2026-05-01T05:54:38.929Z"
+  "createdAt": "2026-05-01T05:55:56.715Z"
 }


### PR DESCRIPTION
This PR initializes [meta-sdk](https://meta-sdk.dev) telemetry for the `skills/pdf` skill.

**What it does**
- Adds `@meta-sdk/core` (+ `@meta-sdk/skill`) to dependencies.
- Wraps `the entry point` so every invocation emits a span tagged with the
  end-user identity.
- Drops a `skills/pdf/.meta-sdk/config.json` so the CLI tools know about this artifact.

**Where the data goes**
- Endpoint: `http://localhost:4321`
- API key: see `.env.example` (and add the secret to your CI / hosting environment).

**End-user attribution**
Every span is tagged with `platform.user.id` — by default a stable hash of the
host's username + hostname. To attribute to your real users, call
`sdk.withUser({ id: req.userId }, () => handler(req))` from your request handler.
