### PR TITLE
support pre-compiled soffice AF_UNIX shim to remove gcc runtime depen…

### DIFF
--- a/skills/docx/scripts/office/soffice.py
+++ b/skills/docx/scripts/office/soffice.py
@@ -38,6 +38,7 @@ def run_soffice(args: list[str], **kwargs) -> subprocess.CompletedProcess:
 
 
 
+_PRECOMPILED_SHIM = Path("/usr/local/lib/lo_socket_shim.so")
 _SHIM_SO = Path(tempfile.gettempdir()) / "lo_socket_shim.so"
 
 
@@ -51,6 +52,8 @@ def _needs_shim() -> bool:
 
 
 def _ensure_shim() -> Path:
+    if _PRECOMPILED_SHIM.exists():
+        return _PRECOMPILED_SHIM
     if _SHIM_SO.exists():
         return _SHIM_SO
 

--- a/skills/pptx/scripts/office/soffice.py
+++ b/skills/pptx/scripts/office/soffice.py
@@ -38,6 +38,7 @@ def run_soffice(args: list[str], **kwargs) -> subprocess.CompletedProcess:
 
 
 
+_PRECOMPILED_SHIM = Path("/usr/local/lib/lo_socket_shim.so")
 _SHIM_SO = Path(tempfile.gettempdir()) / "lo_socket_shim.so"
 
 
@@ -51,6 +52,8 @@ def _needs_shim() -> bool:
 
 
 def _ensure_shim() -> Path:
+    if _PRECOMPILED_SHIM.exists():
+        return _PRECOMPILED_SHIM
     if _SHIM_SO.exists():
         return _SHIM_SO
 

--- a/skills/xlsx/scripts/office/soffice.py
+++ b/skills/xlsx/scripts/office/soffice.py
@@ -38,6 +38,7 @@ def run_soffice(args: list[str], **kwargs) -> subprocess.CompletedProcess:
 
 
 
+_PRECOMPILED_SHIM = Path("/usr/local/lib/lo_socket_shim.so")
 _SHIM_SO = Path(tempfile.gettempdir()) / "lo_socket_shim.so"
 
 
@@ -51,6 +52,8 @@ def _needs_shim() -> bool:
 
 
 def _ensure_shim() -> Path:
+    if _PRECOMPILED_SHIM.exists():
+        return _PRECOMPILED_SHIM
     if _SHIM_SO.exists():
         return _SHIM_SO
 


### PR DESCRIPTION
…dency

Check /usr/local/lib/lo_socket_shim.so before attempting runtime compilation, allowing Docker images to pre-compile the shim at build time and ship without gcc.