### PR TITLE
skill-creator: fix run_eval.py crash on Windows when reading from subprocess pipe

### DIFF
--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -8,9 +8,10 @@ for a set of queries. Outputs results as JSON.
 import argparse
 import json
 import os
-import select
+import queue
 import subprocess
 import sys
+import threading
 import time
 import uuid
 from concurrent.futures import ProcessPoolExecutor, as_completed
@@ -90,6 +91,25 @@ def run_single_query(
             env=env,
         )
 
+        # Read stdout in a background thread. select.select() on a subprocess
+        # pipe raises OSError [WinError 10038] on Windows because select only
+        # accepts socket fds there; a thread + queue is the simplest portable
+        # alternative and works the same on POSIX.
+        chunk_queue: "queue.Queue[bytes | None]" = queue.Queue()
+
+        def _reader() -> None:
+            try:
+                while True:
+                    chunk = process.stdout.read(8192)
+                    if not chunk:
+                        break
+                    chunk_queue.put(chunk)
+            finally:
+                chunk_queue.put(None)  # EOF sentinel
+
+        reader_thread = threading.Thread(target=_reader, daemon=True)
+        reader_thread.start()
+
         triggered = False
         start_time = time.time()
         buffer = ""
@@ -99,19 +119,12 @@ def run_single_query(
 
         try:
             while time.time() - start_time < timeout:
-                if process.poll() is not None:
-                    remaining = process.stdout.read()
-                    if remaining:
-                        buffer += remaining.decode("utf-8", errors="replace")
-                    break
-
-                ready, _, _ = select.select([process.stdout], [], [], 1.0)
-                if not ready:
+                try:
+                    chunk = chunk_queue.get(timeout=1.0)
+                except queue.Empty:
                     continue
-
-                chunk = os.read(process.stdout.fileno(), 8192)
-                if not chunk:
-                    break
+                if chunk is None:
+                    break  # reader thread saw EOF
                 buffer += chunk.decode("utf-8", errors="replace")
 
                 while "\n" in buffer:


### PR DESCRIPTION
## Summary

`run_eval.py` is unusable on Windows: every query gets recorded as "not triggered" regardless of the description being tested, so the optimization loop reports `precision=100% recall=0%` on every iteration. Symptom is a flood of `Warning: query failed: [WinError 10038] An operation was attempted on something that is not a socket` lines.

Root cause is the read loop that polls the child process's stdout pipe with `select.select`:

```python
ready, _, _ = select.select([process.stdout], [], [], 1.0)
```

On Windows, `select.select()` only accepts socket file descriptors — pipe fds raise `OSError WinError 10038`. The exception bubbles up to `run_eval`'s broad `except Exception`, which logs the warning and pushes `False` into the per-query result list. With every read failing instantly, no `claude -p` invocation ever has its stdout consumed, so trigger detection always fails.

## Fix

Replace the `select`-based poll with a daemon thread that reads stdout into a `queue.Queue`, and use `queue.get(timeout=1.0)` on the main loop. Same time budget, same back-pressure semantics, works identically on POSIX.

```python
chunk_queue: "queue.Queue[bytes | None]" = queue.Queue()

def _reader() -> None:
    try:
        while True:
            chunk = process.stdout.read(8192)
            if not chunk:
                break
            chunk_queue.put(chunk)
    finally:
        chunk_queue.put(None)  # EOF sentinel

reader_thread = threading.Thread(target=_reader, daemon=True)
reader_thread.start()

# main loop:
try:
    chunk = chunk_queue.get(timeout=1.0)
except queue.Empty:
    continue
if chunk is None:
    break  # reader thread saw EOF
buffer += chunk.decode("utf-8", errors="replace")
```

The thread is `daemon=True`, so it dies when the parent process exits; the existing `process.kill()` in the surrounding `finally` causes the reader's `read()` to return `b''` and push the `None` sentinel cleanly.

## Reproduction

On any Windows host with Claude Code authenticated:

```powershell
# Any non-trivial skill works; smaller is faster.
python -m scripts.run_loop `
  --eval-set my-eval.json `
  --skill-path C:\path\to\my-skill `
  --model claude-sonnet-4-5 `
  --max-iterations 1 `
  --verbose
```

Pre-fix output (excerpt):

```
Warning: query failed: [WinError 10038] An operation was attempted on something that is not a socket
Warning: query failed: [WinError 10038] An operation was attempted on something that is not a socket
... (one per query) ...
Train: 12/24 correct, precision=100% recall=0% accuracy=50%
  [FAIL] rate=0/3 expected=True: <every should-trigger query>
  [PASS] rate=0/3 expected=False: <every should-not-trigger query>
```

Post-fix on the same eval set:

- Run completes without `WinError 10038`
- Per-query trigger rates vary by query (no longer uniformly 0)
- Both true positives and true negatives are reachable

## Test environment

- Windows 11 24H2
- Python 3.13.12
- Claude Code 2.1.101 (authenticated to a Max plan, no `ANTHROPIC_API_KEY`)
- Eval set with 10 should-trigger and 10 should-not-trigger queries

## Notes

- No changes to behavior on POSIX. The thread approach matches the original poll cadence (1 second wakeups).
- I deliberately removed the `if process.poll() is not None: ... read remaining` early-exit branch because the reader thread already drains stdout naturally and pushes the `None` sentinel as soon as the child closes its stdout (which happens when it exits). The previous branch was an optimization that became redundant.
- I considered a platform gate (`if sys.platform == "win32"`) but chose the unconditional thread approach because it eliminates the platform-specific code path and the per-platform test surface. Performance is identical for skill-eval workloads (kilobytes per query, single-digit events per second).
