### PR TITLE
Add skill-publisher skill v1.0.0

### DIFF
--- a/skills/skill-publisher/SKILL.md
+++ b/skills/skill-publisher/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: skill-publisher
+description: "Generic publishing tool for Claude Code skills. Validates, packages, and publishes to ClawHub, Hermes Agent, and anthropics/skills with bilingual README support."
+version: 1.0.0
+author: Claude Code
+license: MIT
+dependencies: []
+metadata:
+  hermes:
+    tags: [Skill, Publishing, ClawHub, Hermes, Claude, Workflow, Automation]
+    related_skills: [ascii-excalidraw]
+---
+
+# Skill Publisher
+
+A generic publishing workflow for any Claude Code skill. Package, validate, and publish to **ClawHub** (OpenClaw), **Hermes Agent**, and **anthropics/skills** (Claude Code).
+
+## When to Use
+
+- User wants to publish a skill they've built to one or more marketplaces
+- User needs a bilingual (EN/ZH) README for their skill
+- User wants to validate SKILL.md format before publishing
+- User needs help with `clawhub publish` or GitHub PR submission
+
+## Prerequisites
+
+Before using this skill, check for the following in the environment (or ask the user):
+
+### Authentication
+
+These tokens are pre-configured in `~/.env` and shell environment. Read them automatically — do not ask the user:
+
+| Token | Env Var | Source |
+|---|---|---|
+| GitHub PAT | `GITHUB_TOKEN` | `~/.env` or env |
+| GitHub user | `GITHUB_USER` | `~/.env` or env |
+| ClawHub token | `CLAWHUB_TOKEN` | `~/.env` or env |
+
+If a variable is missing, read `~/.env` first, then ask the user.
+
+### Network Connectivity
+
+Before any GitHub API call, **test connectivity first**:
+
+```bash
+curl -s -m 5 https://api.github.com/repos/NousResearch/hermes-agent > /dev/null 2>&1 && echo "direct OK" || echo "direct FAIL"
+```
+
+If direct access fails (common in restricted networks), load proxy from `~/.env`:
+
+```bash
+source ~/.env
+# ~/.env may contain (possibly commented-out):
+# https_proxy=http://192.168.28.92:7897
+# http_proxy=http://192.168.28.92:7897
+# Export the proxy ONLY if direct access failed:
+export https_proxy=http://192.168.28.92:7897
+export http_proxy=http://192.168.28.92:7897
+# Re-test with proxy:
+https_proxy=$https_proxy curl -s -m 10 https://api.github.com/ > /dev/null 2>&1 && echo "proxy OK" || echo "proxy FAIL"
+```
+
+**Fallback strategy** (ordered by priority):
+1. Direct HTTPS access — works in unrestricted networks
+2. Proxy from `~/.env` — read `https_proxy`/`http_proxy` values; if commented out, uncomment and export them for this session only
+3. SSH on port 22 — `git@github.com:...` works without proxy in most environments; use for `git clone/push`, but NOT for GitHub REST API (`curl`/`gh api`)
+
+**When proxy is also down**: skip GitHub API PR creation. Push branch via SSH and instruct user to create PR manually via browser.
+
+## Workflow
+
+### Step 1: Validate Source Skill
+
+```bash
+python3 ~/.skills/skill-publisher/scripts/validate_skill.py <skill-path>
+```
+
+Checks: SKILL.md exists, valid YAML frontmatter, required fields (`name`, `description`), name format (lowercase, hyphens), description <= 1024 chars, no hardcoded secrets, file size <= 100,000 chars.
+
+### Step 2: Generate Publish Package
+
+```bash
+python3 ~/.skills/skill-publisher/scripts/generate_package.py \
+  --source ~/.skills/<skill-name> \
+  --output /tmp/publish-<skill-name> \
+  --platforms clawhub hermes anthropics
+```
+
+Produces:
+
+```
+/tmp/publish-<skill-name>/
+├── SKILL.md            # Copied from source
+├── README.md           # Bilingual (EN/ZH) README with examples
+├── examples/           # Copied from source skill
+└── .clawhub.json       # ClawHub manifest
+```
+
+### Step 3: Platform-Specific Publishing
+
+#### ClawHub (OpenClaw)
+
+```bash
+cd /tmp/publish-<skill-name>
+clawhub publish .
+```
+
+If CLI unavailable: install `npm i -g clawhub` or upload via clawhub.ai.
+
+#### Hermes Agent (GitHub PR)
+
+Target: `NousResearch/hermes-agent` → `skills/creative/<skill-name>/SKILL.md`
+
+1. Fork repo on GitHub
+2. Clone fork, copy SKILL.md to `skills/creative/<skill-name>/`
+3. Commit, push, create PR
+
+#### anthropics/skills (GitHub PR)
+
+Target: `anthropics/skills` → `skills/<skill-name>/SKILL.md`
+
+Same process as Hermes, different repo.
+
+### Step 4: Verify
+
+```bash
+# ClawHub
+curl -s "https://clawhub.ai/api/v1/skills?slug=<skill-name>"
+# Hermes / anthropics — check raw GitHub URLs
+```
+
+## Helper Scripts
+
+| Script | Purpose |
+|---|---|
+| `scripts/validate_skill.py` | Validate SKILL.md format |
+| `scripts/generate_package.py` | Generate publish package with bilingual README |
+| `scripts/gen_clawhub_manifest.py` | Generate .clawhub.json |
+| `scripts/create_pr.py` | Create GitHub PR via API |
+
+## Common Pitfalls
+
+1. **SKILL.md first bytes must be `---`** — no BOM, no blank line
+2. **ClawHub rejects hardcoded secrets** — scan scripts/ before publishing
+3. **Hermes requires metadata** — `metadata.hermes.tags` and `related_skills`
+4. **Network issues** — always test connectivity first. If direct HTTPS fails, load proxy from `~/.env` and re-test. If proxy also fails, use SSH (`git@github.com:...`) for git operations and tell user to create PR manually via browser

--- a/skills/skill-publisher/SKILL.md
+++ b/skills/skill-publisher/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: skill-publisher
 description: "Generic publishing tool for Claude Code skills. Validates, packages, and publishes to ClawHub, Hermes Agent, and anthropics/skills with bilingual README support."
-version: 1.0.0
+version: 1.1.0
 author: Claude Code
 license: MIT
 dependencies: []
@@ -100,9 +100,10 @@ Produces:
 
 #### ClawHub (OpenClaw)
 
+**CRITICAL**: Always pass `--slug <skill-name>` to prevent ClawHub from using the directory name as the slug. Without `--slug`, a publish from `/tmp/publish-my-skill/` would create a duplicate entry named `publish-my-skill` instead of `my-skill`.
+
 ```bash
-cd /tmp/publish-<skill-name>
-clawhub publish .
+clawhub publish /tmp/publish-<skill-name> --version <version> --slug <skill-name>
 ```
 
 If CLI unavailable: install `npm i -g clawhub` or upload via clawhub.ai.
@@ -144,3 +145,4 @@ curl -s "https://clawhub.ai/api/v1/skills?slug=<skill-name>"
 2. **ClawHub rejects hardcoded secrets** — scan scripts/ before publishing
 3. **Hermes requires metadata** — `metadata.hermes.tags` and `related_skills`
 4. **Network issues** — always test connectivity first. If direct HTTPS fails, load proxy from `~/.env` and re-test. If proxy also fails, use SSH (`git@github.com:...`) for git operations and tell user to create PR manually via browser
+5. **ClawHub slug mismatch** — always pass `--slug <skill-name>` when publishing; otherwise the directory name becomes the slug, creating a wrong/duplicate entry (e.g. `publish-my-skill` instead of `my-skill`)

--- a/skills/skill-publisher/scripts/generate_package.py
+++ b/skills/skill-publisher/scripts/generate_package.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""generate_package.py - Generate a publish package for any Claude Code skill.
+
+Creates a directory with:
+- SKILL.md (copied from source)
+- README.md (bilingual EN/ZH, extracted from SKILL.md)
+- examples/ (copied from source)
+- .clawhub.json (ClawHub manifest)
+"""
+
+import argparse
+import json
+import os
+import re
+import shutil
+import sys
+import yaml
+
+
+def copy_skill(source_dir, output_dir):
+    """Copy SKILL.md and scripts/ to the output directory."""
+    os.makedirs(output_dir, exist_ok=True)
+
+    src_skill = os.path.join(source_dir, "SKILL.md")
+    if not os.path.isfile(src_skill):
+        print(f"Error: SKILL.md not found at {src_skill}", file=sys.stderr)
+        sys.exit(1)
+
+    shutil.copy2(src_skill, os.path.join(output_dir, "SKILL.md"))
+
+    src_scripts = os.path.join(source_dir, "scripts")
+    if os.path.isdir(src_scripts):
+        dst_scripts = os.path.join(output_dir, "scripts")
+        shutil.copytree(src_scripts, dst_scripts, dirs_exist_ok=True)
+
+
+def parse_skill(skill_path):
+    """Parse SKILL.md into frontmatter data and body sections."""
+    with open(skill_path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        print("Error: Invalid SKILL.md — missing YAML frontmatter", file=sys.stderr)
+        sys.exit(1)
+
+    data = yaml.safe_load(parts[1].strip())
+    body = parts[2].strip()
+    return data, body
+
+
+def extract_sections(body):
+    """Split body into named sections for reuse in README."""
+    sections = {}
+    current_heading = None
+    current_lines = []
+
+    for line in body.split("\n"):
+        m = re.match(r"^(#{1,3})\s+(.+)", line)
+        if m:
+            if current_heading:
+                sections[current_heading] = "\n".join(current_lines).strip()
+            current_heading = m.group(2).strip().lower()
+            current_lines = []
+        else:
+            current_lines.append(line)
+
+    if current_heading:
+        sections[current_heading] = "\n".join(current_lines).strip()
+
+    return sections
+
+
+def find_section(sections, keywords):
+    """Find a section matching any of the keywords (case-insensitive partial match)."""
+    for heading, content in sections.items():
+        for kw in keywords:
+            if kw.lower() in heading.lower():
+                return content
+    return None
+
+
+def extract_examples_from_source(source_dir):
+    """List example files in the source skill directory."""
+    examples_dir = os.path.join(source_dir, "examples")
+    if not os.path.isdir(examples_dir):
+        return []
+    examples = []
+    for f in sorted(os.listdir(examples_dir)):
+        if f.endswith((".ascii", ".excalidraw", ".md", ".txt", ".png", ".jpg")):
+            examples.append(f)
+    return examples
+
+
+def generate_readme(data, body, sections, output_path):
+    """Generate a bilingual README.md from any skill's SKILL.md."""
+    name = data.get("name", "skill")
+    description = data.get("description", "")
+    display_name = name.replace("-", " ").title()
+
+    # Try to find overview/when-to-use content
+    overview = (
+        find_section(sections, ["when to use", "overview", "about"])
+        or "See SKILL.md for full documentation."
+    )
+
+    # Try to find features section
+    features_content = (
+        find_section(sections, ["features", "capabilities", "functionality"])
+        or find_section(sections, ["pattern", "color"])
+        or find_section(sections, ["conversion", "workflow", "step"])
+    )
+
+    # Extract tables from sections if present (useful for config/color/palette sections)
+    tables = []
+    for heading, content in sections.items():
+        if any(kw in heading for kw in ["color", "palette", "config", "mapping"]):
+            table_lines = [l for l in content.split("\n") if l.strip().startswith("|")]
+            if table_lines:
+                tables.append((heading, "\n".join(table_lines)))
+
+    # Find example references
+    examples = extract_examples_from_source(os.path.dirname(output_path).replace("/tmp/publish-" + name, os.path.join(os.path.expanduser("~"), ".skills", name)))
+
+    readme_parts = []
+    readme_parts.append(f"# {display_name} / {display_name}")
+    readme_parts.append("")
+    readme_parts.append(f"> {description}")
+    readme_parts.append("")
+    readme_parts.append("---")
+    readme_parts.append("")
+    readme_parts.append("## Overview / 概述")
+    readme_parts.append("")
+    readme_parts.append(overview)
+    readme_parts.append("")
+    readme_parts.append("---")
+    readme_parts.append("")
+    readme_parts.append("## Features / 功能特性")
+    readme_parts.append("")
+    if features_content:
+        readme_parts.append(features_content)
+    else:
+        readme_parts.append(f"See SKILL.md for details on {display_name}.")
+    readme_parts.append("")
+
+    for heading, table_content in tables:
+        readme_parts.append(f"### {heading}")
+        readme_parts.append("")
+        readme_parts.append(table_content)
+        readme_parts.append("")
+
+    readme_parts.append("---")
+    readme_parts.append("")
+    readme_parts.append("## Quick Start / 快速开始")
+    readme_parts.append("")
+    readme_parts.append("### English")
+    readme_parts.append("")
+    readme_parts.append("1. Trigger the skill in Claude Code: `/ {name}`")
+    readme_parts.append("2. Follow the interactive prompts")
+    readme_parts.append("")
+    readme_parts.append("### 中文")
+    readme_parts.append("")
+    readme_parts.append("1. 在 Claude Code 中触发技能：`/ {name}`")
+    readme_parts.append("2. 按照交互提示操作")
+    readme_parts.append("")
+
+    if examples:
+        readme_parts.append("---")
+        readme_parts.append("")
+        readme_parts.append("## Examples / 示例")
+        readme_parts.append("")
+        readme_parts.append("Example files are included in the `examples/` directory.")
+        readme_parts.append("")
+        readme_parts.append("示例文件位于 `examples/` 目录中。")
+        readme_parts.append("")
+
+    readme_parts.append("---")
+    readme_parts.append("")
+    readme_parts.append("## License / 许可")
+    readme_parts.append("")
+    readme_parts.append(data.get("license", "MIT"))
+    readme_parts.append("")
+    readme_parts.append("---")
+    readme_parts.append("")
+    readme_parts.append("*Generated by skill-publisher*")
+    readme_parts.append("")
+
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(readme_parts))
+
+    print(f"Generated README.md at {output_path}")
+
+
+def generate_clawhub_manifest(data, output_path):
+    """Generate .clawhub.json manifest for ClawHub."""
+    manifest = {
+        "name": data.get("name", ""),
+        "description": data.get("description", ""),
+        "version": data.get("version", "1.0.0"),
+        "author": data.get("author", ""),
+        "license": data.get("license", "MIT"),
+    }
+
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2)
+
+    print(f"Generated .clawhub.json at {output_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate a publish package for any Claude Code skill"
+    )
+    parser.add_argument("--source", required=True, help="Path to the source skill directory")
+    parser.add_argument("--output", required=True, help="Output directory for the publish package")
+    parser.add_argument("--platforms", nargs="+", default=["clawhub", "hermes", "anthropics"],
+                        help="Target platforms (default: all)")
+    parser.add_argument("--examples-dir", help="Directory with example files")
+    parser.add_argument("--screenshots", help="Directory with screenshot files")
+    args = parser.parse_args()
+
+    print(f"Generating publish package for: {args.source}")
+    print(f"Output directory: {args.output}")
+    print(f"Platforms: {', '.join(args.platforms)}")
+    print()
+
+    # Parse source skill
+    src_skill = os.path.join(args.source, "SKILL.md")
+    data, body = parse_skill(src_skill)
+    sections = extract_sections(body)
+
+    # Step 1: Copy skill files
+    copy_skill(args.source, args.output)
+
+    # Step 2: Generate bilingual README
+    generate_readme(data, body, sections, os.path.join(args.output, "README.md"))
+
+    # Step 3: Copy examples
+    examples_src = args.examples_dir or os.path.join(args.source, "examples")
+    if os.path.isdir(examples_src):
+        examples_dst = os.path.join(args.output, "examples")
+        shutil.copytree(examples_src, examples_dst, dirs_exist_ok=True)
+        print(f"Copied examples from {examples_src}")
+
+    # Step 4: Generate ClawHub manifest
+    if "clawhub" in args.platforms:
+        generate_clawhub_manifest(data, os.path.join(args.output, ".clawhub.json"))
+
+    # Step 5: Copy screenshots
+    if args.screenshots and os.path.isdir(args.screenshots):
+        screenshots_dst = os.path.join(args.output, "screenshots")
+        shutil.copytree(args.screenshots, screenshots_dst, dirs_exist_ok=True)
+        print(f"Copied screenshots from {args.screenshots}")
+
+    # Summary
+    print(f"\nPublish package ready at: {args.output}")
+    print("\nNext steps:")
+    if "clawhub" in args.platforms:
+        print("  ClawHub:    cd {} && clawhub publish .".format(args.output))
+    if "hermes" in args.platforms:
+        print("  Hermes:     Copy SKILL.md to skills/creative/<name>/ in NousResearch/hermes-agent fork")
+    if "anthropics" in args.platforms:
+        print("  Anthropic:  Copy SKILL.md to skills/<name>/ in anthropics/skills fork")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/skill-publisher/scripts/scripts/generate_package.py
+++ b/skills/skill-publisher/scripts/scripts/generate_package.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""generate_package.py - Generate a publish package for any Claude Code skill.
+
+Creates a directory with:
+- SKILL.md (copied from source)
+- README.md (bilingual EN/ZH, extracted from SKILL.md)
+- examples/ (copied from source)
+- .clawhub.json (ClawHub manifest)
+"""
+
+import argparse
+import json
+import os
+import re
+import shutil
+import sys
+import yaml
+
+
+def copy_skill(source_dir, output_dir):
+    """Copy SKILL.md and scripts/ to the output directory."""
+    os.makedirs(output_dir, exist_ok=True)
+
+    src_skill = os.path.join(source_dir, "SKILL.md")
+    if not os.path.isfile(src_skill):
+        print(f"Error: SKILL.md not found at {src_skill}", file=sys.stderr)
+        sys.exit(1)
+
+    shutil.copy2(src_skill, os.path.join(output_dir, "SKILL.md"))
+
+    src_scripts = os.path.join(source_dir, "scripts")
+    if os.path.isdir(src_scripts):
+        dst_scripts = os.path.join(output_dir, "scripts")
+        shutil.copytree(src_scripts, dst_scripts, dirs_exist_ok=True)
+
+
+def parse_skill(skill_path):
+    """Parse SKILL.md into frontmatter data and body sections."""
+    with open(skill_path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        print("Error: Invalid SKILL.md — missing YAML frontmatter", file=sys.stderr)
+        sys.exit(1)
+
+    data = yaml.safe_load(parts[1].strip())
+    body = parts[2].strip()
+    return data, body
+
+
+def extract_sections(body):
+    """Split body into named sections for reuse in README."""
+    sections = {}
+    current_heading = None
+    current_lines = []
+
+    for line in body.split("\n"):
+        m = re.match(r"^(#{1,3})\s+(.+)", line)
+        if m:
+            if current_heading:
+                sections[current_heading] = "\n".join(current_lines).strip()
+            current_heading = m.group(2).strip().lower()
+            current_lines = []
+        else:
+            current_lines.append(line)
+
+    if current_heading:
+        sections[current_heading] = "\n".join(current_lines).strip()
+
+    return sections
+
+
+def find_section(sections, keywords):
+    """Find a section matching any of the keywords (case-insensitive partial match)."""
+    for heading, content in sections.items():
+        for kw in keywords:
+            if kw.lower() in heading.lower():
+                return content
+    return None
+
+
+def extract_examples_from_source(source_dir):
+    """List example files in the source skill directory."""
+    examples_dir = os.path.join(source_dir, "examples")
+    if not os.path.isdir(examples_dir):
+        return []
+    examples = []
+    for f in sorted(os.listdir(examples_dir)):
+        if f.endswith((".ascii", ".excalidraw", ".md", ".txt", ".png", ".jpg")):
+            examples.append(f)
+    return examples
+
+
+def generate_readme(data, body, sections, output_path):
+    """Generate a bilingual README.md from any skill's SKILL.md."""
+    name = data.get("name", "skill")
+    description = data.get("description", "")
+    display_name = name.replace("-", " ").title()
+
+    # Try to find overview/when-to-use content
+    overview = (
+        find_section(sections, ["when to use", "overview", "about"])
+        or "See SKILL.md for full documentation."
+    )
+
+    # Try to find features section
+    features_content = (
+        find_section(sections, ["features", "capabilities", "functionality"])
+        or find_section(sections, ["pattern", "color"])
+        or find_section(sections, ["conversion", "workflow", "step"])
+    )
+
+    # Extract tables from sections if present (useful for config/color/palette sections)
+    tables = []
+    for heading, content in sections.items():
+        if any(kw in heading for kw in ["color", "palette", "config", "mapping"]):
+            table_lines = [l for l in content.split("\n") if l.strip().startswith("|")]
+            if table_lines:
+                tables.append((heading, "\n".join(table_lines)))
+
+    # Find example references
+    examples = extract_examples_from_source(os.path.dirname(output_path).replace("/tmp/publish-" + name, os.path.join(os.path.expanduser("~"), ".skills", name)))
+
+    readme_parts = []
+    readme_parts.append(f"# {display_name} / {display_name}")
+    readme_parts.append("")
+    readme_parts.append(f"> {description}")
+    readme_parts.append("")
+    readme_parts.append("---")
+    readme_parts.append("")
+    readme_parts.append("## Overview / 概述")
+    readme_parts.append("")
+    readme_parts.append(overview)
+    readme_parts.append("")
+    readme_parts.append("---")
+    readme_parts.append("")
+    readme_parts.append("## Features / 功能特性")
+    readme_parts.append("")
+    if features_content:
+        readme_parts.append(features_content)
+    else:
+        readme_parts.append(f"See SKILL.md for details on {display_name}.")
+    readme_parts.append("")
+
+    for heading, table_content in tables:
+        readme_parts.append(f"### {heading}")
+        readme_parts.append("")
+        readme_parts.append(table_content)
+        readme_parts.append("")
+
+    readme_parts.append("---")
+    readme_parts.append("")
+    readme_parts.append("## Quick Start / 快速开始")
+    readme_parts.append("")
+    readme_parts.append("### English")
+    readme_parts.append("")
+    readme_parts.append("1. Trigger the skill in Claude Code: `/ {name}`")
+    readme_parts.append("2. Follow the interactive prompts")
+    readme_parts.append("")
+    readme_parts.append("### 中文")
+    readme_parts.append("")
+    readme_parts.append("1. 在 Claude Code 中触发技能：`/ {name}`")
+    readme_parts.append("2. 按照交互提示操作")
+    readme_parts.append("")
+
+    if examples:
+        readme_parts.append("---")
+        readme_parts.append("")
+        readme_parts.append("## Examples / 示例")
+        readme_parts.append("")
+        readme_parts.append("Example files are included in the `examples/` directory.")
+        readme_parts.append("")
+        readme_parts.append("示例文件位于 `examples/` 目录中。")
+        readme_parts.append("")
+
+    readme_parts.append("---")
+    readme_parts.append("")
+    readme_parts.append("## License / 许可")
+    readme_parts.append("")
+    readme_parts.append(data.get("license", "MIT"))
+    readme_parts.append("")
+    readme_parts.append("---")
+    readme_parts.append("")
+    readme_parts.append("*Generated by skill-publisher*")
+    readme_parts.append("")
+
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(readme_parts))
+
+    print(f"Generated README.md at {output_path}")
+
+
+def generate_clawhub_manifest(data, output_path):
+    """Generate .clawhub.json manifest for ClawHub."""
+    manifest = {
+        "name": data.get("name", ""),
+        "description": data.get("description", ""),
+        "version": data.get("version", "1.0.0"),
+        "author": data.get("author", ""),
+        "license": data.get("license", "MIT"),
+    }
+
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2)
+
+    print(f"Generated .clawhub.json at {output_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate a publish package for any Claude Code skill"
+    )
+    parser.add_argument("--source", required=True, help="Path to the source skill directory")
+    parser.add_argument("--output", required=True, help="Output directory for the publish package")
+    parser.add_argument("--platforms", nargs="+", default=["clawhub", "hermes", "anthropics"],
+                        help="Target platforms (default: all)")
+    parser.add_argument("--examples-dir", help="Directory with example files")
+    parser.add_argument("--screenshots", help="Directory with screenshot files")
+    args = parser.parse_args()
+
+    print(f"Generating publish package for: {args.source}")
+    print(f"Output directory: {args.output}")
+    print(f"Platforms: {', '.join(args.platforms)}")
+    print()
+
+    # Parse source skill
+    src_skill = os.path.join(args.source, "SKILL.md")
+    data, body = parse_skill(src_skill)
+    sections = extract_sections(body)
+
+    # Step 1: Copy skill files
+    copy_skill(args.source, args.output)
+
+    # Step 2: Generate bilingual README
+    generate_readme(data, body, sections, os.path.join(args.output, "README.md"))
+
+    # Step 3: Copy examples
+    examples_src = args.examples_dir or os.path.join(args.source, "examples")
+    if os.path.isdir(examples_src):
+        examples_dst = os.path.join(args.output, "examples")
+        shutil.copytree(examples_src, examples_dst, dirs_exist_ok=True)
+        print(f"Copied examples from {examples_src}")
+
+    # Step 4: Generate ClawHub manifest
+    if "clawhub" in args.platforms:
+        generate_clawhub_manifest(data, os.path.join(args.output, ".clawhub.json"))
+
+    # Step 5: Copy screenshots
+    if args.screenshots and os.path.isdir(args.screenshots):
+        screenshots_dst = os.path.join(args.output, "screenshots")
+        shutil.copytree(args.screenshots, screenshots_dst, dirs_exist_ok=True)
+        print(f"Copied screenshots from {args.screenshots}")
+
+    # Summary
+    print(f"\nPublish package ready at: {args.output}")
+    print("\nNext steps:")
+    if "clawhub" in args.platforms:
+        print("  ClawHub:    cd {} && clawhub publish .".format(args.output))
+    if "hermes" in args.platforms:
+        print("  Hermes:     Copy SKILL.md to skills/creative/<name>/ in NousResearch/hermes-agent fork")
+    if "anthropics" in args.platforms:
+        print("  Anthropic:  Copy SKILL.md to skills/<name>/ in anthropics/skills fork")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/skill-publisher/scripts/scripts/validate_skill.py
+++ b/skills/skill-publisher/scripts/scripts/validate_skill.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""validate_skill.py - Validate a skill's SKILL.md format and content."""
+
+import argparse
+import json
+import os
+import re
+import sys
+import yaml
+
+
+def load_yaml_frontmatter(filepath):
+    """Load and parse YAML frontmatter from SKILL.md."""
+    with open(filepath, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    # Check first bytes are ---
+    if not content.startswith("---"):
+        return None, "File must start with '---' (YAML frontmatter delimiter)"
+
+    # Split frontmatter
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        return None, "Missing closing '---' delimiter for frontmatter"
+
+    yaml_text = parts[1].strip()
+    body = parts[2].strip()
+
+    try:
+        data = yaml.safe_load(yaml_text)
+    except yaml.YAMLError as e:
+        return None, f"Invalid YAML frontmatter: {e}"
+
+    if not isinstance(data, dict):
+        return None, "Frontmatter must be a YAML mapping"
+
+    return data, body
+
+
+def validate_skill(skill_path):
+    """Validate a skill directory."""
+    skill_md = os.path.join(skill_path, "SKILL.md")
+
+    if not os.path.isfile(skill_md):
+        return False, [f"SKILL.md not found at {skill_md}"]
+
+    errors = []
+    warnings = []
+
+    # Parse frontmatter
+    data, body_or_err = load_yaml_frontmatter(skill_md)
+    if data is None:
+        return False, [body_or_err]
+
+    body = body_or_err
+
+    # Required fields
+    if not data.get("name"):
+        errors.append("Missing required field: 'name'")
+    else:
+        name = data["name"]
+        if not re.match(r"^[a-z0-9][a-z0-9-]*$", name):
+            errors.append(f"Invalid name format: '{name}' (must be lowercase with hyphens)")
+        if len(name) > 64:
+            errors.append(f"Name too long: {len(name)} chars (max 64)")
+
+    if not data.get("description"):
+        errors.append("Missing required field: 'description'")
+    elif len(data["description"]) > 1024:
+        errors.append(f"Description too long: {len(data['description'])} chars (max 1024)")
+
+    # File size check
+    file_size = len(body)
+    if file_size > 100000:
+        errors.append(f"SKILL.md body too large: {file_size} chars (max 100,000)")
+
+    # Check for hardcoded secrets in scripts/
+    scripts_dir = os.path.join(skill_path, "scripts")
+    if os.path.isdir(scripts_dir):
+        secret_patterns = [
+            r"ghp_[A-Za-z0-9]{36}",
+            r"xox[baprs]-[A-Za-z0-9-]+",
+            r"sk-[A-Za-z0-9]{20,}",
+            r"password\s*=\s*['\"][^'\"]{8,}['\"]",
+            r"api[_-]?key\s*=\s*['\"][^'\"]{8,}['\"]",
+        ]
+        for root, _, files in os.walk(scripts_dir):
+            for fname in files:
+                fpath = os.path.join(root, fname)
+                with open(fpath, "r", encoding="utf-8", errors="ignore") as f:
+                    content = f.read()
+                for pattern in secret_patterns:
+                    if re.search(pattern, content, re.IGNORECASE):
+                        warnings.append(
+                            f"Possible secret in {os.path.relpath(fpath, skill_path)}: "
+                            f"matches pattern '{pattern}'"
+                        )
+
+    # Summary
+    if errors:
+        return False, errors + warnings
+
+    if warnings:
+        return True, [f"Valid with {len(warnings)} warning(s):"] + warnings
+
+    return True, ["Valid — no issues found"]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Validate a Claude Code skill")
+    parser.add_argument("skill_path", help="Path to the skill directory")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    valid, messages = validate_skill(args.skill_path)
+
+    if args.json:
+        result = {"valid": valid, "messages": messages}
+        print(json.dumps(result, indent=2))
+    else:
+        status = "PASS" if valid else "FAIL"
+        print(f"\nSkill validation: {status}")
+        print(f"Path: {args.skill_path}")
+        print()
+        for msg in messages:
+            prefix = "  WARNING" if "warning" in msg.lower() else "  ERROR" if "ERROR" in msg or "Invalid" in msg or "Missing" in msg or "too" in msg.lower() else "  INFO"
+            print(f"{prefix}: {msg}")
+        print()
+
+    sys.exit(0 if valid else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/skill-publisher/scripts/validate_skill.py
+++ b/skills/skill-publisher/scripts/validate_skill.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""validate_skill.py - Validate a skill's SKILL.md format and content."""
+
+import argparse
+import json
+import os
+import re
+import sys
+import yaml
+
+
+def load_yaml_frontmatter(filepath):
+    """Load and parse YAML frontmatter from SKILL.md."""
+    with open(filepath, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    # Check first bytes are ---
+    if not content.startswith("---"):
+        return None, "File must start with '---' (YAML frontmatter delimiter)"
+
+    # Split frontmatter
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        return None, "Missing closing '---' delimiter for frontmatter"
+
+    yaml_text = parts[1].strip()
+    body = parts[2].strip()
+
+    try:
+        data = yaml.safe_load(yaml_text)
+    except yaml.YAMLError as e:
+        return None, f"Invalid YAML frontmatter: {e}"
+
+    if not isinstance(data, dict):
+        return None, "Frontmatter must be a YAML mapping"
+
+    return data, body
+
+
+def validate_skill(skill_path):
+    """Validate a skill directory."""
+    skill_md = os.path.join(skill_path, "SKILL.md")
+
+    if not os.path.isfile(skill_md):
+        return False, [f"SKILL.md not found at {skill_md}"]
+
+    errors = []
+    warnings = []
+
+    # Parse frontmatter
+    data, body_or_err = load_yaml_frontmatter(skill_md)
+    if data is None:
+        return False, [body_or_err]
+
+    body = body_or_err
+
+    # Required fields
+    if not data.get("name"):
+        errors.append("Missing required field: 'name'")
+    else:
+        name = data["name"]
+        if not re.match(r"^[a-z0-9][a-z0-9-]*$", name):
+            errors.append(f"Invalid name format: '{name}' (must be lowercase with hyphens)")
+        if len(name) > 64:
+            errors.append(f"Name too long: {len(name)} chars (max 64)")
+
+    if not data.get("description"):
+        errors.append("Missing required field: 'description'")
+    elif len(data["description"]) > 1024:
+        errors.append(f"Description too long: {len(data['description'])} chars (max 1024)")
+
+    # File size check
+    file_size = len(body)
+    if file_size > 100000:
+        errors.append(f"SKILL.md body too large: {file_size} chars (max 100,000)")
+
+    # Check for hardcoded secrets in scripts/
+    scripts_dir = os.path.join(skill_path, "scripts")
+    if os.path.isdir(scripts_dir):
+        secret_patterns = [
+            r"ghp_[A-Za-z0-9]{36}",
+            r"xox[baprs]-[A-Za-z0-9-]+",
+            r"sk-[A-Za-z0-9]{20,}",
+            r"password\s*=\s*['\"][^'\"]{8,}['\"]",
+            r"api[_-]?key\s*=\s*['\"][^'\"]{8,}['\"]",
+        ]
+        for root, _, files in os.walk(scripts_dir):
+            for fname in files:
+                fpath = os.path.join(root, fname)
+                with open(fpath, "r", encoding="utf-8", errors="ignore") as f:
+                    content = f.read()
+                for pattern in secret_patterns:
+                    if re.search(pattern, content, re.IGNORECASE):
+                        warnings.append(
+                            f"Possible secret in {os.path.relpath(fpath, skill_path)}: "
+                            f"matches pattern '{pattern}'"
+                        )
+
+    # Summary
+    if errors:
+        return False, errors + warnings
+
+    if warnings:
+        return True, [f"Valid with {len(warnings)} warning(s):"] + warnings
+
+    return True, ["Valid — no issues found"]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Validate a Claude Code skill")
+    parser.add_argument("skill_path", help="Path to the skill directory")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    valid, messages = validate_skill(args.skill_path)
+
+    if args.json:
+        result = {"valid": valid, "messages": messages}
+        print(json.dumps(result, indent=2))
+    else:
+        status = "PASS" if valid else "FAIL"
+        print(f"\nSkill validation: {status}")
+        print(f"Path: {args.skill_path}")
+        print()
+        for msg in messages:
+            prefix = "  WARNING" if "warning" in msg.lower() else "  ERROR" if "ERROR" in msg or "Invalid" in msg or "Missing" in msg or "too" in msg.lower() else "  INFO"
+            print(f"{prefix}: {msg}")
+        print()
+
+    sys.exit(0 if valid else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Generic publishing tool for Claude Code skills with network connectivity fallback.

Key features:
- Validates SKILL.md format
- Generates bilingual README + ClawHub manifest
- Publishes to ClawHub, Hermes Agent, and anthropics/skills
- Network Connectivity section: proxy fallback from ~/.env, SSH fallback

Files:
- SKILL.md
- scripts/validate_skill.py
- scripts/generate_package.py