### PR TITLE
Fix issue with pdf output dir not found

### DIFF
--- a/skills/pdf/scripts/convert_pdf_to_images.py
+++ b/skills/pdf/scripts/convert_pdf_to_images.py
@@ -7,6 +7,7 @@ from pdf2image import convert_from_path
 
 
 def convert(pdf_path, output_dir, max_dim=1000):
+    os.makedirs(output_dir, exist_ok=True)
     images = convert_from_path(pdf_path, dpi=200)
 
     for i, image in enumerate(images):


### PR DESCRIPTION
Fixes #1025 ✅ Fixed convert_pdf_to_images.py

Summary:
Added os.makedirs(output_dir, exist_ok=True) before writing images.
Now the script creates the output directory automatically if it doesn't exist.