### PR TITLE
docs: add Cruise AI Skills partner reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,4 @@ The markdown content below contains the instructions, examples, and guidelines t
 Skills are a great way to teach Claude how to get better at using specific pieces of software. As we see awesome example skills from partners, we may highlight some of them here:
 
 - **Notion** - [Notion Skills for Claude](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0)
+- **Ola Vacations** - [Cruise AI Skills](https://github.com/sol713/cruise-ai-skills) for cruise package value checks, cruise line comparisons, and shore excursion decisions.


### PR DESCRIPTION
## What this adds

A single one-line entry in the **Partner Skills** section of the README, pointing to an external skill repository:

- **Ola Vacations** - [Cruise AI Skills](https://github.com/sol713/cruise-ai-skills) for cruise package value checks, cruise line comparisons, and shore excursion decisions.

This follows the same one-line partner reference format as the existing Notion entry.

## About the skill collection

Cruise AI Skills is a SKILL.md-based repository for cruise travel planning decisions. It currently includes focused skills for package value checks, cruise line comparisons, and shore excursion decisions.

## Technical notes

- Repository: https://github.com/sol713/cruise-ai-skills
- Source of truth: lives in the linked repo so the skills can be maintained in one place
- Change scope: README-only partner reference

## Test plan

- [x] One-line README edit
- [x] git diff --check
- [x] No changes outside README.md