### PR TITLE
Add idea-validator skill

### DIFF
--- a/skills/idea-validator/LICENSE.txt
+++ b/skills/idea-validator/LICENSE.txt
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Support. While redistributing the Work or
+      Derivative Works thereof, You may choose to offer, and charge a
+      fee for, acceptance of support, warranty, indemnity, or other
+      liability obligations and/or rights consistent with this License.
+      However, in accepting such obligations, You may act only on Your
+      own behalf and on Your sole responsibility, not on behalf of any
+      other Contributor, and only if You agree to indemnify, defend,
+      and hold each Contributor harmless for any liability incurred by,
+      or claims asserted against, such Contributor by reason of your
+      accepting any such warranty or support.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 shadkhan
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/idea-validator/SKILL.md
+++ b/skills/idea-validator/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: idea-validator
+description: >
+  Run a structured, multi-phase idea validation flow for app or business ideas BEFORE
+  building anything. Use this skill whenever the user mentions: validating an idea,
+  checking if an idea is worth building, pre-build validation, idea stress-test,
+  market research for a product, should I build X, is X a good idea, checking PMF
+  (product-market fit), or any variation of "I have an idea for [X]". Also trigger
+  when the user describes a product concept and wants feedback, competitive analysis,
+  or a go/no-go recommendation. This skill produces a structured Idea Validation Report
+  as a markdown file covering all five phases: problem clarity, market & competition,
+  prototype feasibility, technical risk, and a go/no-go decision memo.
+license: Apache-2.0
+compatibility: Requires internet access for Phase 2 web research.
+metadata:
+  author: shadkhan
+  version: "1.0.0"
+---
+
+# Idea Validator Skill
+
+Produces a thorough **Idea Validation Report** before any code is written.
+The goal: kill bad ideas in hours, not weeks.
+
+## Overview of Phases
+
+| Phase | Name | Key Output |
+|-------|------|-----------|
+| 1 | Problem & User Clarity | Kill/refine decision on the problem itself |
+| 2 | Market & Competition | Competitor matrix + gap analysis |
+| 3 | Prototype & UX Feasibility | Fake-door / MVP scope |
+| 4 | Technical Risk Assessment | Spike targets + architecture risks |
+| 5 | Go / No-Go Decision Memo | Confidence score + top assumption to validate |
+
+---
+
+## Step 0 — Gather Context
+
+Before running phases, extract or ask for:
+
+1. **The idea** — one sentence description
+2. **Target user** — who specifically (persona, not demographics)
+3. **Core problem being solved** — what pain, how acute?
+4. **Tech stack in mind** (if any)
+5. **Time/resource budget** the builder has
+6. **Existing traction** (any users, feedback, revenue?)
+
+If the user has described the idea in the conversation already, extract these from context. Ask only for what's missing — max 2 clarifying questions.
+
+---
+
+## Phase 1 — Problem & User Clarity
+
+Read: `references/phase1-problem.md`
+
+Run the devil's advocate analysis, fake review generation, and persona grid.
+
+Output: a `## Phase 1` section in the report with:
+- Problem statement (sharpened)
+- 3 reasons the idea could fail
+- 2 user personas (would pay vs. wouldn't pay)
+- One fake 1-star review surfacing the sharpest edge case
+
+---
+
+## Phase 2 — Market & Competition
+
+Read: `references/phase2-market.md`
+
+Use web search to find real competitors. Build a competitor matrix.
+
+Output: `## Phase 2` section with:
+- Competitor matrix (name, pricing, key feature, weakness)
+- Gap analysis — where does the idea uniquely fit?
+- Market signal assessment (is anyone paying for adjacent solutions?)
+- Red flags if the market is too crowded or too thin
+
+---
+
+## Phase 3 — Prototype Feasibility
+
+Read: `references/phase3-prototype.md`
+
+Assess what can be faked/prototyped without real backend.
+Define the minimum fake-door test.
+
+Output: `## Phase 3` section with:
+- What can be prototyped with Claude Artifacts or a static page
+- What the fake-door CTA should be
+- What question the prototype answers (UX/demand/pricing)
+- Estimate: 1-day prototype scope
+
+---
+
+## Phase 4 — Technical Risk Assessment
+
+Read: `references/phase4-tech.md`
+
+Identify the hardest technical problem. Recommend spike targets.
+
+Output: `## Phase 4` section with:
+- Top 3 technical risks ranked by severity
+- Recommended spike: "build this one thing first before anything else"
+- Third-party dependency risks (APIs, scrapers, infra)
+- Scale risk flags (what breaks at 10k / 100k users)
+
+---
+
+## Phase 5 — Go / No-Go Decision Memo
+
+Read: `references/phase5-decision.md`
+
+Synthesize all phases into a ruthless investor-style verdict.
+
+Output: `## Phase 5` section with:
+- **Verdict**: GO / CONDITIONAL GO / NO-GO
+- **Confidence score**: X/10
+- **Single biggest unvalidated assumption**
+- **If GO**: the one thing to build first
+- **If CONDITIONAL GO**: the condition that must be true before building
+- **If NO-GO**: the fundamental flaw and a pivot suggestion
+
+---
+
+## Output Format
+
+Save the full report as:
+```
+idea-validation-report-[slug].md
+```
+
+The report must be structured with these top-level sections:
+```markdown
+# Idea Validation Report: [Idea Name]
+**Date:** [date]
+**Validator:** Claude Idea Validator Skill
+
+## Executive Summary
+[3 sentences max — problem, verdict, biggest risk]
+
+## Phase 1 — Problem & User Clarity
+...
+
+## Phase 2 — Market & Competition
+...
+
+## Phase 3 — Prototype Feasibility
+...
+
+## Phase 4 — Technical Risk Assessment
+...
+
+## Phase 5 — Go / No-Go Decision Memo
+...
+
+## Appendix — Validation Checklist
+[checklist of what's been validated vs. still open]
+```
+
+Present the file to the user when complete.
+
+---
+
+## Tone & Style Rules
+
+- Be **ruthlessly honest** — this is pre-build, not a pitch deck review
+- Use **specific language** — no vague hedges like "it depends"
+- When you don't know something (e.g., real competitor pricing), **use web search**
+- Flag when an assumption is **critical and still unvalidated** — don't paper over it
+- Keep each phase focused — the user is a developer, not a business analyst
+
+---
+
+## Example Trigger Phrases
+
+- "I want to build an AI tool that does X — is it worth it?"
+- "Validate my idea: [description]"
+- "Should I build X before I start coding?"
+- "Help me stress-test this idea"
+- "Run an idea validation on [concept]"
+- "I'm thinking of building [X] — what do you think?"

--- a/skills/idea-validator/assets/example-report-nogo.md
+++ b/skills/idea-validator/assets/example-report-nogo.md
@@ -1,0 +1,382 @@
+> **Real-world example:** skill output for an interview-prep AI agent idea. Verdict: **NO-GO as scoped**, with four pivot suggestions. Included to demonstrate the skill catching a duplicative idea before any code was written.
+
+---
+
+# Idea Validation Report: Interview Prep Agents (JD × Profile × Employer)
+
+**Date:** 2026-05-01
+**Validator:** Claude Idea Validator Skill
+**Idea (verbatim):** "Helping job seeker to prepare for Interview. These Agents will automate the interview preparation for candidate by evaluating and mapping JD, Prospect Employer with Profile."
+**Confirmed scope:** Personalized prep brief + mock interview chat/voice + Q&A practice bank + real-time interview copilot, targeting tech/engineering candidates.
+
+---
+
+## Executive Summary
+
+You are proposing to rebuild Final Round AI (10M+ users, ~$25–149/mo) plus Cluely ($5.3M raised, ~$3M ARR), at the 
+moment when the space is reaching peak saturation, real-time copilots are being actively detected and banned, 
+and a fully free open-source alternative (Natively) already exists with BYOK + local RAG. 
+The four deliverables you picked are individually commoditized and collectively defined as
+"the Final Round AI feature set." Verdict is **NO-GO as scoped**, with a specific pivot path 
+to a **CONDITIONAL GO** if you narrow to one wedge.
+
+---
+
+## Phase 1 — Problem & User Clarity
+
+### 1.1 Problem Sharpening
+
+```
+Pain Trigger:    Recruiter schedules a 5-round technical loop in 7 days; candidate
+                 has a stale resume, hasn't interviewed in 3 years, and has no
+                 inside info on the company's bar or interviewers.
+Current Workaround: Manual cocktail of LeetCode + Glassdoor + Blind + ChatGPT
+                 prompting + Final Round AI + a 1-on-1 coach ($150–300/hr).
+Workaround Failure: Fragmented across 5+ tabs, generic answers, no single
+                 artifact tying resume gaps → JD requirements → employer-specific
+                 expectations. Coaches don't scale; ChatGPT doesn't research.
+Cost of Problem:  Lost offer = $30k–150k+ in delta TC for tech roles. Each
+                 failed loop = ~30 hrs prep + ~6 weeks calendar time before
+                 the next try.
+```
+
+The core pain is real. Tech candidates do spend 40–80 hours per loop preparing,
+and the integration pain across tools is genuine. **But none of that is the problem you're solving uniquely** — 
+every competitor in Phase 2 already addresses it.
+
+### 1.2 Devil's Advocate — 5 Failure Modes
+
+1. **Final Round AI already does this exactly.** Their site explicitly 
+2. says: "upload your resume and job description to get personalized questions" + Interview Copilot™  + behavioral + system design + post-interview feedback. You will be re-implementing their feature list.
+2. **Real-time copilot is becoming an ethics/detection minefield.** Cluely got banned at Columbia, repositioned away from "cheating," and companies (Honorlock, Sherlock, etc.) now sell *detection* tooling. Users are increasingly afraid to use these in real interviews.
+3. **You have no proprietary data wedge.** The defensible moats here are (a) employer-specific interviewer intel, (b) verified question banks, or (c) coach network — none of which are on your roadmap.
+4. **Distribution is brutal.** SEO is dominated by Final Round AI's content engine and 10+ "Top 10 AI Interview Tools 2026" listicles all written by the incumbents themselves. CAC for "interview prep" keywords is high; the tools that win do so via TikTok/YouTube/influencer not search.
+5. **Retention is structural ~3–8 weeks per user.** A candidate prepares for a loop, accepts an offer, and churns for 2–4 years. Final Round AI's monthly pricing ($149/mo) is a reaction to this — they extract LTV in one window. You'll need the same brutal pricing or constant new acquisition.
+
+### 1.3 Persona Grid
+
+**Persona A — The Buyer (Aarav, 28, SDE-2 trying to jump from a Tier-2 IT services co. to a FAANG/Tier-1 product co.)**
+- Pain trigger: Got a Google L4 onsite scheduled 10 days out, has never done a Google-style system design round
+- Pays: ~$30–60/mo for 1–2 months only
+- Churns when: he gets the offer, OR fails 2 loops and switches to a human coach
+
+**Persona B — The Skeptic (Maya, 35, staff engineer at a unicorn, casually exploring)**
+- Won't pay because: she has a strong network, recruiters approach her, she'd rather get a referral than rehearse
+- 1-star review: *"This is just ChatGPT with extra steps and a worse UI. The 'employer research' was three Glassdoor bullet points it could have scraped in 10 seconds. The mock interview agent is stiff and asks the same questions every other tool asks. Not worth $30."*
+
+### 1.4 Fake 1-Star Review
+
+```
+★☆☆☆☆ "Felt like a wrapper, charged like a SaaS"
+I uploaded my resume and the Stripe JD. The 'agents' generated a 12-page
+prep brief that was 80% boilerplate I could have written myself, plus a
+mock interview that asked 'tell me about yourself' three times in a row.
+The 'employer mapping' was just public Glassdoor data. The real-time
+copilot stuttered for 4 seconds on a system design question and the
+interviewer noticed me staring off screen. Cancelled.
+— Aarav, SDE-2
+```
+
+### 1.5 Scoring
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| Acuity | **4/5** | Real, expensive, high-stakes |
+| Frequency | **2/5** | Happens once every 2–4 years per user — bad for SaaS |
+| Willingness to Pay | **4/5** | Final Round AI proves people pay $25–149/mo |
+
+**Frequency = 2 is a red flag.** This is fundamentally a transactional, high-CAC, low-LTV market unless you bolt on a recurring use case (career growth, skill tracking, job-search dashboard).
+
+---
+
+## Phase 2 — Market & Competition
+
+### 2.1 Competitor Matrix
+
+| Competitor | Pricing | Key Strength | Key Weakness | Target User |
+|---|---|---|---|---|
+| **Final Round AI** | $25–149/mo (10M+ users) | Full-stack: prep + mock + copilot + post-feedback; 26 languages; "stealth mode" copilot | Expensive monthly; Trustpilot 3.9/5; stealth mode visible in some screen-shares; ethics complaints | All white-collar |
+| **LockedIn AI** | Free + premium | Real-time, code solutions, instant answers; very engineer-friendly | Ethical risk; quality variance | Tech & finance |
+| **Verve AI** | Free + paid tiers | Listens during real interviews + screen analysis | Real-time-only positioning, undifferentiated | Job seekers broadly |
+| **Sensei AI** | Paid | Resume + JD upload → real-time tailored answers; "undetectable" | Ethics; commoditized | Job seekers broadly |
+| **Yoodli** | Freemium | **Delivery/communication coaching** (Allen AI roots, 300k Toastmasters users) — *not* answer-generation | Doesn't do JD/employer mapping; no copilot | Communicators, soft-skills |
+| **Skillora** | Paid | Live voice mock interviewer; resume vs JD matching; adaptive follow-ups | Single feature focus, smaller brand | Job seekers broadly |
+| **Big Interview** | $39+/mo | Industry-specific question sets, video recording + analysis, expert curriculum | Less AI-native, dated UX | Career switchers, MBA |
+| **Teal InterviewAI** | Free / $9 / $29 | **Bundled inside Teal job-tracker** — best workflow integration | Interview features are not the lead product | Active job seekers |
+| **AIApply** | Freemium | Type-in-JD-get-questions; cheap and fast | Thin product, weak differentiation | Mass-market |
+| **Interviews.Chat** | Credits-based | Unlimited sessions, dual-response, multi-model | Generic; no employer angle | Job seekers broadly |
+| **Cluely** | Paid (~$20+/mo) | Brand notoriety; $5.3M raised; $3M ARR | Banned at Columbia; reputational/legal cloud; pivoting away from "cheat" framing | Cheaters → now meeting assistant |
+| **Natively** | **FREE, open-source, BYOK** | Local RAG, no subscription, no data risk, undetectable stealth — **direct OSS replacement for Final Round AI** | DIY setup; no managed service | Privacy-conscious, technical users |
+| **Google Interview Warmup** | **Free, no login** | Backed by Google; lightweight; trustworthy brand | Limited categories; warm-up only | Casual practice |
+| **Interviewing.io** | $225+/mo, marketplace | Real engineers from FAANG; verified signal | Expensive; humans not AI | Senior engineers |
+
+**This is one of the most crowded AI consumer markets right now.** Twelve to twenty named competitors with overlapping feature sets, plus a free Google offering and a free open-source clone.
+
+### 2.2 Gap Analysis
+
+```
+Unique Angle:       NONE as currently scoped. The four-deliverable bundle
+                    is identical to Final Round AI's feature page.
+Defensibility:      LOW
+Defensibility Reason: No proprietary data, no network effect, no integration
+                    moat, no brand. "Multi-agent architecture" is an
+                    implementation detail, not a moat — every competitor
+                    will be on the same architecture in 6 months.
+```
+
+**Potential angles you could carve out (none of which are in your current scope):**
+- **Employer-specific intel as the wedge** — proprietary data on specific companies' interview loops (interviewer profiles, recent question patterns from Blind/Levels/Reddit, calibration bars). This is the *only* defensible thing not yet well-served.
+- **Vertical depth for one role family** — e.g., L5+ system design only, or ML research interviews only, or PM case interviews only. Niche enough that incumbents don't cover it well.
+- **Coach-augmentation, not coach-replacement** — sell to human interview coaches as a research/workflow tool. B2B, higher willingness to pay, no consumer CAC.
+- **Ethics-clean positioning** — explicitly NOT a real-time copilot. "Pre-interview only, never during" — this is a real differentiator since corporate detection is rising.
+
+### 2.3 Market Signal Assessment
+
+- **Green flags:** $1.2B → $2.5B market by 2033 (8.9% CAGR); Final Round AI has 10M+ users; Cluely at $3M ARR; multiple paid alternatives; active Reddit communities (r/leetcode, r/cscareerquestions, r/ExperiencedDevs); Final Round AI alone advertises and ranks for thousands of interview-prep keywords.
+- **Red flags:** Tech hiring is *cooler* than 2020–2022 — fewer SWE openings globally, fewer remote roles. The TAM is shrinking on the candidate side at the exact moment supply of competing tools is exploding.
+
+### 2.4 Market Sizing (Back-of-Envelope)
+
+- **ICP:** Mid-level tech IC (3–10 yrs) actively interviewing in a given quarter. Globally, ~2–5M unique candidates/quarter; ~500k–1M serious-spend candidates.
+- **At 0.5% capture and $40 ARPU × 2 months:** ~5,000 paying users × $80 = **$400k/yr.** Achievable but unimpressive.
+- **At 0.05% capture (more realistic given competition):** ~$40k/yr. Below indie-hacker viability for the build effort required.
+- **Ceiling matters:** Final Round AI captured a multi-million-user wave by being early. That window is closed.
+
+### 2.5 Red Flags
+
+- **Crowded space, multiple well-funded incumbents** (Final Round AI = 10M+ users, Cluely = $5.3M raised). ✗
+- **Direct free + open-source alternative exists (Natively).** ✗ — this is rare and brutal in consumer AI.
+- **Real-time copilot category is becoming actively contested** (corporate detection tools, university bans, brand risk). ✗
+- **Tech hiring market headwind** (fewer roles, smaller candidate pool). ✗
+- **No proprietary data, no network effect, no obvious moat in current scope.** ✗
+
+---
+
+## Phase 3 — Prototype Feasibility
+
+### 3.1 Core Assumption to Test
+
+```
+Core Assumption: A multi-agent system can produce a prep brief that is
+                 *meaningfully better* than Final Round AI's existing
+                 personalized prep — enough that a candidate would switch
+                 (or pay incrementally on top).
+Test Method:     Side-by-side blind comparison: 5 candidates with real
+                 upcoming interviews receive (A) Final Round AI's brief
+                 and (B) your prototype's brief. Measure preference and
+                 willingness-to-pay.
+```
+
+This is the *only* test worth running. If your output is not visibly better than Final Round AI on a head-to-head, no other validation matters. **Do not skip this.**
+
+### 3.2 Recommended Prototype Level
+
+**Level 3 — Wizard of Oz (1–2 days), NOT a full multi-agent build.**
+
+Build the cheapest possible thing that produces a prep brief:
+- Single Claude prompt chain (resume + JD + scraped Glassdoor/Levels/Blind summary) → 4-section brief (gap analysis, top 20 likely questions w/ tailored answers, employer-specific intel, system-design topics if SDE).
+- No agents. No orchestration. No UI beyond a Google Form + email delivery.
+- For mock interview: a single Claude API session with a system prompt that does role-play. Voice optional in v0.
+- For real-time copilot: **DO NOT BUILD THIS YET.** It is the least defensible, most ethically risky, and most commoditized of the four. Cut it.
+
+### 3.3 Fake-Door Test Plan
+
+```
+Prototype Type:  Level 3 (Wizard of Oz brief delivery)
+Build Time:      ~12–16 hours total
+Platform:        Google Form (intake) + Claude API (generation) + email (delivery)
+CTA:             "Get a free personalized interview brief in 24 hours.
+                  Upload your resume + paste the JD."
+Traffic Source:  r/cscareerquestions, r/leetcode "Free interview prep
+                  brief — feedback wanted" post; LinkedIn personal network;
+                  one Blind post if you have a Blind account.
+Pass Condition:  >= 5 of 10 recipients say "this is better than Final
+                  Round AI's brief I already used" OR ">= 3 say they'd
+                  pay $20+ for the next one." Anything less = pivot.
+```
+
+### 3.4 What NOT to Build Yet
+
+- ❌ Multi-agent orchestration (LangGraph/CrewAI) — fake it with sequential Claude calls
+- ❌ Real-time copilot — ethically/competitively toxic, defer indefinitely
+- ❌ Voice mock interview — text-only first; voice doubles complexity
+- ❌ Auth, billing, dashboard, Stripe
+- ❌ Mobile app / browser extension
+- ❌ Scraping infrastructure — manually curate the first 20 employer profiles by hand
+
+---
+
+## Phase 4 — Technical Risk Assessment
+
+### 4.1 Risk Matrix
+
+| Risk | Category | Severity | Likelihood | Mitigation |
+|---|---|---|---|---|
+| Output indistinguishable from Final Round AI / ChatGPT | Quality/Differentiation | **H** | **H** | Wedge to one role family; add proprietary employer data |
+| Real-time copilot detection / corporate ban | Compliance/Reputational | **H** | **H** | Drop real-time copilot from scope |
+| Employer-data scraping (Blind, Glassdoor, Levels) ToS | Legal | **H** | **M** | Use only public ToS-clean sources; partner; or manually curate |
+| LLM cost at scale (multi-agent × tokens × users) | Scale/Cost | **M** | **H** | Sequential not parallel agents; aggressive prompt caching; cap tokens per brief |
+| Voice latency (if real-time copilot is built) | Performance | **H** | **H** | Drop real-time scope (see above) |
+| Hallucinated employer/interviewer info → user embarrassment | AI/Reputation | **H** | **M** | Citation-required pattern; flag low-confidence sections; never invent |
+| Multi-agent orchestration complexity at MVP | Eng | **M** | **H** | Don't use agents at MVP. Sequential Claude calls. |
+| Distribution channel saturation | Go-to-market | **H** | **H** | Pick a vertical community (e.g., Blind) and own it, vs. broad SEO |
+
+### 4.2 Spike Recommendation
+
+```
+Spike Target:     Brief Quality Spike — generate prep briefs for 3 real
+                  recent JDs (Stripe SDE, Anthropic ML, Datadog SRE) using
+                  resume + JD + manually-gathered employer intel. Compare
+                  side-by-side against Final Round AI's output for the
+                  same JDs.
+Why This One:     If your Claude-orchestrated output doesn't visibly beat
+                  the incumbent on quality, every other technical question
+                  is moot. This is the "is there a there there" test.
+Time Estimate:    ~2 days
+Success Criteria: Blind reviewers (3 senior engineers) prefer your brief
+                  on >= 2 of 3 JDs.
+Failure Signal:   Reviewers say "they're basically the same" or prefer
+                  Final Round AI's. -> Either pivot wedge or kill idea.
+```
+
+### 4.3 Stack Recommendation
+
+- **Backend:** Python/FastAPI (better LLM ergonomics) or Node/Fastify if you're stronger in TS. Either works.
+- **AI Layer:** **Anthropic API directly with Claude Sonnet 4.6.** Use prompt caching aggressively — the resume, JD, and employer intel are reused across sub-tasks. Skip agent frameworks at MVP.
+- **Data:** Postgres for users + briefs. Redis only if you add async generation. No vector DB needed at MVP — context fits in window.
+- **Scraping:** Don't. Manually curate top 20 employer profiles by hand. Solve the data problem after PMF.
+- **Hosting:** Railway or Fly.io. $20/mo.
+- **Cost ceiling:** Cap each brief at ~50k input + 8k output tokens with caching → ~$0.15–0.30/brief. At $20/brief, gross margin is fine.
+
+### 4.4 Agentic System Assessment
+
+You said "agents" but **at MVP you should not use a multi-agent framework.** A sequential Claude call pipeline is faster to build, cheaper to run, easier to debug, and produces equivalent quality for this domain. Reserve agentic orchestration for:
+- Async deep-research employer briefs that take 5–15 minutes (legitimate agentic use case)
+- Adaptive follow-up question generation in mock interview (mid-flight branching)
+
+But only after PMF on a sequential pipeline.
+
+---
+
+## Phase 5 — Go / No-Go Decision Memo
+
+### 5.1 Scoring Rubric
+
+| Dimension | Score | Weight | Weighted | Notes |
+|-----------|-------|--------|----------|-------|
+| Problem Acuity | 4/5 | 25% | 1.00 | Pain is real and expensive |
+| Market Demand Signal | 4/5 | 25% | 1.00 | People pay; multiple incumbents profitable |
+| Competitive Differentiation | **1/5** | 20% | 0.20 | None as scoped — direct overlap with Final Round AI |
+| Technical Feasibility | 4/5 | 15% | 0.60 | Easy to build; that's part of why it's commoditized |
+| Prototype Testability | 4/5 | 15% | 0.60 | Brief-quality A/B is fast and decisive |
+| **Weighted Total** | | | **3.40** / 5.0 | |
+
+The weighted score lands in CONDITIONAL GO range *because* the problem is real and feasible — but the **1/5 on differentiation is the load-bearing number**, and if that doesn't move, the score is illusory.
+
+### 5.2 Verdict
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+VERDICT:        NO-GO as scoped
+                CONDITIONAL GO if narrowed to one wedge
+CONFIDENCE:     8 / 10
+WEIGHTED SCORE: 3.40 / 5.0  (held up almost entirely by the
+                problem being real, not by the proposed solution)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+### 5.3 Single Biggest Unvalidated Assumption
+
+> **"A new entrant can produce an interview prep brief that is meaningfully better than Final Round AI's — without proprietary data, network effects, or a coach network — because of a smarter agent architecture."**
+
+This is the assumption that, if false, kills the idea. Everything else (acuity, willingness to pay, technical feasibility) is already validated by the competitive landscape. The Wizard-of-Oz brief test in Phase 3 is the **direct test of this assumption** and it costs you ~16 hours.
+
+### 5.4 The Core Flaw (NO-GO reasoning)
+
+You scoped four deliverables: prep brief + mock interview + Q&A bank + real-time copilot for tech candidates. **That is the exact 1:1 feature set of Final Round AI**, which has 10M+ users, $25–149/mo pricing, multilingual support, dedicated coding/system-design modes, and a free-tier funnel. There is also a **free open-source clone (Natively)** with BYOK and local RAG. Building the same product for the same audience without a wedge is the canonical "second mover with no advantage" trap. Even if you ship in 8 weeks, you start at distribution zero against an incumbent doing seven-figure paid acquisition.
+
+The real-time copilot piece compounds this with active reputational risk: corporate detection tools are now a category, and Cluely's pivot away from "cheat" framing tells you which way the wind is blowing.
+
+### 5.5 Pivot Options (CONDITIONAL GO paths)
+
+Pick **one** of these. Don't try two. Each is a real wedge that an incumbent doesn't own.
+
+**Pivot A — Vertical depth: "L5+ Tech System Design Coach"**
+- Drop everything except mock interview + prep brief, but only for senior+ system design.
+- Wedge: incumbents are mile-wide-inch-deep; senior system design is the hardest, highest-stakes round and worst-served by current AI tools.
+- Validation: 5 senior engineers running a mock SD interview in your tool vs. Final Round AI. Which one do they pay $50/session for?
+
+**Pivot B — Employer intelligence: "The Interviewer Briefing"**
+- The product is a research dossier on the *specific people interviewing you* (LinkedIn-derived background, recent talks, papers, GitHub, calibration patterns from Blind), plus likely loop structure for that exact employer.
+- Wedge: this is the one feature Final Round AI cannot match generically — it requires either curated data or careful real-time research, and incumbents are commoditized on the question side, not the employer side.
+- Validation: produce 3 dossiers manually (your time, no AI). If candidates say "I'd pay $40 for this," you have a wedge.
+
+**Pivot C — B2B sell to coaches**
+- Reposition as workflow software for human interview coaches: client intake, JD parsing, prep brief generation, session notes. Coaches charge $150–300/hr; they'll pay $50–100/mo for tooling that 2x's their throughput.
+- Wedge: every consumer tool is selling to candidates; nobody serious is selling shovels to the coaches.
+- Validation: 5 cold messages to coaches on LinkedIn. If 2 take a call, there's signal.
+
+**Pivot D — Ethics-clean pre-interview only**
+- Explicitly rule out the real-time copilot. Lead with "We will never run during your live interview." Sell trust as the wedge as detection tooling matures.
+- Wedge: differentiation through *what you refuse to do.* Real moat once corporate detection becomes table stakes.
+
+### 5.6 If You Insist on Building Now
+
+Do this and only this for the first 2 weeks:
+1. Pick **one** pivot above. Write it down. Don't change for 30 days.
+2. Wizard-of-Oz brief test (Phase 3.3) for that wedge — ~16 hours.
+3. Get 10 real candidates' feedback.
+4. **Stop and re-decide before writing any production code.**
+
+If you cannot pick a pivot, the answer is to not build this and find a different problem.
+
+---
+
+## Appendix — Validation Checklist
+
+### ✅ Validated by this report
+- [x] Problem is real and acute (Phase 1)
+- [x] People pay for solutions in this space (Phase 2 — Final Round AI, Cluely, Big Interview, etc.)
+- [x] Competitor landscape mapped (Phase 2)
+- [x] Technical feasibility — can be built in weeks, not months (Phase 4)
+- [x] Cost economics work at MVP scale (Phase 4)
+
+### ⚠️ Critical / Still Open
+- [ ] **Quality differentiation vs. Final Round AI** — UNTESTED, this is the make-or-break (run Phase 3.3)
+- [ ] **Pivot wedge selection** — none chosen yet; building without one = guaranteed NO-GO
+- [ ] **Distribution channel** — no plan beyond "post on Reddit"; needs concrete first-100-user motion
+- [ ] **Pricing willingness-to-pay for *your* product specifically** (not for the category)
+- [ ] **Retention model** — frequency = 2/5 means you need either career-long value loop or accept transactional economics
+
+### 🚫 Out of scope until first 10 paying users
+- [ ] Real-time interview copilot (also: ethically risky — reconsider permanently)
+- [ ] Voice mock interviews
+- [ ] Multi-agent orchestration framework
+- [ ] Scraped employer database
+- [ ] Mobile / browser extension
+- [ ] Stripe + auth + dashboard
+
+---
+
+## Sources
+
+- [Final Round AI homepage](https://www.finalroundai.com/)
+- [Final Round AI Subscription / Pricing](https://www.finalroundai.com/subscription)
+- [Final Round AI Review 2026 — Interview Sidekick](https://interviewsidekick.com/blog/final-round-ai-review)
+- [Final Round AI Review 2026 — Shadecoder](https://www.shadecoder.com/blogs/final-round-ai-review-2026-features-pricing-honest-verdict)
+- [Best AI Interview Prep Tools in 2026 — Interview Sidekick](https://interviewsidekick.com/blog/ai-interview-prep-tools)
+- [10 Best AI Interview Prep Tools in 2026 — Final Round AI Blog](https://www.finalroundai.com/blog/best-ai-interview-prep-tools)
+- [Yoodli — AI Roleplays for Interview Preparation](https://yoodli.ai/use-cases/interview-preparation)
+- [LockedIn AI](https://www.lockedinai.com/)
+- [Verve AI](https://www.vervecopilot.com/)
+- [Skillora](https://skillora.ai/)
+- [Interviews.Chat](https://www.interviews.chat/)
+- [Natively (open-source Cluely / Final Round AI alternative) — GitHub](https://github.com/Natively-AI-assistant/natively-cluely-ai-assistant)
+- [Cluely — Wikipedia](https://en.wikipedia.org/wiki/Cluely)
+- [Banned by Columbia, backed by millions — Yahoo Finance on Cluely](https://finance.yahoo.com/news/banned-columbia-backed-millions-21-190238271.html)
+- [Interview Cheating in 2026: Cluely & Interview Coder — Fabric](https://fabrichq.ai/blogs/interview-cheating-in-2026-the-rise-of-ai-tools-like-cluely-and-interview-coder)
+- [Rise of AI Interview Fraud 2026 — Sherlock](https://www.withsherlock.ai/blog/rise-of-ai-interview-fraud)
+- [What Is Cluely AI & How to Block It — Honorlock](https://honorlock.com/blog/what-is-cluely-how-to-block-it/)
+- [Interview Preparation Tool Market Size — Verified Market Research](https://www.verifiedmarketresearch.com/product/interview-preparation-tool-market/)
+- [Mock Interview Service Market Size — WiseGuy Reports](https://www.wiseguyreports.com/reports/mock-interview-service-market)
+- [The Reality of Tech Interviews in 2025 — Pragmatic Engineer](https://newsletter.pragmaticengineer.com/p/the-reality-of-tech-interviews)

--- a/skills/idea-validator/assets/example-report.md
+++ b/skills/idea-validator/assets/example-report.md
@@ -1,0 +1,178 @@
+# Example: Idea Validation Report — InterviewOps
+
+> This is a reference example showing the expected output format and depth.
+> Use this to calibrate your own reports.
+
+---
+
+# Idea Validation Report: InterviewOps
+**Date:** 2025-05-01
+**Validator:** Claude Idea Validator Skill
+
+## Executive Summary
+InterviewOps targets a high-acuity pain (job seekers failing interviews for preventable reasons) with a differentiated AI-agentic approach that goes beyond generic prep tools. The go/no-go verdict is **CONDITIONAL GO**: the core technical pipeline is feasible, but monetization and trust in AI-generated prep plans remain unvalidated. The highest-risk assumption — that candidates trust AI enough to practice with it over a human coach — must be tested before scaling.
+
+---
+
+## Phase 1 — Problem & User Clarity
+
+**Pain Trigger:** A software developer receives an interview invite from a target company. They have 5–7 days. They don't know the company's engineering culture, tech stack quirks, or what past interviewees faced.
+
+**Current Workaround:** Google the company + "interview experience", scroll Glassdoor reviews, look up LeetCode company tags, ask friends.
+
+**Workaround Failure:** Fragmented, inconsistent, outdated, and doesn't connect to their specific resume or the JD they applied for.
+
+**Cost of Problem:** An unprepared candidate wastes 7 days of prep on generic material, fails a dream-company interview, and loses a $20k–$100k salary opportunity.
+
+### Failure Modes
+1. **Distribution risk** — job seekers don't know where to find niche tools; discoverability is brutal without SEO or community traction.
+2. **Trust risk** — AI-generated prep plans may feel generic; candidates default to human coaches for high-stakes interviews.
+3. **Timing risk** — interview windows are short (5–7 days); if the tool takes >30 min to set up, they'll skip it.
+4. **Data staleness risk** — scraped interview data goes stale fast; Glassdoor reviews from 2022 don't reflect current engineering bars.
+5. **Retention risk** — this is an event-driven tool; users churn between job searches, making recurring revenue hard.
+
+### Persona A — The Buyer
+- **Role:** Mid-level software engineer, 3–6 YoE, actively job hunting
+- **Pain trigger:** Got a Google interview after 2 years of trying; terrified of wasting it
+- **Would pay:** $30–$50 for a single company prep report; $19/mo for active job search period
+- **Churn trigger:** Gets the job (positive churn); tool gives generic answers they could Google
+
+### Persona B — The Skeptic
+- **Role:** Senior engineer, confident in interviews, skeptical of AI tools
+- **Won't pay because:** "I can find this on Glassdoor myself" + low trust in AI accuracy for company-specific culture
+
+### Fake 1-Star Review
+```
+★☆☆☆☆ "Felt like ChatGPT with a Glassdoor skin"
+I paid $29 for a Google prep report. The "company pain points" were just
+generic complaints I'd already seen on Reddit. The practice questions
+were LeetCode mediums I'd done 3 years ago. Nothing felt specific to
+the current engineering bar. Went with a human coach for my actual prep.
+— Priya K., Staff Engineer
+```
+
+**Problem Scores:** Acuity: 5/5 | Frequency: 3/5 (event-driven) | Willingness to Pay: 4/5
+
+---
+
+## Phase 2 — Market & Competition
+
+| Competitor | Pricing | Key Strength | Key Weakness | Target User |
+|---|---|---|---|---|
+| Interviews.chat | $29/mo | AI mock interviews | Generic, not company-specific | All job seekers |
+| Final Round AI | $96/mo | Real-time interview assist | Ethically grey, bans risk | Aggressive candidates |
+| Glassdoor | Free / $10/mo | Real user reviews | Fragmented, no synthesis | All |
+| Grokking the Interview | $39/mo | Structured patterns | No company-specific context | Engineers |
+| Exponent | $12/mo | PM/SWE human coaching | Expensive at scale | Senior candidates |
+
+**Gap:** Nobody connects company-specific intelligence (culture, pain points, actual questions) to a candidate's specific resume + JD and generates a personalized prep plan. That's the gap InterviewOps fills.
+
+**Differentiation:** `Unique Angle: Company-specific + resume-matched + JD-aligned prep plan in one automated pipeline`
+`Defensibility: MEDIUM — the data pipeline is moatable but the AI layer is commoditizing`
+
+**Market Signal:** Exponent, Final Round AI all have paying customers. Glassdoor Premium exists. Coaching market ($2B+) is proven. Green flags.
+
+**ICP:** Software engineers + PMs, 2–8 YoE, actively interviewing at top-50 tech companies.
+1% of 500k active job seekers at $25/report = **$125k/month ceiling at MVP pricing**. Viable.
+
+---
+
+## Phase 3 — Prototype Feasibility
+
+**Core Assumption:** Users trust a company-specific prep plan generated from scraped data + their resume enough to follow it over generic resources.
+
+**Test Method:** Build a Wizard of Oz prototype — manually run the pipeline for 10 job seekers, deliver the report via PDF or Notion. See if they say "this is worth $X."
+
+```
+Prototype Type: Level 3 (Wizard of Oz)
+Build Time: ~1 day of manual work per report
+Platform: Claude chat + Notion template + PDF export
+CTA: "Get your custom [Company] interview prep report — $0 for first 10 beta users"
+Traffic Source: Blind, Reddit r/cscareerquestions, Twitter/X #jobsearch
+Pass Condition: 7/10 beta users say "I would have paid $20+ for this"
+```
+
+**What NOT to build yet:** Auth, billing, user accounts, company database UI, admin dashboard, mobile app.
+
+---
+
+## Phase 4 — Technical Risk Assessment
+
+| Risk | Category | Severity | Likelihood | Mitigation |
+|---|---|---|---|---|
+| Glassdoor/LinkedIn scraping ToS violations | Data/Legal | HIGH | HIGH | Use Firecrawl + rotate sources; long-term build partnerships or use official APIs |
+| AI output quality variance (hallucinated "company facts") | AI/ML | HIGH | MEDIUM | Implement source citation in every claim; human review flag for low-confidence data |
+| Data staleness — interview reviews age quickly | Data | MEDIUM | HIGH | Timestamp all data; flag reviews >6 months old; allow user submission to augment |
+| Cost at scale — multi-agent pipeline is expensive | Scale | MEDIUM | MEDIUM | Cache company research aggressively; separate scrape cadence from user-triggered runs |
+| Resume parsing accuracy for non-standard formats | Integration | LOW | MEDIUM | Use existing libs (resume-parser, Affinda API) rather than building custom |
+
+```
+Spike Target: The scraping pipeline — specifically, can you reliably extract structured
+              interview questions + sentiment from Glassdoor/Blind without getting blocked?
+Why This One: If the data quality is poor or scraping is blocked, the whole value prop collapses.
+Time Estimate: ~2 days
+Success Criteria: 50+ structured interview data points extracted for 3 companies with >80% relevance
+Failure Signal: Block rate >30% within 24h, or data quality too noisy to be useful
+```
+
+**Stack (for your profile):**
+- **Backend:** Node/Fastify or Python/FastAPI (FastAPI preferred for agent orchestration)
+- **AI Layer:** Anthropic API (Claude Sonnet 4.x) — direct API, not LangChain at MVP
+- **Scraping:** Firecrawl + Playwright fallback; BrightData for production
+- **Data:** Postgres + pgvector for resume/JD embeddings; Redis for job queue
+- **Hosting:** Railway for MVP
+
+**Agentic Assessment:** You built a multi-agent system — that was the right destination. But at MVP, you could have validated with **sequential API calls**: scrape → extract → match → generate. Full agent orchestration is worth it after you validate data quality and output trust.
+
+---
+
+## Phase 5 — Go / No-Go Decision Memo
+
+| Dimension | Score | Weight | Weighted |
+|---|---|---|---|
+| Problem Acuity | 5/5 | 25% | 1.25 |
+| Market Demand Signal | 4/5 | 25% | 1.00 |
+| Competitive Differentiation | 4/5 | 20% | 0.80 |
+| Technical Feasibility | 3/5 | 15% | 0.45 |
+| Prototype Testability | 4/5 | 15% | 0.60 |
+| **Total** | | | **4.10/5.0** |
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+VERDICT: CONDITIONAL GO
+CONFIDENCE: 7/10
+WEIGHTED SCORE: 4.1/5.0
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+**Biggest Unvalidated Assumption:**
+"Candidates trust AI-synthesized company intelligence enough to follow the prep plan instead of defaulting to a human coach or Googling it themselves."
+
+**The Condition:** Run the Wizard of Oz for 10 beta users. If 7/10 say they would have paid $20+, the trust bar is cleared. Proceed to technical build.
+
+**If condition is met:** Build the scraping spike first. Don't touch auth or billing until 50 users have used a free report and 10 have asked to pay.
+
+**If condition fails:** The trust gap is real. Pivot to a **human-in-the-loop** model — AI drafts the plan, a human coach reviews and personalizes it. Lower margin, but the trust problem is solved.
+
+---
+
+## Appendix — Validation Checklist
+
+### ✅ Validated
+- [x] Problem exists and is high-acuity
+- [x] Competitors identified — gap confirmed
+- [x] Differentiation articulated (company-specific + resume-matched)
+- [x] Tech stack de-risked (feasible with known tools)
+- [x] Market signal exists (adjacent tools have paying customers)
+
+### ⚠️ Still Open
+- [ ] User trust in AI-generated prep plans (the condition)
+- [ ] Pricing sensitivity ($19/mo vs $29/report vs free+upsell)
+- [ ] Data quality from scraping pipeline (spike required)
+- [ ] Retention model — how to monetize between job searches
+
+### 🚫 Out of Scope Until First Revenue
+- [ ] Enterprise / recruiting team use case
+- [ ] Mobile app
+- [ ] Real-time interview coaching (Final Round AI territory)
+- [ ] Browser extension

--- a/skills/idea-validator/references/phase1-problem.md
+++ b/skills/idea-validator/references/phase1-problem.md
@@ -1,0 +1,78 @@
+# Phase 1 — Problem & User Clarity
+
+## Goal
+Sharpen the problem statement and stress-test the core assumption:
+"Does this pain exist acutely enough that people will pay to fix it?"
+
+---
+
+## 1.1 Problem Sharpening
+
+Ask (or infer from context) and answer:
+- What is the **exact moment** a user feels this pain? (Trigger event)
+- How are they **currently solving it**? (Existing workaround)
+- Why is the workaround **not good enough**?
+- What does the user **lose** by not having this solved? (Time, money, stress, opportunity)
+
+Format output as:
+```
+Pain Trigger: [specific moment]
+Current Workaround: [what they do today]
+Workaround Failure: [why it's inadequate]
+Cost of Problem: [quantify if possible]
+```
+
+---
+
+## 1.2 Devil's Advocate — 5 Failure Modes
+
+Generate the top 5 reasons this idea fails. Think like a skeptical investor who has seen 500 pitches. Consider:
+- **Timing risk** — Is the market ready? Too early or too late?
+- **Distribution risk** — How does the first 100 users find this?
+- **Monetization risk** — Will people pay, or do they expect it free?
+- **Retention risk** — Is this a one-time-use tool or recurring value?
+- **Founder risk** — Is this builder uniquely positioned to win here?
+
+Format as a numbered list, one sentence each, no hedging.
+
+---
+
+## 1.3 Persona Grid
+
+Create two personas:
+
+**Persona A — The Buyer** (would pay on day 1)
+- Role / situation
+- Specific pain trigger
+- What they'd pay per month
+- What would make them churn
+
+**Persona B — The Skeptic** (would try free, never convert)
+- Role / situation
+- Why they won't pay
+- What they'd say in a 1-star review
+
+---
+
+## 1.4 Fake 1-Star Review
+
+Write a realistic, specific 1-star review from Persona B six months after launch.
+It should surface the sharpest product-market fit failure.
+
+Format:
+```
+★☆☆☆☆ [Review Title]
+[2-4 sentences as a frustrated user]
+— [Persona name], [role]
+```
+
+---
+
+## Scoring Criteria
+
+Rate the problem 1–5 on:
+- **Acuity** — How badly does this hurt? (1 = mild inconvenience, 5 = daily blocker)
+- **Frequency** — How often does the trigger occur?
+- **Willingness to Pay** — Evidence that adjacent solutions get paid for
+
+Flag if any score is ≤ 2 — this is a red flag requiring more validation before Phase 2.

--- a/skills/idea-validator/references/phase2-market.md
+++ b/skills/idea-validator/references/phase2-market.md
@@ -1,0 +1,80 @@
+# Phase 2 — Market & Competition
+
+## Goal
+Find out if a market exists, who owns it, and whether there's a real gap.
+
+---
+
+## 2.1 Competitor Discovery
+
+Use **web search** to find real competitors. Search for:
+- Direct competitors (same solution, same audience)
+- Indirect competitors (different solution, same problem)
+- Adjacent tools the target user already pays for
+
+Search queries to run:
+- `"[problem keyword] tool" OR "software" site:producthunt.com`
+- `"best [solution category] for [audience]" 2024 OR 2025`
+- `"[problem keyword] alternative"`
+- Check: G2, Capterra, Product Hunt, Hacker News "Show HN"
+
+---
+
+## 2.2 Competitor Matrix
+
+Build a table with these columns:
+
+| Competitor | Pricing | Key Strength | Key Weakness | Target User |
+|------------|---------|--------------|--------------|-------------|
+| [Name]     | $X/mo   | ...          | ...          | ...         |
+
+Include 3–6 real competitors. If fewer than 3 exist, flag this as either:
+- **Blue ocean** (opportunity) — explain why
+- **Graveyard** (people tried, all failed) — investigate why they failed
+
+---
+
+## 2.3 Gap Analysis
+
+After the matrix, answer explicitly:
+- **What does every competitor get wrong?** (UX, pricing, audience, scope)
+- **Where is the idea uniquely positioned?**
+- **Is the differentiation defensible?** (Can a competitor copy it in a sprint?)
+
+Format as:
+```
+Unique Angle: [one sentence]
+Defensibility: HIGH / MEDIUM / LOW
+Defensibility Reason: [why]
+```
+
+---
+
+## 2.4 Market Signal Assessment
+
+Look for evidence that people pay for adjacent solutions:
+- Are there paid alternatives in the space (even if imperfect)?
+- Are there active communities discussing this problem? (Reddit, Slack, Discord)
+- Any "jobs to be done" evidence — people cobbling together workarounds?
+
+These are **green flags**. If none exist, flag as a **demand risk**.
+
+---
+
+## 2.5 Market Sizing (Back-of-Envelope Only)
+
+Don't over-engineer this. Just answer:
+- **Who is the ICP** (Ideal Customer Profile) — job title, company size, industry
+- **Rough addressable count** — how many of these people exist?
+- **If 1% converted at $X/month** — what does that revenue look like?
+
+Keep this to 3 sentences. The point is whether the ceiling is worth pursuing, not a DCF model.
+
+---
+
+## Red Flags to Call Out
+
+- Space dominated by a well-funded incumbent with the same roadmap
+- Market too niche (< 10k addressable buyers globally)
+- Competitors tried and shut down with no clear reason why
+- Problem only exists because of a temporary condition (regulation, trend, API access)

--- a/skills/idea-validator/references/phase3-prototype.md
+++ b/skills/idea-validator/references/phase3-prototype.md
@@ -1,0 +1,87 @@
+# Phase 3 — Prototype Feasibility
+
+## Goal
+Define the smallest possible thing that tests the riskiest assumption — before writing
+production code. The output is a **fake-door or paper prototype plan**, not actual code.
+
+---
+
+## 3.1 Identify the Core Assumption to Test
+
+Every idea has one assumption that, if wrong, kills everything.
+Pick the single most important one to test first:
+
+Examples:
+- "Users will trust AI-generated prep plans" (trust assumption)
+- "People will pay $29/mo for this" (monetization assumption)
+- "The UX flow makes sense to a new user in < 60 seconds" (usability assumption)
+- "Users have this problem frequently enough to return" (retention assumption)
+
+State this explicitly:
+```
+Core Assumption: [one sentence]
+Test Method: [how the prototype proves/disproves it]
+```
+
+---
+
+## 3.2 Prototype Options (pick the right level)
+
+Choose based on what assumption is being tested:
+
+### Level 1 — Static Landing Page (1–3 hours)
+- One-page site with value prop, feature list, pricing, CTA ("Join waitlist" / "Get early access")
+- Test: **demand** — will people click and give their email?
+- Build with: Claude Artifact (HTML), Carrd, Framer, or a simple React component
+- Success metric: >5% conversion on cold traffic, or 20+ signups from personal network
+
+### Level 2 — Clickable UI Mock (4–8 hours)
+- Claude Artifact (React) showing the core user flow with fake/hardcoded data
+- Test: **UX clarity** — does the flow make sense without explanation?
+- Include: The single most important screen (dashboard, results page, wizard step)
+- Success metric: A new user can describe what the product does in 30 seconds without prompting
+
+### Level 3 — Wizard of Oz (1–2 days)
+- Real UI, but Claude (or a human) does the work behind the scenes manually
+- Test: **value quality** — is the output actually useful enough to pay for?
+- Build with: Claude API-powered artifact, or just do it manually via chat
+- Success metric: User says "I'd pay for this" or "This saved me X hours"
+
+### Level 4 — Spike / Technical Prototype (2–5 days)
+- Build only the hardest technical piece — not the full product
+- Test: **feasibility** — can this actually be built to the required quality?
+- See Phase 4 for guidance on what to spike
+
+---
+
+## 3.3 Fake-Door Test Plan
+
+Define concretely:
+- **What page/flow to build**
+- **Where to send traffic** (Twitter/X, Reddit, a community, personal network)
+- **The CTA** — what the user clicks or submits
+- **What you measure** in 48–72 hours
+- **Pass threshold** — what result means "proceed to Phase 4"
+
+Format:
+```
+Prototype Type: Level [1/2/3/4]
+Build Time: ~X hours
+Platform: [where you'd build it]
+CTA: [exact button text or action]
+Traffic Source: [where you'd send people]
+Pass Condition: [specific measurable outcome]
+```
+
+---
+
+## 3.4 What NOT to Build Yet
+
+List 3–5 features the idea probably includes that should NOT be in the prototype:
+- Auth / user accounts
+- Persistent database
+- Admin dashboard
+- Billing / payments
+- Onboarding flow
+
+These are validated later. Prototyping them first is sunk cost.

--- a/skills/idea-validator/references/phase4-tech.md
+++ b/skills/idea-validator/references/phase4-tech.md
@@ -1,0 +1,95 @@
+# Phase 4 — Technical Risk Assessment
+
+## Goal
+Surface the hardest technical problems before committing to a stack.
+Recommend the one spike that de-risks the most.
+
+The user is a developer (JS/TS/Node/React/Python). Speak at that level.
+
+---
+
+## 4.1 Risk Identification Framework
+
+For each idea, assess risks across these categories:
+
+### Data Risks
+- Where does core data come from? (scraping, APIs, user-generated, proprietary)
+- Is that source stable? (ToS compliance, rate limits, cost at scale)
+- What happens if the data source changes or disappears?
+
+### AI/ML Risks
+- Is the quality of AI output central to the product's value?
+- What's the failure mode when the model is wrong?
+- Latency requirements — can the user wait 5–30 seconds, or must it be <1s?
+- Context window / cost at scale — what's the $/query at 10k MAU?
+
+### Integration Risks
+- Third-party APIs that are flaky, expensive, or poorly documented
+- Auth complexity (OAuth flows, enterprise SSO)
+- Webhook reliability requirements
+
+### Scale Risks
+- What's the bottleneck at 10k users? (DB, LLM calls, scraping infra, storage)
+- What changes architecturally at 100k users?
+- Any state management that gets painful at scale? (sessions, queues, rate limiting)
+
+### Compliance/Legal Risks
+- Does the idea involve scraping sites that prohibit it?
+- User data that triggers GDPR / CCPA?
+- AI-generated content in regulated domains (finance, health, legal)?
+
+---
+
+## 4.2 Risk Matrix
+
+Format as a table:
+
+| Risk | Category | Severity (H/M/L) | Likelihood (H/M/L) | Mitigation |
+|------|----------|-------------------|---------------------|------------|
+| [Risk description] | Data | H | M | [one-line mitigation] |
+
+Severity × Likelihood → priority order.
+
+---
+
+## 4.3 Spike Recommendation
+
+Pick **one** thing to build first that:
+1. Is the highest-risk technical assumption
+2. Can be validated in 1–3 days
+3. If it fails, kills the idea without wasted infrastructure
+
+Format:
+```
+Spike Target: [what to build]
+Why This One: [why this is the hardest/riskiest thing]
+Time Estimate: ~X days
+Success Criteria: [what "it works" means technically]
+Failure Signal: [what outcome means rethink the approach]
+```
+
+---
+
+## 4.4 Stack Recommendation (brief)
+
+Given the idea and the builder's stack (JS/TS/Node/React/Python), recommend:
+- **Backend**: [e.g., Node/Fastify, Python/FastAPI — and why]
+- **AI Layer**: [e.g., Anthropic API with Claude Sonnet, or LangChain if orchestration is complex]
+- **Data**: [e.g., Postgres + pgvector for embeddings, Redis for job queue]
+- **Scraping** (if relevant): [e.g., Playwright + BrightData, or Firecrawl]
+- **Hosting**: [e.g., Railway/Fly.io for MVP, then migrate]
+
+Keep this to one bullet per category. No over-engineering.
+
+---
+
+## 4.5 Agentic System Assessment (if applicable)
+
+If the idea involves multiple agents, orchestration, or async pipelines:
+- How many distinct agent roles are needed at MVP?
+- What's the failure/retry strategy when an agent step fails?
+- Is a full agent framework needed (LangGraph, CrewAI) or is direct API orchestration sufficient?
+- What's the observability plan? (logging, tracing LLM calls)
+
+Flag: "Do you need an agentic system now, or can you fake it with sequential API calls first?"
+Sequential is almost always faster to validate.

--- a/skills/idea-validator/references/phase5-decision.md
+++ b/skills/idea-validator/references/phase5-decision.md
@@ -1,0 +1,116 @@
+# Phase 5 — Go / No-Go Decision Memo
+
+## Goal
+Synthesize all four phases into a clear, ruthless verdict.
+This is the document the builder reads before opening their IDE.
+
+---
+
+## 5.1 Synthesis Inputs
+
+Pull the following from previous phases:
+- Phase 1: Problem acuity score, strongest failure mode, persona fit
+- Phase 2: Competitor gap, market signal strength, red flags
+- Phase 3: Prototype feasibility, pass condition likelihood
+- Phase 4: Top technical risk, spike recommendation
+
+---
+
+## 5.2 Scoring Rubric
+
+Score each dimension 1–5:
+
+| Dimension | Score | Weight | Notes |
+|-----------|-------|--------|-------|
+| Problem Acuity (how badly does it hurt?) | /5 | 25% | From Phase 1 |
+| Market Demand Signal (evidence people pay) | /5 | 25% | From Phase 2 |
+| Competitive Differentiation | /5 | 20% | From Phase 2 |
+| Technical Feasibility | /5 | 15% | From Phase 4 |
+| Prototype Testability (can we validate fast?) | /5 | 15% | From Phase 3 |
+
+**Weighted Score = sum(score × weight)**
+
+Interpretation:
+- 4.0–5.0 → **GO** — strong signal across all dimensions
+- 3.0–3.9 → **CONDITIONAL GO** — viable but one key condition must be true
+- 2.0–2.9 → **HIGH RISK** — proceed only if builder has unique advantage
+- < 2.0 → **NO-GO** — fundamental flaw, pivot recommended
+
+---
+
+## 5.3 Verdict Block
+
+Format this as a clear, prominent block:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+VERDICT: [GO / CONDITIONAL GO / NO-GO]
+CONFIDENCE: [X]/10
+WEIGHTED SCORE: [X.X]/5.0
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+---
+
+## 5.4 Single Biggest Unvalidated Assumption
+
+Name the one thing, if wrong, that kills this idea.
+Be specific. Not "product-market fit" — but e.g.:
+"Users will trust AI-generated interview answers enough to practice with them instead of a human coach."
+
+This is the thing to validate before writing production code.
+
+---
+
+## 5.5 Verdict-Specific Guidance
+
+### If GO:
+- **Build this first**: [the one feature that delivers the core value, nothing else]
+- **Ignore until after first 10 paying users**: [list of scope traps]
+- **First distribution channel**: [where to find the first 10 users specifically]
+
+### If CONDITIONAL GO:
+- **The condition**: [exact statement of what must be true]
+- **How to test the condition**: [specific action, < 1 week]
+- **If condition is met**: proceed to Phase 4 spike
+- **If condition fails**: [pivot direction]
+
+### If NO-GO:
+- **The core flaw**: [one sentence, no softening]
+- **Why this can't be patched**: [brief explanation]
+- **Pivot option**: [adjacent idea that avoids the flaw, if one exists]
+
+---
+
+## 5.6 Validation Checklist (Appendix)
+
+Generate a checklist of open vs. closed items:
+
+```markdown
+## Validation Checklist
+
+### ✅ Validated
+- [ ] Problem exists (from Phase 1)
+- [ ] Competitors identified (from Phase 2)
+- [ ] Differentiation articulated (from Phase 2)
+- [ ] Tech stack de-risked (from Phase 4)
+
+### ⚠️ Still Open (must validate before scaling)
+- [ ] [Specific assumption from Phase 1 still open]
+- [ ] [Pricing hypothesis untested]
+- [ ] [Retention assumption unverified]
+
+### 🚫 Out of Scope (validate after first revenue)
+- [ ] Enterprise sales motion
+- [ ] Mobile app
+- [ ] Internationalization
+```
+
+---
+
+## Tone Guidance for Phase 5
+
+- Write like a trusted technical co-founder, not a consultant
+- No hedge words: "potentially", "might", "could" — state things directly
+- If the score is bad, say so clearly — false encouragement costs the builder months
+- If the score is good, be specific about why — vague positivity is useless


### PR DESCRIPTION
## What this skill does

A 5-phase pre-build validation flow for app or business ideas: problem clarity → market & competition → prototype feasibility → technical risk → go/no-go decision memo. Output is a structured markdown Idea Validation Report.

## Why it's useful

Most "validate my idea" requests get vague answers. This skill produces a ruthlessly honest, research-backed report (uses web search in Phase 2) that kills bad ideas before code is written. The five-phase progression mirrors how an experienced founder/operator would stress-test an idea, and each phase has a concrete output and pass/fail criterion.

## Real-world tested

Used on actual business ideas before opening this PR. Two example reports included in `assets/`:
- `example-report.md` — a CONDITIONAL/GO-shaped output
- `example-report-nogo.md` — a real-world NO-GO: the skill correctly identified a duplicative idea (interview-prep AI agent vs. Final Round AI / Cluely) and proposed four concrete pivot paths instead

## Spec compliance

- `SKILL.md` is 181 lines (well under the 500-line recommendation)
- All reference files under 120 lines (under the 300-line TOC threshold)
- Frontmatter validates against the [Agent Skills spec](https://agentskills.io/specification): `name`, `description`, `license: Apache-2.0`, `compatibility`, `metadata` all present and within constraints
- Apache-2.0 licensed with bundled `LICENSE.txt`
- Folder layout follows the convention used by `skill-creator` and `mcp-builder` (`SKILL.md` + `LICENSE.txt` + `references/` + `assets/`)

## Folder layout

~~~
skills/idea-validator/
├── SKILL.md
├── LICENSE.txt
├── references/
│   ├── phase1-problem.md
│   ├── phase2-market.md
│   ├── phase3-prototype.md
│   ├── phase4-tech.md
│   └── phase5-decision.md
└── assets/
    ├── example-report.md
    └── example-report-nogo.md
~~~

Happy to iterate on tone, trigger phrasing, or structure based on review feedback.