### PR TITLE
docs: add FantasyNextLevel partner skill (NFL Fantasy Football)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,4 @@ The markdown content below contains the instructions, examples, and guidelines t
 Skills are a great way to teach Claude how to get better at using specific pieces of software. As we see awesome example skills from partners, we may highlight some of them here:
 
 - **Notion** - [Notion Skills for Claude](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0)
+- **FantasyNextLevel** - [Fantasy Football Skills (lineup-nein: format-aware Start/Sit for NFL Fantasy Football, MIT)](https://github.com/patehartmann-arch/fnl-skills)


### PR DESCRIPTION
## What this adds

A single one-line entry in the **Partner Skills** section of the README, pointing to an external skill repository:

```markdown
- **FantasyNextLevel** - [Fantasy Football Skills (lineup-nein: format-aware Start/Sit for NFL Fantasy Football, MIT)](https://github.com/patehartmann-arch/fnl-skills)
```

This follows the same one-line format as the existing Notion partner entry on the line above.

## About the skill

`lineup-nein` is a Start/Sit decision skill for NFL Fantasy Football. It is format-aware: the right call in Dynasty is the wrong call in Redraft, and the skill explicitly handles Dynasty / Redraft / BestBall / Chopped (Survivor) leagues. It triggers on Start/Sit questions in English and German and produces a structured recommendation with a clear NO + WHY for the wrong choice plus the better alternative + WHY.

## Technical notes

- **Repository**: https://github.com/patehartmann-arch/fnl-skills
- **License**: MIT
- **API dependency**: Sleeper public API, no authentication required
- **Source of truth**: lives in the linked repo so the skill can be maintained in one place

## Why partner-link instead of inline

Keeping the skill in the external repo avoids dual maintenance when bug fixes or new format adapters land. If you would prefer an inline copy under `skills/` instead, I am happy to open a follow-up PR.

## Test plan

- [x] One-line README edit, follows existing Notion entry format
- [x] Skill repo is MIT-licensed and self-contained
- [x] No changes to anything outside the README