### PR TITLE
Add frontend-law-auditor skill and update example skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -23,7 +23,7 @@
     },
     {
       "name": "example-skills",
-      "description": "Collection of example skills demonstrating various capabilities including skill creation, MCP building, visual design, algorithmic art, internal communications, web testing, artifact building, Slack GIFs, and theme styling",
+      "description": "Collection of example skills demonstrating various capabilities including skill creation, MCP building, visual design, frontend law auditing, algorithmic art, internal communications, web testing, artifact building, Slack GIFs, and theme styling",
       "source": "./",
       "strict": false,
       "skills": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,6 +32,7 @@
         "./skills/canvas-design",
         "./skills/doc-coauthoring",
         "./skills/frontend-design",
+        "./skills/frontend-law-auditor",
         "./skills/internal-comms",
         "./skills/mcp-builder",
         "./skills/skill-creator",

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For more information, check out:
 
 # About This Repository
 
-This repository contains skills that demonstrate what's possible with Claude's skills system. These skills range from creative applications (art, music, design) to technical tasks (testing web apps, MCP server generation) to enterprise workflows (communications, branding, etc.).
+This repository contains skills that demonstrate what's possible with Claude's skills system. These skills range from creative applications (art, music, design) to technical tasks (testing web apps, MCP server generation, frontend human-centered law auditing) to enterprise workflows (communications, branding, etc.).
 
 Each skill is self-contained in its own folder with a `SKILL.md` file containing the instructions and metadata that Claude uses. Browse through these skills to get inspiration for your own skills or to understand different patterns and approaches.
 
@@ -27,6 +27,11 @@ Many skills in this repo are open source (Apache 2.0). We've also included the d
 - [./skills](./skills): Skill examples for Creative & Design, Development & Technical, Enterprise & Communication, and Document Skills
 - [./spec](./spec): The Agent Skills specification
 - [./template](./template): Skill template
+
+## Highlighted Example Skills
+- [skills/frontend-design](./skills/frontend-design): Distinctive, production-grade frontend interface creation.
+- [skills/webapp-testing](./skills/webapp-testing): Playwright-based local web app testing toolkit.
+- [skills/frontend-law-auditor](./skills/frontend-law-auditor): Human-centered frontend quality gate and theory-based audit across core UX laws.
 
 # Try in Claude Code, Claude.ai, and the API
 

--- a/skills/frontend-law-auditor/LICENSE.txt
+++ b/skills/frontend-law-auditor/LICENSE.txt
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/skills/frontend-law-auditor/SKILL.md
+++ b/skills/frontend-law-auditor/SKILL.md
@@ -49,6 +49,7 @@ python scripts/law_audit.py --input /tmp/frontend-evidence.json --strict --fail-
 4. **Interpret results using two layers**
 - **Layer A: Fast gate** (binary pass/fail checks).
 - **Layer B: Deep law analysis** (cause-based diagnosis per principle).
+- For each failed principle, open its mapped rule file under `rules/`.
 
 5. **Produce fix backlog**
 - Sort by severity and expected impact on completion/conversion.
@@ -85,6 +86,8 @@ If evidence is incomplete, explicitly list missing keys and mark affected laws a
 ## References
 
 Load only what you need:
+- `rules/_sections.md` for full rule index and priority groups
+- `rules/<law>.md` for implementation-level diagnosis and fixes
 - `references/metrics-schema.md` for metric definitions and thresholds
 - `references/theory-playbook.md` for deep principle explanations and fixes
 - `examples/evidence.sample.json` for input format

--- a/skills/frontend-law-auditor/SKILL.md
+++ b/skills/frontend-law-auditor/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: frontend-law-auditor
+description: Human-centered frontend quality gate and theory-based audit skill. Use when reviewing or debugging web/mobile UI for cognitive friction, conversion drop-offs, confusing forms, weak feedback, poor interaction flow, or pre-release UX signoff. Audits interfaces against Fitts, Hick, Gestalt, Von Restorff, Jakob, Miller, Goal-Gradient, Zeigarnik, Tesler, Peak-End, Postel, Doherty, Serial Position, Occam, and Parkinson laws.
+license: Apache-2.0
+---
+
+# Frontend Law Auditor
+
+Use this skill to detect whether a frontend actually follows human-centered design laws, not just visual trends.
+
+## When to Apply
+
+Apply this skill when the user asks to:
+- review frontend usability or UX quality
+- diagnose drop-offs in onboarding/signup/checkout flows
+- build a launch gate for design quality
+- evaluate whether UI follows psychology-based design principles
+- produce a remediation plan with measurable acceptance criteria
+
+Skip when the task is purely backend/infrastructure with no user interface impact.
+
+## Mandatory Workflow
+
+Always follow this sequence.
+
+1. **Collect evidence**
+- Screenshots or recordings for key flows (signup, checkout, search, settings).
+- Interaction timings and loading states.
+- Form validation behavior and error messaging.
+- Navigation/action layout for first and last positions.
+
+2. **Initialize a metrics template**
+- Run:
+```bash
+python scripts/law_audit.py --init-template /tmp/frontend-evidence.json
+```
+- Fill measured values in the generated JSON file.
+
+3. **Run audit**
+- Run:
+```bash
+python scripts/law_audit.py --input /tmp/frontend-evidence.json --output /tmp/frontend-audit.md --json-out /tmp/frontend-audit.json
+```
+- For CI-style gating:
+```bash
+python scripts/law_audit.py --input /tmp/frontend-evidence.json --strict --fail-threshold 85
+```
+
+4. **Interpret results using two layers**
+- **Layer A: Fast gate** (binary pass/fail checks).
+- **Layer B: Deep law analysis** (cause-based diagnosis per principle).
+
+5. **Produce fix backlog**
+- Sort by severity and expected impact on completion/conversion.
+- Provide concrete acceptance criteria per fix.
+
+## Output Contract
+
+For every audit, output in this shape:
+
+1. **Fast Gate Failures**
+- Only failed checks with direct evidence.
+
+2. **Law Diagnosis**
+- `Principle -> Observed friction -> Why it happens (theory) -> UI change`.
+
+3. **Priority Fix Plan**
+- P0/P1/P2 buckets with measurable thresholds (target size, feedback ms, choice count, etc.).
+
+4. **Recheck Checklist**
+- What must pass in the next audit run.
+
+## Evidence Requirements
+
+Minimum evidence for a valid audit:
+- target size and reachability data for critical actions
+- choice density and progressive disclosure status
+- progress visibility for multi-step flows
+- validation behavior and error specificity
+- interaction acknowledgment timing (p95 ms)
+- completion-state quality (end feedback)
+
+If evidence is incomplete, explicitly list missing keys and mark affected laws as `unknown`.
+
+## References
+
+Load only what you need:
+- `references/metrics-schema.md` for metric definitions and thresholds
+- `references/theory-playbook.md` for deep principle explanations and fixes
+- `examples/evidence.sample.json` for input format
+
+## Notes
+
+- Use this skill as a detector and decision aid, not as a replacement for product judgment.
+- If laws conflict, prioritize task completion and safety-critical clarity first.

--- a/skills/frontend-law-auditor/SKILL.md
+++ b/skills/frontend-law-auditor/SKILL.md
@@ -32,18 +32,18 @@ Always follow this sequence.
 2. **Initialize a metrics template**
 - Run:
 ```bash
-python scripts/law_audit.py --init-template /tmp/frontend-evidence.json
+python3 scripts/law_audit.py --init-template /tmp/frontend-evidence.json
 ```
 - Fill measured values in the generated JSON file.
 
 3. **Run audit**
 - Run:
 ```bash
-python scripts/law_audit.py --input /tmp/frontend-evidence.json --output /tmp/frontend-audit.md --json-out /tmp/frontend-audit.json
+python3 scripts/law_audit.py --input /tmp/frontend-evidence.json --output /tmp/frontend-audit.md --json-out /tmp/frontend-audit.json
 ```
 - For CI-style gating:
 ```bash
-python scripts/law_audit.py --input /tmp/frontend-evidence.json --strict --fail-threshold 85
+python3 scripts/law_audit.py --input /tmp/frontend-evidence.json --strict --fail-threshold 85
 ```
 
 4. **Interpret results using two layers**

--- a/skills/frontend-law-auditor/SKILL.md
+++ b/skills/frontend-law-auditor/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: frontend-law-auditor
 description: Human-centered frontend quality gate and theory-based audit skill. Use when reviewing or debugging web/mobile UI for cognitive friction, conversion drop-offs, confusing forms, weak feedback, poor interaction flow, or pre-release UX signoff. Audits interfaces against Fitts, Hick, Gestalt, Von Restorff, Jakob, Miller, Goal-Gradient, Zeigarnik, Tesler, Peak-End, Postel, Doherty, Serial Position, Occam, and Parkinson laws.
-license: Apache-2.0
+license: Complete terms in LICENSE.txt
 ---
 
 # Frontend Law Auditor

--- a/skills/frontend-law-auditor/examples/evidence.sample.json
+++ b/skills/frontend-law-auditor/examples/evidence.sample.json
@@ -1,0 +1,36 @@
+{
+  "meta": {
+    "project": "notemd-web",
+    "flow": "account-signup",
+    "auditor": "qa-team",
+    "notes": "Sample evidence with mixed pass/fail to demonstrate report output."
+  },
+  "metrics": {
+    "primary_cta_count": 2,
+    "min_target_size_px": 40,
+    "primary_action_reach": "hard",
+    "critical_action_at_task_end": false,
+    "screen_choice_count": 10,
+    "progressive_disclosure": false,
+    "group_spacing_ratio": 1.4,
+    "role_style_consistency": true,
+    "continuity_cue": false,
+    "closure_support": true,
+    "figure_ground_contrast": true,
+    "motion_group_consistency": true,
+    "focal_points": 3,
+    "isolated_key_element_count": 4,
+    "pattern_familiarity": true,
+    "chunk_count": 12,
+    "progress_visible": false,
+    "unfinished_resume_path": false,
+    "system_handles_complexity": false,
+    "positive_end_state": false,
+    "input_tolerant_parsing": false,
+    "feedback_ms_p95": 670,
+    "critical_actions_boundary_placement": false,
+    "inline_validation_clear": false,
+    "simplicity_score": 55,
+    "scope_creep_signals": true
+  }
+}

--- a/skills/frontend-law-auditor/references/metrics-schema.md
+++ b/skills/frontend-law-auditor/references/metrics-schema.md
@@ -1,0 +1,59 @@
+# Frontend Law Auditor Metrics Schema
+
+This file defines the evidence keys consumed by `scripts/law_audit.py`.
+
+## Input Structure
+
+```json
+{
+  "meta": {
+    "project": "string",
+    "flow": "string",
+    "auditor": "string",
+    "notes": "string"
+  },
+  "metrics": {
+    "key": "value"
+  }
+}
+```
+
+## Metric Dictionary
+
+| Key | Type | Threshold / Expected | Related law(s) | Collection hint |
+|---|---|---|---|---|
+| `primary_cta_count` | number | exactly `1` | Focal Point, Von Restorff | Count dominant primary actions on key screen |
+| `min_target_size_px` | number | `>= 44` | Fitts | Inspect CSS computed size of critical controls |
+| `primary_action_reach` | enum | `natural`, `stretch`, `near`, `edge` preferred | Fitts | Mobile thumb-zone or pointer travel estimate |
+| `critical_action_at_task_end` | bool | `true` | Fitts | Confirm submit/continue appears where task ends |
+| `screen_choice_count` | number | `<= 7` | Hick | Count concurrent visible action choices |
+| `progressive_disclosure` | bool | `true` | Hick | Check advanced options are hidden by default |
+| `group_spacing_ratio` | number | `>= 2.0` | Gestalt Proximity | External group gap / internal element gap |
+| `role_style_consistency` | bool | `true` | Gestalt Similarity | Same role components share visual token patterns |
+| `continuity_cue` | bool | `true` | Gestalt Continuity | Peeking cards, aligned flow, next-step hints |
+| `closure_support` | bool | `true` | Gestalt Closure | Partial structures remain interpretable |
+| `figure_ground_contrast` | bool | `true` | Gestalt Figure/Ground | Modal/sheet foreground distinctly isolated |
+| `motion_group_consistency` | bool | `true` | Gestalt Common Fate | Grouped elements move in synchronized direction/timing |
+| `focal_points` | number | exactly `1` | Gestalt Focal Point | Count dominant attention anchors per screen |
+| `isolated_key_element_count` | number | `1` to `2` | Von Restorff | Count intentionally isolated memory anchors |
+| `pattern_familiarity` | bool | `true` | Jakob | Evaluate critical conventions vs user expectations |
+| `chunk_count` | number | `3` to `9` | Miller | Count meaningful information chunks |
+| `progress_visible` | bool | `true` | Goal-Gradient | Presence of stepper/progress indicators |
+| `unfinished_resume_path` | bool | `true` | Zeigarnik | Presence of resume link/state for interrupted flow |
+| `system_handles_complexity` | bool | `true` | Tesler | Autocomplete/default/mask/parser support |
+| `positive_end_state` | bool | `true` | Peak-End | Clear completion feedback and next step |
+| `input_tolerant_parsing` | bool | `true` | Postel | Multi-format tolerant parsing and normalization |
+| `feedback_ms_p95` | number | `<= 400` | Doherty | p95 click-to-feedback latency |
+| `critical_actions_boundary_placement` | bool | `true` | Serial Position | Critical items at start/end positions |
+| `inline_validation_clear` | bool | `true` | Postel, Peak-End | Requirements visible + field-level actionable errors |
+| `simplicity_score` | number | `>= 80` | Occam | Internal heuristic simplification score |
+| `scope_creep_signals` | bool | `false` | Parkinson | Feature creep indicators present or not |
+
+## Practical Guidance
+
+- Use real measurements whenever possible (DevTools, analytics, session replay, Playwright captures).
+- If a metric cannot be measured, leave it out and document why. The audit will mark corresponding laws as `unknown`.
+- For strict release gates, require:
+  - zero fast-gate failures
+  - score >= team threshold (default 85)
+  - no unresolved unknowns on P0/P1 laws

--- a/skills/frontend-law-auditor/references/theory-playbook.md
+++ b/skills/frontend-law-auditor/references/theory-playbook.md
@@ -1,0 +1,103 @@
+# Theory Playbook: Human-Centered Frontend Laws
+
+Use this playbook when generating deep-dive diagnosis after running the automated audit.
+
+## 1) Fitts's Law
+- **Mechanism**: Target acquisition time depends on distance and size.
+- **Failure pattern**: tiny controls, far-away submit button, high mis-tap.
+- **Fix pattern**: enlarge hit area, reduce travel distance, place critical action at endpoint.
+
+## 2) Hick's Law
+- **Mechanism**: More visible options increase decision latency.
+- **Failure pattern**: overloaded menus/forms, stalled first action.
+- **Fix pattern**: reduce concurrent choices, stage options with progressive disclosure.
+
+## 3) Gestalt Principles
+
+### Proximity
+- **Mechanism**: Near elements are interpreted as related.
+- **Fix**: tighten internal spacing, widen inter-group spacing.
+
+### Similarity
+- **Mechanism**: Visual sameness implies functional sameness.
+- **Fix**: enforce role-based style tokens.
+
+### Continuity
+- **Mechanism**: Eyes follow uninterrupted paths.
+- **Fix**: align flow lines and continuation cues.
+
+### Closure
+- **Mechanism**: Users complete partial structures mentally.
+- **Fix**: keep simplification interpretable; avoid ambiguous partials.
+
+### Figure/Ground
+- **Mechanism**: Clear foreground/background separation drives focus.
+- **Fix**: stronger scrim, contrast, and layer hierarchy for overlays.
+
+### Common Fate
+- **Mechanism**: Co-moving elements are perceived as one group.
+- **Fix**: synchronize direction/timing for grouped animations.
+
+### Focal Point
+- **Mechanism**: strongest contrast wins first attention.
+- **Fix**: keep exactly one dominant visual target per screen.
+
+## 4) Von Restorff Effect
+- **Mechanism**: Distinct items are remembered better than uniform items.
+- **Failure pattern**: everything highlighted, nothing memorable.
+- **Fix pattern**: isolate one key action/info against stable baseline.
+
+## 5) Jakob's Law
+- **Mechanism**: Users expect familiar patterns from other products.
+- **Failure pattern**: unconventional critical flow causing trust friction.
+- **Fix pattern**: preserve conventions in high-risk journeys; innovate in low-risk zones.
+
+## 6) Miller's Law
+- **Mechanism**: Working memory handles limited chunks.
+- **Failure pattern**: dense, all-at-once forms and settings.
+- **Fix pattern**: chunk content and split long tasks into steps.
+
+## 7) Goal-Gradient Hypothesis
+- **Mechanism**: Motivation increases near completion.
+- **Failure pattern**: hidden progress, late-stage abandonment.
+- **Fix pattern**: visible progress bars/counters and milestone reinforcement.
+
+## 8) Zeigarnik Effect
+- **Mechanism**: Incomplete tasks remain cognitively active.
+- **Failure pattern**: interrupted sessions never resumed.
+- **Fix pattern**: explicit unfinished state and easy resume path.
+
+## 9) Tesler's Law
+- **Mechanism**: Complexity is conserved; someone must carry it.
+- **Failure pattern**: users forced to handle formatting and consistency burden.
+- **Fix pattern**: shift complexity into system defaults, parsing, and structured controls.
+
+## 10) Peak-End Rule
+- **Mechanism**: Memory is dominated by peak and ending moments.
+- **Failure pattern**: successful flow ends with uncertainty.
+- **Fix pattern**: strong closure state with clear confirmation and next step.
+
+## 11) Postel's Law
+- **Mechanism**: Be tolerant in input, strict in normalized output.
+- **Failure pattern**: brittle validation and vague errors.
+- **Fix pattern**: accept common variants, normalize internally, return specific errors.
+
+## 12) Doherty Threshold
+- **Mechanism**: Fast feedback preserves cognitive flow.
+- **Failure pattern**: no immediate acknowledgment, repeated taps.
+- **Fix pattern**: instant pressed/loading state and perceived-performance optimizations.
+
+## 13) Serial Position Effect
+- **Mechanism**: First and last sequence items are recalled best.
+- **Failure pattern**: key actions buried mid-list.
+- **Fix pattern**: place critical actions at sequence boundaries.
+
+## 14) Occam's Razor
+- **Mechanism**: Simplest sufficient path minimizes cognitive tax.
+- **Failure pattern**: UI clutter and optional complexity in core flow.
+- **Fix pattern**: remove non-essential elements and decision branches.
+
+## 15) Parkinson's Law
+- **Mechanism**: Work expands without constraints.
+- **Failure pattern**: feature creep and bloated release scope.
+- **Fix pattern**: enforce scope guardrails and defer non-core additions.

--- a/skills/frontend-law-auditor/rules/_sections.md
+++ b/skills/frontend-law-auditor/rules/_sections.md
@@ -1,0 +1,39 @@
+# Frontend Law Auditor Rule Index
+
+Use these files for deep diagnosis after running `scripts/law_audit.py`.
+
+## P0 Critical
+
+- `fitts-law.md`
+- `hicks-law.md`
+- `doherty-threshold.md`
+
+## P1 High
+
+- `gestalt-proximity.md`
+- `gestalt-similarity.md`
+- `gestalt-focal-point.md`
+- `millers-law.md`
+- `teslers-law.md`
+- `postels-law.md`
+- `peak-end-rule.md`
+- `jakobs-law.md`
+
+## P2 Medium
+
+- `gestalt-continuity.md`
+- `gestalt-closure.md`
+- `gestalt-figure-ground.md`
+- `gestalt-common-fate.md`
+- `von-restorff-effect.md`
+- `goal-gradient-hypothesis.md`
+- `zeigarnik-effect.md`
+- `serial-position-effect.md`
+- `occams-razor.md`
+- `parkinsons-law.md`
+
+## Rule Loading Guidance
+
+- Load only failed rule files first.
+- If a rule is `unknown`, load the rule file plus `references/metrics-schema.md`.
+- For cross-law conflicts, prioritize completion-critical and safety-critical flows first.

--- a/skills/frontend-law-auditor/rules/_template.md
+++ b/skills/frontend-law-auditor/rules/_template.md
@@ -1,0 +1,24 @@
+# Rule: <name>
+
+## Why this law matters
+- Mechanism:
+- User risk when violated:
+
+## Failure signals
+- Signal 1:
+- Signal 2:
+
+## Audit checks
+- Check 1:
+- Check 2:
+
+## Typical fixes
+- Fix 1:
+- Fix 2:
+
+## Acceptance criteria
+- Criterion 1:
+- Criterion 2:
+
+## Related metrics
+- `metric_key`

--- a/skills/frontend-law-auditor/rules/doherty-threshold.md
+++ b/skills/frontend-law-auditor/rules/doherty-threshold.md
@@ -1,0 +1,24 @@
+# Rule: Doherty Threshold
+
+## Why this law matters
+- Mechanism: rapid feedback preserves user cognitive flow.
+- User risk when violated: duplicate taps, uncertainty, drop-off.
+
+## Failure signals
+- no immediate pressed/loading state after action.
+- p95 feedback time exceeds control threshold.
+
+## Audit checks
+- `feedback_ms_p95 <= 400`.
+- all async actions provide immediate visual acknowledgment.
+
+## Typical fixes
+- add instant pressed/loading state.
+- use skeletons, optimistic UI, and staged rendering.
+
+## Acceptance criteria
+- p95 intent-to-feedback under threshold.
+- reduced duplicate submit events.
+
+## Related metrics
+- `feedback_ms_p95`

--- a/skills/frontend-law-auditor/rules/fitts-law.md
+++ b/skills/frontend-law-auditor/rules/fitts-law.md
@@ -1,0 +1,26 @@
+# Rule: Fitts's Law
+
+## Why this law matters
+- Mechanism: interaction time increases with distance and decreases with target size.
+- User risk when violated: slow completion, mis-taps, repeated attempts.
+
+## Failure signals
+- critical controls are small or far from task endpoint.
+- users overshoot or repeatedly tap near misses.
+
+## Audit checks
+- `min_target_size_px >= 44` for critical actions.
+- `critical_action_at_task_end == true` and reach in natural/stretch zones.
+
+## Typical fixes
+- increase hit area using padding/wrapper targets.
+- move submit/continue to where the user naturally finishes the task.
+
+## Acceptance criteria
+- no critical target below 44px.
+- measured reduction in tap errors or correction taps.
+
+## Related metrics
+- `min_target_size_px`
+- `primary_action_reach`
+- `critical_action_at_task_end`

--- a/skills/frontend-law-auditor/rules/gestalt-closure.md
+++ b/skills/frontend-law-auditor/rules/gestalt-closure.md
@@ -1,0 +1,24 @@
+# Rule: Gestalt - Closure
+
+## Why this law matters
+- Mechanism: users mentally complete incomplete visual structures.
+- User risk when violated: ambiguous icons and unclear progress states.
+
+## Failure signals
+- partial visuals cannot be reliably interpreted.
+- users ask "what does this symbol/shape mean?"
+
+## Audit checks
+- partial structures remain understandable without extra text.
+- `closure_support == true`.
+
+## Typical fixes
+- simplify only when recognition remains obvious.
+- add minimal context cues for ambiguous partial shapes.
+
+## Acceptance criteria
+- users interpret partial indicators correctly on first pass.
+- no support tickets tied to unclear symbolic states.
+
+## Related metrics
+- `closure_support`

--- a/skills/frontend-law-auditor/rules/gestalt-common-fate.md
+++ b/skills/frontend-law-auditor/rules/gestalt-common-fate.md
@@ -1,0 +1,24 @@
+# Rule: Gestalt - Common Fate
+
+## Why this law matters
+- Mechanism: elements moving together are perceived as belonging together.
+- User risk when violated: motion semantics feel random and misleading.
+
+## Failure signals
+- related items animate with mismatched direction/speed.
+- users fail to understand grouped changes.
+
+## Audit checks
+- grouped transitions share consistent motion behavior.
+- `motion_group_consistency == true`.
+
+## Typical fixes
+- standardize easing, duration, and direction by motion group.
+- avoid unrelated animations competing with core transition.
+
+## Acceptance criteria
+- improved comprehension of grouped state changes.
+- fewer misinterpretations in dynamic panels/menus.
+
+## Related metrics
+- `motion_group_consistency`

--- a/skills/frontend-law-auditor/rules/gestalt-continuity.md
+++ b/skills/frontend-law-auditor/rules/gestalt-continuity.md
@@ -1,0 +1,24 @@
+# Rule: Gestalt - Continuity
+
+## Why this law matters
+- Mechanism: eyes follow continuous paths and expected direction.
+- User risk when violated: broken scan flow and hidden next steps.
+
+## Failure signals
+- list/carousel/step flow has abrupt breaks.
+- users miss off-screen continuation.
+
+## Audit checks
+- progression cues exist (peek, arrow, stepper path).
+- `continuity_cue == true`.
+
+## Typical fixes
+- align content edges and motion direction.
+- reveal next-state hints at viewport boundaries.
+
+## Acceptance criteria
+- higher discovery of next actions/content.
+- fewer dead-end pauses during scanning.
+
+## Related metrics
+- `continuity_cue`

--- a/skills/frontend-law-auditor/rules/gestalt-figure-ground.md
+++ b/skills/frontend-law-auditor/rules/gestalt-figure-ground.md
@@ -1,0 +1,24 @@
+# Rule: Gestalt - Figure/Ground
+
+## Why this law matters
+- Mechanism: users must separate foreground task from background noise.
+- User risk when violated: modal confusion and wrong-context actions.
+
+## Failure signals
+- overlays do not clearly dominate background.
+- users interact with background while dialog expects focus.
+
+## Audit checks
+- foreground layer is clearly isolated.
+- `figure_ground_contrast == true`.
+
+## Typical fixes
+- strengthen scrim and layer hierarchy.
+- enforce focus trap and clear dismiss/confirm affordances.
+
+## Acceptance criteria
+- fewer accidental background interactions during overlays.
+- reduced context-loss errors in modal flows.
+
+## Related metrics
+- `figure_ground_contrast`

--- a/skills/frontend-law-auditor/rules/gestalt-focal-point.md
+++ b/skills/frontend-law-auditor/rules/gestalt-focal-point.md
@@ -1,0 +1,25 @@
+# Rule: Gestalt - Focal Point
+
+## Why this law matters
+- Mechanism: strongest contrast captures first attention.
+- User risk when violated: users cannot tell what to do first.
+
+## Failure signals
+- multiple elements compete as primary action.
+- primary flow action is visually diluted.
+
+## Audit checks
+- exactly one dominant focus anchor exists per screen.
+- `focal_points == 1`.
+
+## Typical fixes
+- reduce competing highlights and preserve one primary CTA.
+- use contrast hierarchy intentionally, not uniformly.
+
+## Acceptance criteria
+- faster first meaningful action.
+- better primary CTA click concentration.
+
+## Related metrics
+- `focal_points`
+- `primary_cta_count`

--- a/skills/frontend-law-auditor/rules/gestalt-proximity.md
+++ b/skills/frontend-law-auditor/rules/gestalt-proximity.md
@@ -1,0 +1,24 @@
+# Rule: Gestalt - Proximity
+
+## Why this law matters
+- Mechanism: nearby elements are interpreted as related.
+- User risk when violated: label-field confusion and scan friction.
+
+## Failure signals
+- related elements are spaced like unrelated sections.
+- users misassociate controls with wrong content blocks.
+
+## Audit checks
+- internal group spacing is clearly tighter than external spacing.
+- `group_spacing_ratio >= 2.0`.
+
+## Typical fixes
+- reduce intra-group gaps and increase inter-group separation.
+- use consistent spacing scale for component and section levels.
+
+## Acceptance criteria
+- faster scanning and fewer association mistakes.
+- consistent spacing hierarchy across similar screens.
+
+## Related metrics
+- `group_spacing_ratio`

--- a/skills/frontend-law-auditor/rules/gestalt-similarity.md
+++ b/skills/frontend-law-auditor/rules/gestalt-similarity.md
@@ -1,0 +1,24 @@
+# Rule: Gestalt - Similarity
+
+## Why this law matters
+- Mechanism: visually similar elements are assumed functionally similar.
+- User risk when violated: role confusion and misclicks.
+
+## Failure signals
+- same-role controls use conflicting visual styles.
+- users hesitate when mapping control meaning.
+
+## Audit checks
+- role-level style rules are tokenized and consistent.
+- `role_style_consistency == true`.
+
+## Typical fixes
+- unify color, shape, weight, and icon style by role.
+- restrict ad hoc styling exceptions in core flows.
+
+## Acceptance criteria
+- users can predict function from appearance.
+- reduced misuse of secondary/destructive actions.
+
+## Related metrics
+- `role_style_consistency`

--- a/skills/frontend-law-auditor/rules/goal-gradient-hypothesis.md
+++ b/skills/frontend-law-auditor/rules/goal-gradient-hypothesis.md
@@ -1,0 +1,24 @@
+# Rule: Goal-Gradient Hypothesis
+
+## Why this law matters
+- Mechanism: motivation increases as users approach completion.
+- User risk when violated: late-stage abandonment from invisible progress.
+
+## Failure signals
+- users cannot tell how close they are to finishing.
+- progress feels static even after completing steps.
+
+## Audit checks
+- visible progress exists throughout staged flows.
+- `progress_visible == true`.
+
+## Typical fixes
+- add explicit step counters/percent bars.
+- reinforce milestone completion with subtle success cues.
+
+## Acceptance criteria
+- higher completion in last-third of flow.
+- lower abandonment after mid-flow.
+
+## Related metrics
+- `progress_visible`

--- a/skills/frontend-law-auditor/rules/hicks-law.md
+++ b/skills/frontend-law-auditor/rules/hicks-law.md
@@ -1,0 +1,25 @@
+# Rule: Hick's Law
+
+## Why this law matters
+- Mechanism: decision latency grows as visible options grow.
+- User risk when violated: hesitation, choice paralysis, abandonment.
+
+## Failure signals
+- high option density on single screens.
+- users take too long before first meaningful action.
+
+## Audit checks
+- `screen_choice_count <= 7` for primary decision steps.
+- `progressive_disclosure == true` for advanced options.
+
+## Typical fixes
+- reduce concurrent options and group related actions.
+- hide advanced settings under "More" or later steps.
+
+## Acceptance criteria
+- first-action latency improves after reduction of choice load.
+- abandonment rate decreases on high-friction steps.
+
+## Related metrics
+- `screen_choice_count`
+- `progressive_disclosure`

--- a/skills/frontend-law-auditor/rules/jakobs-law.md
+++ b/skills/frontend-law-auditor/rules/jakobs-law.md
@@ -1,0 +1,24 @@
+# Rule: Jakob's Law
+
+## Why this law matters
+- Mechanism: users transfer expectations from familiar products.
+- User risk when violated: trust drops in navigation/auth/payment flows.
+
+## Failure signals
+- critical interactions behave unlike common patterns.
+- users need extra explanation for basic navigation tasks.
+
+## Audit checks
+- critical conventions are preserved.
+- `pattern_familiarity == true`.
+
+## Typical fixes
+- restore conventional placement/behavior for core patterns.
+- confine novel interactions to low-risk areas.
+
+## Acceptance criteria
+- reduced onboarding friction and support questions.
+- higher confidence in key flows.
+
+## Related metrics
+- `pattern_familiarity`

--- a/skills/frontend-law-auditor/rules/millers-law.md
+++ b/skills/frontend-law-auditor/rules/millers-law.md
@@ -1,0 +1,25 @@
+# Rule: Miller's Law
+
+## Why this law matters
+- Mechanism: working memory can hold only limited chunks at once.
+- User risk when violated: overload, errors, and form abandonment.
+
+## Failure signals
+- long dense forms or giant option blocks.
+- users repeatedly scroll/backtrack to re-parse content.
+
+## Audit checks
+- information chunk count stays in manageable range.
+- `chunk_count` stays within 3 to 9 where possible.
+
+## Typical fixes
+- split long tasks into step-based flows.
+- group fields/options into meaningful sections.
+
+## Acceptance criteria
+- improved completion rate for long flows.
+- reduced correction loops in complex forms.
+
+## Related metrics
+- `chunk_count`
+- `screen_choice_count`

--- a/skills/frontend-law-auditor/rules/occams-razor.md
+++ b/skills/frontend-law-auditor/rules/occams-razor.md
@@ -1,0 +1,24 @@
+# Rule: Occam's Razor
+
+## Why this law matters
+- Mechanism: simpler sufficient solutions reduce cognitive overhead.
+- User risk when violated: cluttered UI and unnecessary decision tax.
+
+## Failure signals
+- multiple optional branches in core flow.
+- decorative complexity blocking task clarity.
+
+## Audit checks
+- non-essential controls and states are removed.
+- `simplicity_score` stays above team baseline.
+
+## Typical fixes
+- remove low-value actions from primary flows.
+- simplify copy, states, and visual noise.
+
+## Acceptance criteria
+- improved completion speed and lower hesitation.
+- fewer screen elements required for core task completion.
+
+## Related metrics
+- `simplicity_score`

--- a/skills/frontend-law-auditor/rules/parkinsons-law.md
+++ b/skills/frontend-law-auditor/rules/parkinsons-law.md
@@ -1,0 +1,24 @@
+# Rule: Parkinson's Law
+
+## Why this law matters
+- Mechanism: work expands to fill available time and scope.
+- User risk when violated: feature creep degrades core usability.
+
+## Failure signals
+- non-critical features added into core release path.
+- added complexity without measurable user-value gain.
+
+## Audit checks
+- release scope stays aligned to primary user goals.
+- `scope_creep_signals == false`.
+
+## Typical fixes
+- enforce MVP boundaries and defer optional enhancements.
+- require measurable hypothesis for new UI complexity.
+
+## Acceptance criteria
+- leaner release with stable core flow outcomes.
+- fewer regressions from late-stage additions.
+
+## Related metrics
+- `scope_creep_signals`

--- a/skills/frontend-law-auditor/rules/peak-end-rule.md
+++ b/skills/frontend-law-auditor/rules/peak-end-rule.md
@@ -1,0 +1,24 @@
+# Rule: Peak-End Rule
+
+## Why this law matters
+- Mechanism: experience memory is dominated by peak and ending moments.
+- User risk when violated: decent flows are remembered as frustrating due to weak ending.
+
+## Failure signals
+- no clear success/failure closure after submit.
+- final step contains surprise friction or ambiguity.
+
+## Audit checks
+- completion state is explicit and confidence-building.
+- `positive_end_state == true`.
+
+## Typical fixes
+- add clear confirmation with next action.
+- remove last-step surprises and hidden requirements.
+
+## Acceptance criteria
+- reduced "did it work?" uncertainty events.
+- stronger return intent and satisfaction signals.
+
+## Related metrics
+- `positive_end_state`

--- a/skills/frontend-law-auditor/rules/postels-law.md
+++ b/skills/frontend-law-auditor/rules/postels-law.md
@@ -1,0 +1,25 @@
+# Rule: Postel's Law
+
+## Why this law matters
+- Mechanism: robust systems accept varied human input and emit normalized output.
+- User risk when violated: brittle validation and avoidable dead-end errors.
+
+## Failure signals
+- common input variants are rejected.
+- errors are vague and non-actionable.
+
+## Audit checks
+- tolerant parsing is implemented for common formats.
+- inline error guidance is specific and recoverable.
+
+## Typical fixes
+- accept common date/phone/address variants and normalize.
+- rewrite errors to include cause and exact recovery path.
+
+## Acceptance criteria
+- fewer validation dead-ends and retries.
+- improved form completion and reduced support tickets.
+
+## Related metrics
+- `input_tolerant_parsing`
+- `inline_validation_clear`

--- a/skills/frontend-law-auditor/rules/serial-position-effect.md
+++ b/skills/frontend-law-auditor/rules/serial-position-effect.md
@@ -1,0 +1,24 @@
+# Rule: Serial Position Effect
+
+## Why this law matters
+- Mechanism: first and last items are recalled better than middle items.
+- User risk when violated: key actions hidden in low-recall positions.
+
+## Failure signals
+- important actions are placed in the middle of dense menus.
+- users overlook required critical controls.
+
+## Audit checks
+- critical actions are placed at beginning or end of sequences.
+- `critical_actions_boundary_placement == true`.
+
+## Typical fixes
+- reorder navigation/action rows by priority.
+- move support/cart/logout/checkout to boundary positions as appropriate.
+
+## Acceptance criteria
+- higher discovery rate of critical actions.
+- lower miss rate on key menu operations.
+
+## Related metrics
+- `critical_actions_boundary_placement`

--- a/skills/frontend-law-auditor/rules/teslers-law.md
+++ b/skills/frontend-law-auditor/rules/teslers-law.md
@@ -1,0 +1,25 @@
+# Rule: Tesler's Law
+
+## Why this law matters
+- Mechanism: complexity cannot be removed, only shifted.
+- User risk when violated: users carry implementation complexity and fail more often.
+
+## Failure signals
+- manual entry required where system could infer/assist.
+- inconsistent free-text data creates downstream cleanup burden.
+
+## Audit checks
+- system provides smart defaults, autocomplete, and structured controls.
+- `system_handles_complexity == true`.
+
+## Typical fixes
+- replace free text with pickers/masks where appropriate.
+- normalize data structures behind the scenes.
+
+## Acceptance criteria
+- lower input effort and lower invalid-entry rate.
+- improved consistency of captured data.
+
+## Related metrics
+- `system_handles_complexity`
+- `input_tolerant_parsing`

--- a/skills/frontend-law-auditor/rules/von-restorff-effect.md
+++ b/skills/frontend-law-auditor/rules/von-restorff-effect.md
@@ -1,0 +1,25 @@
+# Rule: Von Restorff Effect
+
+## Why this law matters
+- Mechanism: distinct elements are more memorable than uniform ones.
+- User risk when violated: key offer/action is forgotten in visual noise.
+
+## Failure signals
+- no meaningful standout for key decision.
+- too many "special" styles cancel isolation effect.
+
+## Audit checks
+- isolated key elements are limited and intentional.
+- `isolated_key_element_count` stays in a narrow range.
+
+## Typical fixes
+- isolate one recommendation or primary action.
+- normalize non-critical elements to restore contrast baseline.
+
+## Acceptance criteria
+- increased recall and selection of highlighted key action.
+- reduced confusion in high-choice screens.
+
+## Related metrics
+- `isolated_key_element_count`
+- `primary_cta_count`

--- a/skills/frontend-law-auditor/rules/zeigarnik-effect.md
+++ b/skills/frontend-law-auditor/rules/zeigarnik-effect.md
@@ -1,0 +1,25 @@
+# Rule: Zeigarnik Effect
+
+## Why this law matters
+- Mechanism: unfinished tasks remain cognitively active.
+- User risk when violated: interrupted work is forgotten and never resumed.
+
+## Failure signals
+- no visible "in progress" state after interruption.
+- returning users cannot easily continue previous step.
+
+## Audit checks
+- unfinished flows expose clear resume path.
+- `unfinished_resume_path == true`.
+
+## Typical fixes
+- persist draft/progress state.
+- show "continue where you left off" actions.
+
+## Acceptance criteria
+- higher return-to-complete rate for interrupted tasks.
+- reduced restart-from-zero behavior.
+
+## Related metrics
+- `unfinished_resume_path`
+- `progress_visible`

--- a/skills/frontend-law-auditor/scripts/law_audit.py
+++ b/skills/frontend-law-auditor/scripts/law_audit.py
@@ -1,0 +1,842 @@
+#!/usr/bin/env python3
+"""Frontend human-centered law auditor.
+
+Reads evidence JSON, evaluates fast-gate checks and 21 human-centered principles,
+then emits a markdown report and optional JSON output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+PASS = "pass"
+FAIL = "fail"
+UNKNOWN = "unknown"
+
+STATUS_POINTS = {
+    PASS: 1.0,
+    FAIL: 0.0,
+    UNKNOWN: 0.4,
+}
+
+
+@dataclass
+class Principle:
+    key: str
+    name: str
+    weight: int
+    mechanism: str
+    requirement: str
+    signal: str
+    fix: str
+    evaluator: Callable[[dict[str, Any]], tuple[str, str]]
+
+
+@dataclass
+class GateCheck:
+    key: str
+    title: str
+    evaluator: Callable[[dict[str, Any]], tuple[str, str]]
+    fix: str
+
+
+def as_bool(metrics: dict[str, Any], key: str) -> bool | None:
+    value = metrics.get(key)
+    if isinstance(value, bool):
+        return value
+    return None
+
+
+def as_number(metrics: dict[str, Any], key: str) -> float | None:
+    value = metrics.get(key)
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def as_text(metrics: dict[str, Any], key: str) -> str | None:
+    value = metrics.get(key)
+    if isinstance(value, str):
+        return value.strip().lower()
+    return None
+
+
+def flag_missing(metrics: dict[str, Any], keys: list[str]) -> tuple[bool, str]:
+    missing = [key for key in keys if metrics.get(key) is None]
+    if missing:
+        return True, f"Missing required metrics: {', '.join(missing)}"
+    return False, ""
+
+
+def make_bool_evaluator(
+    key: str,
+    expected: bool = True,
+    pass_message: str = "Check passed.",
+    fail_message: str = "Check failed.",
+) -> Callable[[dict[str, Any]], tuple[str, str]]:
+    def evaluator(metrics: dict[str, Any]) -> tuple[str, str]:
+        value = as_bool(metrics, key)
+        if value is None:
+            return UNKNOWN, f"Missing boolean metric: {key}"
+        if value is expected:
+            return PASS, pass_message
+        return FAIL, fail_message
+
+    return evaluator
+
+
+def evaluate_fitts(metrics: dict[str, Any]) -> tuple[str, str]:
+    missing, reason = flag_missing(metrics, ["min_target_size_px", "primary_action_reach", "critical_action_at_task_end"])
+    if missing:
+        return UNKNOWN, reason
+    size = as_number(metrics, "min_target_size_px")
+    reach = as_text(metrics, "primary_action_reach")
+    at_end = as_bool(metrics, "critical_action_at_task_end")
+    if size is None or reach is None or at_end is None:
+        return UNKNOWN, "Invalid metric types for Fitts's Law inputs."
+    good_reach = reach in {"natural", "stretch", "near", "edge"}
+    if size >= 44 and good_reach and at_end:
+        return PASS, f"min_target_size_px={size:g}, reach={reach}, critical action aligned to task end."
+    return FAIL, f"Need larger/easier targets or better placement (size={size:g}, reach={reach}, at_task_end={at_end})."
+
+
+def evaluate_hick(metrics: dict[str, Any]) -> tuple[str, str]:
+    missing, reason = flag_missing(metrics, ["screen_choice_count", "progressive_disclosure"])
+    if missing:
+        return UNKNOWN, reason
+    choices = as_number(metrics, "screen_choice_count")
+    disclosure = as_bool(metrics, "progressive_disclosure")
+    if choices is None or disclosure is None:
+        return UNKNOWN, "Invalid metric types for Hick's Law inputs."
+    if choices <= 7 and disclosure:
+        return PASS, f"screen_choice_count={choices:g}, progressive disclosure enabled."
+    return FAIL, f"Too many concurrent choices or missing progressive disclosure (choices={choices:g}, disclosure={disclosure})."
+
+
+def evaluate_miller(metrics: dict[str, Any]) -> tuple[str, str]:
+    chunk_count = as_number(metrics, "chunk_count")
+    if chunk_count is None:
+        return UNKNOWN, "Missing numeric metric: chunk_count"
+    if 3 <= chunk_count <= 9:
+        return PASS, f"chunk_count={chunk_count:g} within manageable range."
+    return FAIL, f"chunk_count={chunk_count:g} outside 3-9 chunk guidance."
+
+
+def evaluate_doherty(metrics: dict[str, Any]) -> tuple[str, str]:
+    feedback_ms = as_number(metrics, "feedback_ms_p95")
+    if feedback_ms is None:
+        return UNKNOWN, "Missing numeric metric: feedback_ms_p95"
+    if feedback_ms <= 400:
+        return PASS, f"feedback_ms_p95={feedback_ms:g}ms within threshold."
+    return FAIL, f"feedback_ms_p95={feedback_ms:g}ms exceeds 400ms; users may lose flow."
+
+
+def evaluate_focal(metrics: dict[str, Any]) -> tuple[str, str]:
+    focal_points = as_number(metrics, "focal_points")
+    if focal_points is None:
+        return UNKNOWN, "Missing numeric metric: focal_points"
+    if focal_points == 1:
+        return PASS, "Exactly one focal point present."
+    return FAIL, f"focal_points={focal_points:g}; expected exactly 1 dominant focal target."
+
+
+def evaluate_von_restorff(metrics: dict[str, Any]) -> tuple[str, str]:
+    isolates = as_number(metrics, "isolated_key_element_count")
+    if isolates is None:
+        return UNKNOWN, "Missing numeric metric: isolated_key_element_count"
+    if 1 <= isolates <= 2:
+        return PASS, f"isolated_key_element_count={isolates:g} keeps key isolation effective."
+    return FAIL, f"isolated_key_element_count={isolates:g}; isolation is either missing or overused."
+
+
+def evaluate_occam(metrics: dict[str, Any]) -> tuple[str, str]:
+    score = as_number(metrics, "simplicity_score")
+    if score is None:
+        return UNKNOWN, "Missing numeric metric: simplicity_score"
+    if score >= 80:
+        return PASS, f"simplicity_score={score:g} indicates focused scope."
+    return FAIL, f"simplicity_score={score:g}; interface likely has avoidable complexity."
+
+
+def evaluate_parkinson(metrics: dict[str, Any]) -> tuple[str, str]:
+    creep = as_bool(metrics, "scope_creep_signals")
+    if creep is None:
+        return UNKNOWN, "Missing boolean metric: scope_creep_signals"
+    if not creep:
+        return PASS, "No major scope creep signals found."
+    return FAIL, "Feature/scope creep detected; trim non-critical additions."
+
+
+def build_principles() -> list[Principle]:
+    return [
+        Principle(
+            key="fitts",
+            name="Fitts's Law",
+            weight=5,
+            mechanism="Movement time is shaped by target distance and size.",
+            requirement="Critical actions must be large and easy to reach.",
+            signal="Target size and reachability improve hit accuracy and speed.",
+            fix="Increase target size/padding and move high-value actions closer to task endpoints.",
+            evaluator=evaluate_fitts,
+        ),
+        Principle(
+            key="hick",
+            name="Hick's Law",
+            weight=5,
+            mechanism="Decision time rises as visible choices increase.",
+            requirement="Limit concurrent choices and defer advanced options.",
+            signal="Lower first-action latency and reduced decision stall.",
+            fix="Reduce choice density and introduce progressive disclosure.",
+            evaluator=evaluate_hick,
+        ),
+        Principle(
+            key="gestalt-proximity",
+            name="Gestalt: Proximity",
+            weight=4,
+            mechanism="Spatial closeness signals conceptual grouping.",
+            requirement="Related items stay close, unrelated groups stay apart.",
+            signal="Fewer label-field association errors.",
+            fix="Increase intra-group cohesion and inter-group separation.",
+            evaluator=lambda m: _range_eval(
+                m,
+                key="group_spacing_ratio",
+                lower=2.0,
+                pass_message="group_spacing_ratio supports clear grouping.",
+                fail_message="group_spacing_ratio too low; group boundaries unclear.",
+            ),
+        ),
+        Principle(
+            key="gestalt-similarity",
+            name="Gestalt: Similarity",
+            weight=4,
+            mechanism="Shared appearance implies shared function.",
+            requirement="Same component role must keep consistent styling.",
+            signal="Reduced functional misclassification.",
+            fix="Unify role-based tokens for color, shape, and typography.",
+            evaluator=make_bool_evaluator(
+                "role_style_consistency",
+                expected=True,
+                pass_message="Role styles are consistent.",
+                fail_message="Role style inconsistency likely causes behavior confusion.",
+            ),
+        ),
+        Principle(
+            key="gestalt-continuity",
+            name="Gestalt: Continuity",
+            weight=3,
+            mechanism="Eyes follow uninterrupted visual paths.",
+            requirement="Flow and continuation cues should be explicit.",
+            signal="Better discovery of next steps and off-screen content.",
+            fix="Align paths and expose continuation hints (peeking cards, steppers).",
+            evaluator=make_bool_evaluator(
+                "continuity_cue",
+                expected=True,
+                pass_message="Continuity cues are present.",
+                fail_message="Missing continuity cues reduce flow discoverability.",
+            ),
+        ),
+        Principle(
+            key="gestalt-closure",
+            name="Gestalt: Closure",
+            weight=2,
+            mechanism="Users mentally complete incomplete shapes/structures.",
+            requirement="Partial visual structures must remain interpretable.",
+            signal="Cleaner UI with intact comprehension.",
+            fix="Use simplified structure only when completion remains obvious.",
+            evaluator=make_bool_evaluator(
+                "closure_support",
+                expected=True,
+                pass_message="Closure cues are interpretable.",
+                fail_message="Insufficient closure cues make partial structures ambiguous.",
+            ),
+        ),
+        Principle(
+            key="gestalt-figure-ground",
+            name="Gestalt: Figure/Ground",
+            weight=4,
+            mechanism="Attention depends on clear foreground/background separation.",
+            requirement="Focus context should dominate via layering and contrast.",
+            signal="Lower context-loss in modal/sheet flows.",
+            fix="Strengthen scrim/layer contrast and focus hierarchy.",
+            evaluator=make_bool_evaluator(
+                "figure_ground_contrast",
+                expected=True,
+                pass_message="Figure/ground separation is clear.",
+                fail_message="Weak figure/ground separation causes focus ambiguity.",
+            ),
+        ),
+        Principle(
+            key="gestalt-common-fate",
+            name="Gestalt: Common Fate",
+            weight=3,
+            mechanism="Synchronized motion implies grouping.",
+            requirement="Related elements should animate in coordinated direction/timing.",
+            signal="Improved grouping comprehension in motion states.",
+            fix="Unify motion curves/directions for grouped elements.",
+            evaluator=make_bool_evaluator(
+                "motion_group_consistency",
+                expected=True,
+                pass_message="Motion grouping is coherent.",
+                fail_message="Motion inconsistency weakens perceived grouping.",
+            ),
+        ),
+        Principle(
+            key="gestalt-focal-point",
+            name="Gestalt: Focal Point",
+            weight=4,
+            mechanism="Contrast directs first attention.",
+            requirement="Each screen should have one dominant attention anchor.",
+            signal="Higher primary action discoverability.",
+            fix="Converge to one visual priority and demote competing accents.",
+            evaluator=evaluate_focal,
+        ),
+        Principle(
+            key="von-restorff",
+            name="Von Restorff Effect",
+            weight=3,
+            mechanism="Distinct items are more memorable than uniform items.",
+            requirement="Isolate one key action/info node from a stable baseline.",
+            signal="Higher recall and click concentration on key target.",
+            fix="Use selective contrast for one key choice, not all choices.",
+            evaluator=evaluate_von_restorff,
+        ),
+        Principle(
+            key="jakob",
+            name="Jakob's Law",
+            weight=4,
+            mechanism="Users expect familiar interaction patterns from prior products.",
+            requirement="Trust-critical flows should follow established conventions.",
+            signal="Lower navigation and auth confusion.",
+            fix="Align navigation/search/auth/checkout patterns with common standards.",
+            evaluator=make_bool_evaluator(
+                "pattern_familiarity",
+                expected=True,
+                pass_message="Conventions are preserved in critical flows.",
+                fail_message="Unfamiliar critical patterns raise cognitive onboarding cost.",
+            ),
+        ),
+        Principle(
+            key="miller",
+            name="Miller's Law",
+            weight=4,
+            mechanism="Working memory handles limited chunks concurrently.",
+            requirement="Chunk content and stage long tasks.",
+            signal="Improved completion on long forms and flows.",
+            fix="Split dense screens into smaller chunked steps.",
+            evaluator=evaluate_miller,
+        ),
+        Principle(
+            key="goal-gradient",
+            name="Goal-Gradient Hypothesis",
+            weight=3,
+            mechanism="Motivation rises as users approach completion.",
+            requirement="Progress and milestones should remain visible.",
+            signal="Completion acceleration in later steps.",
+            fix="Expose progress counters and milestone reinforcement.",
+            evaluator=make_bool_evaluator(
+                "progress_visible",
+                expected=True,
+                pass_message="Progress visibility supports motivation.",
+                fail_message="Hidden progress weakens completion momentum.",
+            ),
+        ),
+        Principle(
+            key="zeigarnik",
+            name="Zeigarnik Effect",
+            weight=3,
+            mechanism="Incomplete tasks persist in memory and drive return behavior.",
+            requirement="Unfinished states must be visible with a resume path.",
+            signal="Higher interrupted-flow recovery.",
+            fix="Expose completion status and one-click resume mechanisms.",
+            evaluator=make_bool_evaluator(
+                "unfinished_resume_path",
+                expected=True,
+                pass_message="Resume path for unfinished tasks exists.",
+                fail_message="No clear resume path for interrupted tasks.",
+            ),
+        ),
+        Principle(
+            key="tesler",
+            name="Tesler's Law",
+            weight=4,
+            mechanism="Complexity cannot be removed, only redistributed.",
+            requirement="System should absorb complexity from users.",
+            signal="Lower entry friction and cleaner structured data.",
+            fix="Use smart defaults, autocomplete, masks, and structured controls.",
+            evaluator=make_bool_evaluator(
+                "system_handles_complexity",
+                expected=True,
+                pass_message="System absorbs key complexity.",
+                fail_message="User is carrying avoidable complexity burden.",
+            ),
+        ),
+        Principle(
+            key="peak-end",
+            name="Peak-End Rule",
+            weight=4,
+            mechanism="Users remember the peak and the ending disproportionately.",
+            requirement="Final states should be explicit and confidence-building.",
+            signal="Higher satisfaction and reduced uncertainty after submit.",
+            fix="Add clear success/failure closure with next-step guidance.",
+            evaluator=make_bool_evaluator(
+                "positive_end_state",
+                expected=True,
+                pass_message="Ending experience provides clear closure.",
+                fail_message="Weak ending state likely harms recall and trust.",
+            ),
+        ),
+        Principle(
+            key="postel",
+            name="Postel's Law",
+            weight=4,
+            mechanism="Robust systems accept varied input but emit consistent output.",
+            requirement="Input parsing should tolerate common human variations.",
+            signal="Fewer avoidable validation dead-ends.",
+            fix="Support tolerant parsing and provide precise recovery guidance.",
+            evaluator=make_bool_evaluator(
+                "input_tolerant_parsing",
+                expected=True,
+                pass_message="Input handling is tolerant and structured.",
+                fail_message="Rigid input handling likely punishes normal user variations.",
+            ),
+        ),
+        Principle(
+            key="doherty",
+            name="Doherty Threshold",
+            weight=5,
+            mechanism="Fast feedback preserves cognitive flow and productivity.",
+            requirement="Interactions should acknowledge user intent rapidly.",
+            signal="Reduced duplicate taps and waiting confusion.",
+            fix="Provide immediate visual acknowledgment and optimize perceived speed.",
+            evaluator=evaluate_doherty,
+        ),
+        Principle(
+            key="serial-position",
+            name="Serial Position Effect",
+            weight=3,
+            mechanism="First and last sequence items are recalled best.",
+            requirement="Place critical actions/info at sequence boundaries.",
+            signal="Higher discovery/recall of key actions.",
+            fix="Move top-priority actions to start/end positions.",
+            evaluator=make_bool_evaluator(
+                "critical_actions_boundary_placement",
+                expected=True,
+                pass_message="Critical actions are at memorable boundaries.",
+                fail_message="Critical actions are buried in low-recall positions.",
+            ),
+        ),
+        Principle(
+            key="occam",
+            name="Occam's Razor",
+            weight=3,
+            mechanism="Simpler sufficient solutions reduce cognitive load.",
+            requirement="Remove non-essential UI and interaction burden.",
+            signal="Faster task completion and fewer distractions.",
+            fix="Trim unnecessary states/features and simplify task path.",
+            evaluator=evaluate_occam,
+        ),
+        Principle(
+            key="parkinson",
+            name="Parkinson's Law",
+            weight=2,
+            mechanism="Work expands without explicit constraints.",
+            requirement="Guard against feature creep in delivery scope.",
+            signal="Lean implementation aligned to user goal.",
+            fix="Enforce MVP boundaries and defer non-critical additions.",
+            evaluator=evaluate_parkinson,
+        ),
+    ]
+
+
+def _range_eval(
+    metrics: dict[str, Any],
+    key: str,
+    lower: float | None = None,
+    upper: float | None = None,
+    pass_message: str = "Range check passed.",
+    fail_message: str = "Range check failed.",
+) -> tuple[str, str]:
+    value = as_number(metrics, key)
+    if value is None:
+        return UNKNOWN, f"Missing numeric metric: {key}"
+    if lower is not None and value < lower:
+        return FAIL, f"{fail_message} ({key}={value:g}, lower={lower:g})"
+    if upper is not None and value > upper:
+        return FAIL, f"{fail_message} ({key}={value:g}, upper={upper:g})"
+    return PASS, f"{pass_message} ({key}={value:g})"
+
+
+def build_gate_checks() -> list[GateCheck]:
+    return [
+        GateCheck(
+            key="one-primary-cta",
+            title="Single dominant primary CTA",
+            evaluator=lambda m: _range_eval(
+                m,
+                key="primary_cta_count",
+                lower=1,
+                upper=1,
+                pass_message="Exactly one primary CTA found.",
+                fail_message="Need exactly one primary CTA.",
+            ),
+            fix="Keep one dominant primary action and demote secondary actions.",
+        ),
+        GateCheck(
+            key="touch-target-size",
+            title="Critical touch targets >= 44px",
+            evaluator=lambda m: _range_eval(
+                m,
+                key="min_target_size_px",
+                lower=44,
+                pass_message="Target size meets minimum threshold.",
+                fail_message="Target size below threshold.",
+            ),
+            fix="Increase hit area (padding/wrapper) for critical controls.",
+        ),
+        GateCheck(
+            key="task-end-action-placement",
+            title="Primary completion action at task endpoint",
+            evaluator=make_bool_evaluator(
+                "critical_action_at_task_end",
+                expected=True,
+                pass_message="Completion action aligns with task endpoint.",
+                fail_message="Completion action placement breaks task flow.",
+            ),
+            fix="Place submit/continue where user naturally finishes the task.",
+        ),
+        GateCheck(
+            key="choice-density",
+            title="Choice density <= 7 visible options",
+            evaluator=lambda m: _range_eval(
+                m,
+                key="screen_choice_count",
+                upper=7,
+                pass_message="Choice density is manageable.",
+                fail_message="Too many visible choices.",
+            ),
+            fix="Reduce options and defer advanced paths with progressive disclosure.",
+        ),
+        GateCheck(
+            key="progress-visible",
+            title="Progress visible on multi-step flows",
+            evaluator=make_bool_evaluator(
+                "progress_visible",
+                expected=True,
+                pass_message="Progress indicators are visible.",
+                fail_message="Progress indicators are missing or unclear.",
+            ),
+            fix="Add stepper/progress bar/counter for staged tasks.",
+        ),
+        GateCheck(
+            key="fast-feedback",
+            title="Interaction feedback <= 400ms p95",
+            evaluator=evaluate_doherty,
+            fix="Show immediate pressed/loading feedback and reduce response latency.",
+        ),
+        GateCheck(
+            key="inline-validation",
+            title="Validation rules visible with inline recovery",
+            evaluator=make_bool_evaluator(
+                "inline_validation_clear",
+                expected=True,
+                pass_message="Validation behavior is clear and inline.",
+                fail_message="Validation guidance is hidden or vague.",
+            ),
+            fix="Show requirements before submit and field-level actionable errors.",
+        ),
+        GateCheck(
+            key="input-tolerant",
+            title="Input tolerance and normalization",
+            evaluator=make_bool_evaluator(
+                "input_tolerant_parsing",
+                expected=True,
+                pass_message="Input parsing handles common variations.",
+                fail_message="Input handling is brittle for normal human formats.",
+            ),
+            fix="Accept common formats and normalize internally.",
+        ),
+        GateCheck(
+            key="boundary-placement",
+            title="Critical actions are at list/menu boundaries",
+            evaluator=make_bool_evaluator(
+                "critical_actions_boundary_placement",
+                expected=True,
+                pass_message="Critical actions use high-recall positions.",
+                fail_message="Critical actions are placed in low-recall mid positions.",
+            ),
+            fix="Move high-priority actions to beginning or end positions.",
+        ),
+        GateCheck(
+            key="clear-ending",
+            title="Explicit positive ending/closure",
+            evaluator=make_bool_evaluator(
+                "positive_end_state",
+                expected=True,
+                pass_message="Flow ending provides clear closure.",
+                fail_message="Ending lacks confidence and closure feedback.",
+            ),
+            fix="Add success/failure confirmation and next-step guidance.",
+        ),
+    ]
+
+
+def build_template() -> dict[str, Any]:
+    return {
+        "meta": {
+            "project": "example-product",
+            "flow": "signup",
+            "auditor": "your-name",
+            "notes": "Fill measured values before running strict mode.",
+        },
+        "metrics": {
+            "primary_cta_count": 1,
+            "min_target_size_px": 44,
+            "primary_action_reach": "natural",
+            "critical_action_at_task_end": True,
+            "screen_choice_count": 6,
+            "progressive_disclosure": True,
+            "group_spacing_ratio": 2.0,
+            "role_style_consistency": True,
+            "continuity_cue": True,
+            "closure_support": True,
+            "figure_ground_contrast": True,
+            "motion_group_consistency": True,
+            "focal_points": 1,
+            "isolated_key_element_count": 1,
+            "pattern_familiarity": True,
+            "chunk_count": 6,
+            "progress_visible": True,
+            "unfinished_resume_path": True,
+            "system_handles_complexity": True,
+            "positive_end_state": True,
+            "input_tolerant_parsing": True,
+            "feedback_ms_p95": 300,
+            "critical_actions_boundary_placement": True,
+            "inline_validation_clear": True,
+            "simplicity_score": 85,
+            "scope_creep_signals": False,
+        },
+    }
+
+
+def evaluate_principles(metrics: dict[str, Any], principles: list[Principle]) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    for principle in principles:
+        status, diagnosis = principle.evaluator(metrics)
+        results.append(
+            {
+                "key": principle.key,
+                "name": principle.name,
+                "weight": principle.weight,
+                "status": status,
+                "diagnosis": diagnosis,
+                "mechanism": principle.mechanism,
+                "requirement": principle.requirement,
+                "signal": principle.signal,
+                "fix": principle.fix,
+            }
+        )
+    return results
+
+
+def evaluate_gates(metrics: dict[str, Any], gates: list[GateCheck]) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    for gate in gates:
+        status, evidence = gate.evaluator(metrics)
+        results.append(
+            {
+                "key": gate.key,
+                "title": gate.title,
+                "status": status,
+                "evidence": evidence,
+                "fix": gate.fix,
+            }
+        )
+    return results
+
+
+def compute_score(results: list[dict[str, Any]]) -> float:
+    total_weight = sum(result["weight"] for result in results)
+    if total_weight == 0:
+        return 0.0
+    weighted_points = 0.0
+    for result in results:
+        points = STATUS_POINTS.get(result["status"], 0.0)
+        weighted_points += result["weight"] * points
+    return round((weighted_points / total_weight) * 100.0, 2)
+
+
+def status_emoji(status: str) -> str:
+    if status == PASS:
+        return "PASS"
+    if status == FAIL:
+        return "FAIL"
+    return "UNKNOWN"
+
+
+def classify_priority(result: dict[str, Any]) -> str:
+    if result["status"] != FAIL:
+        return ""
+    weight = result["weight"]
+    if weight >= 5:
+        return "P0"
+    if weight >= 4:
+        return "P1"
+    return "P2"
+
+
+def render_report(
+    meta: dict[str, Any],
+    gate_results: list[dict[str, Any]],
+    principle_results: list[dict[str, Any]],
+    score: float,
+) -> str:
+    now = datetime.now(timezone.utc).isoformat()
+    gate_failures = [row for row in gate_results if row["status"] == FAIL]
+    unknown_principles = [row for row in principle_results if row["status"] == UNKNOWN]
+    priorities = [row for row in principle_results if row["status"] == FAIL]
+    priorities.sort(key=lambda row: row["weight"], reverse=True)
+
+    lines: list[str] = []
+    lines.append("# Frontend Human-Centered Law Audit")
+    lines.append("")
+    lines.append(f"- Generated (UTC): {now}")
+    lines.append(f"- Project: {meta.get('project', 'unknown')}")
+    lines.append(f"- Flow: {meta.get('flow', 'unknown')}")
+    lines.append(f"- Auditor: {meta.get('auditor', 'unknown')}")
+    lines.append("")
+    lines.append("## Summary")
+    lines.append("")
+    lines.append(f"- Overall score: **{score:.2f}/100**")
+    lines.append(f"- Fast gate failures: **{len(gate_failures)}** / {len(gate_results)}")
+    lines.append(f"- Principle failures: **{len(priorities)}** / {len(principle_results)}")
+    lines.append(f"- Unknown principle checks: **{len(unknown_principles)}**")
+    lines.append("")
+    lines.append("## Fast Gate")
+    lines.append("")
+    lines.append("| Check | Status | Evidence | Fix |")
+    lines.append("|---|---|---|---|")
+    for gate in gate_results:
+        lines.append(
+            f"| {gate['title']} | {status_emoji(gate['status'])} | {gate['evidence']} | {gate['fix']} |"
+        )
+    lines.append("")
+    lines.append("## Principle Results")
+    lines.append("")
+    lines.append("| Priority | Principle | Status | Weight | Diagnosis | Required change |")
+    lines.append("|---|---|---|---:|---|---|")
+    for result in principle_results:
+        priority = classify_priority(result)
+        lines.append(
+            f"| {priority} | {result['name']} | {status_emoji(result['status'])} | {result['weight']} | {result['diagnosis']} | {result['fix']} |"
+        )
+    lines.append("")
+    lines.append("## Priority Fix Backlog")
+    lines.append("")
+    if priorities:
+        for result in priorities:
+            priority = classify_priority(result)
+            lines.append(f"- **{priority} {result['name']}**: {result['diagnosis']}")
+            lines.append(f"  - Why it matters: {result['mechanism']}")
+            lines.append(f"  - Acceptance target: {result['signal']}")
+            lines.append(f"  - Fix: {result['fix']}")
+    else:
+        lines.append("- No failed principles. Keep regression checks in CI.")
+    lines.append("")
+    if unknown_principles:
+        lines.append("## Data Gaps")
+        lines.append("")
+        for result in unknown_principles:
+            lines.append(f"- **{result['name']}**: {result['diagnosis']}")
+        lines.append("")
+    lines.append("## Recheck Criteria")
+    lines.append("")
+    lines.append("- Fast gate failures must be zero.")
+    lines.append("- Overall score should meet or exceed team threshold.")
+    lines.append("- Unknown checks should be resolved by adding missing evidence.")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def load_input(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("Input JSON must be an object.")
+    meta = payload.get("meta")
+    metrics = payload.get("metrics")
+    if not isinstance(meta, dict):
+        raise ValueError("Input JSON must include object field: meta")
+    if not isinstance(metrics, dict):
+        raise ValueError("Input JSON must include object field: metrics")
+    return payload
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Audit frontend evidence against human-centered design laws.")
+    parser.add_argument("--input", type=Path, help="Path to evidence JSON.")
+    parser.add_argument("--output", type=Path, help="Path to markdown report output.")
+    parser.add_argument("--json-out", type=Path, help="Optional JSON results output path.")
+    parser.add_argument("--strict", action="store_true", help="Return non-zero when gate/score threshold fails.")
+    parser.add_argument("--fail-threshold", type=float, default=85.0, help="Minimum score required in strict mode.")
+    parser.add_argument("--init-template", type=Path, help="Write a template evidence JSON to this path and exit.")
+    args = parser.parse_args()
+
+    if args.init_template:
+        template = build_template()
+        write_json(args.init_template, template)
+        print(f"Wrote template evidence JSON: {args.init_template}")
+        return 0
+
+    if not args.input:
+        parser.error("--input is required unless --init-template is used.")
+
+    payload = load_input(args.input)
+    meta = payload["meta"]
+    metrics = payload["metrics"]
+
+    principles = build_principles()
+    gates = build_gate_checks()
+    principle_results = evaluate_principles(metrics, principles)
+    gate_results = evaluate_gates(metrics, gates)
+    score = compute_score(principle_results)
+    report = render_report(meta, gate_results, principle_results, score)
+
+    if args.output:
+        args.output.write_text(report + "\n", encoding="utf-8")
+        print(f"Wrote markdown report: {args.output}")
+    else:
+        print(report)
+
+    result_payload = {
+        "meta": meta,
+        "score": score,
+        "gate_results": gate_results,
+        "principle_results": principle_results,
+        "strict_threshold": args.fail_threshold,
+    }
+    if args.json_out:
+        write_json(args.json_out, result_payload)
+        print(f"Wrote JSON results: {args.json_out}")
+
+    if args.strict:
+        gate_failures = sum(1 for gate in gate_results if gate["status"] == FAIL)
+        if gate_failures > 0 or score < args.fail_threshold:
+            print(
+                f"Strict mode failed: gate_failures={gate_failures}, score={score:.2f}, threshold={args.fail_threshold:.2f}",
+            )
+            return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/frontend-law-auditor/scripts/law_audit.py
+++ b/skills/frontend-law-auditor/scripts/law_audit.py
@@ -24,6 +24,30 @@ STATUS_POINTS = {
     UNKNOWN: 0.4,
 }
 
+RULE_FILE_MAP = {
+    "fitts": "fitts-law.md",
+    "hick": "hicks-law.md",
+    "gestalt-proximity": "gestalt-proximity.md",
+    "gestalt-similarity": "gestalt-similarity.md",
+    "gestalt-continuity": "gestalt-continuity.md",
+    "gestalt-closure": "gestalt-closure.md",
+    "gestalt-figure-ground": "gestalt-figure-ground.md",
+    "gestalt-common-fate": "gestalt-common-fate.md",
+    "gestalt-focal-point": "gestalt-focal-point.md",
+    "von-restorff": "von-restorff-effect.md",
+    "jakob": "jakobs-law.md",
+    "miller": "millers-law.md",
+    "goal-gradient": "goal-gradient-hypothesis.md",
+    "zeigarnik": "zeigarnik-effect.md",
+    "tesler": "teslers-law.md",
+    "peak-end": "peak-end-rule.md",
+    "postel": "postels-law.md",
+    "doherty": "doherty-threshold.md",
+    "serial-position": "serial-position-effect.md",
+    "occam": "occams-razor.md",
+    "parkinson": "parkinsons-law.md",
+}
+
 
 @dataclass
 class Principle:
@@ -628,6 +652,7 @@ def evaluate_principles(metrics: dict[str, Any], principles: list[Principle]) ->
     results: list[dict[str, Any]] = []
     for principle in principles:
         status, diagnosis = principle.evaluator(metrics)
+        rule_file = RULE_FILE_MAP.get(principle.key, f"{principle.key}.md")
         results.append(
             {
                 "key": principle.key,
@@ -639,6 +664,7 @@ def evaluate_principles(metrics: dict[str, Any], principles: list[Principle]) ->
                 "requirement": principle.requirement,
                 "signal": principle.signal,
                 "fix": principle.fix,
+                "rule_file": f"rules/{rule_file}",
             }
         )
     return results
@@ -728,12 +754,12 @@ def render_report(
     lines.append("")
     lines.append("## Principle Results")
     lines.append("")
-    lines.append("| Priority | Principle | Status | Weight | Diagnosis | Required change |")
-    lines.append("|---|---|---|---:|---|---|")
+    lines.append("| Priority | Principle | Status | Weight | Rule | Diagnosis | Required change |")
+    lines.append("|---|---|---|---:|---|---|---|")
     for result in principle_results:
         priority = classify_priority(result)
         lines.append(
-            f"| {priority} | {result['name']} | {status_emoji(result['status'])} | {result['weight']} | {result['diagnosis']} | {result['fix']} |"
+            f"| {priority} | {result['name']} | {status_emoji(result['status'])} | {result['weight']} | `{result['rule_file']}` | {result['diagnosis']} | {result['fix']} |"
         )
     lines.append("")
     lines.append("## Priority Fix Backlog")
@@ -742,6 +768,7 @@ def render_report(
         for result in priorities:
             priority = classify_priority(result)
             lines.append(f"- **{priority} {result['name']}**: {result['diagnosis']}")
+            lines.append(f"  - Rule: `{result['rule_file']}`")
             lines.append(f"  - Why it matters: {result['mechanism']}")
             lines.append(f"  - Acceptance target: {result['signal']}")
             lines.append(f"  - Fix: {result['fix']}")


### PR DESCRIPTION
## Summary

### frontend-law-auditor (new)
- Add a new human-centered frontend audit skill based on established UX/cognitive laws
- Include an executable audit script with strict gating support for CI (`scripts/law_audit.py`)
- Add rulebook architecture (`rules/`) with per-law guidance and remediation patterns
- Add references and example evidence schema for repeatable audits

### Repository updates
- Add `frontend-law-auditor` to `.claude-plugin/marketplace.json` under `example-skills`
- Improve `README.md` references to include the new frontend audit capability
- Add `LICENSE.txt` for the new skill package

## Test plan
- [x] `python3 skills/frontend-law-auditor/scripts/law_audit.py --help`
- [x] `python3 skills/frontend-law-auditor/scripts/law_audit.py --input skills/frontend-law-auditor/examples/evidence.sample.json --output /tmp/frontend-audit.md --json-out /tmp/frontend-audit.json`
- [x] `python3 -m py_compile skills/frontend-law-auditor/scripts/law_audit.py`
- [x] `python3 -m json.tool .claude-plugin/marketplace.json`