### PR TITLE
Add Ejentum to Partner Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,4 @@ The markdown content below contains the instructions, examples, and guidelines t
 Skills are a great way to teach Claude how to get better at using specific pieces of software. As we see awesome example skills from partners, we may highlight some of them here:
 
 - **Notion** - [Notion Skills for Claude](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0)
+- **Ejentum** - [Reasoning Harness Skills for Claude Code](https://github.com/ejentum/ejentum-mcp/tree/main/skills) - Four cognitive operating modes (reasoning, code, anti-deception, memory) over 679 engineered cognitive operations, paired with the [`ejentum-mcp`](https://github.com/ejentum/ejentum-mcp) MCP server

--- a/README.md
+++ b/README.md
@@ -94,4 +94,4 @@ The markdown content below contains the instructions, examples, and guidelines t
 Skills are a great way to teach Claude how to get better at using specific pieces of software. As we see awesome example skills from partners, we may highlight some of them here:
 
 - **Notion** - [Notion Skills for Claude](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0)
-- **Ejentum** - [Reasoning Harness Skills for Claude Code](https://github.com/ejentum/ejentum-mcp/tree/main/skills) - Four cognitive operating modes (reasoning, code, anti-deception, memory) over 679 engineered cognitive operations, paired with the [`ejentum-mcp`](https://github.com/ejentum/ejentum-mcp) MCP server
+- **Ejentum** - [Reasoning Harness Skills for Claude Code](https://github.com/ejentum/ejentum-mcp/tree/main/skills)


### PR DESCRIPTION
Adds an entry under **Partner Skills** mirroring the Notion entry format (name + link to the skills directory).

Five SKILL.md files for Claude Code at `ejentum-mcp/skills/`: one router skill that classifies tasks and picks a mode, plus four per-mode skills (reasoning, code, anti-deception, memory). Skills route to the `ejentum-mcp` MCP server: stdio via `npx -y ejentum-mcp`, or hosted HTTPS at `https://api.ejentum.com/mcp` (Bearer auth via EJENTUM_API_KEY).

## Compliance

- Skills directory public, MIT, actively maintained
- Single line added, matches Notion entry pattern
- Not a duplicate

Maintainer is me; happy to address review feedback.