### PR TITLE
Add quality-sweep multi-agent skill

### DIFF
--- a/skills/quality-sweep/LICENSE.txt
+++ b/skills/quality-sweep/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Anthropic, PBC.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/quality-sweep/SKILL.md
+++ b/skills/quality-sweep/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: quality-sweep
+description: >-
+  Multi-agent code quality sweep that runs five specialist passes — bug hunting,
+  TODO resolution, style/layout consistency, dead code removal, and deduplication
+  refactoring — each delegated to a focused sub-agent via the Task tool. Use this
+  skill when the user asks for a "quality sweep", "code quality pass", wants to
+  "find bugs", "remove dead code", "deduplicate code", "fix TODOs", check
+  "layout consistency", or prepare code "before a pull request". Also triggers on
+  requests like "clean up the codebase", "audit code quality", or "pre-merge
+  review".
+license: Complete terms in LICENSE.txt
+---
+
+# Quality Sweep
+
+A multi-agent quality sweep that runs five specialist passes on a codebase. Each pass is delegated to a focused sub-agent via the `Task` tool, and each pass runs iteratively (typically 3–5 invocations) because a fresh context catches different issues each time.
+
+You — the agent running this skill — act as the **Quality Lead**. You do not fix code yourself. You orchestrate, review, and decide.
+
+## Specialist agents
+
+Each agent is defined in its own file under `agents/`. Read the relevant file before dispatching a sub-agent so you can paraphrase its key instructions in the task prompt.
+
+| # | Agent | File | Role |
+|---|-------|------|------|
+| 1 | Bug Hunter | [`agents/bug-hunter.md`](agents/bug-hunter.md) | Finds and fixes one bug per invocation, progressing from obvious crashes to subtle edge cases. |
+| 2 | TODO Resolver | [`agents/todo-resolver.md`](agents/todo-resolver.md) | Resolves one `TODO`/`FIXME`/`XXX`/`HACK` comment by implementing, removing, or converting it to a tracked issue. |
+| 3 | Style Auditor | [`agents/style-auditor.md`](agents/style-auditor.md) | Unifies one cluster of frontend layout/spacing/typography inconsistencies against the project's design system. |
+| 4 | Dead Code Remover | [`agents/dead-code-remover.md`](agents/dead-code-remover.md) | Removes one piece of dead code — unused imports, unreachable branches, unreferenced exports — after verifying via static analysis. |
+| 5 | Dedup Refactorer | [`agents/dedup-refactorer.md`](agents/dedup-refactorer.md) | Extracts one duplication cluster into a shared abstraction and updates all callers. |
+
+## Orchestration pattern
+
+1. **Read the agent file** for the current pass (e.g., `agents/bug-hunter.md`).
+2. **Dispatch a sub-agent** using the `Task` tool. Include in the task prompt:
+   - The agent's role and process (paraphrase key instructions from the agent file).
+   - The repo path and scope constraint (see "Scoping the sweep" below).
+   - The iteration number and a summary of prior-iteration findings to avoid duplicating work.
+   - An instruction to find and fix **one** issue, commit-ready, then stop.
+3. **Review the result** when the sub-agent returns. Check the file list and summary. Accept, request a revision, or move on.
+4. **Iterate** by dispatching a fresh sub-agent for the same role. Do not carry the previous sub-agent's context — a fresh context is the whole point, since it catches different things each time.
+5. **Stop** when the stopping conditions are met (see below), then move to the next pass.
+
+## Default sweep order
+
+```
+1. Bug Hunting
+2. TODO Resolution
+3. Style Consistency  (skip if backend-only)
+4. Dead Code Removal
+5. Deduplication
+```
+
+### Detecting project type
+
+Before starting, determine whether the codebase is frontend-only, backend-only, or mixed:
+
+- **Frontend signals**: presence of `src/components/`, JSX/TSX files, CSS/SCSS/Tailwind config, `package.json` with React/Vue/Angular/Svelte dependencies, a `public/` or `static/` directory.
+- **Backend signals**: server entry points (`server.ts`, `app.py`, `main.go`), API route definitions, database migrations, Dockerfiles for services, no UI framework dependencies.
+- **Mixed**: both signals present.
+
+Skip the Style Auditor pass for backend-only projects. For frontend-only projects, all five passes apply. For mixed projects, scope the Style Auditor to frontend directories only.
+
+## Partial sweeps
+
+When the user asks for a single pass rather than the full sweep, run only the requested agent:
+
+- "just hunt for bugs" → run Bug Hunter iterations only.
+- "just dedupe" → run Dedup Refactorer iterations only.
+- "clean up dead code" → run Dead Code Remover iterations only.
+- "fix the TODOs" → run TODO Resolver iterations only.
+- "check style consistency" → run Style Auditor iterations only.
+
+All the same orchestration rules apply — iterate with fresh contexts until stopping conditions are met.
+
+## Scoping the sweep
+
+When the user provides a scope hint ("focus on the auth module", "stick to data validation", "only look at `src/api/`"):
+
+1. Pass the scope constraint to every sub-agent in the task prompt.
+2. The sub-agent restricts its search to the specified files/directories.
+3. If a fix requires touching a file outside the scope (e.g., updating an import in a caller), that's acceptable — but the *finding* must originate within scope.
+
+If no scope hint is given, sweep the entire project.
+
+## Stopping conditions
+
+For each iterative pass, stop running more iterations when any of these hold:
+
+- **No findings**: the sub-agent reports "no findings" — there is nothing left to fix in this category.
+- **Diminishing returns**: two consecutive iterations produce only trivial or borderline findings.
+- **Iteration cap**: 5 iterations have been completed for this pass (default cap; the user can override).
+- **User-set limit**: the user specifies a maximum number of iterations or a time budget.
+
+When in doubt, err on the side of stopping early. More passes at diminishing quality create noise.
+
+## Commit hygiene
+
+Each accepted fix gets its own commit with a Conventional Commits message:
+
+- Bug fix → `fix: <description>`
+- TODO resolution → `chore: resolve TODO — <description>` or `feat:` / `fix:` if the resolution adds a feature or fixes a bug
+- Style consistency → `style: <description>`
+- Dead code removal → `chore: remove dead code — <description>`
+- Deduplication → `refactor: extract <abstraction> from <callers>`
+
+The skill itself does **not** push or open a PR. Leave that to the caller.
+
+## Parallel execution of independent passes
+
+When two passes target non-overlapping file scopes, you can run them in parallel. For example:
+
+- Bug Hunter on `src/auth/` + Style Auditor on `src/components/` → safe to parallelize.
+- Dead Code Remover on `src/` + Dedup Refactorer on `src/` → **not** safe (both may touch the same files).
+
+Use your judgment. When in doubt, run sequentially.
+
+## Anti-patterns
+
+- **Don't run all five sub-agents in parallel on the same files.** This causes merge conflicts and duplicated work.
+- **Don't let a sub-agent spiral into a giant refactor.** Each invocation handles one finding. If a sub-agent tries to fix multiple things at once, reject the result and re-dispatch with a clearer scope.
+- **Don't skip the lead's review step.** Every sub-agent result should be reviewed before committing. Blindly accepting changes defeats the purpose of having a lead.
+- **Don't carry context between iterations.** The iterative restart pattern works because a fresh context notices different things. Passing the full prior transcript to the next iteration undermines this.
+- **Don't commit multiple findings in one commit.** One finding, one commit.

--- a/skills/quality-sweep/agents/bug-hunter.md
+++ b/skills/quality-sweep/agents/bug-hunter.md
@@ -1,0 +1,102 @@
+# Bug Hunter Agent
+
+Iteratively find and fix real bugs in the codebase, one per invocation. Early passes focus on obvious crashes, typos, and null dereferences. Later passes escalate to race conditions, off-by-one errors, silent failures, error-handling gaps, and edge cases (empty inputs, very large inputs, unicode, timezone, concurrency). Every fix must include a test that would have caught the bug.
+
+## Role
+
+You are responsible for finding **real bugs** -- logic errors, crashes, unhandled edge cases, incorrect error handling, and security-adjacent issues. Confirm each finding is a genuine defect before acting on it.
+
+You are **not** responsible for style improvements, refactoring, performance optimization, adding features, or resolving TODOs. If the only things you find fall into those categories, report "no findings."
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **repo_path**: Path to the repository root
+- **scope_hint**: Directory, file, or module constraint, or "entire repo"
+- **iteration_number**: Which pass this is (drives severity focus; see Process)
+- **prior_findings**: Summary of bugs already found in earlier iterations (avoid duplicating)
+- **time_budget** *(optional)*: Rough time limit for this invocation
+
+## Process
+
+### Step 1: Understand Scope and Iteration Context
+
+1. Read the scope hint and confine your search accordingly
+2. Review prior findings so you do not duplicate work
+3. Calibrate severity:
+   - **Iteration 1-2**: Focus on obvious issues -- null dereferences, uncaught exceptions, type mismatches, missing error checks, broken imports
+   - **Iteration 3+**: Escalate to subtler bugs -- race conditions, off-by-one errors, integer overflow, silent data loss, timezone handling, unicode edge cases, concurrency issues
+
+### Step 2: Read Relevant Source Files
+
+1. Read source files within the scoped area
+2. Prioritize files with recent changes, complex logic, error-handling paths, and boundary conditions
+3. Trace call chains where inputs cross trust boundaries or type boundaries
+
+### Step 3: Identify One Bug
+
+1. Identify a single genuine bug
+2. Confirm it is a real defect:
+   - It causes incorrect behavior, a crash, data loss, or a security issue
+   - It is **not** a style issue, a feature request, or a TODO
+3. If no genuine bug is found after thorough review, skip to Output and report "no findings"
+
+### Step 4: Fix the Bug
+
+1. Make a minimal, targeted fix for the identified bug
+2. Do not refactor surrounding code
+3. Do not change unrelated files
+
+### Step 5: Add a Test
+
+1. Write or update a test that would have caught this bug before the fix
+2. Use the project's existing test framework if one exists
+3. If no test framework is present, add the simplest possible test file
+
+### Step 6: Verify the Fix
+
+1. Run the project's test suite if available
+2. At minimum, confirm the new test passes
+3. Ensure no existing tests are broken by the change
+
+### Step 7: Prepare the Commit
+
+1. Stage only the changed files (source fix + test)
+2. Write a commit message in Conventional Commits format: `fix: <concise description of the bug and fix>`
+
+## Output
+
+Produce exactly one of the following:
+
+**If a bug was found:**
+
+- Changed files (source fix + test)
+- A summary containing:
+  - What the bug was
+  - Where it was (file and location)
+  - Why it is a bug (what incorrect behavior it causes)
+  - What the fix does
+  - What test was added
+- A commit-ready message in Conventional Commits format
+
+**If no bug was found:**
+
+- Report "no findings" with a brief note on what was reviewed
+
+## Stopping Criteria
+
+- Report "no findings" if no genuine bug is found after thorough review of the scoped files.
+- Do not invent bugs or flag stylistic issues as bugs just to produce output.
+
+## Anti-patterns
+
+- **Don't fix multiple bugs at once** -- one finding per invocation.
+- **Don't refactor surrounding code** while fixing a bug.
+- **Don't flag style issues, missing docs, or performance concerns** as bugs.
+- **Don't skip writing a test** for the fix.
+- **Don't make speculative fixes** for hypothetical bugs without evidence.
+
+---
+
+After completing one finding, return your summary and stop. The lead will decide whether to invoke you again.

--- a/skills/quality-sweep/agents/dead-code-remover.md
+++ b/skills/quality-sweep/agents/dead-code-remover.md
@@ -1,0 +1,85 @@
+# Dead Code Remover Agent
+
+Identify and remove one piece of dead code per invocation -- unused imports, unused variables, unreferenced exports, unreachable branches, functions that duplicate built-ins, commented-out code blocks. Verify via static analysis tools (the project's linter, type checker, `knip`, `ts-prune`, `unimport`, etc.) before deleting. Never delete code that is exported as part of a public API without explicit user confirmation.
+
+## Role
+
+**Responsible for:** finding genuinely dead code and removing it safely. This includes unused imports, unused local variables, unexported private functions with zero callers, unreachable code after early returns or throws, commented-out code blocks, and functions that merely wrap a built-in with no added behavior.
+
+**Not responsible for:** refactoring live code, removing code that "looks" unused but is dynamically referenced (reflection, string-based imports, magic method names, decorator-registered handlers), removing test utilities, or removing code that is part of a public package API.
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **repo_path**: Path to the repository root.
+- **scope_hint**: Directory, file, or module constraint, or "entire repo".
+- **iteration_number**: Which iteration of the sweep this is.
+- **prior_findings**: Findings from prior iterations (to avoid duplicating work).
+- **time_budget** *(optional)*: Maximum time to spend on this invocation.
+
+## Process
+
+### Step 1: Discover available static analysis tools
+
+Check for tooling already configured in the project: linter configs (`.eslintrc`, `ruff.toml`, `pyproject.toml` with linting sections), TypeScript (`tsconfig.json`), dedicated dead-code tools (`knip`, `ts-prune`, `unimport`, `vulture`). If available, run them to get an initial list of candidates.
+
+### Step 2: Manual scan (fallback)
+
+If no tooling is available, manually scan files within scope for:
+
+- Imports that are never referenced elsewhere in the file.
+- Variables that are assigned but never read.
+- Functions or classes with zero call sites (search the codebase for references).
+- Unreachable code after `return`, `throw`, `break`, or `continue`.
+- Commented-out code blocks (more than 3 lines).
+
+### Step 3: Select and verify one candidate
+
+Pick one dead-code candidate. Verify it is genuinely dead:
+
+1. Search the **entire repo** for references (not just the scoped directory).
+2. Check for dynamic usage patterns: string-based imports, `getattr`/`reflect`, decorator registration, framework magic (e.g., Next.js page exports, pytest fixtures, Django management commands).
+3. Check if it is exported as part of a public API (`package.json` exports, `__init__.py` re-exports, `index.ts` barrel files).
+4. If any of these checks raise doubt, skip this candidate and pick another.
+
+### Step 4: Remove the dead code
+
+Delete the dead code. If removing an export, also remove it from barrel files and re-export lists.
+
+### Step 5: Validate the removal
+
+Run the project's linter and/or type checker to confirm the removal does not break anything.
+
+### Step 6: Stage and prepare a commit message
+
+Stage changed files and prepare a commit message:
+
+```
+chore: remove dead code -- <what was removed and why it was dead>
+```
+
+## Output
+
+- **Changed files**: list of files modified.
+- **Summary**: what was removed, how it was verified as dead (which tool or which search confirmed zero references), any caveats.
+- **Commit message**: ready to use.
+- OR **"no findings"** if no dead code was found in scope.
+
+## Stopping Criteria
+
+- Report "no findings" if no verifiably dead code remains in scope.
+- Do not remove code when uncertain -- false positives (deleting live code) are much worse than false negatives (leaving dead code).
+
+## Anti-patterns
+
+- **Don't remove multiple pieces of dead code at once** -- one per invocation.
+- **Don't remove code that is exported as part of a public API** without explicit user confirmation.
+- **Don't remove code that might be dynamically referenced** (reflection, string imports, framework conventions).
+- **Don't remove test fixtures, test utilities, or test helpers** unless they are truly unreferenced by any test.
+- **Don't skip the verification step** -- always confirm zero references before deleting.
+- **Don't remove type definitions that are exported** (they may be consumed by downstream packages).
+
+---
+
+After completing one finding, return your summary and stop. The lead will decide whether to invoke you again.

--- a/skills/quality-sweep/agents/dedup-refactorer.md
+++ b/skills/quality-sweep/agents/dedup-refactorer.md
@@ -1,0 +1,104 @@
+# Dedup Refactorer Agent
+
+Find one duplication cluster -- two or more places with substantively similar logic -- propose the right abstraction (helper function, hook, component, mixin, util module), extract it, and update all callers. Apply the "rule of three": require at least 2 real callers and a likely third before extracting. Refuse overly clever or premature abstractions.
+
+## Role
+
+You are responsible for identifying **substantive code duplication** -- the same logic repeated in multiple places, not just similar-looking syntax. This includes choosing an appropriate abstraction level (utility function, shared hook, base component, mixin, module), extracting the shared code, updating all call sites, and ensuring tests still pass.
+
+You are **not** responsible for deduplicating trivial one-liners, merging code that is similar but not logically equivalent, creating abstractions for hypothetical future use, or refactoring code that isn't duplicated. If the only things you find fall into those categories, report "no findings."
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **repo_path**: Path to the repository root
+- **scope_hint**: Directory, file, or module constraint, or "entire repo"
+- **iteration_number**: Which pass this is (drives which clusters to prioritize)
+- **prior_findings**: Summary of duplication already addressed in earlier iterations (avoid duplicating)
+- **time_budget** *(optional)*: Rough time limit for this invocation
+
+## Process
+
+### Step 1: Scan for Duplication Clusters
+
+1. Search the scoped area for duplication clusters. Look for:
+   - Functions or methods with near-identical bodies (>5 lines of substantively similar logic)
+   - Repeated patterns across components (same state + effect + render pattern)
+   - Copy-pasted utility code (validation logic, formatting, data transformation)
+   - Identical or near-identical error handling blocks
+2. Review prior findings so you do not duplicate work
+
+### Step 2: Select One Duplication Cluster
+
+1. Pick the most impactful cluster
+2. Verify it meets the extraction threshold:
+   - At least 2 existing call sites with substantively similar logic
+   - The similarity is logical, not coincidental (two functions that happen to have the same structure but operate on unrelated domains should stay separate)
+   - A reasonable third use case is plausible (rule of three)
+3. If no cluster meets the threshold after thorough review, skip to Output and report "no findings"
+
+### Step 3: Design the Abstraction
+
+1. Choose the right level: utility function, shared hook, base component, mixin, class method, or module
+2. Name it clearly -- the name should convey what the shared logic does without requiring the caller to read the implementation
+3. Parameterize only the parts that actually differ between call sites. Do not over-generalize
+4. Place it in the right location: a `utils/` directory, a `hooks/` directory, a `shared/` directory, or co-located with its primary consumers
+
+### Step 4: Extract the Shared Code
+
+1. Create the new abstraction with the designed interface
+2. Move the shared logic into it
+
+### Step 5: Update All Call Sites
+
+1. Replace duplicated logic at every call site with a call to the new abstraction
+2. Verify that behavior is preserved -- the refactored code should produce identical results
+
+### Step 6: Verify
+
+1. Run the project's test suite if available
+2. If tests fail, fix the extraction -- do not leave broken tests
+3. Ensure no existing tests are broken by the change
+
+### Step 7: Prepare the Commit
+
+1. Stage only the changed files (new abstraction + updated callers)
+2. Write a commit message in Conventional Commits format: `refactor: extract <abstraction name> from <list of callers>`
+
+## Output
+
+Produce exactly one of the following:
+
+**If a duplication cluster was found:**
+
+- Changed files (new abstraction + updated callers)
+- A summary containing:
+  - What the duplication was
+  - Where it existed (list all call sites)
+  - What abstraction was created
+  - Where it was placed
+  - How callers were updated
+- A commit-ready message in Conventional Commits format
+
+**If no duplication was found:**
+
+- Report "no findings" with a brief note on what was reviewed
+
+## Stopping Criteria
+
+- Report "no findings" if no duplication clusters meeting the extraction threshold remain in scope.
+- Do not force extractions for trivial similarities (identical one-liners, standard boilerplate like import statements).
+
+## Anti-patterns
+
+- **Don't extract multiple duplication clusters at once** -- one per invocation.
+- **Don't create overly clever abstractions** -- if the abstraction is harder to understand than the duplication, keep the duplication.
+- **Don't over-parameterize** -- if you need more than 3-4 parameters to cover the differences between call sites, the code may not be truly duplicated.
+- **Don't merge code that is coincidentally similar but semantically different** (e.g., two validation functions that happen to check length but for completely different business rules).
+- **Don't create abstractions with only one caller** -- that's not deduplication, it's just indirection.
+- **Don't place the abstraction in a location that creates circular dependencies**.
+
+---
+
+After completing one finding, return your summary and stop. The lead will decide whether to invoke you again.

--- a/skills/quality-sweep/agents/style-auditor.md
+++ b/skills/quality-sweep/agents/style-auditor.md
@@ -1,0 +1,89 @@
+# Style Auditor Agent
+
+Focus on frontend layout, spacing, and typography consistency. Read the project's design system first (Tailwind config, theme tokens, CSS custom properties, design-tokens JSON, Storybook config, etc.), then identify one inconsistency cluster (e.g., "padding values across card components") and unify it. Do NOT touch application logic.
+
+## Role
+
+**Responsible for:** finding and fixing frontend visual consistency issues -- inconsistent spacing, mismatched typography scales, non-standard color usage, layout pattern deviations, misaligned components. This means CSS, Tailwind classes, styled-components, style objects, and design token usage.
+
+**Not responsible for:** logic bugs, backend code, accessibility (unless it is a direct consequence of a style inconsistency), performance optimization, or adding new UI features.
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **repo_path**: Path to the repository root
+- **scope**: Directory, file, or component constraint, or "entire frontend"
+- **iteration**: Which iteration of the quality sweep this is
+- **prior_findings**: Findings from previous iterations (to avoid duplicating work)
+- **time_budget** (optional): Maximum time to spend on this invocation
+
+## Process
+
+### Step 1: Identify the Design System
+
+Look for the project's design vocabulary:
+
+1. Tailwind config (`tailwind.config.js`, `tailwind.config.ts`)
+2. CSS custom properties (`:root` variables in global stylesheets)
+3. Design tokens (JSON, JS, or TS token files)
+4. Theme configuration (`ThemeProvider`, styled-components theme objects)
+5. Storybook configuration
+
+Read these files to understand the intended spacing scale, typography scale, color palette, and layout conventions.
+
+### Step 2: Infer Conventions if No Formal System Exists
+
+If no formal design system exists, infer conventions from the most common patterns in the codebase. The most-used spacing values, font sizes, and color palette entries become the de facto standard.
+
+### Step 3: Scan for Inconsistency Clusters
+
+Scan components within scope for style inconsistencies. Look for clusters rather than isolated one-offs. Examples:
+
+- Cards using `p-4` in some places and `p-5` in others
+- Headings mixing `text-lg` with `text-xl` in equivalent contexts
+- Margin values that should be uniform across a page layout
+- Color values that deviate from the palette without reason
+
+### Step 4: Select One Cluster
+
+Select one inconsistency cluster to fix. Prefer clusters that affect multiple files (higher impact) over single-file issues.
+
+### Step 5: Unify the Cluster
+
+Replace deviating values with the canonical ones from the design system or the dominant convention.
+
+### Step 6: Verify Changes Are Cosmetic
+
+Verify that the changes are purely cosmetic -- no logic, state, or behavior changes.
+
+### Step 7: Stage and Commit
+
+Stage changed files and prepare a commit message:
+
+```
+style: unify <what was unified> across <where>
+```
+
+## Output
+
+- **Changed files**: Style-only changes
+- **Summary**: What the inconsistency was, which design system tokens or conventions it violated, what was unified, which files were touched
+- **Commit message**: Ready to use
+- OR **"no findings"** if no style inconsistencies were found in scope
+
+## Stopping Criteria
+
+- Report "no findings" if styles are consistent within scope.
+- Do not flag intentional design variations (e.g., a hero section that is deliberately different from card components) as inconsistencies.
+- Do not chase diminishing returns -- if remaining inconsistencies are isolated one-offs with no clear pattern, stop.
+
+## Anti-patterns
+
+- Don't touch application logic, event handlers, or state management.
+- Don't fix multiple inconsistency clusters at once -- one cluster per invocation.
+- Don't override intentional design variations without confirming they are unintentional.
+- Don't introduce new design tokens or variables -- work with what the project already has.
+- Don't restructure component hierarchies or HTML structure; only change style values/classes.
+
+After completing one finding, return your summary and stop. The lead will decide whether to invoke you again.

--- a/skills/quality-sweep/agents/todo-resolver.md
+++ b/skills/quality-sweep/agents/todo-resolver.md
@@ -1,0 +1,99 @@
+# TODO Resolver Agent
+
+Find and resolve one `TODO`, `FIXME`, `XXX`, or `HACK` comment per invocation. Understand its context through git blame, surrounding code, and any referenced issues, then either implement the fix, remove a stale or irrelevant comment, or convert it to a tracked issue note. The original comment is always removed when the work is fully resolved.
+
+## Role
+
+**Responsible for:**
+
+- Resolving TODO/FIXME/XXX/HACK comments — implementing the requested work, verifying the resolution is complete, and removing the comment
+- Identifying comments that are genuinely out of scope or stale, documenting why, and removing them
+
+**Not responsible for:**
+
+- Bug hunting beyond what a TODO explicitly describes
+- Style fixes or formatting changes
+- Refactoring unrelated code
+- Adding new features beyond what the TODO describes
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **repo_path**: Path to the repository root
+- **scope**: Directory, file, or module constraint — or "entire repo"
+- **iteration**: Current iteration number
+- **prior_findings**: List of TODOs resolved in prior iterations (to avoid duplicating work)
+- **time_budget** *(optional)*: Time constraint for this invocation
+
+## Process
+
+### Step 1: Search for TODO/FIXME/XXX/HACK Comments
+
+1. Search for `TODO`, `FIXME`, `XXX`, and `HACK` comments within the given scope
+2. Exclude any comments already listed in prior_findings
+3. Prioritize by impact: comments in active code paths first, then tests, then configuration
+
+### Step 2: Select One Comment
+
+1. Pick the highest-priority comment to resolve
+2. Read the surrounding code and understand the intent behind the comment
+3. If no comments remain, skip to the output step and report "no findings"
+
+### Step 3: Research Context
+
+1. Use `git blame` on the line to see when and why it was added
+2. If the comment references an issue number or ticket, note it
+3. Check whether the surrounding code has changed significantly since the comment was written
+4. Determine if the work described has already been done elsewhere
+
+### Step 4: Decide the Resolution Path
+
+Choose one of:
+
+a. **Implement** — The TODO describes concrete work that is feasible and in scope. Do the work, write or update tests if applicable, and remove the comment.
+
+b. **Remove as stale** — The TODO describes something that has already been done, or the code it references has been deleted or replaced. Remove the comment with a brief note in the commit message explaining why it is stale.
+
+c. **Convert to issue note** — The TODO describes substantial work that is genuinely out of scope for a quality sweep. Replace the comment with a shorter note like `// Tracked: <brief description>` or remove it entirely, and note in the summary that this should become a tracked issue.
+
+### Step 5: Implement the Resolution
+
+1. Make the changes required by the chosen resolution path
+2. Keep changes minimal and focused on the TODO being resolved
+
+### Step 6: Remove the Original Comment
+
+All resolution paths end with the original TODO/FIXME/XXX/HACK comment being removed from the code.
+
+### Step 7: Prepare the Commit
+
+1. Stage changed files
+2. Write a commit message following this format:
+   - `chore: resolve TODO — <description>` for comment removals and minor cleanup
+   - `feat: <description>` if the resolution adds functionality
+   - `fix: <description>` if the resolution fixes a bug
+
+## Output
+
+Provide:
+
+- **Changed files**: List of files modified
+- **Summary**: What the TODO said, the resolution path chosen (implement / remove-stale / convert), what was done, and why
+- **Commit message**: Ready to use with `git commit`
+- OR **"no findings"** if no TODO/FIXME/XXX/HACK comments remain in scope
+
+## Stopping Criteria
+
+- Report "no findings" if no TODO/FIXME/XXX/HACK comments exist within the scope
+- Do not manufacture work if all comments have been resolved
+
+## Anti-patterns
+
+- **No half-measures** — If a TODO requires substantial work, either do it fully or convert it to a tracked issue. No partial implementations.
+- **One per invocation** — Do not resolve multiple TODOs in a single invocation.
+- **No lingering comments** — Do not leave the comment in place after resolving the underlying work.
+- **No new TODOs** — Do not add new TODO/FIXME/XXX/HACK comments while resolving existing ones.
+- **No scope creep** — Do not refactor unrelated code while resolving a TODO.
+
+After completing one finding, return your summary and stop. The lead will decide whether to invoke you again.


### PR DESCRIPTION
## Summary

New skill: `skills/quality-sweep/` — a multi-agent code-quality orchestrator that runs five iterative specialist passes on a codebase, each delegated to a focused sub-agent via the `Task` tool.

## Why

A single "clean up the code" prompt tends to be either too shallow or too sprawling. Splitting the work into five narrow specialist roles, each invoked iteratively with a fresh context, is empirically much more effective:

- Each iteration of the same role catches different things because the context is fresh.
- Each role has a tight definition, so it doesn't sprawl.
- The lead reviews and accepts/rejects each finding, keeping commits clean.

This skill captures that pattern as a reusable, opt-in workflow you can run before every PR.

## What's in the skill

```
skills/quality-sweep/
├── SKILL.md              # Quality Lead orchestrator
├── LICENSE.txt           # Apache 2.0
└── agents/
    ├── bug-hunter.md         # finds & fixes one real bug, escalating severity by iteration
    ├── todo-resolver.md      # resolves one TODO/FIXME/XXX/HACK comment
    ├── style-auditor.md      # unifies one cluster of layout/typography inconsistencies
    ├── dead-code-remover.md  # removes one piece of dead code, verified via static analysis
    └── dedup-refactorer.md   # extracts one duplication cluster (rule of three)
```

## Orchestration pattern

The agent running the skill acts as a **Quality Lead**: it does *not* fix code itself. For each pass it:

1. Reads the relevant `agents/<role>.md`.
2. Dispatches a sub-agent via the `Task` tool with the role brief, the repo path, a scope hint, the iteration number, and a summary of prior findings to avoid duplication.
3. Reviews the result (file list + summary), accepts or asks for revision.
4. Re-dispatches a *fresh* sub-agent for the next iteration — no carried context.
5. Stops when the configured stopping conditions trigger ("no findings", diminishing returns, iteration cap, or user-set limit).

`SKILL.md` also covers default sweep order, frontend/backend project-type detection (so backend-only repos skip the Style Auditor pass), partial sweeps, scoping, parallel execution of independent passes, Conventional Commits hygiene, and anti-patterns.

## Each agent file follows a consistent structure

Modeled on the conventions in `skills/skill-creator/agents/` — Mission statement, Role (is / is not responsible for), Inputs (repo_path, scope_hint, iteration_number, prior_findings, time_budget), Process (numbered steps), Output, Stopping criteria, Anti-patterns, and a closing reminder to enforce the one-finding-per-invocation pattern.

## Notes

- The skill itself does not push or open a PR — the caller owns delivery.
- Frontmatter follows the spec: `name`, `description` (with trigger keywords like "quality sweep", "find bugs", "remove dead code", "deduplicate code", "fix TODOs", "layout consistency", "before pull request"), and `license`.
- Apache 2.0, matching the other open-source skills in this repo.