### PR TITLE
fix(skill-creator): warn authors to quote YAML description values

### DIFF
--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -65,6 +65,7 @@ Based on the user interview, fill in these components:
 
 - **name**: Skill identifier
 - **description**: When to trigger, what it does. This is the primary triggering mechanism - include both what the skill does AND specific contexts for when to use it. All "when to use" info goes here, not in the body. Note: currently Claude has a tendency to "undertrigger" skills -- to not use them when they'd be useful. To combat this, please make the skill descriptions a little bit "pushy". So for instance, instead of "How to build a simple fast dashboard to display internal Anthropic data.", you might write "How to build a simple fast dashboard to display internal Anthropic data. Make sure to use this skill whenever the user mentions dashboards, data visualization, internal metrics, or wants to display any kind of company data, even if they don't explicitly ask for a 'dashboard.'"
+  Always wrap `description` values in double quotes — YAML treats unquoted colons, `#`, and `{` as syntax: `description: "Triggers on: push or tag"`
 - **compatibility**: Required tools, dependencies (optional, rarely needed)
 - **the rest of the skill :)**
 


### PR DESCRIPTION
## Summary

Adds a one-line note under the `description` field guidance in the skill-creator SKILL.md reminding authors to wrap description values in double quotes. This is because several skills that I've created using `skill-creator` have used phrases like "Triggers on: X", which produces YAML parse errors.

Double-quoting also covers other special characters like `#` and `{`

## Test plan

- [ ] Verify the added line renders correctly in the skill-creator SKILL.md
- [ ] Confirm a skill with a description like `description: "Triggers on: push or tag"` parses without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)