### PR TITLE
Remove non-existent purpose field from Files API examples

### DIFF
--- a/skills/claude-api/curl/managed-agents.md
+++ b/skills/claude-api/curl/managed-agents.md
@@ -248,8 +248,7 @@ curl -X POST https://api.anthropic.com/v1/files \
   -H "x-api-key: $ANTHROPIC_API_KEY" \
   -H "anthropic-version: 2023-06-01" \
   -H "anthropic-beta: files-api-2025-04-14" \
-  -F "file=@path/to/file.txt" \
-  -F "purpose=agent"
+  -F "file=@path/to/file.txt"
 ```
 
 ---

--- a/skills/claude-api/shared/managed-agents-client-patterns.md
+++ b/skills/claude-api/shared/managed-agents-client-patterns.md
@@ -168,7 +168,7 @@ The `Promise.all([stream, send])` shape works too, but stream-first is simpler a
 **The mounted resource has a different `file_id` than the file you uploaded.** Session creation makes a session-scoped copy.
 
 ```ts
-const uploaded = await client.beta.files.upload({ file, purpose: 'agent_resource' })
+const uploaded = await client.beta.files.upload({ file })
 // uploaded.id         → the original file
 const session = await client.beta.sessions.create({
   /* ... */

--- a/skills/claude-api/shared/managed-agents-environments.md
+++ b/skills/claude-api/shared/managed-agents-environments.md
@@ -63,7 +63,6 @@ Upload a file first via the Files API, then reference by `file_id` + `mount_path
 // 1. Upload
 const file = await client.beta.files.upload({
   file: fs.createReadStream("data.csv"),
-  purpose: "agent",
 });
 
 // 2. Attach as a session resource

--- a/skills/claude-api/typescript/managed-agents/README.md
+++ b/skills/claude-api/typescript/managed-agents/README.md
@@ -273,7 +273,6 @@ import fs from "fs";
 
 const file = await client.beta.files.upload({
   file: fs.createReadStream("data.csv"),
-  purpose: "agent",
 });
 
 // Use in a session


### PR DESCRIPTION
The Files API upload endpoint does not accept a `purpose` parameter. Drop it from the managed-agents skill examples.

Affected files:
- `skills/claude-api/shared/managed-agents-client-patterns.md`
- `skills/claude-api/shared/managed-agents-environments.md`
- `skills/claude-api/typescript/managed-agents/README.md`
- `skills/claude-api/curl/managed-agents.md`