### PR TITLE
Add notemdpro skill and update example skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -23,7 +23,7 @@
     },
     {
       "name": "example-skills",
-      "description": "Collection of example skills demonstrating various capabilities including skill creation, MCP building, visual design, algorithmic art, internal communications, web testing, artifact building, Slack GIFs, and theme styling",
+      "description": "Collection of example skills demonstrating various capabilities including skill creation, MCP building, visual design, markdown knowledge workflows, algorithmic art, internal communications, web testing, artifact building, Slack GIFs, and theme styling",
       "source": "./",
       "strict": false,
       "skills": [
@@ -34,6 +34,7 @@
         "./skills/frontend-design",
         "./skills/internal-comms",
         "./skills/mcp-builder",
+        "./skills/notemdpro",
         "./skills/skill-creator",
         "./skills/slack-gif-creator",
         "./skills/theme-factory",

--- a/skills/notemdpro/LICENSE.txt
+++ b/skills/notemdpro/LICENSE.txt
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/skills/notemdpro/SKILL.md
+++ b/skills/notemdpro/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: notemdpro
+description: "NoteMD Pro skill pack for markdown knowledge workflows: linking, generation, research, translation, concept extraction, diagram generation, and syntax healing."
+license: Complete terms in LICENSE.txt
+---
+
+# NoteMD Pro - Skill Router
+
+## Overview
+
+`notemdpro` is a portable skill library that mirrors modern NotEMD workflows for non-Obsidian runtimes.
+Use this file as the top-level router to select the correct skill folder.
+
+## Workflow Decision Tree
+
+### Content + Knowledge Graph
+- Add wiki-links to existing notes -> `skills/link-analyzer/SKILL.md`
+- Generate long-form content from title/topic -> `skills/content-generator/SKILL.md`
+- Extract core concepts from documents -> `skills/concept-extractor/SKILL.md`
+- Process a selected excerpt instead of full file -> `skills/selection-processor/SKILL.md`
+
+### Research + Translation
+- Perform web research and summarize findings -> `skills/web-researcher/SKILL.md`
+- Translate documents while preserving markdown -> `skills/text-translator/SKILL.md`
+
+### Diagram Workflows
+- Summarize document into Mermaid mindmap -> `skills/mermaid-summarizer/SKILL.md`
+- Generate canonical diagram flow (NotEMD parity): `generate-diagram`
+- Legacy compatibility alias (NotEMD parity): `generate-experimental-diagram` -> normalize to `generate-diagram`
+- Preview command parity reference: `preview-diagram` (UI/runtime-specific in plugin; keep as conceptual action in skill docs)
+
+### Syntax Healing
+- Heal Mermaid syntax with regex-first pipeline -> `skills/mermaid-healer/SKILL.md`
+- Heal LaTeX math formatting -> `skills/formula-healer/SKILL.md`
+
+### Extraction + Batch
+- Extract Q&A or targeted passages -> `skills/qa-extractor/SKILL.md`
+- Run workflows over many files safely -> `skills/batch-processor/SKILL.md`
+
+### Architecture + Engineering
+- Understand system composition and call chains -> `skills/system-architecture/SKILL.md`
+- Apply TDD workflow for new changes -> `skills/test-driven-development/SKILL.md`
+
+## Skills Index
+
+| Skill Folder | Purpose |
+| --- | --- |
+| `skills/link-analyzer` | Add/update `[[wiki-links]]` in markdown |
+| `skills/content-generator` | Generate technical markdown from title/topic |
+| `skills/web-researcher` | Web research + synthesis |
+| `skills/text-translator` | Translate markdown content |
+| `skills/concept-extractor` | Extract concept nodes for graph building |
+| `skills/qa-extractor` | Extract answers from reference text |
+| `skills/selection-processor` | Process selected text spans only |
+| `skills/mermaid-summarizer` | Create Mermaid summary diagrams |
+| `skills/mermaid-healer` | Repair Mermaid syntax |
+| `skills/formula-healer` | Repair LaTeX syntax |
+| `skills/batch-processor` | Batch execution patterns |
+| `skills/system-architecture` | Runtime architecture map |
+| `skills/test-driven-development` | TDD planning and execution |
+
+## Prompt Variable Reference
+
+| Variable | Typical Use |
+| --- | --- |
+| `{TITLE}` | Title-driven generation |
+| `{LANGUAGE}` | Translation/target output language |
+| `{TEXT}` | Raw content payload |
+| `{REFERENCE_CONTENT}` | Reference corpus for extraction |
+| `{USER_INPUT}` | Query/question payload |
+| `{TOPIC}` | Research topic |
+| `{SEARCH_RESULTS_CONTEXT}` | Search snippets/context |
+
+## Notes
+
+- Keep workflows file-system agnostic: avoid direct Obsidian API assumptions when running outside plugin runtime.
+- For diagram command migration, prefer canonical action naming (`generate-diagram`, `preview-diagram`) and keep legacy alias compatibility where needed.

--- a/skills/notemdpro/skills/batch-processor/SKILL.md
+++ b/skills/notemdpro/skills/batch-processor/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: batch-processor
+description: "Use when processing 10+ markdown files in bulk, encountering HTTP 429 rate limits, or needing OOM-safe Base64 sanitization before LLM chunking"
+---
+
+# NoteMD Pro - Batch Processing
+
+## Overview
+
+This skill provides utilities for batch processing multiple markdown files with proper concurrency control, rate limiting, and error handling. It prevents API rate limits and ensures stable processing of large vaults.
+
+## When to Use
+
+- **Large vault migrations**: Process 100+ files
+- **Bulk operations**: Translate, generate, or extract from multiple files
+- **Rate limit prevention**: Avoid overwhelming LLM APIs
+- **Progress tracking**: Monitor batch progress
+
+## Key Functions (from utils.ts)
+
+### createConcurrentProcessor
+
+Creates a concurrent processor with staggered task execution.
+
+```typescript
+export function createConcurrentProcessor<T, R>(
+  concurrency: number,
+  apiCallIntervalMs: number,
+  progressReporter: ProgressReporter,
+): (tasks: (() => Promise<T>)[]) => Promise<R[]>;
+
+// Features:
+// - Staggered worker start (prevents burst)
+// - Progress reporting
+// - Cancellation support
+// - Result ordering
+```
+
+### chunkArray
+
+Splits an array into chunks of specified size.
+
+```typescript
+export function chunkArray<T>(arr: T[], size: number): T[][];
+
+// Example:
+chunkArray([1, 2, 3, 4, 5, 6, 7, 8], 3);
+// Returns: [[1,2,3], [4,5,6], [7,8]]
+```
+
+### retry
+
+Retry with exponential backoff.
+
+```typescript
+export async function retry<T>(
+  fn: () => Promise<T>,
+  maxRetries?: number,
+  delayMs?: number,
+  signal?: AbortSignal,
+): Promise<T>;
+
+// Features:
+// - Exponential backoff (delay * 2^i)
+// - Abort signal support
+// - Error propagation
+```
+
+## Batch Processing Flow
+
+```
+batchOperation
+├── Get list of files
+├── Create concurrent processor
+├── Create task functions
+│   └── For each file
+│       └── Process file
+├── Execute with staggered start
+├── Handle errors per file
+└── Collect results
+```
+
+## Settings
+
+### Concurrency Settings
+
+| Setting                  | Description                     | Default |
+| ------------------------ | ------------------------------- | ------- |
+| `enableBatchParallelism` | Enable parallel processing      | false   |
+| `batchConcurrency`       | Number of concurrent operations | 1       |
+| `batchSize`              | Files per batch                 | 10      |
+| `batchInterDelayMs`      | Delay between batches           | 1000    |
+| `apiCallIntervalMs`      | Delay between API calls         | 0       |
+
+### API Stability
+
+| Setting               | Description                 |
+| --------------------- | --------------------------- |
+| `enableStableApiCall` | Enable stable API calls     |
+| `apiCallInterval`     | Interval between calls (ms) |
+| `apiCallMaxRetries`   | Max retry attempts          |
+
+## Concurrency Strategy
+
+### Staggered Start
+
+Instead of starting all workers at once, workers are started with delays:
+
+```
+Worker 0: starts at 0ms
+Worker 1: starts at interval * 1ms
+Worker 2: starts at interval * 2ms
+...
+Worker N: starts at interval * Nms
+```
+
+This prevents API rate limits by distributing requests over time.
+
+### Inter-batch Delays
+
+For very large batches, delays between batches prevent overwhelming APIs:
+
+```
+Batch 1: [====] → delay → Batch 2: [====] → delay → Batch 3: [====]
+```
+
+## Error Handling Strategy
+
+### Per-File Errors
+
+Each file is processed independently. Errors don't stop the entire batch:
+
+```typescript
+try {
+  await processFile(file);
+  results.push({ file, success: true });
+} catch (error) {
+  results.push({ file, success: false, error });
+}
+```
+
+### Retry Logic
+
+For transient errors (network, rate limits), use exponential backoff:
+
+```
+Attempt 1: wait 1000ms
+Attempt 2: wait 2000ms
+Attempt 3: wait 4000ms
+```
+
+### 🛑 Fatal Errors & HTTP 429 (Independent Operation)
+
+When running as an independent AI agent, you must rigorously guard against LLM API failures:
+
+1. **HTTP 429 (Rate Limit Exceeded)**: Immeadiately pause the batch processor. Do not rely on naive retries if the bucket is exhausted. Implement a generic `AbortSignal` to gracefully halt the queue.
+2. **Gateway Timeouts/502**: API providers often return HTML instead of JSON during outages. Wrap all `JSON.parse` or provider SDK calls in resilient `try/catch` blocks that log the raw text to `error_processing_filename.log` before aborting.
+
+### Persistent Error Logging (saveErrorLog)
+
+> [!IMPORTANT] Essential Debugging Output
+> The `notemd-batch` processor utilizes `saveErrorLog` (from `fileUtils.ts`) to write detailed stack traces to `error_processing_filename.log` in the Vault root. When acting as an AI Agent, if a user reports a batch failure, you MUST proactively read this log file to secure the stack trace rather than asking the user for screenshots.
+
+### Progress Reporting
+
+```typescript
+progressReporter.log(`Processing file ${i}/${total}: ${file.name}`);
+progressReporter.updateStatus(`Processing...`, Math.floor((i / total) * 100));
+progressReporter.updateActiveTasks(1); // Increment active tasks
+```
+
+## Usage Example
+
+```typescript
+import { createConcurrentProcessor, chunkArray, delay } from "./utils";
+
+// Settings
+const concurrency = 5;
+const apiCallIntervalMs = 1000;
+const batchSize = 10;
+
+// Get files
+const files = app.vault.getMarkdownFiles();
+
+// Create processor
+const processor = createConcurrentProcessor(
+  concurrency,
+  apiCallIntervalMs,
+  progressReporter,
+);
+
+// Create tasks
+const tasks = files.map((file) => async () => {
+  await processFile(file, settings, progressReporter);
+  return { file: file.name, success: true };
+});
+
+// Process in batches
+const fileBatches = chunkArray(tasks, batchSize);
+for (const batch of fileBatches) {
+  const results = await processor(batch);
+
+  // Handle batch results
+  const errors = results.filter((r) => !r.success);
+  if (errors.length > 0) {
+    console.log(`Batch had ${errors.length} errors`);
+  }
+
+  // Delay between batches
+  await delay(1000);
+}
+```
+
+## Best Practices
+
+1. **Start with low concurrency**: Test with 1-3 concurrent operations
+2. **Monitor rate limits**: Adjust delays based on API responses
+3. **Use meaningful progress messages**: Help users understand status
+4. **Collect errors**: Don't fail fast; collect all errors for review
+5. **Implement cancellation**: Allow users to stop long-running batches
+6. **Log every N files**: Don't log every file; log every 10-50
+
+## Common Issues
+
+### Rate Limit (429)
+
+- **Symptom**: API returns 429 error
+- **Solution**: Increase `apiCallIntervalMs`, reduce `batchConcurrency`
+
+### Timeout
+
+- **Symptom**: Request times out
+- **Solution**: Increase timeout settings, check network
+
+### Memory Issues & OOM Avoidance
+
+- **Symptom**: Heap Out of Memory (OOM) with large vaults or large files.
+- **Root Cause**: `splitContent` attempts to chunk by word count, which fails completely if the Markdown file contains massive Base64 encoded images `(![[data:image/png;base64,...]])`. This causes massive strings to be cloned in memory during parallel processing.
+- **Solution (Mandatory Pre-processing)**:
+  1. **Base64 Sanitization**: Before passing any file to the chunker, strip or replace Base64 strings with a placeholder.
+  2. Reduce `batchSize` heavily (e.g., to 2).
+  3. Reduce `batchConcurrency` to 1 for extremely large vaults.
+
+### 🧠 Token-Safe Chunking Guidelines
+
+When building an independent implementation of `splitContent`, the AI **MUST NOT** blindly slice strings at the Nth character or word.
+
+1. **Never Split Code Fences**: Do not split inside ` ``` ... ``` ` blocks.
+2. **Never Split LaTeX**: Do not split inside `$$ ... $$` math blocks.
+3. **Never Split Frontmatter**: Do not split inside the YAML `---` header.
+4. **Safe Boundaries**: Always attempt to split at Markdown headers (`##`, `###`) or at least at double newlines `\n\n`.

--- a/skills/notemdpro/skills/concept-extractor/SKILL.md
+++ b/skills/notemdpro/skills/concept-extractor/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: concept-extractor
+description: "Use to exhaustively extract core knowledge concepts, scientific terms, and specialized vocabulary from a document to build a comprehensive wiki-linked knowledge graph."
+---
+
+# NoteMD Pro - Concept Extraction (Agentic Workflow)
+
+## Overview
+
+This skill transforms standard Markdown text into an interconnected Knowledge Graph by **exhaustively** extracting every relevant concept and generating atomic notes with proper backlinks.
+
+## ⚠️ Critical Rule: Exhaustive Extraction
+
+When executing this skill, **DO NOT STOP at 3 to 5 concepts**. You must thoroughly scan the entire document and extract **every single** core knowledge point, technical term, scientific principle, proper noun, and specialized vocabulary word. A comprehensive document (e.g., 1000 words) might yield 15-30 distinct concepts.
+
+Your goal is to be as complete and reasonable as possible, ensuring the end-user's Knowledge Graph is densely populated and highly interconnected.
+
+## Step-by-Step Agent Instructions
+
+When the user asks you to extract concepts from a specific Markdown file (or text), follow these steps strictly:
+
+### Step 1: Comprehensive Parsing
+
+Read the entire target document thoroughly. Mentally (or in your scratchpad) list every concept following these criteria:
+
+- **Scientific & Technical Terms:** e.g., "DNA Replication", "Ribosome", "Stellar Nucleosynthesis", "Isotope", "Spectroscopy", "Amino Acid".
+- **Theories & Principles:** e.g., "Statistical Mechanics", "Conservation of Energy".
+- **Proper Nouns & Tools:** e.g., "Tesseract OCR", "Python multiprocessing", "Markdown".
+- **Abstract Concepts:** Limit abstract ideas unless they are central to the domain. Focus on specific noun-phrases.
+- **Normalization:** Always normalize to the singular form (e.g., "Isotope" instead of "Isotopes") and capitalize Title Case (e.g., "DNA Replication").
+
+### Step 2: Generate Atomic Concept Notes
+
+For _every single concept_ you identified in Step 1, create a separate atomic note file in the target directory (often a `Concepts/` folder or the same folder as the source).
+
+**Filename:** `[Concept Name].md`
+
+**Content Format:**
+
+```markdown
+# [Concept Name]
+
+Brief 1-2 sentence definition or summary of the concept (derive this from your internal knowledge base or the source text context).
+
+## Linked From
+
+- [[Name of the Original Source File]]
+```
+
+_(Note: Always append the exact name of the file you are extracting from to the `## Linked From` section, wrapped in `[[wiki-links]]`)_
+
+### Step 3: Inject Wiki-Links into Source
+
+After creating the atomic concept notes, you must run the `link-analyzer` skill (or do it manually if instructed) to go back into the original source file and wrap the occurrences of those concepts with Obsidian wiki-links: `[[Concept Name|original text]]`.
+
+---
+
+## Output Quality Checklist for the Agent
+
+- [ ] Did I extract _all_ possible valid concepts, or did I stop early out of laziness? (Aim for exhaustive depth).
+- [ ] Are the concepts normalized to singular, Title Case forms?
+- [ ] Did I create an individual `.md` file for every extracted concept?
+- [ ] Did I add the `## Linked From` backlink in every concept note?

--- a/skills/notemdpro/skills/content-generator/SKILL.md
+++ b/skills/notemdpro/skills/content-generator/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: content-generator
+description: "Use when a note has only a title and needs comprehensive AI-generated content, optionally enriched with web research context"
+---
+
+# NoteMD Pro - Generate Content from Title
+
+## Overview
+
+This feature generates comprehensive content for a note based solely on its title. It can optionally perform web research first, then generates detailed documentation including explanations, tables, equations (LaTeX), and Mermaid diagrams.
+
+## When to Use
+
+- **Create new notes**: Generate detailed content from a title
+- **Expand outlines**: Turn brief titles into full documents
+- **Research summaries**: Get comprehensive overviews with web context
+- **Technical docs**: Generate scientific/technical documentation
+
+## Function Call Chain
+
+```
+generateContentForTitle (fileUtils.ts)
+├── getProviderForTask('generateTitle', settings)
+├── _performResearch(app, settings, title, reporter)  [IF enabled]
+│   ├── SearchManager.getProvider
+│   ├── provider.search(query)
+│   └── fetchContentFromUrl(url)
+├── call[Provider]API(prompt, title + researchContext)
+├── cleanupLatexDelimiters(content)
+├── refineMermaidBlocks(content)  ← AUTO-FIX
+└── fixMermaidSyntaxInFile(outputPath, reporter)  ← AUTO-RUN AFTER LLM
+    └── checkMermaidErrors(content)
+```
+
+## Key Functions (from fileUtils.ts)
+
+### generateContentForTitle
+
+Generates content for a note based on its title using LLM.
+
+```typescript
+export async function generateContentForTitle(
+  settings: NotemdSettings,
+  inputPath: string,
+  progressReporter: ProgressReporter,
+);
+```
+
+### batchGenerateContentForTitles
+
+Batch generates content for all markdown files in a folder.
+
+```typescript
+export async function batchGenerateContentForTitles(
+  settings: NotemdSettings,
+  folderPath: string,
+  progressReporter: ProgressReporter,
+);
+// Flow:
+// 1. Get all .md files in folder
+// 2. Create "complete" output folder
+// 3. Process files (serial or parallel based on settings)
+// 4. Move processed files to complete folder
+```
+
+### fixMermaidSyntaxInFile
+
+Fixes Mermaid syntax in a file (auto-run after generation).
+
+```typescript
+export async function fixMermaidSyntaxInFile(
+  filePath: string,
+  reporter: ProgressReporter,
+): Promise<boolean>;
+```
+
+## Settings
+
+### Research Settings
+
+| Setting                           | Description                           |
+| --------------------------------- | ------------------------------------- |
+| `enableResearchInGenerateContent` | Enable web research before generation |
+| `searchProvider`                  | 'tavily' or 'duckduckgo'              |
+| `tavilyApiKey`                    | API key for Tavily                    |
+| `maxResearchContentTokens`        | Max tokens for research context       |
+| `tavilyMaxResults`                | Number of Tavily results              |
+| `ddgMaxResults`                   | Number of DuckDuckGo results          |
+
+### Contextual Context (Macro Settings)
+
+| Setting                 | Description                                                             |
+| ----------------------- | ----------------------------------------------------------------------- |
+| `enableFocusedLearning` | Inject macro user domain preferences globally                           |
+| `focusedLearningDomain` | The specific domain context (e.g., "Computer Graphics", "Biochemistry") |
+
+### Output Settings
+
+| Setting                              | Description                                |
+| ------------------------------------ | ------------------------------------------ |
+| `useCustomGenerateTitleOutputFolder` | Use custom output folder                   |
+| `generateTitleOutputFolderName`      | Custom folder name (default: "\_complete") |
+
+### Language Settings
+
+| Setting                         | Description                   |
+| ------------------------------- | ----------------------------- |
+| `language`                      | Target language code          |
+| `useDifferentLanguagesForTasks` | Per-task language selection   |
+| `generateTitleLanguage`         | Language for title generation |
+
+## Prompt Template (generateTitle)
+
+From `promptUtils.ts`:
+
+````
+Create comprehensive technical documentation about "{TITLE}" with a focus on
+scientific and mathematical rigor.
+{RESEARCH_CONTEXT_SECTION}
+
+Include:
+1. Detailed explanation of core concepts with their mathematical foundations.
+   Start with a Level 2 Header (## {TITLE}).
+2. Key technical specifications with precise values and units (use tables).
+3. Common use cases with quantitative performance metrics.
+4. Implementation considerations with algorithmic complexity analysis.
+5. Performance characteristics with statistical measures.
+6. Related technologies with comparative mathematical models.
+7. Mathematical equations in LaTeX format (using $$...$$ for display and
+   $...$ for inline) with detailed explanations.
+8. Mermaid.js diagram code blocks using the format ```mermaid ... ```
+   IMPORTANT: without brackets "()" or "{}" for Mermaid diagrams.
+   Enclosed node names with spaces/special characters in square brackets [ and ].
+   Avoids special LaTeX syntax and Added quotes around subgraph titles.
+   "subgraph" and "end" cannot appear on the same line!
+9. Use bullet points for lists longer than 3 items.
+10. Include references to academic papers with DOI where applicable.
+11. Preserve all mathematical formulas and scientific principles.
+12. Define all variables and parameters used in equations.
+
+Format directly for Obsidian markdown. Do NOT wrap the entire response in
+a markdown code block. Start directly with the Level 2 Header.
+````
+
+## Auto-Fix After Generation
+
+After LLM generates content, the following fixes are automatically applied:
+
+1. **cleanupLatexDelimiters**:
+   - Converts `\( \) ` to `$`
+   - Removes extra whitespace in math expressions
+   - Protects display math `$$...$$`
+
+2. **refineMermaidBlocks**:
+   - Fixes unquoted labels
+   - Closes unclosed blocks
+   - Applies 20+ fix patterns
+
+3. **fixMermaidSyntaxInFile** (auto-run):
+   - Validates Mermaid syntax using `mermaid.parse`
+   - Applies deep debug fixes if errors found
+   - Logs validation results
+
+See [notemd-mermaid-fix](../mermaid-fix/SKILL.md) for full Mermaid fixing code.
+
+## Error Handling
+
+### Common Errors
+
+1. **No research context**
+   - Warning: "Research for 'title' returned no results"
+   - Solution: Check API keys, network connection
+
+2. **Mermaid syntax errors**
+   - Warning: "Mermaid errors found after generation"
+   - Solution: Auto-fix applied, check logs
+
+3. **Content too long**
+   - Error: Max tokens exceeded
+   - Solution: Reduce research context or chunk size

--- a/skills/notemdpro/skills/formula-healer/SKILL.md
+++ b/skills/notemdpro/skills/formula-healer/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: formula-healer
+description: "Use when LaTeX math delimiters are broken, single-dollar display math needs converting to double-dollar, or inline vs block math is malformatted"
+---
+
+# NoteMD Pro - Formula Fixing
+
+## Overview
+
+This skill fixes LaTeX math formula formatting in markdown files. It converts single-line formulas delimited by single `$` to double `$$` for proper display math rendering.
+
+## When to Use
+
+- **Fix inline math**: Convert `$ formula $` to display math `$$ formula $$`
+- **Batch repair**: Fix multiple files at once
+- **Format consistency**: Ensure proper math rendering
+
+## Function Call Chain
+
+```
+fixFormulaFormats (formulaFixer.ts)
+├── read file content
+├── apply regex pattern: /^(\s*)\$(\s*)$/gm
+├── replace with: $1$$$$$2
+└── return fixed content
+
+fixFormulaFormatsInFile
+├── read_file(inputPath)
+├── fixFormulaFormats(content)
+├── if changed: write_file(inputPath, content)
+└── return: boolean (modified or not)
+
+batchFixFormulaFormatsInFolder
+├── get files in folder (.md, .txt)
+├── for each file
+│   └── fixFormulaFormatsInFile
+└── return: { modifiedCount, errors[] }
+```
+
+## Code File
+
+The full TypeScript code is available in: `formulaFixer.ts`
+
+This file contains:
+
+- `fixFormulaFormats()` - Core fix function
+- `fixFormulaFormatsInFile()` - Single file processing
+- `batchFixFormulaFormatsInFolder()` - Batch processing
+
+## Fix Pattern
+
+### Single-line Formula Conversion
+
+**Input:**
+
+```markdown
+$
+
+x^2 + y^2 = z^2
+
+$
+```
+
+**Output:**
+
+```markdown
+$$
+
+x^2 + y^2 = z^2
+
+
+$$
+```
+
+### Regex Pattern (Current Limitation)
+
+```typescript
+// Pattern: ^(\s*)\$(\s*)$
+// Matches: start of line, optional whitespace, single $, optional whitespace, end of line
+
+// Replacement: $1$$$$$2
+// Result: optional whitespace + $$ + $$ + optional whitespace
+```
+
+> [!WARNING] Regex Fragility
+> The current line-based regex is highly brittle. It **fails** to properly handle inline math (`The value is $x=2$`), single-line block math containing text (`$x=2$`), or multi-line single-dollar blocks.
+
+### 🚀 Future Robustness Upgrade (AST Parsing)
+
+To make this Agentic skill enterprise-grade, the AI should be instructed to replace this simple Regex with an Abstract Syntax Tree (AST) parser like `remark-math`, or write heavily context-aware regex patterns that track state to safely distinguish between inline `$..$` and block `$$..$$` requirements.
+
+### Usage Example
+
+```typescript
+import {
+  fixFormulaFormats,
+  fixFormulaFormatsInFile,
+  batchFixFormulaFormatsInFolder,
+} from "./formulaFixer";
+
+// Fix formulas in a string
+const content = `...
+$
+
+f(x) = \int_{-\infty}^{\infty} e^{-x^2} dx
+
+$
+...`;
+
+const fixed = fixFormulaFormats(content);
+
+// Fix formulas in a single file
+await fixFormulaFormatsInFile(inputPath, reporter);
+
+// Fix formulas in a folder
+const result = await batchFixFormulaFormatsInFolder(folderPath, reporter);
+// Returns: { modifiedCount: number, errors: { file: string, message: string }[] }
+```
+
+## Batch Processing
+
+### Settings
+
+| Setting                  | Description                     |
+| ------------------------ | ------------------------------- |
+| `enableBatchParallelism` | Enable parallel processing      |
+| `batchConcurrency`       | Number of concurrent operations |
+| `batchSize`              | Files per batch                 |
+
+### Progress Reporting
+
+The batch function reports:
+
+- Current file being processed
+- Progress percentage
+- Cancellation support
+- Error collection
+
+## Integration with Other Skills
+
+### Links Processing
+
+After adding wiki-links, `cleanupLatexDelimiters()` is called to fix LaTeX:
+
+```typescript
+// From mermaidProcessor.ts
+export function cleanupLatexDelimiters(content: string): string {
+    // 1. Protect escaped dollars
+    processed = processed.replace(/\\\$/g, placeholder);
+
+    // 2. Convert \( and \) to $
+    processed = processed.replace(/\\\(/g, '$').replace(/\\\)/g, '$');
+
+    // 3. Trim whitespace inside single $...$
+    processed = processed.replace(/\$\s*([^$]*?)\s*\$/g, ...);
+
+    // 4. Restore escaped dollars
+    processed = processed.replace(new RegExp(placeholder, 'g'), '$');
+
+    return processed;
+}
+```
+
+This function handles:
+
+- Converting `\( formula \)` to `$ formula $`
+- Removing extra whitespace
+- Protecting display math `$$...$$`

--- a/skills/notemdpro/skills/formula-healer/formulaFixer.ts
+++ b/skills/notemdpro/skills/formula-healer/formulaFixer.ts
@@ -1,0 +1,97 @@
+import { App, TFile, TFolder } from 'obsidian';
+import { ProgressReporter } from './types';
+import { delay } from './utils';
+
+/**
+ * Fixes single-line math formulas delimited by single '$' to double '$$'
+ * Matches: ^(\s*)\$(\s*)$
+ * Replaces with: $1$$$$$2
+ * 
+ * @param content The markdown content to process
+ * @returns The content with fixed formulas
+ */
+export function fixFormulaFormats(content: string): string {
+    // (?m) is handled by 'm' flag in JS regex
+    // ^      Start of line
+    // (\s*)  Group 1: Leading whitespace
+    // \$     Literal $
+    // (\s*)  Group 2: Trailing whitespace
+    // $      End of line
+    const pattern = /^(\s*)\$(\s*)$/gm;
+    return content.replace(pattern, '$1$$$$$2');
+}
+
+/**
+ * Fixes formula formats in a single file.
+ * Reads the file, applies fixFormulaFormats, and writes back if changed.
+ */
+export async function fixFormulaFormatsInFile(app: App, file: TFile, reporter?: ProgressReporter): Promise<boolean> {
+    try {
+        const content = await app.vault.read(file);
+        const newContent = fixFormulaFormats(content);
+        
+        if (newContent !== content) {
+            await app.vault.modify(file, newContent);
+            if (reporter) reporter.log(`Fixed formulas in ${file.name}`);
+            return true;
+        } else {
+            // if (reporter) reporter.log(`No formula fixes needed for ${file.name}`);
+            return false;
+        }
+    } catch (error) {
+        const msg = `Error processing formulas in ${file.name}: ${error}`;
+        if (reporter) reporter.log(msg);
+        console.error(msg);
+        throw error;
+    }
+}
+
+/**
+ * Batch fixes formula formats in a folder.
+ */
+export async function batchFixFormulaFormatsInFolder(
+    app: App, 
+    folderPath: string, 
+    reporter: ProgressReporter
+): Promise<{ modifiedCount: number; errors: { file: string; message: string }[] }> {
+    
+    const folder = app.vault.getAbstractFileByPath(folderPath);
+    if (!folder || !(folder instanceof TFolder)) {
+        throw new Error(`Invalid folder path: ${folderPath}`);
+    }
+
+    const files = app.vault.getFiles().filter(f => 
+        (f.extension === 'md' || f.extension === 'txt') &&
+        (f.path === folderPath || f.path.startsWith(folderPath === '/' ? '' : folderPath + '/'))
+    );
+
+    if (files.length === 0) {
+        reporter.log(`No eligible files found in ${folderPath}`);
+        return { modifiedCount: 0, errors: [] };
+    }
+
+    let modifiedCount = 0;
+    const errors: { file: string; message: string }[] = [];
+
+    for (let i = 0; i < files.length; i++) {
+        const file = files[i];
+        if (reporter.cancelled) break;
+
+        const progress = Math.floor((i / files.length) * 100);
+        reporter.updateStatus(`Checking formulas in ${file.name}...`, progress);
+
+        try {
+            const modified = await fixFormulaFormatsInFile(app, file, reporter);
+            if (modified) modifiedCount++;
+        } catch (error: any) {
+            const message = error.message || String(error);
+            errors.push({ file: file.name, message });
+            reporter.log(`❌ Error in ${file.name}: ${message}`);
+        }
+        
+        // Small delay to keep UI responsive
+        if (i % 10 === 0) await delay(10);
+    }
+
+    return { modifiedCount, errors };
+}

--- a/skills/notemdpro/skills/link-analyzer/SKILL.md
+++ b/skills/notemdpro/skills/link-analyzer/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: link-analyzer
+description: "Use when markdown notes need automatic wiki-link insertion for core concepts to build an interconnected knowledge graph"
+---
+
+# NoteMD Pro - Add Wiki-Links
+
+## Overview
+
+This feature processes markdown files to add wiki-links (`[[concept]]`) between related concepts using an LLM. It analyzes the content and identifies core knowledge points, then adds appropriate backlinks.
+
+## When to Use
+
+- **Organize notes**: Connect related concepts in your vault
+- **Build knowledge graph**: Create interconnected notes for better navigation
+- **Enhance linking**: Automatically add links that might be missed manually
+
+## Function Call Chain
+
+```
+processFile (fileUtils.ts)
+├── read_file(inputPath)
+├── splitContent(content, settings)
+├── getProviderForTask('addLinks', settings)
+├── call[Provider]API(prompt, chunk)
+├── createConceptNotes(settings, concepts, filename)
+│   ├── normalizeNameForFilePath(concept)
+│   └── write_file(notePath, content)
+├── handleDuplicates(content, settings)
+├── cleanupLatexDelimiters(content)
+├── refineMermaidBlocks(content)  ← AUTO-FIX
+└── saveOrMoveProcessedFile(settings, inputPath, content)
+    └── write_file(outputPath, content)
+```
+
+## Key Functions (from fileUtils.ts)
+
+### processFile
+
+Processes a single file: reads content, calls LLM, adds links, applies fixes, and saves.
+
+```typescript
+export async function processFile(
+  settings: NotemdSettings,
+  inputPath: string,
+  progressReporter: ProgressReporter,
+  currentProcessingFileBasename: { value: string | null },
+);
+```
+
+### splitContent
+
+Splits content into chunks based on word count for LLM processing.
+
+```typescript
+export function splitContent(
+  content: string,
+  settings: NotemdSettings,
+): string[];
+// Returns: Array of content chunks
+```
+
+### saveOrMoveProcessedFile
+
+Handles saving or moving the processed file based on settings.
+
+```typescript
+async function saveOrMoveProcessedFile(
+  settings: NotemdSettings,
+  inputPath: string,
+  processedContent: string,
+  progressReporter: ProgressReporter,
+);
+```
+
+## Settings
+
+### Core Settings
+
+| Setting                     | Description                         |
+| --------------------------- | ----------------------------------- |
+| `chunkWordCount`            | Words per chunk (default: 2000)     |
+| `maxTokens`                 | Max tokens for LLM response         |
+| `moveOriginalFileOnProcess` | Move original file after processing |
+
+### Output Settings
+
+| Setting                        | Description                      |
+| ------------------------------ | -------------------------------- |
+| `useCustomProcessedFileFolder` | Use custom output folder         |
+| `processedFileFolder`          | Custom output folder path        |
+| `useCustomAddLinksSuffix`      | Use custom filename suffix       |
+| `addLinksCustomSuffix`         | Custom suffix (e.g., "\_linked") |
+
+### Mermaid/LaTeX Settings
+
+| Setting                       | Description                         |
+| ----------------------------- | ----------------------------------- |
+| `removeCodeFencesOnAddLinks`  | Remove code fences after processing |
+| `autoMermaidFixAfterGenerate` | Auto-fix Mermaid syntax             |
+
+### Duplicate Detection
+
+| Setting                    | Description                     |
+| -------------------------- | ------------------------------- |
+| `enableDuplicateDetection` | Enable duplicate word detection |
+
+## Prompt Template (addLinks)
+
+From `promptUtils.ts`:
+
+```
+Completely decompose and structure the knowledge points in this markdown document,
+outputting them in markdown format supported by Obsidian. Core knowledge points
+should be labelled with Obsidian's backlink format [[]]. Do not output anything
+other than the original text and the requested "Obsidian's backlink format [[]]".
+
+Rules:
+1. Only add Obsidian backlinks [[like this]] to core concepts. Do not modify the
+   original text content or formatting otherwise.
+2. Skip conventional names (common products, company names, dates, times, individual
+   names) unless they represent a core technical or scientific concept within the
+   text's context.
+3. Output the *entire* original content of the chunk, preserving all formatting
+   (headers, lists, code blocks, etc.), with only the added backlinks.
+4. Handle duplicate concepts carefully:
+   a. If both singular and plural forms of a word/concept appear (e.g., "model" and
+      "models"), only add the backlink to the *first occurrence* of the *singular* form.
+   b. If a single-word concept also appears as part of a multi-word concept, only
+      add the backlink to the multi-word concept.
+   c. Do not add duplicate backlinks for the exact same concept within this chunk.
+5. Ignore any "References", "Bibliography", or similar sections.
+```
+
+## Error Handling
+
+### Common Errors
+
+1. **No valid LLM provider**
+   - Error: "No valid LLM provider configured for 'Add Links' task"
+   - Solution: Configure a provider in settings
+
+2. **API rate limiting**
+   - Error: Rate limit exceeded
+   - Solution: Adjust `apiCallInterval` in settings
+
+3. **File permission errors**
+   - Error: Cannot modify/create file
+   - Solution: Check folder permissions
+
+### Cancellation
+
+- User can cancel processing via progress reporter
+- Already processed chunks are preserved
+- Progress saved in log
+
+## Auto-fix Integration
+
+After LLM processing, the following fixes are automatically applied:
+
+1. **cleanupLatexDelimiters**: Fix LaTeX math delimiters
+2. **refineMermaidBlocks**: Fix Mermaid diagram syntax
+3. **Boxed content removal**: Remove `\boxed{` wrappers
+
+See [notemd-mermaid-fix](../mermaid-fix/SKILL.md) for full Mermaid fixing code.

--- a/skills/notemdpro/skills/mermaid-healer/SKILL.md
+++ b/skills/notemdpro/skills/mermaid-healer/SKILL.md
@@ -1,0 +1,291 @@
+---
+name: mermaid-healer
+description: "Use when mermaid diagrams have syntax errors like broken arrows, unquoted labels, or malformed subgraphs that cause render failures"
+---
+
+# NoteMD Pro - Mermaid Diagram Fixing
+
+## Overview
+
+This skill fixes Mermaid diagram syntax errors in markdown files. It includes comprehensive fixing logic for 20+ common Mermaid syntax issues including unquoted labels, malformed arrows, nested brackets, and more.
+
+## When to Use
+
+- **Fix broken diagrams**: Repair Mermaid syntax errors in notes
+- **Auto-fix after generation**: Automatically fix diagrams after LLM content generation
+- **Batch repair**: Fix multiple files at once
+
+## Function Call Chain
+
+````
+refineMermaidBlocks (mermaidProcessor.ts)
+├── split content by lines
+├── detect ```mermaid blocks
+├── apply fix rules in order:
+│   ├── fixSmartQuotes
+│   ├── fixMermaidPipes
+│   ├── fixMermaidNotes
+│   ├── fixNotesToNodes
+│   ├── fixMalformedArrows
+│   ├── fixInvalidArrows
+│   ├── mergeDoubleLabels
+│   ├── fixMissingBrackets
+│   ├── fixInlineSubgraphs
+│   ├── fixMermaidComments
+│   ├── fixDoubleSlashComments
+│   ├── fixUnquotedNodeLabels
+│   ├── fixIntermediateNodes
+│   ├── fixDoubledID
+│   ├── fixExcessiveBrackets
+│   ├── fixSemicolonPositioning
+│   ├── fixConcatenatedLabels
+│   ├── fixUnquotedLabelsWithSemicolons
+│   ├── enhancedNoteAndSemicolonCleanup
+│   ├── fixReverseArrows
+│   ├── fixSubgraphDirection
+│   ├── fixDuplicateLabels
+│   ├── fixNestedMermaidQuotes
+│   ├── fixQuotedLabelsAfterSemicolon
+│   ├── fixDoubleDashToArrow
+│   ├── fixTargetedNotes
+│   ├── fixDoubleArrowLabels
+│   ├── fixUnquotedEdgeLabels
+│   ├── fixShapeMismatch
+│   ├── fixPlaceholderArtifacts
+│   └── fixBlankArrows
+├── close unclosed blocks
+└── checkMermaidErrors (if errors found, apply deepDebugMermaid)
+
+cleanupLatexDelimiters (mermaidProcessor.ts)
+├── protect escaped dollars
+├── convert \( \) to $
+├── trim whitespace in math
+└── restore escaped dollars
+````
+
+## Code File
+
+The full TypeScript code is available in: `mermaidProcessor.ts`
+
+This file contains all the fix functions:
+
+- `refineMermaidBlocks()` - Main entry point
+- `checkMermaidErrors()` - Validate syntax
+- `cleanupLatexDelimiters()` - Fix LaTeX
+- `deepDebugMermaid()` - Apply all fix passes
+- 20+ individual fix functions
+
+## Auto-Fix Integration
+
+### After Generate (generate SKILL.md)
+
+After LLM generates content, these functions are automatically called:
+
+1. `cleanupLatexDelimiters(content)`
+2. `refineMermaidBlocks(content)`
+3. `fixMermaidSyntaxInFile(app, file, reporter)` - Validates and reports errors
+
+### Manual Fix
+
+Call `refineMermaidBlocks(content)` on any markdown content to fix Mermaid syntax.
+
+## Fix Patterns
+
+### 1. Unquoted Labels with Nested Brackets
+
+```
+Input:  Investment[Corporate Investment "[企业投资]"]
+Output: Investment["Corporate Investment [企业投资]"]
+```
+
+### 2. Broken Edge Labels
+
+```
+Input:  CapRate --["Inverse Relationship["--> PropValue
+Output: CapRate -- "Inverse Relationship" --> PropValue
+```
+
+### 3. Arrow Fixes
+
+```
+Input:  A --|> B
+Output: A --> B
+```
+
+### 4. Comment Conversion
+
+```
+Input:  A --> B; % Comment
+Output: A -- "Comment" --> B;
+```
+
+### 5. Note Transformations
+
+```
+Input:  note right of A: Text
+Output: A -- "Text" --> (as label)
+```
+
+### 6. Excessive Brackets
+
+```
+Input:  A["Text"]]]
+Output: A["Text"]
+```
+
+## Usage Example
+
+```typescript
+import {
+  refineMermaidBlocks,
+  cleanupLatexDelimiters,
+} from "./mermaidProcessor";
+
+// Fix Mermaid in content
+const content = `...
+\`\`\`mermaid
+graph LR
+A[Node --> B]
+\`\`\`
+...`;
+
+const fixed = await refineMermaidBlocks(content);
+const cleaned = cleanupLatexDelimiters(fixed);
+```
+
+## Error Detection
+
+The `checkMermaidErrors()` function uses `mermaid.parse()` to validate syntax:
+
+```typescript
+const errorCount = await checkMermaidErrors(content);
+// Returns: number of errors found
+```
+
+If errors remain after basic fixes, `deepDebugMermaid()` is applied.
+
+## 🚀 Primary Engine: 37+ Heuristic Regex Fixers
+
+> [!IMPORTANT] Proven Regex Supremacy
+> Based on empirical field testing, **the AI Agent must prioritize the 37 manual heuristic regex fixers** (like `fixMissingBrackets`, `fixReverseArrows`) over directly asking the LLM to fix the diagram. Current Large Reasoning Models often struggle to repair structural Mermaid hallucinations directly. The regex pipeline has been proven to be the most robust method for correcting diagram flows in production.
+
+### Workflow
+
+```
+LLM-Heal-Mermaid
+├── Extract mermaid blocks from content
+├── Try mermaid.parse() to validate
+├── IF errors found
+│   ├── Extract specific error messages
+│   ├── Feed errors back to LLM with prompt
+│   └── Ask for precise correction
+├── Replace original block with LLM-fixed version
+└── Validate again
+```
+
+### Implementation
+
+````typescript
+import mermaid from "mermaid";
+
+async function llmHealMermaid(
+  content: string,
+  llmCall: Function,
+): Promise<string> {
+  // Extract mermaid blocks
+  const blockRegex = /```mermaid\n([\s\S]*?)```/g;
+
+  let fixedContent = content;
+  let match;
+
+  while ((match = blockRegex.exec(content)) !== null) {
+    const block = match[1];
+
+    // Try to parse
+    try {
+      await mermaid.parse(block);
+    } catch (error) {
+      // Get specific error
+      const errorMsg = error.message;
+      console.log(`Mermaid error: ${errorMsg}`);
+
+      // Ask LLM to fix
+      const fixPrompt = `Fix the following Mermaid diagram syntax. 
+Error: ${errorMsg}
+Diagram:
+${block}
+
+Rules:
+1. Use proper bracket syntax: nodeId["Label"]
+2. Use proper arrow syntax: -->
+3. Quote labels with special characters
+4. Close all blocks properly
+
+Fixed diagram:`;
+
+      const fixed = await llmCall(fixPrompt);
+
+      // Replace in content
+      fixedContent = fixedContent.replace(block, fixed);
+    }
+  }
+
+  return fixedContent;
+}
+````
+
+### LLM Fix Prompt Template
+
+```
+Fix the following Mermaid diagram syntax error.
+
+Error message from Mermaid parser:
+{ERROR_MESSAGE}
+
+Current broken diagram:
+{BROKEN_DIAGRAM}
+
+Please fix the syntax and return only the corrected Mermaid code.
+Do not include any explanations or markdown code blocks.
+```
+
+### Advantages
+
+1. **Handles edge cases**: LLM can understand complex errors
+2. **Adaptive**: Improves with better prompts
+3. **Less maintenance**: No need for 37+ regex patterns
+4. **Context-aware**: Understands diagram semantics
+
+### Two-Stage Approach (Regex First, LLM as Last Resort)
+
+Recommended: Always execute the complete battery of regex fixers first. Only escalate to the LLM if `mermaid.parse()` still fails after the regex cascade.
+
+```typescript
+async function healMermaid(
+  content: string,
+  llmCall: Function,
+): Promise<string> {
+  // Stage 1: Exhaustive Regex Heuristics (Primary Engine)
+  let fixed = refineMermaidBlocks(content);
+
+  // Stage 2: Strict Validation
+  const errors = await checkMermaidErrors(fixed);
+
+  // Stage 3: LLM Fallback (Use only when heuristics fail)
+  if (errors > 0) {
+    console.log(
+      `Found ${errors} residual errors after regex cascade, falling back to LLM...`,
+    );
+    fixed = await llmHealMermaid(fixed, llmCall);
+  }
+
+  return fixed;
+}
+```
+
+### When LLM Fallback is Necessary
+
+- **Complex nested structures**: Subgraphs with multiple levels
+- **Custom shapes**: Non-standard node definitions
+- **Edge cases**: Rare syntax combinations
+- **Semantic errors**: Valid syntax but wrong diagram logic

--- a/skills/notemdpro/skills/mermaid-healer/mermaidProcessor.ts
+++ b/skills/notemdpro/skills/mermaid-healer/mermaidProcessor.ts
@@ -1,0 +1,1897 @@
+import mermaid from 'mermaid';
+
+/**
+ * Checks if the content contains any Mermaid syntax errors using mermaid.parse.
+ * Also detects unclosed Mermaid blocks.
+ * @param content The markdown content to check.
+ * @returns A promise that resolves to the number of errors found.
+ */
+export async function checkMermaidErrors(content: string): Promise<number> {
+    const mermaidBlockRegex = /^(?:[ \t]*)(?:```|~~~)\s*mermaid\b[^\n]*\n([\s\S]*?)\n(?:[ \t]*)(?:```|~~~)/gim;
+    let match;
+    let errorCount = 0;
+    
+    // Initialize mermaid if needed (though usually handled by the app/plugin load)
+    // We use a safe configuration
+    mermaid.initialize({ startOnLoad: false, suppressErrorRendering: true });
+
+    // Check closed blocks
+    while ((match = mermaidBlockRegex.exec(content)) !== null) {
+        try {
+            await mermaid.parse(match[1]);
+        } catch (error) {
+            errorCount++;
+        }
+    }
+    return errorCount;
+}
+
+/**
+ * Processes markdown content to validate and fix Mermaid syntax issues.
+ * Specifically ensures that ```mermaid blocks are properly closed after the last arrow (`-->`).
+ * Also applies deep debug fixes if Mermaid errors still exist after basic fixes.
+ * Adapted from logic in LMStudio-Markdown-Content-Generator/mermaid.py.
+ */
+export async function refineMermaidBlocks(content: string): Promise<string> {
+	const lines = content.split('\n');
+	let resultLines: string[] = [];
+	let inMermaid = false;
+	let currentBlockLines: string[] = [];
+	let lastArrowIndexInBlock = -1;
+
+	for (let line of lines) { // Use 'let' so we can modify the line
+		const stripped = line.trim();
+
+		// Regex to detect ```(mermaid) or ``` mermaid with optional space/parentheses
+		const mermaidStartRegex = /^```\s*\(?\s*mermaid\s*\)?/;
+
+
+		if (mermaidStartRegex.test(stripped)) {
+			// Normalize the starting line
+			line = line.replace(mermaidStartRegex, '```mermaid');
+
+			// If already in a block, finish the previous one before starting new
+			if (inMermaid) {
+				if (lastArrowIndexInBlock !== -1) {
+					// Ensure the line after the last arrow isn't already the closer
+					if (currentBlockLines[lastArrowIndexInBlock + 1]?.trim() !== '```') {
+						currentBlockLines.splice(lastArrowIndexInBlock + 1, 0, '```');
+					}
+				} else if (currentBlockLines.length > 0) {
+                    // Block started but no arrows, ensure it's closed if not already
+                     if (currentBlockLines[0].trim().startsWith('```mermaid') && currentBlockLines[currentBlockLines.length - 1].trim() !== '```') {
+                         // Check if the line after start isn't the closer
+                         if (currentBlockLines.length === 1 || currentBlockLines[1]?.trim() !== '```') {
+                            currentBlockLines.splice(1, 0, '```'); // Close after the opening line
+                         }
+                     }
+                }
+				resultLines.push(...currentBlockLines);
+			}
+			// Start new block
+			inMermaid = true;
+			currentBlockLines = [line];
+			lastArrowIndexInBlock = -1;
+		} else if (inMermaid) {
+			// Handle ; # comments - convert to labeled arrows
+			const commentMatch = line.match(/^(\w+)\s*-->\s*(\w+);\s*#(.*)$/);
+			if (commentMatch) {
+				line = `${commentMatch[1]} -- "${commentMatch[3].trim()}" --> ${commentMatch[2]};`;
+			}
+
+			// Apply new quote rules BEFORE removing brackets, ONLY if 'subgraph' is NOT on the line
+			if (!line.includes('subgraph')) {
+				// 先保护 |" 和 "| 的情况
+				const placeholder = '___PROTECTED_QUOTE___';
+				line = line.replace(/\|"/g, `|${placeholder}`);
+				line = line.replace(/"\|/g, `${placeholder}|`);
+
+				// Rule 1 (Revised - No Lookbehind):
+				// 1a: Handle quote at the start of the line
+				line = line.replace(/^"(?!;|\s)(?!\])/g, '["');
+				// 1b: Handle quote preceded by a non-space, non-[ character
+				line = line.replace(/([^\s\[])"(?!;|\s)(?!\])/g, '$1["');
+
+				// Rule 2: Replace "; with ];
+				line = line.replace(/";/g, '"];');
+
+				// 还原被保护的引号
+				line = line.replace(new RegExp(placeholder, 'g'), '"');
+				
+				// Rule 3: Replace ["; with "];
+				line = line.replace(/\[";/g, '"];');
+				// New Rule 4: Replace ?["; with ?"];
+				line = line.replace(/\?\[";/g, '?"];');
+				
+				// 添加额外的清理步骤，确保没有残留的[";模式
+				// 重复应用Rule 3直到没有更多的[";模式
+				while (line.includes('[";')) {
+					line = line.replace(/\[";/g, '"];');
+					
+					// New Rule 4: Replace ?["; with ?"];
+					line = line.replace(/\?\[";/g, '?"];');
+				}
+                // Safeguard: Final replacements to ensure ["; and ?["; are corrected
+                line = line.replace(/\[";/g, '"];');
+                line = line.replace(/\?\[";/g, '?"];');
+
+				// New User Rule 1: If line ends with [;";, change to "];
+				line = line.replace(/\[";$/, '"];');
+				// New User Rule 2: Then, if line ends with [", change to "]
+				line = line.replace(/\["$/, '"]');
+
+                // New User Rule 3: Fix broken edge labels `--["Text["-->` to `-- "Text" -->`
+                // Example: `CapRate --["Inverse Relationship["-->` becomes `CapRate -- "Inverse Relationship" -->`
+                line = line.replace(/--\s*\["(.+?)\["\s*-->/g, '-- "$1" -->');
+
+                // --- User Requested "Fix Mode" Logic for [ ... ] ---
+                // Detects Node[Label] where Label isn't fully quoted but contains brackets/quotes.
+                // Targeted cases:
+                // 1. `Investment[Corporate Investment "[企业投资]"]` -> `Investment["Corporate Investment [企业投资]"]`
+                // 2. `Consumption[Consumption [消费]]` -> `Consumption["Consumption [消费]"]`
+                // 3. `WhiteDwarf[白矮星 [White Dwarf]]` -> `WhiteDwarf["白矮星 [White Dwarf]"]`
+                
+                // Improved regex to handle one level of nested brackets:
+                // ([^\s\[]+)  : NodeID (non-whitespace AND non-[ chars)
+                // \s*\[       : Opening bracket
+                // (?!"|')     : Content does NOT start with " or ' (already quoted nodes are skipped)
+                // (           : Start capturing content
+                //   (?:       : Non-capturing group for content parts
+                //     [^\[\]] : Any character EXCEPT [ or ]
+                //     |       : OR
+                //     \[[^\[\]]*\] : A nested [...] block with no brackets inside
+                //   )*        : Repeat content parts
+                // )           : End capturing content
+                // \]          : Closing bracket
+                
+                line = line.replace(/([^\s\[]+)\s*\[(?!"|')((?:[^\[\]]|\[[^\[\]]*\])*)\]/g, (match, nodeId, content) => {
+                     // Filter out matches that don't actually contain broken characters we care about.
+                     // The regex already excludes things starting with ".
+                     // We specifically want to fix things that have [ or ] inside.
+                     if (/[\[\]|]/.test(content)) {
+                         // Logic:
+                         // 1. Remove existing double quotes from content to avoid syntax errors (as per user example where inner quotes were removed).
+                         // 2. Wrap in double quotes.
+                         const cleanContent = content.replace(/"/g, ''); 
+                         return `${nodeId}["${cleanContent}"]`;
+                     }
+                     return match;
+                });
+			}
+
+			// Remove parentheses and curly braces from the line content within the mermaid block
+			let lineWithoutBrackets = line.replace(/[(){}]/g, ''); // Updated regex
+
+			// Fix [" at the end of the line
+			if (lineWithoutBrackets.endsWith('\["')) {
+				lineWithoutBrackets = lineWithoutBrackets.slice(0, -2) + '"]';
+			}
+
+			currentBlockLines.push(lineWithoutBrackets);
+			if (lineWithoutBrackets.includes('-->')) { // Check the modified line for arrows
+				lastArrowIndexInBlock = currentBlockLines.length - 1; // Index within currentBlockLines
+			}
+			if (stripped === '```') {
+				// Found the intended closing tag, finalize this block
+				resultLines.push(...currentBlockLines);
+				inMermaid = false;
+				currentBlockLines = [];
+				lastArrowIndexInBlock = -1;
+			}
+		} else {
+			// Line outside any mermaid block
+			resultLines.push(line);
+		}
+	}
+
+	// Handle unclosed block at the very end of the file
+	if (inMermaid) {
+		if (lastArrowIndexInBlock !== -1) {
+			// Ensure the line after the last arrow isn't already the closer
+            // Check if the index exists before accessing trim()
+			if (lastArrowIndexInBlock + 1 >= currentBlockLines.length || currentBlockLines[lastArrowIndexInBlock + 1]?.trim() !== '```') {
+				currentBlockLines.splice(lastArrowIndexInBlock + 1, 0, '```');
+			}
+		} else if (currentBlockLines.length > 0) {
+            // Block started but no arrows, ensure it's closed if not already
+            if (currentBlockLines[0].trim().startsWith('```mermaid') && currentBlockLines[currentBlockLines.length - 1].trim() !== '```') {
+                 // Check if the line after start isn't the closer
+                 if (currentBlockLines.length === 1 || currentBlockLines[1]?.trim() !== '```') {
+                    currentBlockLines.splice(1, 0, '```'); // Close after the opening line
+                 } else if (currentBlockLines[currentBlockLines.length -1].trim() !== '```') {
+                     // If it wasn't closed after line 1, add closer at the end
+                     currentBlockLines.push('```');
+                 }
+            } else if (currentBlockLines[currentBlockLines.length -1].trim() !== '```') {
+                 // Failsafe if somehow the last line isn't a closer
+                 currentBlockLines.push('```');
+            }
+        }
+		resultLines.push(...currentBlockLines);
+	}
+
+	let result = resultLines.join('\n');
+
+	// Check for remaining errors to decide if we need deep debug
+	const errorCount = await checkMermaidErrors(result);
+
+    // Regex to find mermaid blocks and apply fixes ONLY inside them
+    // Matches ```mermaid followed by content and ending with ```
+    // We use [\s\S]*? for non-greedy multiline match
+    const mermaidBlockRegex = /(```\s*mermaid\n)([\s\S]*?)(\n```)/gi;
+
+    result = result.replace(mermaidBlockRegex, (match, startTag, blockContent, endTag) => {
+        let processedBlock = blockContent;
+
+        // Apply scoped replacements inside mermaid blocks
+        
+        // Replace note "Sentences" with Note1[/"Sentences"/], Note2[/"Sentences"/]...
+        let noteCounter = 1;
+        processedBlock = processedBlock.replace(/note\s+"([^"]*)"/g, (match: string, noteContent: string) => {
+            return `Note${noteCounter++}[/"${noteContent}"/]`;
+        });
+
+        // Remove content after ; if the line contains % after ;
+        processedBlock = processedBlock.replace(/;(.*)$/gm, (match: string, p1: string) => p1.includes('%') ? ';' : match);
+
+        // Apply deep debug fixes if errors were found in the file
+        // (Optimally we would check this block specifically, but this preserves original logic trigger)
+        if (errorCount > 0) {
+            processedBlock = deepDebugMermaid(processedBlock);
+        }
+
+        return `${startTag}${processedBlock}${endTag}`;
+    });
+
+	return result;
+}
+
+/**
+ * Applies deep debug fixes ONLY to the content within Mermaid code blocks.
+ * This is a safe alternative to calling deepDebugMermaid on the entire file.
+ * @param content The markdown content.
+ * @returns The processed content with Mermaid blocks debugged.
+ */
+export function applyDeepDebugToMermaidBlocks(content: string): string {
+    const mermaidBlockRegex = /(```\s*mermaid\n)([\s\S]*?)(\n```)/gi;
+
+    return content.replace(mermaidBlockRegex, (match, startTag, blockContent, endTag) => {
+        const processedBlock = deepDebugMermaid(blockContent);
+        return `${startTag}${processedBlock}${endTag}`;
+    });
+}
+
+/**
+ * Cleans up LaTeX math delimiters.
+ * Converts \( and \) to $.
+ * Removes extra spaces around $.
+ * Ensures space before $ if preceded by a hyphen.
+ * Removes \$ escape sequence.
+ *
+ * @param content The markdown content string.
+ * @returns Content with cleaned math delimiters.
+ */
+export function cleanupLatexDelimiters(content: string): string {
+	const placeholder = '___TEMP_DOLLAR_ESCAPE___';
+	let processed = content;
+
+	// 1. Protect escaped dollars
+	processed = processed.replace(/\\\$/g, placeholder);
+
+	// 2. Convert \( and \) to $
+	processed = processed.replace(/\\\(/g, '$').replace(/\\\)/g, '$');
+
+	// 3. Trim whitespace inside single $...$ (non-greedy)
+	// This regex finds a $ followed by optional whitespace, captures the content (non-greedily),
+	// followed by optional whitespace and a closing $. It replaces the whole match with $content$.
+	// It avoids matching $$ by ensuring the captured content doesn't start or end with $.
+	processed = processed.replace(/\$\s*([^$]*?)\s*\$/g, (match, group1) => {
+        // Avoid affecting display math $$...$$
+        if (match.startsWith('$$') && match.endsWith('$$')) {
+            return match; // Leave display math untouched
+        }
+        // Trim the captured group and reconstruct
+        const trimmedGroup = group1.trim();
+        return `$${trimmedGroup}$`;
+    });
+
+
+	// 4. Restore escaped dollars
+	processed = processed.replace(new RegExp(placeholder, 'g'), '$');
+
+	return processed;
+}
+
+/**
+ * Deep debug function for Mermaid syntax.
+ * Applies all available fixes in a specific order.
+ * 0. Fix Smart Quotes (curly quotes to straight quotes, slashed notes).
+ * 1. Fix Mermaid Pipes (handle `|`).
+ * 2. Fix Mermaid Notes.
+ * 3. Fix Malformed Arrows.
+ * 4. Merge Double Labels.
+ * 5. Fix Missing Brackets.
+ * 6. Fix Inline Subgraphs.
+ * 7. Fix Mermaid Comments.
+ * 8. Fix Unquoted Node Labels.
+ * 9. Fix Intermediate Nodes.
+ * 10. Fix Doubled IDs.
+ * 11. Fix Excessive Brackets (including ]]] -> ]).
+ * 12. Fix Semicolon Positioning.
+ * 13. Fix Unquoted Labels with Semicolons.
+ * 14. Enhanced Note and Semicolon Cleanup.
+ */
+export function deepDebugMermaid(content: string): string {
+    // --- SAFEGUARD: Protect Table Lines ---
+    // User requirement: Ensure no modification to lines containing ':-- :'
+    // Also protecting standard markdown table separators to prevent corruption
+    const tableLinePlaceholderPrefix = '___PROTECTED_TABLE_LINE_';
+    const protectedTableLines: string[] = [];
+    
+    // Regex for table separator line: starts with |, contains dashes/colons/pipes, ends with | (roughly)
+    const tableSeparatorRegex = /^\s*\|(?:[\s\t]*:?[\s\t]*-+[\s\t]*:?[\s\t]*\|)+[\s\t]*$/;
+
+    let processed = content.split('\n').map(line => {
+        if (line.includes(':-- :') || tableSeparatorRegex.test(line)) {
+            const placeholder = `${tableLinePlaceholderPrefix}${protectedTableLines.length}___`;
+            protectedTableLines.push(line);
+            return placeholder;
+        }
+        return line;
+    }).join('\n');
+
+    // 0. Fix Smart Quotes FIRST - handles “” -> "" and Note["/“text”/"] -> Note["/text/"]
+    processed = fixSmartQuotes(processed);
+
+    // 1. Fix Mermaid Pipes (handle `|`) - Requested to be first
+    processed = fixMermaidPipes(processed);
+
+    // 2. Fix Mermaid Notes (move "note right of" to edge labels)
+    processed = fixMermaidNotes(processed);
+
+    // 2.5. Fix Notes to Nodes (note right of A : Text -> NoteA["Note: Text"] A -.- NoteA)
+    processed = fixNotesToNodes(processed);
+
+    // 3. Fix Malformed Arrows (handle `-->"` and `"-- `)
+    processed = fixMalformedArrows(processed);
+
+    // 3.5 Fix Invalid Arrows (handle `--|>` -> `-->`)
+    processed = fixInvalidArrows(processed);
+
+    // 4. Merge Double Labels
+    processed = mergeDoubleLabels(processed);
+
+    // 5. Fix Missing Brackets (existing logic)
+    processed = fixMissingBrackets(processed);
+
+    // 6. Fix Inline Subgraphs (convert subgraph "Label" end; to edge label)
+    processed = fixInlineSubgraphs(processed);
+
+    // 7. Fix Mermaid Comments (Move % comments to label)
+    processed = fixMermaidComments(processed);
+
+    // 17. Fix Double Slash Comments (// -> -- "..." -->) - Apply before general label fixes
+    processed = fixDoubleSlashComments(processed);
+
+    // 8. Fix Unquoted Node Labels (Quote labels with special chars)
+    processed = fixUnquotedNodeLabels(processed);
+
+    // 9. Fix Intermediate Nodes (NodeA -- NodeB[...] --> NodeC)
+    processed = fixIntermediateNodes(processed);
+
+    // 10. Fix Doubled IDs (SplitSplit Sample -> Split[Split Sample])
+    processed = fixDoubledID(processed);
+
+    // 11. Fix Excessive Brackets (including ]]] -> ]).
+    processed = fixExcessiveBrackets(processed);
+
+    // 12. Fix Semicolon Positioning (Move "] before ;)
+    processed = fixSemicolonPositioning(processed);
+
+    // 12.5. Fix Concatenated Labels (SubdivideSubdivide... -> Subdivide["Subdivide..."])
+    processed = fixConcatenatedLabels(processed);
+
+    // 13. Fix Unquoted Labels Ending with Semicolons
+    processed = fixUnquotedLabelsWithSemicolons(processed);
+
+    // 14. Enhanced Note and Semicolon Cleanup.
+    processed = enhancedNoteAndSemicolonCleanup(processed);
+
+    // 15. Fix Reverse Arrows (<--)
+    processed = fixReverseArrows(processed);
+
+    // 16. Fix Subgraph Direction (Direction -> direction)
+    processed = fixSubgraphDirection(processed);
+
+    // 18. Fix Duplicate Labels (["..."]["..."] -> ["..."])
+    processed = fixDuplicateLabels(processed);
+
+    // 19. Fix Nested Mermaid Quotes (["...["..."]...."] -> ["...[...]..."])
+    processed = fixNestedMermaidQuotes(processed);
+
+    // 20. Fix Quoted Labels After Semicolon (A --> B; "Label" -> A -- "Label" --> B;)
+    processed = fixQuotedLabelsAfterSemicolon(processed);
+
+    // 21. Fix Double Dash To Arrow (... -- ...; -> ... --> ...;)
+    processed = fixDoubleDashToArrow(processed);
+
+    // 22. Fix Targeted Notes (note Node "Content" -> NoteNode["Content"] \n Node -.- NoteNode)
+    processed = fixTargetedNotes(processed);
+
+    // 23. Fix Double Arrow Labels (Node -- L1 -- L2 --> Node)
+    processed = fixDoubleArrowLabels(processed);
+
+    // 24. Fix Unquoted Edge Labels (Node -- Unquoted --> Node)
+    processed = fixUnquotedEdgeLabels(processed);
+
+    // 26. Fix Shape Mismatch ([/["...["/] -> ["..."])
+    processed = fixShapeMismatch(processed);
+
+    // 27. Cleanup Placeholder Artifacts
+    processed = fixPlaceholderArtifacts(processed);
+
+    // 28. Cleanup `|\"\"|\"`
+    processed = processed.replace(/\|""\|"/g, '');
+
+    // 29. Cleanup `\[""\]`
+    processed = processed.replace(/\[""\]/g, '');
+
+    // 29 Fix Misplaced Pipes (>|"..."| ...)
+    processed = fixMisplacedPipes(processed);
+
+    // 30 Fix Misplaced Pipes (>|"..."| ...)
+    processed = processed.replace(/\"\[\]\"/g, '');
+
+    // 31 Fix Misplaced Pipes (>|"..."| ...)
+    processed = fixBlankArrows(processed);
+
+    
+    // --- RESTORE: Table Lines ---
+    if (protectedTableLines.length > 0) {
+        // We need to restore them. Since we operate on the whole string, we can replace the placeholders.
+        // However, some functions might have shifted things around? 
+        // Most functions are line-preserving or map lines.
+        // But `fixMermaidNotes` removes lines. `fixTargetedNotes` adds lines.
+        // The placeholders should persist as lines.
+        
+        // We iterate through the protected lines and replace their corresponding placeholder
+        protectedTableLines.forEach((originalLine, index) => {
+             const placeholder = `${tableLinePlaceholderPrefix}${index}___`;
+             // Use split/join to replace all occurrences (though strictly should be one)
+             processed = processed.split(placeholder).join(originalLine);
+        });
+    }
+
+    return processed;
+}
+
+/**
+ * Fixes invalid arrow syntax `--|>` by converting it to the standard `-->`.
+ * This often appears as a malformed attempt at an arrow or a typo.
+ * @param content The markdown content.
+ * @returns Content with `--|>` replaced by `-->`.
+ */
+export function fixInvalidArrows(content: string): string {
+    // Global replacement of --|> with -->
+    return content.replace(/--\|>/g, '-->');
+}
+
+
+/**
+ * Fixes invalid arrow syntax `--|>` by converting it to the standard `-->`.
+ * This often appears as a malformed attempt at an arrow or a typo.
+ * @param content The markdown content.
+ * @returns Content with `--|>` replaced by `-->`.
+ */
+export function fixBlankArrows(content: string): string {
+    // Global replacement of -- > with -->
+    return content.replace(/-- >/g, '-->');
+}
+
+/**
+ * Fixes shape mismatch where node shape definitions are mixed with quoted labels.
+ * Specifically targets the pattern `[/["...["/]` and converts it to standard `["..."]`.
+ * Example: `note1[/["Path Difference = CB + BD["/] -> note1["Path Difference = CB + BD"]`
+ */
+export function fixShapeMismatch(content: string): string {
+    let processed = content;
+    // Fix start: [/[" -> ["
+    processed = processed.replace(/\[\/\["/g, '["');
+    // Fix end: ["/] -> "]
+    processed = processed.replace(/\["\/\]/g, '"]');
+    return processed;
+}
+
+/**
+ * Cleans up leftover placeholder artifacts.
+ * Deletes '___BRACKET_BLOCK_0___' and similar artifacts.
+ */
+export function fixPlaceholderArtifacts(content: string): string {
+    return content.replace(/___BRACKET_BLOCK_\d+___/g, '');
+}
+
+/**
+ * Fixes double arrow labels.
+ * Pattern: `Node -- Label1 -- Label2 --> Node` or `Node -- Label1 -- Label2 --- Node`
+ * Result: `Node -- "Label1<br>Label2" --> Node`
+ * Handles quoted or unquoted labels.
+ * Refined to avoid matching `---` or `-->` as label separators.
+ */
+export function fixDoubleArrowLabels(content: string): string {
+    const lines = content.split('\n');
+    return lines.map(line => {
+        // Regex: Start -- L1 -- L2 (Arrow) End
+        // Arrow can be --> or ---
+        // We match non-greedy content between dashes.
+        // We use lookbehind (?<!-) and lookahead (?!>|-) to ensure we match exactly "--"
+        // and not parts of "---" or "-->".
+        
+        const regex = /^(.*?)\s*(?<!-)--(?!>|-)\s*((?:(?!-->|---|(?<!-)--(?!>|-)\s).)*?)\s*(?<!-)--(?!>|-)\s*((?:(?!-->|---|(?<!-)--(?!>|-)\s).)*?)\s*(-->|---)\s*(.*)$/;
+        
+        const match = line.match(regex);
+        if (match) {
+            const start = match[1];
+            let l1 = match[2].trim();
+            let l2 = match[3].trim();
+            const arrow = match[4]; // "-->" or "---"
+            const end = match[5];
+
+            // Strip quotes if present
+            if (l1.startsWith('"') && l1.endsWith('"')) l1 = l1.slice(1, -1);
+            if (l2.startsWith('"') && l2.endsWith('"')) l2 = l2.slice(1, -1);
+
+            // Combine with <br>
+            const combined = `${l1}<br>${l2}`;
+            
+            return `${start} -- "${combined}" ${arrow} ${end}`;
+        }
+        return line;
+    }).join('\n');
+}
+
+/**
+ * Fixes unquoted edge labels.
+ * Pattern: `Node -- Unquoted Text --> Node`
+ * Result: `Node -- "Unquoted Text" --> Node`
+ * Skips if already quoted.
+ */
+export function fixUnquotedEdgeLabels(content: string): string {
+    const lines = content.split('\n');
+    return lines.map(line => {
+        // Regex: (Start) -- (Label) --> (End)
+        // Label must NOT start with ".
+        // We need to be careful about `Node -- Node` (no label) which uses `---` or `-->` directly.
+        // This regex targets ` -- ` space-dash-dash-space specifically used for labels.
+        // Refined to use (?<!-)--(?!>|-) to avoid matching ---
+        
+        const regex = /^(.*?)\s*(?<!-)--(?!>|-)\s*([^">]+?)\s*-->\s*(.*)$/;
+        
+        // Exclude if it looks like `Node -- Node -->` (which is invalid anyway but...)
+        // We assume valid label text doesn't contain `-->` which regex enforces.
+        
+        const match = line.match(regex);
+        if (match) {
+            const start = match[1];
+            const label = match[2].trim();
+            const end = match[3];
+
+            // Double check it's not starting with quote (regex might miss if whitespace handled poorly)
+            if (label.startsWith('"')) return line;
+            
+            // Also ignore if label is empty (e.g. `A -- --> B` ? Invalid but possible typo)
+            if (!label) return line;
+
+            return `${start} -- "${label}" --> ${end}`;
+        }
+        return line;
+    }).join('\n');
+}
+
+/**
+ * Fixes "note position of Node : Content" by converting to a Note Node.
+ * Pattern: `note right of A : Text`
+ * Result: 
+ * NoteA["Note: Text"]
+ * A -.- NoteA
+ * 
+ * Also handles `note : Text` (standalone) -> `NoteX["Text"]` (no connection? or standalone)
+ */
+export function fixNotesToNodes(content: string): string {
+    const lines = content.split('\n');
+    const resultLines: string[] = [];
+    let standaloneCounter = 1;
+
+    // Regex for targeted notes (standard mermaid: note right of ...)
+    const targetedRegex = /^\s*note\s+(?:right|left|top|bottom)\s+of\s+([a-zA-Z0-9_]+)\s*:\s*(.*)$/i;
+    
+    // Regex for "note for/of Node Content" (User Extension)
+    // Matches: note for Node "Content"
+    const noteForOfRegex = /^\s*note\s+(?:for|of)\s+([a-zA-Z0-9_]+)\s+(.*)$/i;
+    
+    // Regex for standalone notes (note : Content)
+    // Sometimes people write `note "Content"` which is handled elsewhere, but `note :` is specific.
+    const standaloneRegex = /^\s*note\s*:\s*(.*)$/i;
+
+    for (const line of lines) {
+        // Check Targeted (Standard)
+        const tMatch = line.match(targetedRegex);
+        if (tMatch) {
+            const nodeId = tMatch[1];
+            const text = tMatch[2].trim();
+            const noteId = `Note${nodeId}`;
+            
+            // Format: NoteA["Note: ..."]
+            // If text is already quoted, strip them?
+            // User example: `Very High...` -> `["Note: Very High..."]`
+            let cleanText = text;
+            if (cleanText.startsWith('"') && cleanText.endsWith('"')) {
+                cleanText = cleanText.slice(1, -1);
+            }
+            
+            resultLines.push(`${noteId}["Note: ${cleanText}"]`);
+            resultLines.push(`${nodeId} -.- ${noteId}`);
+            continue;
+        }
+
+        // Check Targeted (Note For/Of - User Extension)
+        const nfMatch = line.match(noteForOfRegex);
+        if (nfMatch) {
+            const nodeId = nfMatch[1];
+            let text = nfMatch[2].trim();
+
+            // Handle artifact where line ends with ]
+            if (text.endsWith(']')) {
+                 text = text.slice(0, -1).trim();
+            }
+
+            const noteId = `Note${nodeId}`;
+
+            // Clean quotes
+            if (text.startsWith('"') && text.endsWith('"')) {
+                text = text.slice(1, -1);
+            }
+            
+            // User requested format: NoteM00[" Gaussian Intensity Profile"] (with leading space)
+            resultLines.push(`${noteId}[" ${text}"]`);
+            resultLines.push(`${nodeId} -.- ${noteId}`);
+            continue;
+        }
+
+        // Check Standalone
+        const sMatch = line.match(standaloneRegex);
+        if (sMatch) {
+            let text = sMatch[1].trim();
+             if (text.startsWith('"') && text.endsWith('"')) {
+                text = text.slice(1, -1);
+            }
+            const noteId = `Note${standaloneCounter++}`;
+            resultLines.push(`${noteId}["${text}"]`);
+            continue;
+        }
+
+        resultLines.push(line);
+    }
+    return resultLines.join('\n');
+}
+
+/**
+ * Fixes nested quotes within Mermaid node labels.
+ * Ensures that if a label is wrapped in `["..."]`, any internal double quotes are removed.
+ * This handles cases like: `SP --> Martingale["Martingale<br>E["Future | Past"] = Present"];`
+ * converting it to: `SP --> Martingale["Martingale<br>E[Future | Past] = Present"];`
+ * Uses a balanced bracket approach to identify the outer block.
+ */
+export function fixNestedMermaidQuotes(content: string): string {
+    const lines = content.split('\n');
+    const processedLines = lines.map(line => {
+        // Optimization: Skip if no `["` present
+        if (!line.includes('["')) return line;
+
+        let newLine = '';
+        let currentIndex = 0;
+        
+        while (currentIndex < line.length) {
+            // Find start of a potential `["` block
+            const openQuoteIndex = line.indexOf('["', currentIndex);
+            
+            if (openQuoteIndex === -1) {
+                // No more blocks, append rest of line
+                newLine += line.slice(currentIndex);
+                break;
+            }
+
+            // Append everything before the block
+            newLine += line.slice(currentIndex, openQuoteIndex);
+            
+            // Now scan for the closing `"]` using balanced brackets
+            let depth = 0;
+            let foundClose = false;
+            let closeIndex = -1;
+            
+            // Start scanning from the `[`
+            for (let i = openQuoteIndex; i < line.length; i++) {
+                const char = line[i];
+                
+                if (char === '[') {
+                    depth++;
+                } else if (char === ']') {
+                    depth--;
+                }
+                
+                // Check if we are at depth 0 (closed) and it's a `"]` pattern
+                // The closing pattern is `"]`. So current char is `]` and prev was `"`.
+                // Note: We need to be careful. The block starts with `["`.
+                // If we have `["abc"]`, at `]` depth becomes 0.
+                if (depth === 0) {
+                    // Check if it's `"]`
+                    if (line[i] === ']' && line[i-1] === '"') {
+                        closeIndex = i;
+                        foundClose = true;
+                        break;
+                    }
+                }
+            }
+            
+            if (foundClose) {
+                // We found a complete `[" ... "]` block
+                // Extract content: between `["` (start+2) and `"]` (end-1)
+                const fullBlock = line.slice(openQuoteIndex, closeIndex + 1);
+                const innerContent = line.slice(openQuoteIndex + 2, closeIndex - 1); // remove `["` and `"]`
+                
+                // Process inner content: remove all quotes `"`
+                // Requirement: "remove all redundant `"` characters"
+                // This keeps `["` and `"]` valid as brackets [ ] inside.
+                const cleanContent = innerContent.replace(/"/g, '');
+                
+                // Reconstruct block
+                newLine += `["${cleanContent}"]`;
+                
+                // Advance index past this block
+                currentIndex = closeIndex + 1;
+            } else {
+                // Unbalanced or malformed, just keep the `["` and move on
+                // To avoid infinite loop, advance past the `["`
+                newLine += '["';
+                currentIndex = openQuoteIndex + 2;
+            }
+        }
+        
+        return newLine;
+    });
+    return processedLines.join('\n');
+}
+
+/**
+ * Fixes formatted arrows followed by a semicolon and a string literal.
+ * Converts `A --> B; "Label"` into `A -- "Label" --> B;`.
+ * Example: `Levy --> Stationary; "Increments are stationary"`
+ */
+export function fixQuotedLabelsAfterSemicolon(content: string): string {
+    const lines = content.split('\n');
+    const processedLines = lines.map(line => {
+        // Regex to look for:
+        // 1. Everything before the arrow (Source)
+        // 2. The arrow (-->)
+        // 3. The target node (Target)
+        // 4. A semicolon
+        // 5. Optional whitespace
+        // 6. A quoted string ("Label")
+        // 7. Optional trailing content (ignored or kept?) -> usually assume end of meaningful instruction
+        
+        // We match `-->` specifically as per request.
+        if (!line.includes('-->')) return line;
+        
+        // Regex:
+        // ^(start) (-->) (target) (;)\s* " (label) " \s* $
+        const regex = /^(.*?)\s*(-->)\s*(.*?);\s*"([^"]+)"\s*$/;
+        
+        const match = line.match(regex);
+        if (match) {
+            const source = match[1].trim();
+            const arrow = match[2].trim(); // "-->"
+            const target = match[3].trim();
+            const label = match[4].trim(); // content inside quotes
+            
+            // Construct new line
+            // Source -- "Label" --> Target;
+            // We insert the label into the arrow.
+            return `${source} -- "${label}" ${arrow} ${target};`;
+        }
+        
+        return line;
+    });
+    return processedLines.join('\n');
+}
+
+
+/**
+ * Fixes excessive brackets like `[["` -> `["` and `["]` -> `"]`.
+ * Also ensures `[";` becomes `"];` if not already handled.
+ * Enhanced to handle complex patterns like:
+ * - `Target -- Result --> PT___BRACKET_BLOCK_0______BRACKET_BLOCK_0______BRACKET_BLOCK_0___[["Final...["` 
+ * - Should become: `Target -- Result --> PT___BRACKET_BLOCK_0______BRACKET_BLOCK_0______BRACKET_BLOCK_0___["Final..."]`
+ */
+export function fixExcessiveBrackets(content: string): string {
+    let lines = content.split('\n');
+    lines = lines.map(line => {
+        let processedLine = line;
+        
+        // Multiple passes to handle nested/repeated patterns
+        let previousLine = '';
+        let maxIterations = 10; // Prevent infinite loops
+        let iteration = 0;
+        
+        while (processedLine !== previousLine && iteration < maxIterations) {
+            previousLine = processedLine;
+            
+            // Replace [[" with ["
+            processedLine = processedLine.replace(/\[\["/g, '["');
+            
+            // Replace ["] with "] (but be careful not to break valid patterns)
+            // Only replace if it's truly excessive (e.g., ends improperly)
+            processedLine = processedLine.replace(/\["\]/g, '"]');
+            
+            // Fix pattern like `text["` at end of line -> `text"]`
+            processedLine = processedLine.replace(/\["$/g, '"]');
+            
+            // Fix pattern like `text[";` -> `text"];`
+            processedLine = processedLine.replace(/\[";/g, '"];');
+            
+            // Fix pattern like [[[ or ]]] (excessive brackets without quotes)
+            processedLine = processedLine.replace(/\[\[\[/g, '[');
+            processedLine = processedLine.replace(/\]\]\]/g, ']');
+
+            // NEW: Fix end of line ]] or ]];
+            processedLine = processedLine.replace(/\]\](;?)\s*$/g, ']$1');
+            
+            iteration++;
+        }
+
+        return processedLine;
+    });
+    return lines.join('\n');
+}
+
+/**
+ * Fixes intermediate nodes defined inside an edge.
+ * Pattern: `A -- B[...] --> C`
+ * Result:
+ * A --> B[...]
+ * B[...] --> C
+ */
+export function fixIntermediateNodes(content: string): string {
+    const lines = content.split('\n');
+    const resultLines: string[] = [];
+
+    for (const line of lines) {
+        // Regex to detect: NodeA ... -- NodeB[...] ... --> NodeC
+        // We look for ` -- ` followed by `NodeID[...]` followed by ` --> `
+        // Be careful with greedy matches.
+        // We assume the intermediate node has brackets [ ... ]
+        
+        // Group 1: Start (NodeA)
+        // Group 2: Intermediate Node (NodeB[...])
+        // Group 3: End (NodeC)
+        const match = line.match(/^(.*?)\s*--\s*([a-zA-Z0-9_]+\s*\[.*?\])\s*-->\s*(.*)$/);
+        
+        if (match) {
+            const start = match[1].trim();
+            const middle = match[2].trim();
+            const end = match[3].trim();
+            
+            // Extract the NodeID from middle to use in the second line
+            const middleIdMatch = middle.match(/^([a-zA-Z0-9_]+)/);
+            const middleId = middleIdMatch ? middleIdMatch[1] : middle; // Fallback to full middle if parse fails (unlikely)
+
+            // Line 1: A --> B[...] 
+            // Note: Use --> for the first connection as well, or preserve --?
+            // The user example converted `Reactants -- Barrier1 -->` to `Reactants --> Barrier1`.
+            resultLines.push(`${start} --> ${middle}`);
+            
+            // Line 2: B[...] --> C
+            // User example: Barrier1["..."] --> Products
+            // Actually user example uses the full definition `Barrier1["..."]` in the second line too.
+            // "Barrier1["Activation Energy Ea1"] --> Products[...]"
+            // This is valid Mermaid (re-defining node is fine).
+            resultLines.push(`${middle} --> ${end}`);
+        } else {
+            resultLines.push(line);
+        }
+    }
+    return resultLines.join('\n');
+}
+
+/**
+ * Fixes doubled IDs causing malformed definitions.
+ * Pattern: `Arrow SplitSplit Sample` -> `Arrow Split[Split Sample]`
+ */
+export function fixDoubledID(content: string): string {
+    const lines = content.split('\n');
+    const processedLines = lines.map(line => {
+        // Look for pattern: (Arrow) (Word)(SameWord) (Space) (Rest)
+        // \1 backreference to match repeated word
+        // We only target lines with arrows to avoid false positives in text
+        if (!line.includes('-->') && !line.includes('---') && !line.includes('--')) {
+            return line;
+        }
+
+        return line.replace(/(\s*(?:---|-->|--)\s*)([A-Z][a-z]+)\2(\s+)(.*)$/, (match, arrow, word, space, rest) => {
+            // arrow: " --> "
+            // word: "Split"
+            // space: " "
+            // rest: "Sample for..."
+            
+            // Result: " --> Split[Split Sample for...]"
+            // We append the word back to the start of the label
+            return `${arrow}${word}[${word}${space}${rest}]`;
+        });
+    });
+    return processedLines.join('\n');
+}
+
+/**
+ * Fixes unquoted node labels containing characters that might cause rendering issues.
+ * Heuristic: Quote labels containing ", ', =, *, ±, -
+ * Example: Plot[Plot "A"] -> Plot["Plot "A""]
+ * Handles trailing semicolons by moving them outside the quotes.
+ */
+export function fixUnquotedNodeLabels(content: string): string {
+    const lines = content.split('\n');
+    const processedLines = lines.map(line => {
+        // Match NodeID[Content] where Content is not fully quoted
+        // Exclude content that starts with " (heuristic for already quoted)
+        // We use a safe regex that doesn't cross brackets to avoid breaking nested structures
+        return line.replace(/([a-zA-Z0-9_]+)\s*\[(?!")([^\[\]]+)\]/g, (match, nodeId, innerContent) => {
+             // Check for triggers: quotes, equals, asterisk, plus-minus, minus
+             // These are characters that often require quoting in Mermaid labels
+             if (/["'=*±\/-]/.test(innerContent)) {
+                 // Check if innerContent ends with semicolon
+                 let contentToQuote = innerContent;
+                 let suffix = '';
+                 // Trim trailing whitespace first to check for semicolon
+                 const trimmedContent = contentToQuote.trim();
+                 if (trimmedContent.endsWith(';')) {
+                     // Remove semicolon from content
+                     contentToQuote = trimmedContent.slice(0, -1);
+                     suffix = ';';
+                 }
+                 
+                 return `${nodeId}["${contentToQuote}"]${suffix}`;
+             }
+             return match;
+        });
+    });
+    return processedLines.join('\n');
+}
+
+/**
+ * Fixes Mermaid comments that break syntax by merging them into the label.
+ * Example: `A -- Label --> B; % Comment` -> `A -- "Label(Comment)" --> B;`
+ */
+export function fixMermaidComments(content: string): string {
+    const lines = content.split('\n');
+    const processedLines = lines.map(line => {
+        // Simple check for potential Mermaid comment
+        if (!line.includes('%') || !line.includes('-->')) {
+            return line;
+        }
+
+        // We only care about lines that look like: ... -- ... --> ... % ...
+        // Split by '%' first to safely isolate the comment, ensuring % isn't inside a quoted label.
+        
+        const parts = line.split('%');
+        
+        let codePart = parts[0];
+        let commentPart = '';
+        let foundComment = false;
+        
+        // Re-assemble parts if the % was inside a quote.
+        for (let i = 1; i < parts.length; i++) {
+             const potentialCode = parts.slice(0, i).join('%');
+             const quoteCount = (potentialCode.match(/"/g) || []).length;
+             if (quoteCount % 2 === 0) {
+                 // Even quotes means we are outside a string, so this % starts a comment
+                 codePart = potentialCode;
+                 commentPart = parts.slice(i).join('%');
+                 foundComment = true;
+                 break;
+             }
+        }
+        
+        if (!foundComment) return line; // No valid comment found or % was inside quotes
+        
+        // Clean up parts
+        let cleanCode = codePart.trim();
+        const cleanComment = commentPart.trim();
+        
+        if (!cleanComment) return line; // Empty comment, keep as is
+        
+        // Check for trailing semicolon in code
+        let hasSemi = false;
+        if (cleanCode.endsWith(';')) {
+            cleanCode = cleanCode.slice(0, -1).trim();
+            hasSemi = true;
+        }
+        
+        // Parse the arrow relation in cleanCode
+        // We support: A -- Label --> B
+        // Regex: (Start) (-- ) (Label) ( --> ) (End)
+        const arrowLabelRegex = /^(.*?)(--\s*)(.*?)(\s*-->\s*)(.*?)$/;
+        const match = cleanCode.match(arrowLabelRegex);
+        
+        if (match) {
+            const pre = match[1];
+            const arrowStart = match[2];
+            let label = match[3];
+            const arrowEnd = match[4];
+            const post = match[5];
+            
+            // If label is quoted, strip quotes
+            if (label.startsWith('"') && label.endsWith('"')) {
+                label = label.slice(1, -1);
+            }
+            
+            // Append comment
+            const newLabel = `${label}(${cleanComment})`;
+            
+            // Reconstruct
+            return `${pre}${arrowStart}"${newLabel}"${arrowEnd}${post}${hasSemi ? ';' : ''}`;
+        }
+        
+        return line;
+    });
+    
+    return processedLines.join('\n');
+}
+
+/**
+ * Fixes inline subgraphs used as edge labels.
+ * Pattern: `NodeA --> NodeB; subgraph "Label" end;`
+ * Result: `NodeA -- "Label" --> NodeB;`
+ */
+export function fixInlineSubgraphs(content: string): string {
+    const lines = content.split('\n');
+    const processedLines = lines.map(line => {
+        // Regex to detect: Node ... Arrow ... Node; subgraph "Label" end;
+        // Captures:
+        // 1. Source (lazy)
+        // 2. Arrow (--> or ---)
+        // 3. Target (lazy)
+        // 4. Label (inside quotes)
+        
+        const regex = /^(.*?)\s*(---|-->)\s*(.*?);\s*subgraph\s+"(.*?)"\s*end;?\s*$/;
+        const match = line.match(regex);
+        
+        if (match) {
+            const source = match[1].trim();
+            const arrow = match[2].trim(); // '-->' or '---'
+            const target = match[3].trim();
+            const label = match[4].trim();
+            
+            // Construct new line: source -- "label" --> target;
+            // We use the arrow type to determine the connector.
+            // --> becomes -- "label" -->
+            // --- becomes -- "label" ---
+            
+            let newArrow = arrow;
+            if (arrow === '-->') {
+                newArrow = ` -- "${label}" --> `;
+            } else if (arrow === '---') {
+                newArrow = ` -- "${label}" --- `;
+            } else {
+                 // Fallback if regex matched something else (unlikely given regex)
+                 newArrow = ` -- "${label}" ${arrow} `;
+            }
+            
+            return `${source}${newArrow}${target};`;
+        }
+        return line;
+    });
+    return processedLines.join('\n');
+}
+
+/**
+ * Merges double labels on a single edge.
+ * Pattern: `-- "Label1" -->|"Label2"|`
+ * Result: `-- "Label1<br>(Label2)" -->`
+ * This relies on fixMermaidPipes having already standardized the pipe label to `|"..."|`.
+ */
+export function mergeDoubleLabels(content: string): string {
+    // Regex to capture:
+    // -- "Label1" --> |"Label2"|
+    // We allow whitespace flexibility.
+    
+    return content.replace(/--\s*"([^"]*)"\s*-->\s*\|"([^"]*)"\|/g, (match, label1, label2) => {
+        return `-- "${label1}<br>(${label2})" -->`;
+    });
+}
+
+/**
+ * Fixes Mermaid edge labels involving pipes `|`.
+ * Ensures that labels are properly quoted and delimited.
+ * 1. `-->|Text|` -> `-->|"Text"|`
+ * 2. `-- Text |` -> `--|"Text"|`
+ * 3. Handles complex cases like `-->|Fourier Transform|^2|` -> `|"Fourier Transform|^2"|` (quoting the content)
+ */
+export function fixMermaidPipes(content: string): string {
+    const lines = content.split('\n');
+    const processedLines = lines.map(line => {
+        // Skip lines without pipes or arrows
+        if (!line.includes('|') || (!line.includes('-->') && !line.includes('--'))) {
+            return line;
+        }
+
+        // 1. Protect Bracketed Content [...]
+        const placeholders: string[] = [];
+        let protectedLine = '';
+        let depth = 0;
+        let currentBlock = '';
+        
+        for (let i = 0; i < line.length; i++) {
+            const char = line[i];
+            if (char === '[') {
+                if (depth === 0) protectedLine += '___BRACKET_BLOCK_' + placeholders.length + '___';
+                depth++;
+                currentBlock += char;
+            } else if (char === ']') {
+                depth--;
+                currentBlock += char;
+                if (depth === 0) {
+                    placeholders.push(currentBlock);
+                    currentBlock = '';
+                }
+            } else {
+                if (depth > 0) currentBlock += char;
+                else protectedLine += char;
+            }
+        }
+        if (depth > 0) protectedLine += currentBlock;
+
+        // 2. Fix Pipes in Protected Line
+        // Regex: (Arrow)(Space)(Content Ending in Pipe)(Space)(NodeStart)
+        // Content must NOT contain Arrow markers to prevent over-greediness.
+        // NodeStart includes brackets, parens, quotes, or word chars.
+        
+        const arrowRegex = /((?:---|-->|--))(\s*)((?:(?!(?:---|-->|--)).)*\|)(\s*)(?=[a-zA-Z0-9_\[\(\{\"])/g;
+        
+        protectedLine = protectedLine.replace(arrowRegex, (match, arrow, space1, labelCandidate, space2) => {
+            // labelCandidate is the text between arrow and Node, ending with `|`.
+            
+            let content = labelCandidate.trim();
+            
+            // Logic:
+            // If it matches `|...|` (standard), extract inner.
+            // If it matches `...|` (separator), extract all.
+            // If it matches `|...|...|`, extract inner from first/last pipe?
+            
+            let inner = content;
+            
+            if (content.startsWith('|') && content.endsWith('|') && content.length > 1) {
+                // Remove outer pipes
+                inner = content.substring(1, content.length - 1);
+            } else if (content.endsWith('|')) {
+                // Remove trailing pipe
+                inner = content.substring(0, content.length - 1).trim();
+            }
+            
+            // Check if already quoted
+            if (inner.startsWith('"') && inner.endsWith('"')) {
+                return match;
+            }
+            
+            // Quote it and wrap in pipes
+            return `${arrow}${space1}|"${inner}"|${space2}`;
+        });
+
+        // 3. Restore Bracketed Content
+        placeholders.forEach((block, index) => {
+            const placeholder = '___BRACKET_BLOCK_' + index + '___';
+            protectedLine = protectedLine.split(placeholder).join(block);
+        });
+
+        return protectedLine;
+    });
+
+    return processedLines.join('\n');
+}
+
+
+/**
+ * Fixes malformed arrow labels where the arrow syntax is absorbed into quotes.
+ * Rule: Replace ` -->"` with `" -->` and `"-- ` with `--" `, unless inside `[...]`.
+ * Example: `AbInitio -- "Provides Parameters For -->" MM` -> `AbInitio -- "Provides Parameters For" --> MM`
+ */
+export function fixMalformedArrows(content: string): string {
+    const lines = content.split('\n');
+    const processedLines = lines.map(line => {
+        // Simple check to avoid processing lines without arrow-like patterns
+        if (!line.includes('--') && !line.includes('-->')) {
+            return line;
+        }
+
+        // 1. Protect Bracketed Content [...]
+        // We use a placeholder to hide content inside top-level brackets
+        const placeholders: string[] = [];
+        let protectedLine = '';
+        let depth = 0;
+        let currentBlock = '';
+        
+        for (let i = 0; i < line.length; i++) {
+            const char = line[i];
+            
+            if (char === '[') {
+                if (depth === 0) {
+                    protectedLine += '___BRACKET_BLOCK_' + placeholders.length + '___';
+                }
+                depth++;
+                currentBlock += char;
+            } else if (char === ']') {
+                depth--;
+                currentBlock += char;
+                if (depth === 0) {
+                    placeholders.push(currentBlock);
+                    currentBlock = '';
+                }
+            } else {
+                if (depth > 0) {
+                    currentBlock += char;
+                } else {
+                    protectedLine += char;
+                }
+            }
+        }
+        // Handle unclosed brackets (append remaining)
+        if (depth > 0) {
+            protectedLine += currentBlock;
+        }
+
+        // 2. Perform Replacements on Protected Line
+        // Fix A: ` -->"` -> `" -->`
+        // We look for the pattern and replace it. 
+        // Note: The user said "instances of ` -->"` ".
+        // We assume this means literally space-dash-dash-gt-quote.
+        protectedLine = protectedLine.replace(/ -->"/g, '" -->');
+
+        // Fix B: `"-- ` -> `--" `
+        // Quote-dash-dash-space
+        protectedLine = protectedLine.replace(/"-- /g, '--" ');
+
+        // 3. Restore Bracketed Content
+        placeholders.forEach((block, index) => {
+            const placeholder = '___BRACKET_BLOCK_' + index + '___';
+            protectedLine = protectedLine.split(placeholder).join(block);
+        });
+
+        return protectedLine;
+    });
+
+    return processedLines.join('\n');
+}
+
+/**
+ * Internal function to fix missing brackets in Mermaid nodes.
+ * Example: `... --> SpreadCalc价差计算 Spread Calculation;` -> `... --> SpreadCalc[价差计算 Spread Calculation];`
+ */
+export function fixMissingBrackets(content: string): string {
+    const lines = content.split('\n');
+    const processedLines = lines.map(line => {
+        // Skip if not in a mermaid block context or no arrows
+        if (!line.includes('-->') && !line.includes('---') && !line.includes('--')) {
+            return line;
+        }
+
+        // Regex to find:
+        // 1. Arrow (standard or labeled). We use a flexible match for labeled arrows: -- ... -->
+        // 2. ASCII NodeID ([a-zA-Z0-9_]+)
+        // 3. Content that is NOT empty, DOES NOT START with [, and ends at ;
+        // We use non-greedy match .*? to capture content until ;
+        
+        const regex = /((?:---|-->|--.*?-->)\s*)([a-zA-Z0-9_]+\b)\s*([^\[\n].*?)(;)/g;
+        
+        if (regex.test(line)) {
+             return line.replace(regex, '$1$2[$3]$4');
+        }
+        
+        return line;
+    });
+    return processedLines.join('\n');
+}
+
+/**
+ * Converts "note right of Node: Text" lines into edge labels on the nearest preceding connection.
+ * Requirements:
+ * - Detect `note right of words: ...`
+ * - Relocate sentence to nearest `words -->` block (Source) or `--> words` block (Target).
+ * - Replace `-->` with `-- "Sentences" -->`.
+ * - Remove the original note line.
+ */
+export function fixMermaidNotes(content: string): string {
+    const lines = content.split('\n');
+    const notesToProcess: { lineIndex: number; nodeId: string; text: string; }[] = [];
+
+    // 1. Identify all notes
+    // Regex allows "note right/left/top/bottom of Node: Text"
+    const noteRegex = /^\s*note\s+(right|left|top|bottom)\s+of\s+([a-zA-Z0-9_]+)\s*:\s*(.*)$/i;
+
+    lines.forEach((line, index) => {
+        const match = line.match(noteRegex);
+        if (match) {
+            notesToProcess.push({
+                lineIndex: index,
+                nodeId: match[2],
+                text: match[3].trim()
+            });
+        }
+    });
+
+    if (notesToProcess.length === 0) return content;
+
+    const linesToDelete = new Set<number>();
+    
+    // Process notes
+    for (const note of notesToProcess) {
+        const { lineIndex, nodeId, text } = note;
+        let found = false;
+
+        // Search backwards from the note's position
+        for (let j = lineIndex - 1; j >= 0; j--) {
+            if (linesToDelete.has(j)) continue;
+
+            const line = lines[j];
+            
+            // Check for Node as SOURCE (Outgoing)
+            // Regex: Start or space(s) + NodeID + word boundary + optional brackets + space + (---|-->)
+            const sourceRegex = new RegExp(`(?:^|\\s+)${nodeId}\\b(?:\\[.*?\\])?\\s*(---|-->)`);
+            
+            // Check for Node as TARGET (Incoming)
+            // Regex: (---|-->) + space + NodeID + word boundary + optional brackets + (semicolon, end, or space)
+            const targetRegex = new RegExp(`(---|-->)\\s*${nodeId}\\b(?:\\[.*?\\])?(?:;|$|\\s)`);
+
+            // Apply replacement
+            // Priority: Source (Outgoing) first, then Target (Incoming)
+            
+            if (sourceRegex.test(line)) {
+                const escapedText = text.replace(/"/g, '\\"');
+                lines[j] = line.replace(sourceRegex, (match) => {
+                    return match.replace(/\s*(---|-->)$/, (fullMatch, arrow) => ` -- "${escapedText}" ${arrow}`);
+                });
+                found = true;
+            } else if (targetRegex.test(line)) {
+                const escapedText = text.replace(/"/g, '\\"');
+                lines[j] = line.replace(targetRegex, (match) => {
+                     return match.replace(/^(---|-->)/, (arrow) => `-- "${escapedText}" ${arrow}`);
+                });
+                found = true;
+            }
+
+            if (found) {
+                linesToDelete.add(lineIndex);
+                break; // Stop searching for this note
+            }
+        }
+    }
+
+    // Return joined lines, filtering out deleted ones
+    return lines.filter((_, index) => !linesToDelete.has(index)).join('\n');
+}
+
+/**
+ * Fixes semicolon positioning in Mermaid node labels.
+ * Ensures that closing brackets `"]` appear before semicolons `;`.
+ * Example: `Node["Label"];` is correct, but `Node["Label];` should become `Node["Label"];`
+ * Also handles: `text];` -> `text"];` when text should be quoted
+ */
+export function fixSemicolonPositioning(content: string): string {
+    const lines = content.split('\n');
+    const processedLines = lines.map(line => {
+        // Skip lines without semicolons or arrows
+        if (!line.includes(';') || (!line.includes('-->') && !line.includes('--'))) {
+            return line;
+        }
+
+        // Pattern 1: Fix `"];` that might be incorrectly positioned
+        // Look for patterns where ] comes after ; when it should be before
+        // Pattern: `"...];` should be `"..."];`
+        let processedLine = line.replace(/("\s*)\];/g, '"];');
+
+        // Pattern 2: Ensure quoted labels ending with semicolon have proper bracket placement
+        // `["text;` -> `["text"];`
+        processedLine = processedLine.replace(/\["([^"\]]*);/g, '["$1"];');
+
+        // Pattern 3: Handle unquoted text after arrow ending with semicolon
+        // This catches patterns like: `--> NodeIDText Text;` and converts to `--> NodeID["Text Text"];`
+        // We need to be careful to identify where the NodeID ends and label begins
+        
+        return processedLine;
+    });
+    return processedLines.join('\n');
+}
+
+/**
+ * Fixes unquoted node labels that end with semicolons.
+ * Converts patterns like: `NodeID Text Content;` to `NodeID["Text Content"];`
+ * Example: `Evaluate1E: Evaluate $f$;` -> `Evaluate1["E: Evaluate $f$"];`
+ */
+export function fixUnquotedLabelsWithSemicolons(content: string): string {
+    const lines = content.split('\n');
+    const processedLines = lines.map(line => {
+        // Skip lines without semicolons or arrows
+        if (!line.includes(';') || (!line.includes('-->') && !line.includes('--'))) {
+            return line;
+        }
+
+        // Pattern: Arrow followed by NodeID followed by unquoted text ending with semicolon
+        // Regex: (Arrow) (Space) (NodeID) (Unquoted Text Content) (Semicolon)
+        // We look for: `--> NodeIDText Text...;` where there's no opening bracket after NodeID
+        
+        // Match pattern: `(-->) (NodeID)(Content without brackets)(;)`
+        const regex = /((?:--|---)->)\s*([a-zA-Z0-9_]+)([^[\n;]+);/g;
+        
+        return line.replace(regex, (match, arrow, nodeId, content) => {
+            // Check if content starts with a bracket (already has label)
+            if (content.trim().startsWith('[')) {
+                return match;
+            }
+            
+            // Extract the label from content
+            // Often NodeID is partially in the content (e.g., "E: Text" where NodeID was "Evaluate1E")
+            const trimmedContent = content.trim();
+            
+            // If content is empty or very short, skip
+            if (!trimmedContent || trimmedContent.length < 2) {
+                return match;
+            }
+            
+            // Build new syntax: arrow NodeID["Content"];
+            return `${arrow} ${nodeId}["${trimmedContent}"];`;
+        });
+    });
+    return processedLines.join('\n');
+}
+
+/**
+ * Enhanced note pattern and semicolon content removal.
+ * 1. Replaces `note "Sentences"` with `Note1[/"Sentences"/]`
+ * 2. Removes content after `;` if line contains `%` after the semicolon
+ * 3. Specifically handles `-.- Words["Sentences"]; % notes` pattern
+ */
+export function enhancedNoteAndSemicolonCleanup(content: string): string {
+    let processed = content;
+    
+    // 1. Replace note "Sentences" with Note1[/"Sentences"/]
+    // This pattern catches standalone note statements (not "note right of")
+    // Use a counter to avoid aliasing multiple notes to Note1
+    let noteCounter = 1;
+    processed = processed.replace(/\bnote\s+"([^"]*)"/gi, (match: string, noteContent: string) => {
+        return `Note${noteCounter++}[/"${noteContent}"/]`;
+    });
+    
+    // 2. Remove content after ; if the line contains % after ;
+    // Pattern: `;...%...` on any line
+    // We want to keep everything before `;`, the `;` itself, but remove everything after if `%` appears
+    processed = processed.replace(/;([^;\n]*%[^\n]*)/g, ';');
+    
+    // 3. Specific pattern: Lines with `-.-` (dotted lines) containing `["..."];` followed by `% comment`
+    // Example: `A -.- B["Text"]; % comment` -> `A -.- B["Text"];`
+    // This is already handled by rule 2 above
+    
+    return processed;
+}
+
+/**
+ * Fixes smart (curly) quotes in Mermaid labels.
+ * Converts “” ‘’ to "" ''
+ * Specifically fixes Note["/“Sentences”/"] -> Note["/Sentences/"]
+ * Also handles general cases of excessive closing brackets if needed.
+ */
+export function fixSmartQuotes(content: string): string {
+    let processed = content
+        .replace(/[\u201C\u201D]/g, '"') // Curly double quotes to straight
+        .replace(/[\u2018\u2019]/g, "'"); // Curly single quotes to straight
+
+    // Fix slashed note pattern: Note["/“Sentences”/"] -> Note["/Sentences/"]
+    // Handle with spaces or without
+    processed = processed.replace(/Note\s*\["\s*\/\s*(["\u201C][^"\u201D]*["\u201D])\s*\/\s*"\]/g, (match, innerQuotes) => {
+        const innerText = innerQuotes.replace(/[\u201C\u201D]/g, '"').replace(/^["']|["']$/g, '');
+        return `Note["/${innerText}/"]`;
+    });
+    processed = processed.replace(/Note\s*\["\/([^"]+)\"\/"\]/g, (match, text) => `Note["/${text.trim()}/"]`);
+
+    // General for any node: [" / “text” / "] -> [" / text / "]
+    processed = processed.replace(/\["\s*\/\s*(["\u201C][^"\u201D]*["\u201D])\s*\/\s*"\]/g, (match, innerQuotes) => {
+        const innerText = innerQuotes.replace(/[\u201C\u201D]/g, '"').replace(/^["']|["']$/g, '');
+        return `["/${innerText}/"]`;
+    });
+    processed = processed.replace(/\["\/([^"]+)\"\/"\]/g, (match, text) => `["/${text.trim()}/"]`);
+
+    return processed;
+}
+
+/**
+ * Fixes reverse arrows `A <-- B` to `B --> A`.
+ * Supports optional brackets/quotes on nodes.
+ * Example: `ExSitu["Ex-situ..."] <-- Sample;` -> `Sample --> ExSitu["Ex-situ..."];`
+ */
+export function fixReverseArrows(content: string): string {
+    const lines = content.split('\n');
+    const processedLines = lines.map(line => {
+        if (!line.includes('<--')) return line;
+
+        // Regex to capture:
+        // Group 1: Left Node (lazy)
+        // Group 2: <-- (literal)
+        // Group 3: Right Node (lazy)
+        // Group 4: Optional Semicolon
+        const regex = /^(.*?)\s*<--\s*(.*?)(;?)\s*$/;
+        const match = line.match(regex);
+
+        if (match) {
+            const leftNode = match[1].trim();
+            const rightNode = match[2].trim();
+            const semicolon = match[3] || '';
+            
+            return `${rightNode} --> ${leftNode}${semicolon}`;
+        }
+        return line;
+    });
+    return processedLines.join('\n');
+}
+
+/**
+ * Fixes `Direction` keyword case in subgraphs.
+ * Mermaid is case-sensitive inside subgraphs: `Direction TB` -> `direction TB`.
+ */
+export function fixSubgraphDirection(content: string): string {
+    const lines = content.split('\n');
+    let insideSubgraph = false;
+    const processedLines = lines.map(line => {
+        if (line.trim().startsWith('subgraph')) {
+            insideSubgraph = true;
+        } else if (line.trim() === 'end') {
+            insideSubgraph = false;
+        }
+
+        if (insideSubgraph) {
+            // Replace `Direction` with `direction` if followed by TB, BT, LR, RL, TD
+            return line.replace(/^\s*Direction\s+(TB|BT|LR|RL|TD)\b/g, (match) => {
+                return match.replace('Direction', 'direction');
+            });
+        }
+        return line;
+    });
+    return processedLines.join('\n');
+}
+
+/**
+ * Fixes comments designated by `//` on arrow lines, converting them to edge labels.
+ * Example: `Thermal --> Optical; // Thermo-optic effect` 
+ * Become: `Thermal -- "Thermo-optic effect" --> Optical;`
+ */
+export function fixDoubleSlashComments(content: string): string {
+    const lines = content.split('\n');
+    const processedLines = lines.map(line => {
+        if (!line.includes('//') || !line.includes('-->')) return line;
+
+        // Regex to find arrow relation followed by // comment
+        // Handle optional semicolon before //
+        // Group 1: Pre-arrow part
+        // Group 2: Arrow (-->)
+        // Group 3: Post-arrow part (target node)
+        // Group 4: Semicolon (optional)
+        // Group 5: Comment text
+        
+        // This regex assumes standard `-->` arrow. 
+        // We match `//` specifically.
+        
+        const regex = /^(.*?)(\s*-->\s*)(.*?)(;?)\s*\/\/\s*(.*)$/;
+        const match = line.match(regex);
+        
+        if (match) {
+            const preArrow = match[1]; // "Thermal"
+            const arrow = match[2]; // " --> "
+            const target = match[3].trim(); // "Optical"
+            const semicolon = match[4]; // ";"
+            const comment = match[5].trim(); // "Thermo-optic effect"
+            
+            if (comment) {
+                // Construct: Pre -- "Comment" --> Target;
+                // Note: arrow variable contains " --> ". We change it to " -- "Comment" --> "
+                const newArrow = ` -- "${comment}" --> `;
+                return `${preArrow}${newArrow}${target}${semicolon}`;
+            }
+        }
+        return line;
+    });
+    return processedLines.join('\n');
+}
+
+/**
+ * Fixes duplicated bracketed labels.
+ * Example: `Node["Label"]["Label"]` -> `Node["Label"]`
+ * Retains only the last occurrence if they differ, or just collapses them.
+ * The prompt says: "only the final occurrence shall be retained".
+ */
+export function fixDuplicateLabels(content: string): string {
+    const lines = content.split('\n');
+    const processedLines = lines.map(line => {
+        // Regex to match consecutive quoted brackets: ["..."]["..."]...
+        // We want to replace the whole sequence with just the last ["..."]
+        
+        // Improved Regex to handle escaped quotes: \[\"(?:[^"\\]|\\.)*\"\]
+        const blockRegexStr = '\\["(?:[^"\\\\]|\\\\.)*"\\]';
+        const blockRegex = new RegExp(blockRegexStr, 'g');
+        
+        // We look for 2 or more occurrences
+        const chainRegex = new RegExp(`((?:${blockRegexStr}\\s*){2,})`, 'g');
+        
+        return line.replace(chainRegex, (match) => {
+             // Split match into blocks
+             const blocks = match.match(blockRegex);
+             if (blocks && blocks.length > 0) {
+                 return blocks[blocks.length - 1];
+             }
+             return match;
+        });
+    });
+    return processedLines.join('\n');
+}
+
+/**
+ * Fixes lines ending with `;` where the last delimiter is `--` instead of `-->`.
+ * Example: `A -- B;` -> `A --> B;`
+ */
+export function fixDoubleDashToArrow(content: string): string {
+    const lines = content.split('\n');
+    const processedLines = lines.map(line => {
+        // Target: ... -- Words...; where Words contains no -- or -->
+        if (!line.trim().endsWith(';')) return line;
+        
+        // Regex to capture:
+        // Group 1: Everything before
+        // Group 2: Pre-dash whitespace
+        // Group 3: Post-dash whitespace
+        // Group 4: Content
+        
+        // We match `--` explicitly using lookbehind/lookahead to avoid ---
+        // (?<!-)--(?!>|-)
+        
+        const regex = /^(.*?)(\s*)(?<!-)--(?!>|-)(\s*)((?:(?!--|-->).)*?);\s*$/;
+        
+        const match = line.match(regex);
+        if (match) {
+            const p1 = match[1];
+            const s1 = match[2];
+            const s2 = match[3];
+            const p4 = match[4]; // Content
+            
+            // The regex lookbehind handles the --- cases now, but we can double check logic
+            // strict logic is better
+            
+            // We reconstruct with -->
+            // We preserve s1 and s2 whitespace.
+            return `${p1}${s1}-->${s2}${p4};`;
+        }
+        return line;
+    }).join('\n');
+    return processedLines;
+}
+
+/**
+ * Scans the content to identify valid Node IDs.
+ * Used to heuristically fix malformed node definitions.
+ */
+function getValidNodeIDs(content: string): Set<string> {
+    const validIDs = new Set<string>();
+    
+    // Regex patterns to find node IDs
+    // We strictly look for definitions (brackets) or usage as SOURCE.
+    // We exclude usage as TARGET (--> Node) because that might be the typo we are trying to fix (e.g. --> BSupercapacitor).
+    const patterns = [
+        /\b([a-zA-Z0-9_]+)\s*\[/g,       // Node[...
+        /\b([a-zA-Z0-9_]+)\s*-->/g,      // Node -->
+        // /-->\s*([a-zA-Z0-9_]+)\b/g,   // REMOVED: --> Node (Target)
+        /\b([a-zA-Z0-9_]+)\s*---/g,      // Node ---
+        // /---\s*([a-zA-Z0-9_]+)\b/g,   // REMOVED: --- Node (Target)
+        /^\s*([a-zA-Z0-9_]+)\s*-->/gm,   // Start of line Node -->
+        /^\s*([a-zA-Z0-9_]+)\s*--\s/gm,  // Start of line Node -- (Labeled arrow start)
+        /\b([a-zA-Z0-9_]+)\s*--\s/g,     // Node -- (anywhere)
+    ];
+
+    patterns.forEach(regex => {
+        let match;
+        while ((match = regex.exec(content)) !== null) {
+            // Filter out common keywords
+            const id = match[1];
+            if (!['graph', 'subgraph', 'style', 'class', 'click', 'linkStyle', 'TD', 'LR', 'TB', 'BT', 'RL'].includes(id)) {
+                validIDs.add(id);
+            }
+        }
+    });
+    
+    return validIDs;
+}
+
+/**
+ * Fixes concatenated node labels where the NodeID is repeated or the label starts with the NodeID,
+ * and the label is unquoted.
+ * Example: `... --> SubdivideSubdivide into 8 Octants;`
+ * If `Subdivide` is a valid ID, converts to `... --> Subdivide["Subdivide into 8 Octants"];`
+ */
+export function fixConcatenatedLabels(content: string): string {
+    const validIDs = getValidNodeIDs(content);
+    // console.log('Valid IDs:', Array.from(validIDs));
+    
+    const lines = content.split('\n');
+    const processedLines = lines.map(line => {
+        // Skip lines that don't look like they have arrows and unquoted text
+        // Relaxed check for semicolon or arrow
+        if ((!line.includes('-->') && !line.includes('---'))) {
+            return line;
+        }
+        
+        // Regex:
+        // Group 1: Arrow prefix (e.g. `-->` or `--> |Label| `)
+        // Group 2: The Unquoted Text (NodeID + Label)
+        // Match up to ; or end of line
+        const regex = /((?:---|-->)(?:\s*\|[^|]+\|)?\s*)([^"\[\];\n]+)(?:;|$)/;
+        
+        const match = line.match(regex);
+        if (match) {
+            const arrowPrefix = match[1];
+            const text = match[2].trim();
+            // console.log('Checking text:', text);
+            
+            // Check if text starts with a valid ID
+            // We iterate over validIDs to find a match at the start
+            // Prefer longest match?
+            let bestId = '';
+            
+            for (const id of validIDs) {
+                if (text.startsWith(id)) {
+                    if (id.length > bestId.length) {
+                        bestId = id;
+                    }
+                }
+            }
+            
+            if (bestId) {
+                // Determine label.
+                // If text is exactly the ID, we might not want to do anything?
+                // Example `A --> B;`. Text "B". ID "B".
+                // We leave it as is.
+                if (text === bestId) {
+                    return line;
+                }
+                
+                // If text is longer, we assume it's `ID` + `Label` (concatenated or just unquoted)
+                // Example `SubdivideSubdivide...` ID `Subdivide`.
+                // Example `BLabel Text`. ID `B`.
+                
+                // Construct replacement: Arrow ID["Text"]
+                // But wait, the `text` variable contains the FULL text including the ID prefix.
+                // In `SubdivideSubdivide...`, the full text IS the label we want?
+                // User example: `SubdivideSubdivide into...` -> `Subdivide["Subdivide into..."]`
+                // Wait, if the text is `SubdivideSubdivide into...`
+                // And we output `Subdivide["Subdivide into..."]`.
+                // The label inside quotes starts with `Subdivide`.
+                // So we assume the *entire* text is the label?
+                // Or do we strip the ID?
+                // `SubdivideSubdivide...`. ID `Subdivide`. Remainder `Subdivide...`.
+                // If we treat remainder as label: `Subdivide["Subdivide..."]`.
+                // If we treat whole text as label: `Subdivide["SubdivideSubdivide..."]`.
+                // The user example output is `Subdivide["Subdivide into 8 Octants"]`.
+                // Broken input: `SubdivideSubdivide into 8 Octants`.
+                // It seems the "broken" text is basically `ID` + `Label`.
+                // And the User wants `ID` + `["Label"]`.
+                // So we need to remove the FIRST instance of ID from the text.
+                // `Subdivide` (ID) + `Subdivide into...` (Label).
+                // `text` starts with `bestId`.
+                // Label = text.substring(bestId.length).
+                
+                let label = text.substring(bestId.length).trim();
+                
+                // Special check for `SubdivideSubdivide` pattern where label matches ID?
+                // Actually if `label` itself starts with `bestId`?
+                // In `SubdivideSubdivide...`, label is `Subdivide into...`.
+                // It starts with `Subdivide`.
+                // This seems consistent.
+                
+                // What if `BLabel Text`. ID `B`. Label `Label Text`.
+                // Result `B["Label Text"]`.
+                
+                // If label is empty (e.g. `A --> A;`), we already skipped it.
+                if (!label) return line;
+
+                // FIX: Check if label looks like valid Mermaid syntax (e.g. starts with --- or --> or -- )
+                // This happens when we match `C1 --- C2` and capture `C1 --- C2` as text.
+                // bestId is C1. Label is `--- C2`.
+                if (label.startsWith('---') || label.startsWith('-->') || label.startsWith('-- ')) {
+                    return line;
+                }
+
+                // Determine if we need to append a semicolon
+                // If the original line had a semicolon at the end of the match, or generally ended with it.
+                // The regex `(?:;|$)` consumed the semicolon if present.
+                // To be safe, we append `;` if the line ends with `;` or if the match consumed it.
+                // But `match[0]` includes the consumed part?
+                // `match[0]` is the whole match.
+                const hadSemi = match[0].trim().endsWith(';');
+                const suffix = hadSemi ? ';' : '';
+                
+                return line.replace(match[0], `${arrowPrefix}${bestId}["${label}"]${suffix}`);
+            }
+        }
+        
+        return line;
+    });
+    
+    return processedLines.join('\n');
+}
+
+/**
+ * Fixes misplaced edge labels that appear at the start of the line with a leading `>`.
+ * Pattern: `>|"Label"| Source --> Target` or `> | "Label" | Source --> Target`
+ * Result: `Source -->|"Label"| Target`
+ * Now supports escaped quotes inside the label and flexible whitespace.
+ */
+export function fixMisplacedPipes(content: string): string {
+    const lines = content.split('\n');
+    const processedLines = lines.map(line => {
+        // Regex to capture:
+        // > | "Label" | Source Arrow Target
+        // We handle --> and ---
+        // Label matches: "((?:[^"\\]|\\.)*)" -> non-greedy quoted string with escapes
+        const regex = /^\s*>\s*\|\s*"((?:[^"\\]|\\.)*)"\s*\|\s*(.*?)\s*(-->|---)\s*(.*)$/;
+        const match = line.match(regex);
+        
+        if (match) {
+            const label = match[1];
+            const source = match[2].trim();
+            const arrow = match[3]; // "-->" or "---"
+            const target = match[4].trim();
+            
+            // Construct: Source Arrow|"Label"| Target
+            return `${source} ${arrow}|"${label}"| ${target}`;
+        }
+        return line;
+    });
+    return processedLines.join('\n');
+}
+
+/**
+ * Fixes targeted note format: `note NodeId "Content"`
+ * Converts to:
+ * NoteNodeId["Content"]
+ * NodeId -.- NoteNodeId
+ * Also removes `[""]` artifacts from the content.
+ */
+export function fixTargetedNotes(content: string): string {
+    const lines = content.split('\n');
+    const processedLines = lines.flatMap(line => {
+        // Regex: note (NodeID) "(Content)"
+        // Use greedy match (.*) to handle potential unescaped quotes inside, assuming line ends with quote.
+        const regex = /^\s*note\s+([a-zA-Z0-9_]+)\s+"(.*)"\s*$/;
+        
+        const match = line.match(regex);
+        if (match) {
+            const nodeId = match[1];
+            let content = match[2];
+            
+            // Clean content: remove [""] if present
+            content = content.replace(/\[""\]/g, '');
+            // Handle potentially escaped versions if they exist
+            content = content.replace(/\[\\""\\""\]/g, '');
+            content = content.replace(/\[\\"\\"\]/g, '');
+
+            const noteId = `Note${nodeId}`;
+            
+            // Return two lines
+            return [
+                `${noteId}["${content}"]`,
+                `${nodeId} -.- ${noteId}`
+            ];
+        }
+        return [line];
+    });
+    return processedLines.join('\n');
+}

--- a/skills/notemdpro/skills/mermaid-summarizer/SKILL.md
+++ b/skills/notemdpro/skills/mermaid-summarizer/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: mermaid-summarizer
+description: "Use when summarizing a document into a visual Mermaid mindmap diagram for study aids or knowledge mapping"
+---
+
+# NoteMD Pro - Summarize as Mermaid Diagram
+
+## Overview
+
+This feature converts markdown document content into a Mermaid mindmap diagram. It uses LLM to analyze the document structure and generate a hierarchical mindmap with summaries and key sentences.
+
+## When to Use
+
+- **Visual summaries**: Create visual mindmaps of documents
+- **Outline generation**: Generate hierarchical structure
+- **Study aids**: Create visual study guides
+- **Knowledge mapping**: Map relationships between ideas
+
+## Function Call Chain
+
+```
+summarizeToMermaidCommand (main.ts)
+├── read_file(inputPath)
+├── getProviderAndModelForTask('summarizeToMermaid')
+├── getPromptForTask('summarizeToMermaid')
+├── call[Provider]API(prompt, content)
+├── saveMermaidSummaryFile(settings, inputPath, mermaidContent)
+│   ├── mkdir_p(outputFolderPath)
+│   └── write_file(outputPath, content)
+└── [Optional] Translate output
+```
+
+## Key Functions
+
+### summarizeToMermaidCommand (main.ts)
+
+Main command handler for summarization.
+
+### saveMermaidSummaryFile (fileUtils.ts)
+
+Saves the generated mermaid content to a file.
+
+```typescript
+export async function saveMermaidSummaryFile(
+  settings: NotemdSettings,
+  inputPath: string,
+  mermaidContent: string,
+  progressReporter: ProgressReporter,
+): Promise<string>;
+```
+
+## Settings
+
+### Provider Settings
+
+| Setting                      | Description                    |
+| ---------------------------- | ------------------------------ |
+| `summarizeToMermaidProvider` | LLM provider for summarization |
+| `summarizeToMermaidModel`    | Model for summarization        |
+| `summarizeToMermaidLanguage` | Language for output            |
+
+### Contextual Context (Macro Settings)
+
+| Setting                 | Description                                                 |
+| ----------------------- | ----------------------------------------------------------- |
+| `enableFocusedLearning` | Inject macro user domain preferences globally               |
+| `focusedLearningDomain` | The specific domain context (e.g., "Software Architecture") |
+
+### Output Settings
+
+| Setting                               | Description                       |
+| ------------------------------------- | --------------------------------- |
+| `useCustomSummarizeToMermaidSuffix`   | Use custom filename suffix        |
+| `summarizeToMermaidCustomSuffix`      | Custom suffix (default: "\_summ") |
+| `useCustomSummarizeToMermaidSavePath` | Use custom save path              |
+| `summarizeToMermaidSavePath`          | Custom save path                  |
+
+### Translation
+
+| Setting                             | Description              |
+| ----------------------------------- | ------------------------ |
+| `translateSummarizeToMermaidOutput` | Translate mermaid output |
+| `disableAutoTranslation`            | Disable auto-translation |
+
+## Prompt Template (summarizeToMermaid)
+
+Full prompt from `promptUtils.ts`:
+
+````
+You are an AI assistant specializing in text analysis and data visualization.
+Your sole task is to act as a processor that converts the user-provided
+document into a single, comprehensive Mermaid diagram.
+
+The most important point is: Delete all parentheses.
+Parentheses are not allowed in Mermaid diagrams.
+
+Primary Instructions:
+- Analyze and Summarize: Read the entire provided document to understand
+  its structure and identify its primary sections and key ideas.
+- Generate Mermaid Diagram Only: Your entire output must be a single
+  Mermaid code block. Do not include any titles, explanations,
+  greetings, or any text whatsoever outside of the mermaid ... block.
+
+Critical Syntax Rules for Obsidian Compatibility:
+1. Diagram Type: The diagram must begin with the mindmap keyword on the first line.
+2. Hierarchy via Indentation: The structure of the mind map is defined
+   only by indentation. Use a consistent four (4) spaces for each level.
+3. Root Node: The first node after the mindmap declaration should be
+   the root, with its text enclosed in double parentheses: root(("Title")).
+4. No List Markers: Never use hyphens (-), double hyphens (--),
+   asterisks (*), or any other characters to denote list items.
+5. Character Replacement: Replace --> with "to" or "implies" to avoid conflicts.
+
+Content and Structure Rules:
+- Hierarchical Structure: Mirror the document structure
+- Root: Document's title as root node
+- Section Branches: Each major section as primary branch
+- Section Summary: Maximum 5 summary points per section (max 300 words each)
+- Key Sentences: Critical verbatim sentences from each section
+
+Example Output Format:
+```mermaid
+mindmap
+    Article Title
+        Section 1: Title of the First Section
+            Summary Point 1 for Section 1
+            Summary Point 2 for Section 1
+            Key Sentences
+                Critical sentence from section 1.
+                Another critical sentence.
+        Section 2: Title of the Second Section
+            Summary Point 1 for Section 2
+            Key Sentences
+                Critical sentence from section 2.
+````
+
+````
+
+## Output Example
+
+Input: A document about Machine Learning
+Output:
+```mermaid
+mindmap
+    Machine Learning
+        Introduction to ML
+            Definition and types of machine learning
+            Supervised vs unsupervised learning
+            Key Sentences
+                Machine learning is a subset of artificial intelligence.
+        Neural Networks
+            Structure of neurons
+            Activation functions
+            Key Sentences
+                Neural networks are inspired by biological neurons.
+        Applications
+            Computer vision
+            Natural language processing
+            Key Sentences
+                ML powers many modern applications.
+````
+
+## Integration with Auto-fix
+
+After generating mermaid, the output can be auto-fixed using:
+
+- `refineMermaidBlocks()` - Fix syntax errors
+- `checkMermaidErrors()` - Validate syntax
+
+See [notemd-mermaid-fix](../mermaid-fix/SKILL.md) for details.
+
+## Error Handling
+
+### Common Errors
+
+1. **Parentheses in content**
+   - Issue: LLM includes parentheses in mermaid
+   - Solution: Prompt instructs to remove all parentheses
+
+2. **Invalid syntax**
+   - Issue: Mermaid syntax errors in output
+   - Solution: Auto-fix applied, check validation
+
+3. **Large documents**
+   - Issue: Content too long for single call
+   - Solution: Use chunking (if implemented)

--- a/skills/notemdpro/skills/qa-extractor/SKILL.md
+++ b/skills/notemdpro/skills/qa-extractor/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: qa-extractor
+description: "Use when extracting verbatim answers to specific questions from a long document, with optional translation of extracted text"
+---
+
+# NoteMD Pro - Text Extraction (Q&A)
+
+## Overview
+
+This feature extracts specific answers from markdown files based on user-configured questions. It uses LLM to analyze the content and provide precise answers to each question.
+
+## When to Use
+
+- **Q&A extraction**: Get specific answers from long documents
+- **Data mining**: Extract structured information from unstructured text
+- **Survey analysis**: Parse responses to multiple questions
+- **Research**: Pull key findings from papers
+
+## Function Call Chain
+
+```
+extractOriginalText (extractOriginalText.ts)
+├── read_file(inputPath)
+├── settings.extractQuestions (split by newlines)
+├── getProviderAndModelForTask('extractOriginalText')
+├── IF mergedMode
+│   └── callLLM with all questions combined
+├── ELSE (individual mode)
+│   └── for each question
+│       └── callLLM with single question
+├── Format results
+└── save to output file
+    ├── mkdir_p(outputFolderPath)
+    └── write_file(outputPath, content)
+```
+
+## Key Function (from extractOriginalText.ts)
+
+### extractOriginalText
+
+Extracts answers to configured questions from a file.
+
+```typescript
+export async function extractOriginalText(
+  plugin: NotemdPlugin,
+  inputPath: string,
+  reporter: ProgressReporter,
+): Promise<void>;
+// Outputs: File with Q&A extracted
+```
+
+## Settings
+
+### Question Configuration
+
+| Setting                         | Description                           |
+| ------------------------------- | ------------------------------------- |
+| `extractQuestions`              | Questions to ask (one per line)       |
+| `extractOriginalTextMergedMode` | Process all questions in one LLM call |
+
+### Provider Settings
+
+| Setting                       | Description                 |
+| ----------------------------- | --------------------------- |
+| `extractOriginalTextProvider` | LLM provider for extraction |
+| `extractOriginalTextModel`    | Model for extraction        |
+| `extractOriginalTextLanguage` | Language for output         |
+
+### Contextual Context (Macro Settings)
+
+| Setting                 | Description                                           |
+| ----------------------- | ----------------------------------------------------- |
+| `enableFocusedLearning` | Inject macro user domain preferences globally         |
+| `focusedLearningDomain` | The specific domain context (e.g., "Quantum Physics") |
+
+### Output Settings
+
+| Setting                              | Description            |
+| ------------------------------------ | ---------------------- |
+| `extractOriginalTextUseCustomOutput` | Use custom output path |
+| `extractOriginalTextCustomPath`      | Custom output folder   |
+| `extractOriginalTextCustomSuffix`    | Custom filename suffix |
+
+### Translation
+
+| Setting                              | Description              |
+| ------------------------------------ | ------------------------ |
+| `translateExtractOriginalTextOutput` | Translate extracted text |
+
+## Prompt Templates (extractOriginalText)
+
+### Individual Mode
+
+```
+You are a strict Data Extraction and Verification Agent.
+Your task is to extract the answer to the user's question from the provided reference content.
+
+Reference Content:
+{REFERENCE_CONTENT}
+
+User Question:
+{USER_INPUT}
+
+Instructions:
+1. Answer ONLY based on the reference content provided
+2. If the answer is not found, state "Answer not found in the provided text"
+3. Be precise and concise
+4. Include relevant context if necessary
+```
+
+### Merged Mode
+
+```
+You are a strict Data Extraction and Verification Agent.
+Your task is to extract answers to ALL questions from the provided reference content.
+
+Reference Content:
+{REFERENCE_CONTENT}
+
+Questions:
+{USER_INPUT}
+
+Instructions:
+1. Answer EACH question based ONLY on the reference content
+2. Format each answer as: "Q: [question] A: [answer]"
+3. If the answer is not found for a question, state "Answer not found"
+4. Be precise and concise
+```
+
+## Output Format
+
+### Individual Mode Output
+
+```
+Q: [Question 1]
+A: [Answer 1]
+
+Q: [Question 2]
+A: [Answer 2]
+```
+
+### Merged Mode Output
+
+```
+1. [Question 1]
+[Answer 1]
+
+2. [Question 2]
+[Answer 2]
+```
+
+## Processing Modes
+
+### Individual Mode (Default)
+
+- Processes each question separately
+- More accurate for complex questions
+- Higher API usage
+
+### Merged Mode
+
+- Combines all questions in one call
+- Faster processing
+- Less accurate for complex questions
+
+## Error Handling
+
+### Common Errors
+
+1. **No questions configured**
+   - Error: "No questions configured in settings for extraction"
+   - Solution: Add questions in plugin settings
+
+2. **Empty file**
+   - Error: Cannot extract from empty file
+   - Solution: Check source file content
+
+3. **API errors**
+   - Error: LLM API failure
+   - Solution: Check API key, network, retry
+
+### Best Practices
+
+1. **Specific questions**: Use clear, specific questions
+2. **Limit questions**: 5-10 questions per file works best
+3. **Check output**: Always verify extracted answers

--- a/skills/notemdpro/skills/selection-processor/SKILL.md
+++ b/skills/notemdpro/skills/selection-processor/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: selection-processor
+description: "Use when processing only a selected portion of text rather than a full file, to save tokens and enable targeted AI operations"
+---
+
+# NoteMD Pro - Selection-Based Processing
+
+## Overview
+
+This skill enables processing of selected text portions within files, rather than forcing full-file rewrites. This saves tokens, reduces processing time, and allows targeted AI operations on specific sections.
+
+## When to Use
+
+- **Partial content generation**: Generate content for just a section
+- **Selective linking**: Add links to specific paragraphs
+- **Targeted translation**: Translate selected portions
+- **Efficient processing**: Save tokens by processing only what's needed
+
+## Function Call Chain
+
+```
+Process Selection
+├── Get selected text from editor
+├── Get surrounding context (optional)
+├── Process selected content (LLM)
+├── Replace or append selected content
+└── Update file
+```
+
+## Selection Processing Patterns
+
+### 1. Get Selected Text
+```typescript
+// From Obsidian editor
+const editor = view.editor;
+const selection = editor.getSelection();
+
+// From VS Code
+const selection = editor.selection;
+const text = editor.document.getText(selection);
+```
+
+### 2. Process with Context
+For better results, include surrounding context:
+```typescript
+// Get context before and after selection
+const lineNum = editor.getCursor().line;
+const beforeLines = editor.getRange({line: 0, ch: 0}, {line: lineNum, ch: 0});
+const afterLines = editor.getRange({line: lineNum, ch: 0}, {line: maxLine, ch: 0});
+const fullContext = beforeLines + selection + afterLines;
+```
+
+### 3. Replace Selection
+```typescript
+// Replace selected text with processed result
+editor.replaceSelection(processedContent);
+
+// Or append after selection
+editor.replaceRange('\n\n' + processedContent, {line: lineNum + 1, ch: 0});
+```
+
+## Use Cases
+
+### Wiki-Link from Selection
+```typescript
+// Selected: "Machine learning is a subset of AI"
+// Process: Add links to key concepts
+// Result: "Machine learning is a subset of [[AI]]"
+async function addLinksToSelection(app: App, editor: Editor) {
+    const selection = editor.getSelection();
+    const prompt = getSystemPrompt('addLinks');
+    const result = await callLLM(prompt, selection);
+    editor.replaceSelection(result);
+}
+```
+
+### Generate from Selection
+```typescript
+// Selected: "Neural Networks"
+// Process: Generate expanded content
+// Result: Full explanation of neural networks
+async function generateFromSelection(app: App, editor: Editor) {
+    const selection = editor.getSelection();
+    const prompt = getSystemPrompt('generateTitle', {TITLE: selection});
+    const result = await callLLM(prompt, '');
+    editor.replaceSelection(result);
+}
+```
+
+### Translate Selection
+```typescript
+// Selected: Some text in English
+// Process: Translate to target language
+// Result: Translated text
+async function translateSelection(app: App, editor: Editor, targetLang: string) {
+    const selection = editor.getSelection();
+    const prompt = getSystemPrompt('translate', {LANGUAGE: targetLang, TEXT: selection});
+    const result = await callLLM(prompt, '');
+    editor.replaceSelection(result);
+}
+```
+
+## Settings
+
+### Selection Processing
+| Setting | Description |
+|---------|-------------|
+| `includeContextLines` | Number of context lines to include |
+| `replaceSelection` | Replace or append processed content |
+| `preserveFormatting` | Preserve original formatting |
+
+### Context Options
+| Setting | Description |
+|---------|-------------|
+| `contextBefore` | Lines before selection |
+| `contextAfter` | Lines after selection |
+| `includeHeadings` | Include parent headings |
+
+## Error Handling
+
+### Common Errors
+
+1. **Empty selection**
+   - Error: No text selected
+   - Solution: Check selection length before processing
+
+2. **Selection too large**
+   - Error: Exceeds token limits
+   - Solution: Split into chunks or use full file mode
+
+3. **Invalid cursor position**
+   - Error: Cannot determine insertion point
+   - Solution: Check editor state before operations
+
+## Platform-Agnostic Approach
+
+### Web/Node.js
+```javascript
+// Get selection from DOM
+const selection = window.getSelection().toString();
+
+// Process with file system
+const content = fs.readFileSync(filepath, 'utf-8');
+// Find and replace range
+```
+
+### CLI (Standard Input/Output)
+```bash
+# Pipe selected content to script
+echo "$SELECTED_TEXT" | notemd-process --operation=links
+
+# Output replaces stdin
+```
+
+## Best Practices
+
+1. **Always validate selection**: Check if selection is non-empty
+2. **Provide context**: Include surrounding text for better results
+3. **Preserve formatting**: Maintain markdown structure
+4. **Preview before replace**: Show preview for user confirmation
+5. **Undo support**: Ensure easy rollback if needed

--- a/skills/notemdpro/skills/system-architecture/SKILL.md
+++ b/skills/notemdpro/skills/system-architecture/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: system-architecture
+description: "Use when understanding module dependencies, function call chains, or the FileSystemPort abstraction layer of the NoteMD Pro pipeline"
+---
+
+# NoteMD Pro - Architecture
+
+## Module Structure
+
+### Source Files
+
+| Module                 | File                                 | Responsibilities                                                             |
+| ---------------------- | ------------------------------------ | ---------------------------------------------------------------------------- |
+| **Main Entry**         | `main.ts`                            | Plugin lifecycle, command registration, settings management, UI coordination |
+| **File Operations**    | `fileUtils.ts`                       | File processing, concept extraction, backlink management, duplicate handling |
+| **LLM Integration**    | `llmUtils.ts`                        | API calls to 9 providers, error handling, retry logic                        |
+| **Prompts**            | `promptUtils.ts`                     | Default prompts for all tasks                                                |
+| **Mermaid Processing** | `mermaidProcessor.ts`                | Syntax validation and fixing                                                 |
+| **Formula Fixing**     | `formulaFixer.ts`                    | LaTeX delimiter fixes                                                        |
+| **Translation**        | `translate.ts`                       | File/folder translation                                                      |
+| **Search**             | `searchUtils.ts`, `SearchManager.ts` | Web research                                                                 |
+| **Text Extraction**    | `extractOriginalText.ts`             | Q&A extraction from text                                                     |
+| **Utilities**          | `utils.ts`                           | Content chunking, token estimation                                           |
+| **UI Components**      | `ui/` directory                      | Settings tab, progress modals, sidebars                                      |
+
+## Vault Event Listeners (Auto Link Refactoring)
+
+The plugin automatically listens to Vault events to maintain link integrity:
+
+### File Rename Handler
+
+When a file is renamed, independently resolve backlinks:
+
+```
+Watch File System / Event Hook
+├── Extract old and new filename
+├── Search all files for [[oldName]] links
+├── Replace with [[newName]]
+└── Log updated count
+```
+
+### File Delete Handler
+
+When a file is deleted, automatically remove backlinks:
+
+```
+Watch File System / Event Hook
+├── Extract deleted filename
+├── Search all files for [[deletedName]] links
+├── Remove links and clean empty list items
+└── Clean extra blank lines
+```
+
+### Core Functions (fileUtils.ts)
+
+````typescript
+### Core Functions (fileUtils.ts)
+
+```typescript
+export async function handleFileRename(
+  oldPath: string,
+  newPath: string,
+);
+export async function handleFileDelete(path: string);
+````
+
+```
+
+## Function Call Chains
+
+### 1. Add Wiki-Links (processFile)
+
+```
+
+processFile
+├── splitContent
+├── getProviderForTask('addLinks')
+├── call[Provider]API (callDeepSeekAPI, callOpenAIApi, etc.)
+├── createConceptNotes
+│ └── normalizeNameForFilePath
+├── handleDuplicates
+│ └── findDuplicates
+├── cleanupLatexDelimiters
+├── refineMermaidBlocks (AUTO-FIX)
+└── saveOrMoveProcessedFile
+
+```
+
+### 2. Generate Content from Title (generateContentForTitle)
+
+```
+
+generateContentForTitle
+├── \_performResearch (optional, if enabled)
+│ ├── SearchManager.getProvider
+│ ├── TavilyProvider.search / DuckDuckGoProvider.search
+│ └── fetchContentFromUrl
+├── getProviderForTask('generateTitle')
+├── call[Provider]API
+├── cleanupLatexDelimiters
+├── refineMermaidBlocks
+└── fixMermaidSyntaxInFile (AUTO-RUN after LLM)
+
+```
+
+### 3. Extract Concepts (extractConceptsFromFile)
+
+```
+
+extractConceptsFromFile
+├── splitContent
+├── getProviderForTask('extractConcepts')
+├── call[Provider]API
+└── Parse CONCEPT: lines from response
+
+```
+
+### 4. Create Concept Notes (createConceptNotes)
+
+```
+
+createConceptNotes
+├── normalizeNameForFilePath
+├── mkdir_p (if not exists)
+├── write_file (for new notes)
+└── append_file (for existing notes)
+
+```
+
+### 5. Research (\_performResearch)
+
+```
+
+\_performResearch
+├── SearchManager.getProvider
+│ ├── TavilyProvider (if searchProvider='tavily')
+│ └── DuckDuckGoProvider (if searchProvider='duckduckgo')
+├── provider.search
+├── fetchContentFromUrl (for DDG)
+└── Combine research context
+
+```
+
+### 6. Extract Original Text (Q&A)
+
+```
+
+extractOriginalText
+├── read_file(inputPath)
+├── settings.extractQuestions (split by newline)
+├── IF mergedMode
+│ └── callLLM with all questions combined
+└── ELSE
+└── for each question, callLLM individually
+└── save to output file
+
+```
+
+### 7. Summarize as Mermaid
+
+```
+
+summarizeToMermaidCommand
+├── read_file(inputPath)
+├── getProviderAndModelForTask('summarizeToMermaid')
+├── call[Provider]API with summarizeToMermaid prompt
+└── saveMermaidSummaryFile
+
+```
+
+### 8. Check Duplicate Concepts
+
+```
+
+checkAndRemoveDuplicateConceptNotes
+├── Get concept folder files
+├── Group by normalized name
+├── Find potential duplicates
+├── Show confirmation modal
+└── Merge or remove duplicates
+
+```
+
+## Interdependency Diagram
+
+```
+
+main.ts
+├── fileUtils.ts
+│ ├── promptUtils.ts (getSystemPrompt)
+│ ├── llmUtils.ts (call\*API functions)
+│ ├── mermaidProcessor.ts (refineMermaidBlocks)
+│ └── searchUtils.ts (\_performResearch)
+├── translate.ts
+│ ├── llmUtils.ts
+│ └── promptUtils.ts
+├── searchUtils.ts
+│ ├── llmUtils.ts
+│ └── SearchManager → TavilyProvider/DuckDuckGoProvider
+├── formulaFixer.ts
+├── mermaidProcessor.ts
+└── utils.ts (splitContent, getProviderForTask)
+
+````
+
+## Settings Architecture
+
+### NotemdSettings (types.ts)
+
+- `providers`: Array of LLMProviderConfig
+- `activeProvider`: Currently selected provider
+- `useMultiModelSettings`: Enable per-task model selection
+- Task-specific providers: `addLinksProvider`, `researchProvider`, `generateTitleProvider`, `translateProvider`, `summarizeToMermaidProvider`, `extractConceptsProvider`
+- Task-specific models: `addLinksModel`, `researchModel`, etc.
+- Batch settings: `batchConcurrency`, `batchSize`, `batchInterDelayMs`, `apiCallIntervalMs`
+- Custom prompts: `useCustomPromptFor*`, `customPrompt*`
+
+### Constants Default Parity (constants.ts)
+
+The `constants.ts` file holds `DEFAULT_SETTINGS` which act as fallback configurations.
+**CRITICAL**: When the AI agent interacts with the codebase, it must refer to these defaults to avoid hallucinating configuration states that violate the plugin's established norms.
+
+## Error Handling
+
+### Error Types (types.ts)
+
+- `NotemdError`: Base error class
+- `NetworkError`: API and network issues
+- `FileOperationError`: File access issues
+- `ValidationError`: Invalid input/configuration
+
+### Persistent Error Logging (saveErrorLog)
+
+The source project actively maintains an `error_processing_filename.log` file in the Vault root using the `saveErrorLog(app, reporter, error, settings)` utility.
+**Agent Instruction**: When debugging failed batch processes or unexpected API errors, the AI agent MUST prioritize reading this log file to instantly access complete, persistent stack traces without waiting for user UI screenshots.
+
+### Progress Reporting & UI Abstraction
+
+- **Interface**: `ProgressReporter` (Bridges backend logic with frontend UI)
+- **Implementations**:
+  - `NotemdSidebarView` (Persistent sidebar tracking)
+  - `ProgressModal` (Blocking modal for intensive tasks)
+- **Methods**: `log()`, `updateStatus()`, `requestCancel()`, `clearDisplay()`
+- **Properties**: `cancelled`, `abortController`, `activeTasks`
+
+## Batch Processing
+
+### Concurrency Control
+
+```typescript
+createConcurrentProcessor(concurrency, delayMs, progressReporter)
+├── Promise.all with limit
+├── Chunk array processing
+└── Delay between batches
+````
+
+### Flow
+
+```
+batchGenerateContentForTitles
+├── filter eligible files
+├── create complete folder
+├── chunkArray(files, batchSize)
+└── processor(tasks) for each batch
+```
+
+### Generic Independent Interface
+
+Create a platform-agnostic interface to ensure the logic isn't tied to any client runtime:
+
+```typescript
+interface FileSystemPort {
+  read(path: string): Promise<string>;
+  write(path: string, content: string): Promise<void>;
+  exists(path: string): Promise<boolean>;
+  listFiles(pattern: string): Promise<string[]>;
+  createDir(path: string): Promise<void>;
+}
+```
+
+By adhering to this, the `notemdpro` skills can be instantiated inside generic Python or Node.js Docker containers without requiring Obsidian to exist on the host machine.
+
+### Platform-Specific Implementations

--- a/skills/notemdpro/skills/test-driven-development/SKILL.md
+++ b/skills/notemdpro/skills/test-driven-development/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: test-driven-development
+description: "Use when modifying core utilities like mermaidProcessor or formulaFixer, to ensure all 35 Jest regression tests pass before and after changes"
+---
+
+# NoteMD Pro - Testing & Regression Defense
+
+## Overview
+
+The `obsidian-NoteMD_new` source project contains a robust suite of 35 Jest unit tests located in the `src/tests/` directory. When acting as an AI Agent modifying core utilities, heuristic engines, or batch processors within this skill set, you **MUST** engage this testing framework to prevent regressions.
+
+## 🛡️ The Prime Directive
+
+> [!CAUTION] Mandatory Regression Testing
+> If you modify `fileUtils.ts`, `mermaidProcessor.ts`, `formulaFixer.ts`, or any other core utility, you are required to run the local test suite and ensure all 35 mocked tests pass. Do not present a "completed" refactor to the user without terminal proof that `npm test` succeeded.
+
+## Test Suite Structure
+
+The tests are located in `src/tests/` and use Obsidian-specific mocks (`src/__mocks__/`):
+
+| Test File                     | Responsibilities                                                                             |
+| ----------------------------- | -------------------------------------------------------------------------------------------- |
+| `mermaidDeepDebug.test.ts`    | Validates complex Mermaid structural repairs                                                 |
+| `mermaidFix*.test.ts`         | 15+ individual files testing specific Mermaid regex fixes (e.g., arrows, quotes, semicolons) |
+| `conceptNoteCreation.test.ts` | Tests the `createConceptNotes` logic and de-duplication                                      |
+| `formulaCorrection.test.ts`   | Validates the LaTeX delimiter `$..$` conversions                                             |
+| `parallelBatch.test.ts`       | Tests concurrency control and processor limits                                               |
+| `processFile.test.ts`         | End-to-end testing of the wiki-link processing pipeline                                      |
+
+## Executing Tests
+
+To run the full suite:
+
+```bash
+npm run test
+```
+
+To run a specific test file when iterating on a feature:
+
+```bash
+npm run test -- mermaidDeepDebug.test.ts
+```
+
+## Creating New Tests
+
+When implementing new features (e.g., upgrading to an AST parser for formulas or adding the xAI provider), you must create a corresponding `.test.ts` file.
+
+**Standard Mocking Pattern:**
+
+```typescript
+import { App, TFile } from "obsidian";
+import { myNewFunction } from "../myModule";
+
+// The Obsidian App mock is auto-injected by Jest setup
+describe("My New Feature", () => {
+  let mockApp: App;
+
+  beforeEach(() => {
+    mockApp = new App();
+    // Setup mock vault files if needed
+  });
+
+  it("should correctly process the input", async () => {
+    const result = await myNewFunction(mockApp, "input data");
+    expect(result).toBe("expected output");
+  });
+});
+```
+
+## Handling Test Failures
+
+If a test fails during your work:
+
+1. **Read the Output**: Jest will output the exact `Expected` vs `Received` diff.
+2. **Do Not Skip**: Never comment out a failing test to push a feature through.
+3. **Analyze the Regression**: Determine if your change broke existing functionality or if the test itself needs to be updated to reflect a new, correct behavior (e.g., if you change the Mermaid output format).

--- a/skills/notemdpro/skills/text-translator/SKILL.md
+++ b/skills/notemdpro/skills/text-translator/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: text-translator
+description: "Use when translating markdown notes to a different language while preserving formatting, images, and special elements"
+---
+
+# NoteMD Pro - Translation
+
+## Overview
+
+This feature translates markdown notes to different languages using LLM. It supports single file translation, batch folder translation, and preserves markdown formatting and special elements like images.
+
+## When to Use
+
+- **Multi-language vault**: Create translated versions of notes
+- **Language learning**: Translate content for study
+- **International collaboration**: Share notes across languages
+- **Content localization**: Adapt content for different audiences
+
+## Function Call Chain
+
+```
+translateFile (translate.ts)
+├── read_file(inputPath)
+├── splitContent(content, settings)
+├── getProviderForTask('translate', settings)
+├── callLLM(provider, prompt, chunk)
+│   └── Translated chunk
+├── join translated chunks
+├── save translated file
+│   └── write_file(outputPath, content)
+└── open file (if enabled)
+
+batchTranslateFolder
+├── filter .md files in folder
+├── createConcurrentProcessor
+├── processFile for each file
+└── ProgressModal reporting
+```
+
+## Key Functions (from translate.ts)
+
+### translateFile
+
+Translates a single file to target language.
+
+```typescript
+export async function translateFile(
+  settings: NotemdSettings,
+  inputPath: string,
+  targetLanguage: string,
+  progressReporter: ProgressReporter,
+  openFile?: boolean,
+  signal?: AbortSignal,
+): Promise<string | null>;
+// Returns: Path to translated file
+```
+
+### batchTranslateFolder
+
+Translates all markdown files in a folder.
+
+```typescript
+export async function batchTranslateFolder(
+  settings: NotemdSettings,
+  folderPath: string,
+  targetLanguage: string,
+): Promise<void>;
+```
+
+## Settings
+
+### Translation Settings
+
+| Setting             | Description                  |
+| ------------------- | ---------------------------- |
+| `translateProvider` | LLM provider for translation |
+| `translateModel`    | Model for translation        |
+
+### Output Settings
+
+| Setting                        | Description                          |
+| ------------------------------ | ------------------------------------ |
+| `useCustomTranslationSuffix`   | Use custom filename suffix           |
+| `translationCustomSuffix`      | Custom suffix (e.g., "\_es", "\_fr") |
+| `useCustomTranslationSavePath` | Use custom save path                 |
+| `translationSavePath`          | Custom save path                     |
+
+### Language Settings
+
+| Setting              | Description                 |
+| -------------------- | --------------------------- |
+| `language`           | Default language code       |
+| `availableLanguages` | List of supported languages |
+
+## Prompt Template (translate)
+
+From `promptUtils.ts`:
+
+```
+Translate the following text to {LANGUAGE}.
+Only output the translated text.
+Do not include the original text.
+Note: For special image formats, please retain them as they are,
+for example: ![](images/3c6d56a5dd52751121cefd4868e7b3a3ceb929b566eb63fc931a335d85a0095e.jpg)
+
+Text to translate:
+{TEXT}
+```
+
+## Supported Languages
+
+The plugin supports multiple languages including:
+
+- English (en)
+- Spanish (es)
+- French (fr)
+- German (de)
+- Chinese (zh)
+- Japanese (ja)
+- Korean (ko)
+- And more...
+
+## Output File Naming
+
+| Setting        | Example Input               | Output                 |
+| -------------- | --------------------------- | ---------------------- |
+| Default suffix | `note.md`                   | `note_es.md`           |
+| Custom suffix  | `note.md`                   | `note.es.md`           |
+| Custom path    | `note.md` + `translations/` | `translations/note.md` |
+
+## Error Handling
+
+### Common Errors
+
+1. **No provider configured**
+   - Error: "No provider configured for translation"
+   - Solution: Configure translate provider in settings
+
+2. **Empty file**
+   - Warning: "File is empty"
+   - Solution: Check source file content
+
+3. **Translation timeout**
+   - Error: "Translation cancelled"
+   - Solution: Reduce chunk size, check network
+
+### Cancellation
+
+- Users can cancel translation via AbortSignal
+- Already translated chunks are preserved
+- Partial results not saved on cancellation

--- a/skills/notemdpro/skills/web-researcher/SKILL.md
+++ b/skills/notemdpro/skills/web-researcher/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: web-researcher
+description: "Use when gathering web research context via Tavily or DuckDuckGo before content generation or topic summarization"
+---
+
+# NoteMD Pro - Web Research
+
+## Overview
+
+This feature researches topics using web search providers and provides summarized context. It supports both Tavily (API-based) and DuckDuckGo (scraper-based) providers.
+
+## When to Use
+
+- **Research before writing**: Gather context for content generation
+- **Summarize topics**: Get overview of any subject
+- **Fact-checking**: Verify information from web sources
+- **Literature review**: Collect information from multiple sources
+
+## Function Call Chain
+
+```
+_performResearch (searchUtils.ts)
+├── SearchManager.getProvider(settings)
+│   ├── TavilyProvider (if searchProvider='tavily')
+│   └── DuckDuckGoProvider (if searchProvider='duckduckgo')
+├── provider.search(query, settings)
+│   └── Returns SearchResult[]
+├── fetchContentFromUrl(url)  [For DuckDuckGo only]
+│   └── requestUrl({url, method: 'GET'})
+│   └── Extract text from HTML
+├── Combine research context
+└── Return combined context string
+```
+
+## Search Providers
+
+### Tavily Provider
+
+- API-based search (requires API key)
+- Returns snippets/summaries
+- Faster, more reliable
+- Configuration: `tavilyApiKey`, `tavilyMaxResults`, `tavilySearchDepth`
+
+### DuckDuckGo Provider
+
+- Web scraping (no API key needed)
+- Returns URLs, fetches full content
+- More results, slower
+- Configuration: `ddgMaxResults`, `ddgFetchTimeout`
+
+## Key Functions (from searchUtils.ts)
+
+### \_performResearch
+
+Performs web research for a topic and returns combined context.
+
+```typescript
+export async function _performResearch(
+  settings: NotemdSettings,
+  topic: string,
+  progressReporter: ProgressReporter,
+): Promise<string | null>;
+```
+
+### fetchContentFromUrl
+
+Fetches content from a URL and extracts text.
+
+```typescript
+export async function fetchContentFromUrl(
+  url: string,
+  progressReporter: ProgressReporter,
+  debugMode?: boolean,
+): Promise<string>;
+// Returns extracted text or error message
+```
+
+### SearchManager (search/SearchManager.ts)
+
+Factory for getting search provider.
+
+```typescript
+export class SearchManager {
+  static getProvider(settings: NotemdSettings): SearchProvider;
+  // Returns TavilyProvider or DuckDuckGoProvider
+}
+```
+
+## Settings
+
+### Provider Settings
+
+| Setting          | Description              |
+| ---------------- | ------------------------ |
+| `searchProvider` | 'tavily' or 'duckduckgo' |
+| `tavilyApiKey`   | API key for Tavily       |
+
+### Tavily Settings
+
+| Setting             | Description                    |
+| ------------------- | ------------------------------ |
+| `tavilyMaxResults`  | Number of results (default: 5) |
+| `tavilySearchDepth` | 'basic' or 'advanced'          |
+
+### DuckDuckGo Settings
+
+| Setting           | Description                      |
+| ----------------- | -------------------------------- |
+| `ddgMaxResults`   | Number of results (default: 5)   |
+| `ddgFetchTimeout` | Timeout in seconds (default: 10) |
+
+### Contextual Context (Macro Settings)
+
+| Setting                 | Description                                              |
+| ----------------------- | -------------------------------------------------------- |
+| `enableFocusedLearning` | Inject macro user domain preferences globally            |
+| `focusedLearningDomain` | The specific domain context (e.g., "Physics", "History") |
+
+### Research Limits
+
+| Setting                    | Description                     |
+| -------------------------- | ------------------------------- |
+| `maxResearchContentTokens` | Max tokens for research context |
+| `enableApiErrorDebugMode`  | Enable detailed error logging   |
+
+## Prompt Template (researchSummarize)
+
+From `promptUtils.ts`:
+
+```
+Summarize the following search results for the topic "{TOPIC}".
+Provide a concise yet comprehensive overview.
+Focus on key findings, data, and important conclusions.
+Format the summary in Markdown.
+The output language should be {LANGUAGE}.
+
+Search Results:
+{SEARCH_RESULTS_CONTEXT}
+```
+
+## Output Format
+
+Research context is formatted as:
+
+```
+Research context for "{query}" (via {provider}):
+
+Result 1:
+Title: {title}
+URL: {url}
+Content: {content}
+
+Result 2:
+Title: {title}
+...
+```
+
+## Error Handling
+
+### Common Errors
+
+1. **No API key for Tavily**
+   - Error: "Tavily API key not configured"
+   - Solution: Add API key in settings or switch to DuckDuckGo
+
+2. **Network timeout**
+   - Error: "Timeout fetching {url}"
+   - Solution: Increase `ddgFetchTimeout`
+
+3. **No search results**
+   - Warning: "Search returned no results"
+   - Solution: Try different search query
+
+### Debug Mode
+
+Enable `enableApiErrorDebugMode` for detailed error information including:
+
+- Full API request/response
+- HTTP status codes
+- Error stack traces


### PR DESCRIPTION
## Summary

### notemdpro (new)
- Add a new `notemdpro` markdown knowledge-workflow skill pack
- Include routing guidance for note workflows: linking, generation, research, translation, extraction, diagram generation, and syntax healing
- Bundle specialized workflow subskills under `skills/notemdpro/skills/*`

### Repository updates
- Add `./skills/notemdpro` to `.claude-plugin/marketplace.json` under `example-skills`
- Update `example-skills` description to include markdown knowledge workflows
- Add `LICENSE.txt` to the new skill package

## Test plan
- [x] `python3 -m json.tool .claude-plugin/marketplace.json`
- [x] `npx skills add . --list` confirms `notemdpro` appears in available skills
- [x] Verify expected files exist under `skills/notemdpro` and `skills/notemdpro/skills/*`
