### PR TITLE
Add persona-lens: thought-leader/playbook decomposition registry

### DIFF
--- a/skills/persona-lens/LICENSE.txt
+++ b/skills/persona-lens/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Zennith OS
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/persona-lens/SKILL.md
+++ b/skills/persona-lens/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: persona-lens
+description: "Taste + DTC-playbook intelligence layer. A registry of decomposable 'lenses' — thought-leader perspectives (Steve Jobs, Rick Rubin, Hormozi, Dieter Rams, etc.) and brand-funnel playbooks (Huel, Hims, AG1, Oura, Gymshark, etc.) — that you can apply, fuse, and digest into the 底层逻辑 (first-principles) of a creative space. Each lens stores a 12-30 field decomposition: pillars, frameworks, anti-patterns, vocabulary, signature moves. Agents compose [lens + brand DNA + use-case] into ready-to-use prompts. New lenses can be proposed by humans or auto-proposed by upstream skills (e.g., when a trend scraper finds a recurring creator pattern)."
+---
+
+# persona-lens
+
+> The quantitative-to-qualitative layer. Decompose creators / brands / playbooks into structured patterns, then **apply** / **fuse** / **digest** to extract first-principles.
+
+## What a lens is
+
+A **lens** is a structured decomposition of a person, brand, or playbook into queryable fields. Example structure for a thought-leader lens:
+
+```yaml
+slug: steve-jobs
+bucket: founders
+patterns:
+  signature_moves: ["one-more-thing reveal", "less but better", "demos > slides"]
+  pillars: ["focus", "simplicity", "vertical integration"]
+  frameworks: ["computers as bicycles for the mind", "skate to where the puck is going"]
+  anti_patterns: ["committee design", "speeds-and-feeds marketing"]
+  vocabulary: ["insanely great", "magical", "delight"]
+  voice: "calm conviction, demos > claims, second-person ('you')"
+promotion_status: active
+proposed_by: user:default
+```
+
+Example structure for a DTC-playbook lens:
+
+```yaml
+slug: huel-funnel
+bucket: dtc-playbook
+patterns:
+  category: meal-replacement
+  funnel_stages: ["TOFU: science-of-nutrition video ads", "MOFU: subscribe-and-save offer", "BOFU: shaker-bottle gift", "retention: macro tracker community"]
+  conversion_tactics: ["limited-time bundle", "free shaker on first order", "Forbes/Times badges above the fold"]
+  email_subjects: ["Your bottle, your way", "27g protein in 90 seconds"]
+  takeaway_one_liner: "Science authority + frictionless first-bottle = sticky retention via community."
+```
+
+## Safety: mutating verbs default to dry-run
+
+`add` / `propose` / `promote` / `deprecate` / `fuse` / `digest` all print what they WOULD do unless you pass `--live`. Read-only verbs (`list`, `--help`, `--selftest`) fire normally.
+
+## The verbs
+
+```bash
+# Add a lens (immediate active)
+bash scripts/persona-lens.sh add steve-jobs --bucket founders --register founder-confident --live
+
+# Propose a lens (agent path — lands as 'candidate', awaits promote)
+bash scripts/persona-lens.sh propose fayyaz-ahmed --by agent:scout \
+  --bucket emerging --evidence "https://youtube.com/..." --register casual --live
+
+# Promote a candidate → active
+bash scripts/persona-lens.sh promote fayyaz-ahmed --live
+
+# Fuse two lenses into a hybrid (status=candidate)
+bash scripts/persona-lens.sh fuse steve-jobs rick-rubin --live
+
+# Digest a bucket — extract the shared first-principles (底层逻辑) via an LLM call
+bash scripts/persona-lens.sh digest --bucket founders --live
+
+# List
+bash scripts/persona-lens.sh list                              # table
+bash scripts/persona-lens.sh list --bucket founders --status active --format json
+
+# Deprecate
+bash scripts/persona-lens.sh deprecate stale-slug --live
+```
+
+## Apply a lens to a creative brief
+
+`lens-apply.sh` composes a prompt from three pieces: the lens decomposition, an optional brand DNA file, and a use-case (manifesto / ad-headline / email-flow / etc.).
+
+```bash
+# With explicit brand-dna path (most portable)
+bash scripts/lens-apply.sh \
+  --lens steve-jobs \
+  --brand-dna /path/to/your-brand/BRAND-DNA.md \
+  --use-case manifesto \
+  --user-input "We're launching a new pour-over kettle."
+
+# With brand slug + brands-dir convention
+export PERSONA_LENS_BRANDS_DIR=$HOME/.persona-lens/brands   # or your path
+bash scripts/lens-apply.sh --lens hormozi --brand my-brand --use-case ad-headline
+```
+
+If neither `--brand-dna` nor `--brand` is provided, the composition uses only `[lens + use-case + user-input]` — still useful.
+
+Output is JSON with `composed_prompt` + metadata (`lens_id`, `brand_dna_path`, `composition_token_count`, `gate_warnings`).
+
+## Auto-router: brand → best playbook
+
+`brand-to-playbook.sh` picks the highest-ranked DTC-playbook lens for a brand by matching the brand's detected category to the lenses' categories, body richness, and use-count.
+
+```bash
+bash scripts/brand-to-playbook.sh \
+  --brand my-brand \
+  --use-case ad-headline \
+  --auto-apply
+
+# or with explicit DNA path
+bash scripts/brand-to-playbook.sh --brand-dna /path/to/BRAND-DNA.md --with-trial
+```
+
+Modes: `--auto-apply` (fire top match), `--with-trial` (apply top-N in parallel), or no flag (print ranked list).
+
+## Storage (all skill-local by default)
+
+| Item | Default path | Override env var |
+|---|---|---|
+| Registry SQLite DB | `<skill>/data/persona-lens.db` | `LENSES_DB_PATH` |
+| Lens markdown bodies | `<skill>/patterns/lenses/` | `LENSES_DIR` |
+| Wiki digests | `<skill>/wiki/` | `LENSES_WIKI_DIR` |
+| Decomposition sidecars | `<skill>/intel/` | `LENSES_INTEL_DIR` |
+| Event logs | `<skill>/logs/` | `LENSES_LOG_DIR` |
+| 30-field schema | `<skill>/schemas/lens-30field.json` | `PERSONA_LENS_SCHEMA_PATH` |
+| Brand DNA directory | `$HOME/.persona-lens/brands/` | `PERSONA_LENS_BRANDS_DIR` |
+| Optional policy gate | (none — skipped if unset) | `MEMPALACE_POLICY_SH` |
+
+All paths default to skill-local so the skill works standalone on clone. Override via env vars if you want to share a registry across multiple skill clones (e.g., shared `LENSES_DB_PATH` for an org).
+
+## Decomposer (build lenses from sources)
+
+`lens-decomposer.sh` takes a URL or a transcript and asks an LLM to decompose it into the schema in `schemas/lens-30field.json`.
+
+```bash
+# Decompose from YouTube (uses yt-dlp auto-subs)
+bash scripts/lens-decomposer.sh \
+  --lens hormozi \
+  --url "https://www.youtube.com/watch?v=..." \
+  --live
+
+# Or from a local transcript
+bash scripts/lens-decomposer.sh --lens steve-jobs --transcript /path/to/text.txt --live
+
+# Bulk via CSV (url,lens per row)
+bash scripts/lens-decomposer.sh --bulk-csv urls.csv --max-cost 1.00 --live
+```
+
+Without `--live`, decomposer runs in dry-run mode (transcript is fetched but no LLM call is made).
+
+## Fusion & first-principles digest
+
+The non-obvious primitive: once you have a bucket of 20+ lenses, you can **digest** them to extract their shared first-principles.
+
+```bash
+bash scripts/persona-lens.sh digest --bucket founders --live
+# Returns a JSON:
+#   shared_principles: [...]
+#   meta_template: "..."
+#   candidate_seed_creators: [...]
+```
+
+This is how you go quantitative → qualitative — 20 decompositions → 1 distilled meta-pattern.
+
+## LLM dependency
+
+Two verbs touch an LLM (`lens-decomposer.sh`, `persona-lens.sh digest`). Configure via env:
+
+```bash
+export PERSONA_LENS_LLM_API_KEY=$YOUR_KEY     # or set GEMINI_API_KEY
+export PERSONA_LENS_LLM_MODEL=gemini-2.5-flash # default
+```
+
+All other verbs (`add`, `propose`, `promote`, `deprecate`, `fuse`, `list`, `apply`, `brand-to-playbook`) run locally with no LLM call.
+
+The reference provider is Google Gemini (Generative Language API). The code path is a single `curl` against `https://generativelanguage.googleapis.com/v1beta/models/<model>:generateContent`. Swap providers by editing the two `curl` blocks in `persona-lens.sh::cmd_digest` and `lens-decomposer.sh::decompose_via_llm`.
+
+## Testing
+
+```bash
+bash scripts/persona-lens.sh --selftest      # add/list/fuse/deprecate against a temp DB
+bash scripts/lens-apply.sh --selftest        # compose against a seeded sample lens
+bash scripts/brand-to-playbook.sh --selftest # rank against a seeded sample brand
+bash scripts/lens-decomposer.sh --selftest   # dry-run transcript decomposition (no LLM call)
+bash scripts/lens-wiki-digest.sh --selftest  # generate wiki index against seeded lenses
+bash smokes/smoke.sh                         # invocability + syntax check
+```
+
+All selftests use a per-invocation `mktemp -d` and clean up after themselves. They do NOT touch the default skill-local paths.
+
+## License
+
+MIT — see LICENSE.txt.
+
+## Example brief
+
+See `examples/brief-launch-manifesto.md` for a sample brief + composed output.
+
+## Versioning
+
+- `0.1.0` (2026-05-03) — registry + 4 verbs + decomposer + lens-apply.
+- `0.2.0` (2026-05-03) — dynamic registry (no more hardcoded lists), agent-propose, fusion, digest.
+- `0.3.0` (2026-05-04) — brand-to-playbook auto-router + DTC-playbook bucket.
+- `0.4.0` (2026-05-12) — standalone refactor: self-contained SQLite, full env-var configurability, `--selftest` per script, ships with default 30-field schema.

--- a/skills/persona-lens/examples/brief-launch-manifesto.md
+++ b/skills/persona-lens/examples/brief-launch-manifesto.md
@@ -1,0 +1,67 @@
+# Example brief — Pour-over kettle launch manifesto, through the Steve Jobs lens
+
+## Input brief
+
+> We're launching a new pour-over kettle. Need a 200-word manifesto for the
+> announcement page. Tone: calm conviction. Target reader: a coffee enthusiast
+> who already owns a basic kettle.
+
+## Lens body (excerpt from `patterns/lenses/founders/steve-jobs.md`)
+
+```yaml
+slug: steve-jobs
+bucket: founders
+patterns:
+  signature_moves: ["one-more-thing reveal", "less but better", "demos > slides"]
+  pillars: ["focus", "simplicity", "vertical integration"]
+  vocabulary: ["insanely great", "magical", "delight"]
+  voice: "calm conviction, demos > claims, second-person ('you')"
+  anti_patterns: ["committee design", "speeds-and-feeds marketing", "fear-of-missing-out tactics"]
+```
+
+## CLI
+
+```bash
+bash scripts/lens-apply.sh \
+  --lens steve-jobs \
+  --brand-dna examples/brand-dna-sample.md \
+  --use-case manifesto \
+  --user-input "We're launching a new pour-over kettle for coffee enthusiasts."
+```
+
+## What the script composes
+
+The output is a structured prompt with these sections (sent to your LLM of choice):
+
+```
+You are writing in the voice and frame of {lens.slug}.
+Voice rule: {lens.patterns.voice}
+Pillars: {lens.patterns.pillars}
+Signature moves: {lens.patterns.signature_moves}
+Anti-patterns to avoid: {lens.patterns.anti_patterns}
+Vocabulary to favor: {lens.patterns.vocabulary}
+
+Brand DNA: {brand-dna body}
+
+Use-case: manifesto (200 words, announcement page, calm conviction).
+
+Brief: {user-input}
+
+Now write the manifesto.
+```
+
+## Why this composition works
+
+- **Voice rule + signature moves + anti-patterns** prime the LLM to mimic the lens's *form*, not just topic.
+- **Brand DNA** anchors the manifesto to *your* product, not a hypothetical Apple product.
+- **Use-case scaffold** ("manifesto", 200 words) gives the LLM a strict shape.
+- **First-principles digest** (run `persona-lens.sh digest --bucket founders` if you have ≥5 founder lenses) gives you the meta-template that's stronger than any single lens.
+
+## Fusion variant
+
+```bash
+bash scripts/persona-lens.sh fuse --a steve-jobs --b rick-rubin --slug jobs-rubin
+bash scripts/lens-apply.sh --lens jobs-rubin --use-case manifesto --user-input "..."
+```
+
+The hybrid lens body merges patterns from both parents — Jobs's `calm conviction + demos > slides` meets Rubin's `minimalism + receptive > assertive`. Useful when neither lens alone captures the voice you want.

--- a/skills/persona-lens/schemas/lens-30field.json
+++ b/skills/persona-lens/schemas/lens-30field.json
@@ -1,0 +1,42 @@
+{
+  "narrative": {
+    "arc": "what is the story shape?",
+    "opening_move": "how does this speaker open?",
+    "framework_used": "named framework or none",
+    "anti_pattern": "what they explicitly reject",
+    "stakes": "what hangs in the balance",
+    "resolution": "where they leave the audience"
+  },
+  "vocabulary": {
+    "register": "casual | direct-blunt | quiet-mystic | founder-confident | …",
+    "signature_phrases": ["3-7 phrases this speaker uses repeatedly"],
+    "blocked_words": ["words this speaker never uses"],
+    "rhetorical_devices": ["repetition | tricolon | …"],
+    "vocabulary_density": "dense | spare | technical | poetic",
+    "metaphor_source": "domain (sports, war, biology, music, …)"
+  },
+  "design": {
+    "composition_pref": "what visual layouts they favor (if visual)",
+    "typography": "type choices (if cited)",
+    "restraint": "ornate | balanced | minimal",
+    "palette": ["color motifs"],
+    "spacing": "tight | loose",
+    "iconography": "what shapes/icons recur"
+  },
+  "meta_text": {
+    "framework_used": "named framework",
+    "anchor": "one-line first-principle anchor",
+    "contrarian_take": "what mainstream they push back on",
+    "self_revealing_metaphor": "metaphor they apply to themselves",
+    "wisdom_source": "where they say their insights come from",
+    "vulnerability_marker": "what they admit struggling with"
+  },
+  "creative_direction": {
+    "first_principles_anchor": "one-line statement of root belief",
+    "energy_level": "low-still | calm-resolute | high-intense",
+    "humor_register": "none | dry | playful | absurd",
+    "audience_address": "first | second | third person",
+    "pacing": "slow | medium | rapid",
+    "callback_density": "low | medium | high"
+  }
+}

--- a/skills/persona-lens/scripts/_lens-pool.sh
+++ b/skills/persona-lens/scripts/_lens-pool.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# _lens-pool.sh — emit live list of active lens slugs from the registry
+#
+# Used internally by lens-wiki-digest.sh to populate the digest set from
+# the live registry (not a hardcoded list).
+#
+# Usage:
+#   bash _lens-pool.sh                                # all active
+#   bash _lens-pool.sh --bucket founders              # active in bucket
+#   bash _lens-pool.sh --include-candidates           # active + candidate
+#   bash _lens-pool.sh --format lines|json            # output shape
+
+set -uo pipefail
+
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DB="${LENSES_DB_PATH:-$SKILL_DIR/data/persona-lens.db}"
+
+BUCKET=""
+INCLUDE_CANDIDATES=0
+FORMAT="lines"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bucket)               BUCKET="$2"; shift 2 ;;
+    --include-candidates)   INCLUDE_CANDIDATES=1; shift ;;
+    --format)               FORMAT="$2"; shift 2 ;;
+    *) echo "Unknown: $1" >&2; exit 1 ;;
+  esac
+done
+
+[[ ! -f "$DB" ]] && { echo "WARN: registry DB not found at $DB — run an add first" >&2; exit 0; }
+
+_sq() { printf "%s" "$1" | sed "s/'/''/g"; }
+
+where="persona_lens != ''"
+if (( INCLUDE_CANDIDATES )); then
+  where="$where AND promotion_status IN ('active','candidate')"
+else
+  where="$where AND promotion_status='active'"
+fi
+[[ -n "$BUCKET" ]] && where="$where AND bucket='$(_sq "$BUCKET")'"
+
+slugs=$(sqlite3 "$DB" "SELECT persona_lens FROM patterns WHERE $where ORDER BY bucket, persona_lens")
+
+case "$FORMAT" in
+  lines)
+    echo "$slugs"
+    ;;
+  json)
+    echo "$slugs" | python3 -c "import json, sys; print(json.dumps([l.strip() for l in sys.stdin if l.strip()]))"
+    ;;
+  *)
+    echo "ERROR: --format must be lines | json" >&2; exit 1 ;;
+esac

--- a/skills/persona-lens/scripts/brand-to-playbook.sh
+++ b/skills/persona-lens/scripts/brand-to-playbook.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# brand-to-playbook — auto-route a brand to its best-fit DTC-playbook lens
+# WITHOUT asking "which playbook?".
+#
+# Pipeline:
+#   1. Detect brand category from BRAND-DNA.md (scan for keywords)
+#   2. Query registry for dtc-playbook lenses
+#   3. Score each by category-match + body-richness + use_count + vlm_score
+#   4. (Optional) auto-apply top match via lens-apply.sh
+#   5. (Optional) trial-and-error: apply top-N in parallel
+#
+# Usage:
+#   bash brand-to-playbook.sh --brand <slug>
+#   bash brand-to-playbook.sh --brand <slug> --use-case ad-headline --auto-apply
+#   bash brand-to-playbook.sh --brand <slug> --top 5
+#   bash brand-to-playbook.sh --brand-dna /path/to/BRAND-DNA.md --with-trial
+#   bash brand-to-playbook.sh --selftest
+
+set -uo pipefail
+
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DB="${LENSES_DB_PATH:-$SKILL_DIR/data/persona-lens.db}"
+BRANDS_DIR="${PERSONA_LENS_BRANDS_DIR:-$HOME/.persona-lens/brands}"
+APPLY_SH="$SKILL_DIR/scripts/lens-apply.sh"
+LOG_DIR="${LENSES_LOG_DIR:-$SKILL_DIR/logs}"
+mkdir -p "$LOG_DIR"
+
+BRAND=""
+BRAND_DNA_OVERRIDE=""
+USE_CASE="ad-headline"
+TOP=3
+AUTO_APPLY=0
+WITH_TRIAL=0
+LANGUAGE="en"
+SELFTEST=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --brand)       BRAND="$2"; shift 2 ;;
+    --brand-dna)   BRAND_DNA_OVERRIDE="$2"; shift 2 ;;
+    --use-case)    USE_CASE="$2"; shift 2 ;;
+    --top)         TOP="$2"; shift 2 ;;
+    --auto-apply)  AUTO_APPLY=1; shift ;;
+    --with-trial)  WITH_TRIAL=1; shift ;;
+    --language)    LANGUAGE="$2"; shift 2 ;;
+    --selftest)    SELFTEST=1; shift ;;
+    --help|-h)     sed -n '2,20p' "$0"; exit 0 ;;
+    *) echo "Unknown: $1" >&2; exit 1 ;;
+  esac
+done
+
+log() { echo "[$(date +%H:%M:%S)] brand-to-playbook: $*" >&2; }
+
+# ---- Selftest ----
+if (( SELFTEST )); then
+  echo "[brand-to-playbook] selftest: starting"
+  local_tmp=$(mktemp -d -t b2p-st.XXXXXX)
+  export LENSES_DB_PATH="$local_tmp/persona-lens.db"
+  export LENSES_DIR="$local_tmp/patterns"
+  export LENSES_LOG_DIR="$local_tmp/logs"
+  export PERSONA_LENS_BRANDS_DIR="$local_tmp/brands"
+
+  # Seed a dtc-playbook lens
+  bash "$SKILL_DIR/scripts/persona-lens.sh" add huel-funnel \
+    --bucket dtc-playbook --register direct-response \
+    --rationale "category: food. Science-authority + subscribe-and-save." \
+    --live >/dev/null
+
+  bash "$SKILL_DIR/scripts/persona-lens.sh" add ag1-funnel \
+    --bucket dtc-playbook --register direct-response \
+    --rationale "category: wellness. Forbes badges + risk-free trial." \
+    --live >/dev/null
+
+  # Seed brand
+  mkdir -p "$PERSONA_LENS_BRANDS_DIR/example-food-brand"
+  cat > "$PERSONA_LENS_BRANDS_DIR/example-food-brand/BRAND-DNA.md" << 'EOF'
+# Example Food Brand
+Category: food (plant-based)
+Voice: warm, transparent.
+EOF
+
+  out=$(bash "$SKILL_DIR/scripts/brand-to-playbook.sh" --brand example-food-brand --use-case ad-headline 2>/dev/null)
+  if echo "$out" | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['detected_category']=='food'; assert d['total_candidates']>=1; print('   detected category:', d['detected_category']); print('   candidates:', d['total_candidates'])"; then
+    echo "[brand-to-playbook] selftest: PASS"
+    echo "VERDICT: PASS"
+    rm -rf "$local_tmp"
+    exit 0
+  else
+    echo "[brand-to-playbook] selftest: FAIL"
+    rm -rf "$local_tmp"
+    exit 1
+  fi
+fi
+
+# ---- Resolve brand DNA path ----
+BRAND_DNA_PATH=""
+if [[ -n "$BRAND_DNA_OVERRIDE" && -f "$BRAND_DNA_OVERRIDE" ]]; then
+  BRAND_DNA_PATH="$BRAND_DNA_OVERRIDE"
+elif [[ -n "$BRAND" ]]; then
+  for candidate in "$BRANDS_DIR/$BRAND/BRAND-DNA.md" "$BRANDS_DIR/$BRAND/DNA.json" "$BRANDS_DIR/$BRAND/core.md"; do
+    if [[ -f "$candidate" ]]; then BRAND_DNA_PATH="$candidate"; break; fi
+  done
+fi
+
+if [[ -z "$BRAND_DNA_PATH" && -z "$BRAND" ]]; then
+  echo "ERROR: --brand <slug> or --brand-dna PATH required" >&2
+  echo "usage: $0 --brand <slug> [--use-case X] [--top N] [--auto-apply] [--with-trial]" >&2
+  [[ -d "$BRANDS_DIR" ]] && echo "  available brands: $(ls "$BRANDS_DIR" 2>/dev/null | tr '\n' ' ')" >&2
+  exit 1
+fi
+
+# ---- 1. Detect brand category ----
+detect_category() {
+  local dna_path="$1" slug="$2"
+  if [[ -f "$dna_path" ]]; then
+    local content
+    content=$(cat "$dna_path" | head -200 | tr '[:upper:]' '[:lower:]')
+    for cat in food beverage wellness apparel beauty cookware home tech health; do
+      if echo "$content" | grep -q -E "\\b${cat}\\b"; then
+        echo "$cat"; return 0
+      fi
+    done
+  fi
+  # Slug-based heuristic fallback
+  case "$slug" in
+    *food*|*recipe*|*kitchen*)   echo "food"; return 0 ;;
+    *wellness*|*spirit*|*spa*)   echo "wellness"; return 0 ;;
+    *supplement*|*vitamin*)      echo "wellness"; return 0 ;;
+    *bev*|*juice*|*tea*|*coffee*) echo "beverage"; return 0 ;;
+    *) echo "other"; return 0 ;;
+  esac
+}
+
+CATEGORY=$(detect_category "$BRAND_DNA_PATH" "${BRAND:-(none)}")
+log "brand=${BRAND:-(none)} dna=${BRAND_DNA_PATH:-(none)} category=$CATEGORY use_case=$USE_CASE top=$TOP"
+
+# ---- 2-3. Rank dtc-playbook lenses ----
+RANKED_TMP=$(mktemp -t b2p-ranked.XXXXXX)
+DB="$DB" CATEGORY="$CATEGORY" BRAND="${BRAND:-}" USE_CASE="$USE_CASE" TOP="$TOP" python3 << 'PYEOF' > "$RANKED_TMP"
+import json, os, re, sqlite3
+
+db = os.environ["DB"]
+target_cat = os.environ.get("CATEGORY","other")
+brand = os.environ.get("BRAND","")
+use_case = os.environ.get("USE_CASE","")
+top = int(os.environ.get("TOP","3"))
+
+con = sqlite3.connect(db)
+cur = con.cursor()
+cur.execute("""
+    SELECT persona_lens, length(body) AS body_len, vlm_score_avg, use_count, body, notes
+    FROM patterns
+    WHERE bucket='dtc-playbook' AND promotion_status='active'
+""")
+lenses = []
+for lens, body_len, vlm, uses, body, notes in cur.fetchall():
+    cat = None
+    if body and '"category":' in body:
+        m = re.search(r'\{[^{}]*"category"\s*:\s*"([^"]+)"', body)
+        if m: cat = m.group(1).lower()
+    if not cat and notes and "category:" in notes.lower():
+        m = re.search(r'category:\s*([a-z\-]+)', notes.lower())
+        if m: cat = m.group(1)
+    score = 0
+    if cat and target_cat in cat: score += 50
+    if cat and cat == target_cat: score += 30
+    score += min((body_len or 0) / 100, 30)
+    score += (vlm or 0) * 2
+    score += min(uses or 0, 10)
+    lenses.append({
+        "lens": lens,
+        "category": cat or "?",
+        "score": round(score, 1),
+        "body_len": body_len or 0,
+        "vlm": vlm or 0,
+        "uses": uses or 0,
+        "takeaway": (notes or "")[:150],
+    })
+
+lenses.sort(key=lambda x: x["score"], reverse=True)
+print(json.dumps({
+    "brand": brand,
+    "detected_category": target_cat,
+    "use_case": use_case,
+    "total_candidates": len(lenses),
+    "top": lenses[:top],
+}, indent=2))
+PYEOF
+
+cat "$RANKED_TMP"
+
+# ---- 4. Auto-apply top match ----
+if (( AUTO_APPLY )); then
+  TOP_LENS=$(python3 -c "import json; d=json.load(open('$RANKED_TMP')); print(d['top'][0]['lens'] if d['top'] else '')" 2>/dev/null)
+  if [[ -n "$TOP_LENS" ]]; then
+    log "auto-applying top match: $TOP_LENS"
+    apply_args=(--lens "$TOP_LENS" --use-case "$USE_CASE" --language "$LANGUAGE")
+    [[ -n "$BRAND" ]] && apply_args+=(--brand "$BRAND")
+    [[ -n "$BRAND_DNA_OVERRIDE" ]] && apply_args+=(--brand-dna "$BRAND_DNA_OVERRIDE")
+    bash "$APPLY_SH" "${apply_args[@]}"
+  else
+    log "WARN: no candidates to auto-apply"
+  fi
+fi
+
+# ---- 5. Trial mode (apply top N) ----
+if (( WITH_TRIAL )); then
+  log "trial mode: applying top $TOP lenses"
+  TRIALS_DIR=$(mktemp -d -t b2p-trials.XXXXXX)
+  python3 -c "
+import json
+d = json.load(open('$RANKED_TMP'))
+for x in d['top']: print(x['lens'])
+" > "$TRIALS_DIR/lenses.txt"
+  while read -r lens; do
+    [[ -z "$lens" ]] && continue
+    out="$TRIALS_DIR/${lens}.json"
+    log "  trial: $lens"
+    apply_args=(--lens "$lens" --use-case "$USE_CASE" --language "$LANGUAGE")
+    [[ -n "$BRAND" ]] && apply_args+=(--brand "$BRAND")
+    [[ -n "$BRAND_DNA_OVERRIDE" ]] && apply_args+=(--brand-dna "$BRAND_DNA_OVERRIDE")
+    bash "$APPLY_SH" "${apply_args[@]}" > "$out" 2>/dev/null || true
+  done < "$TRIALS_DIR/lenses.txt"
+  log "trials saved: $TRIALS_DIR"
+  echo "{\"trials_dir\":\"$TRIALS_DIR\",\"trial_count\":$(ls "$TRIALS_DIR"/*.json 2>/dev/null | wc -l | tr -d ' ')}"
+fi
+
+rm -f "$RANKED_TMP"

--- a/skills/persona-lens/scripts/lens-apply.sh
+++ b/skills/persona-lens/scripts/lens-apply.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+# lens-apply — compose [lens × brand-DNA × use-case × user-input] → ready prompt
+#
+# Pipeline:
+#   1. Load lens body from registry (persona_lens=<slug>)
+#   2. (Optional) policy gate via $MEMPALACE_POLICY_SH if set + executable
+#   3. Load brand DNA from --brand-dna PATH (preferred) OR
+#      $PERSONA_LENS_BRANDS_DIR/<brand>/BRAND-DNA.md (fallback)
+#   4. Load use-case template if a pattern with use_case=<X> exists
+#   5. Compose: [lens system] + [brand DNA] + [use-case] + [user input]
+#   6. Emit JSON: composed_prompt + metadata
+#
+# Usage:
+#   bash lens-apply.sh --lens steve-jobs --brand-dna /path/to/BRAND-DNA.md --use-case manifesto
+#   bash lens-apply.sh --lens hormozi --brand my-brand --use-case ad-headline --user-input "..."
+#   bash lens-apply.sh --selftest
+
+set -uo pipefail
+
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DB="${LENSES_DB_PATH:-$SKILL_DIR/data/persona-lens.db}"
+BRANDS_DIR="${PERSONA_LENS_BRANDS_DIR:-$HOME/.persona-lens/brands}"
+LOG_DIR="${LENSES_LOG_DIR:-$SKILL_DIR/logs}"
+MEMPALACE_POLICY="${MEMPALACE_POLICY_SH:-}"
+mkdir -p "$LOG_DIR"
+
+LENS=""
+BRAND=""
+BRAND_DNA_OVERRIDE=""
+USE_CASE=""
+LANGUAGE="en"
+USER_INPUT=""
+SKIP_POLICY=0
+SELFTEST=0
+
+_sq() { printf "%s" "$1" | sed "s/'/''/g"; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --lens)        LENS="$2"; shift 2 ;;
+    --brand)       BRAND="$2"; shift 2 ;;
+    --brand-dna)   BRAND_DNA_OVERRIDE="$2"; shift 2 ;;
+    --use-case)    USE_CASE="$2"; shift 2 ;;
+    --language)    LANGUAGE="$2"; shift 2 ;;
+    --user-input)  USER_INPUT="$2"; shift 2 ;;
+    --skip-policy) SKIP_POLICY=1; shift ;;
+    --selftest)    SELFTEST=1; shift ;;
+    --help|-h)     sed -n '2,20p' "$0"; exit 0 ;;
+    *) echo "Unknown: $1" >&2; exit 1 ;;
+  esac
+done
+
+log() { echo "[$(date +%H:%M:%S)] lens-apply: $*" >&2; }
+
+# ---- Selftest ----
+if (( SELFTEST )); then
+  echo "[lens-apply] selftest: starting"
+  local_tmp=$(mktemp -d -t lens-apply-st.XXXXXX)
+  export LENSES_DB_PATH="$local_tmp/persona-lens.db"
+  export LENSES_DIR="$local_tmp/patterns"
+  export LENSES_LOG_DIR="$local_tmp/logs"
+  export PERSONA_LENS_BRANDS_DIR="$local_tmp/brands"
+
+  # Seed a sample lens
+  bash "$SKILL_DIR/scripts/persona-lens.sh" add steve-jobs \
+    --bucket founders --register founder-confident \
+    --rationale "first principles · less but better · demos > slides" --live >/dev/null
+
+  # Seed a sample brand DNA
+  mkdir -p "$PERSONA_LENS_BRANDS_DIR/example-brand"
+  cat > "$PERSONA_LENS_BRANDS_DIR/example-brand/BRAND-DNA.md" << 'EOF'
+# Example Brand DNA
+Voice: warm, conversational, slightly playful.
+Values: craft, transparency, community.
+Audience: design-leaning prosumers.
+Blocked: hype words, exclamation points.
+EOF
+
+  out=$(bash "$SKILL_DIR/scripts/lens-apply.sh" \
+    --lens steve-jobs \
+    --brand example-brand \
+    --use-case manifesto \
+    --user-input "Announcing the v2 launch." 2>/dev/null)
+
+  if echo "$out" | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['lens_id']=='steve-jobs-lens-v1'; assert d['composition_token_count']>0; print('   tokens:', d['composition_token_count']); print('   brand_dna:', d['brand_dna_path'])"; then
+    echo "[lens-apply] selftest: PASS"
+    echo "VERDICT: PASS"
+    rm -rf "$local_tmp"
+    exit 0
+  else
+    echo "[lens-apply] selftest: FAIL"
+    rm -rf "$local_tmp"
+    exit 1
+  fi
+fi
+
+if [[ -z "$LENS" || -z "$USE_CASE" ]]; then
+  echo "ERROR: --lens and --use-case required" >&2
+  echo "usage: $0 --lens <slug> --use-case <slug> [--brand <slug> | --brand-dna PATH] [--language en|ms|zh] [--user-input <text>]" >&2
+  exit 1
+fi
+
+if [[ -z "$BRAND" && -z "$BRAND_DNA_OVERRIDE" ]]; then
+  log "WARN: no --brand or --brand-dna supplied — composing lens + use-case only"
+fi
+
+# ---- 1. Load lens body ----
+LENS_ID="${LENS}-lens-v1"
+LENS_BODY=$(sqlite3 "$DB" "SELECT body FROM patterns WHERE id='$(_sq "$LENS_ID")' LIMIT 1" 2>/dev/null)
+if [[ -z "$LENS_BODY" ]]; then
+  echo "ERROR: lens not found: $LENS_ID" >&2
+  echo "Available: $(sqlite3 "$DB" "SELECT persona_lens FROM patterns WHERE persona_lens != ''" 2>/dev/null | tr '\n' ' ')" >&2
+  exit 3
+fi
+LENS_REGISTER=$(sqlite3 "$DB" "SELECT register FROM patterns WHERE id='$(_sq "$LENS_ID")'" 2>/dev/null)
+
+# ---- 2. Optional policy gate ----
+GATE_WARNINGS_JSON="[]"
+if [[ "$SKIP_POLICY" -eq 0 && -n "$MEMPALACE_POLICY" && -x "$MEMPALACE_POLICY" ]]; then
+  policy_ctx=$(python3 -c "import json; print(json.dumps({'brand':'${BRAND:-}','intent':'persona-lens-apply','urgency':'normal'}))")
+  policy_out=$(bash "$MEMPALACE_POLICY" decide --task-type read --context "$policy_ctx" 2>&1) || true
+  policy_action=$(echo "$policy_out" | python3 -c "import json,sys; d=json.loads(sys.stdin.read()); print(d.get('action','unknown'))" 2>/dev/null) || policy_action="parse_error"
+  case "$policy_action" in
+    hard_reject|reject)
+      echo "ERROR: policy HARD-REJECT — $policy_out" >&2
+      exit 2 ;;
+    *) log "policy: action=$policy_action" ;;
+  esac
+elif [[ "$SKIP_POLICY" -eq 0 && -n "$MEMPALACE_POLICY" ]]; then
+  log "[lens-apply] WARNING: MEMPALACE_POLICY_SH set but not executable — skipping policy gate"
+fi
+
+# ---- 3. Load brand DNA ----
+BRAND_DNA_PATH=""
+BRAND_DNA=""
+if [[ -n "$BRAND_DNA_OVERRIDE" && -f "$BRAND_DNA_OVERRIDE" ]]; then
+  BRAND_DNA_PATH="$BRAND_DNA_OVERRIDE"
+  BRAND_DNA=$(cat "$BRAND_DNA_OVERRIDE")
+elif [[ -n "$BRAND" ]]; then
+  for candidate in "$BRANDS_DIR/$BRAND/BRAND-DNA.md" "$BRANDS_DIR/$BRAND/DNA.json" "$BRANDS_DIR/$BRAND/core.md"; do
+    if [[ -f "$candidate" ]]; then
+      BRAND_DNA_PATH="$candidate"
+      BRAND_DNA=$(cat "$candidate")
+      break
+    fi
+  done
+fi
+if [[ -z "$BRAND_DNA" ]]; then
+  log "no brand DNA found — composing with lens + use-case only"
+  BRAND_DNA="(no brand DNA supplied. Use --brand <slug> with file at \$PERSONA_LENS_BRANDS_DIR/<slug>/BRAND-DNA.md, or --brand-dna PATH.)"
+  GATE_WARNINGS_JSON='["brand_dna_missing"]'
+fi
+
+# ---- 4. Load use-case template (optional) ----
+USE_CASE_PATTERN_ID=""
+USE_CASE_TEMPLATE=""
+USE_CASE_ROW=$(sqlite3 "$DB" "SELECT id, body FROM patterns WHERE use_case='$(_sq "$USE_CASE")' AND pattern_type IN ('template','framework','block') ORDER BY vlm_score_avg DESC, use_count DESC LIMIT 1" -separator '|||' 2>/dev/null)
+if [[ -n "$USE_CASE_ROW" ]]; then
+  USE_CASE_PATTERN_ID=$(echo "$USE_CASE_ROW" | head -1 | awk -F'\\|\\|\\|' '{print $1}')
+  USE_CASE_TEMPLATE=$(echo "$USE_CASE_ROW" | awk -F'\\|\\|\\|' 'NR==1 {for(i=2;i<=NF;i++) printf "%s", $i; print ""}')
+  log "use-case template found: $USE_CASE_PATTERN_ID"
+else
+  USE_CASE_TEMPLATE="(no specific template for use_case=$USE_CASE — use lens + brand DNA to inform output.)"
+fi
+
+# ---- 5. Compose ----
+COMPOSED=$(cat << EOF
+# SYSTEM PROMPT — composed by persona-lens / lens-apply
+
+You are writing in the voice of the **${LENS}** thought-leader lens for the **${BRAND:-(unbranded)}** brand. Use-case: **${USE_CASE}**. Output language: **${LANGUAGE}**.
+
+## LENS — ${LENS} (register: ${LENS_REGISTER})
+
+The following decomposition was extracted from primary sources (talks, essays, podcasts) and tagged into a structured schema:
+
+\`\`\`
+${LENS_BODY}
+\`\`\`
+
+## BRAND DNA — ${BRAND:-(unbranded)}
+
+The lens supplies HOW to talk; the brand supplies WHAT can be said. Brand DNA always wins on values + facts:
+
+\`\`\`
+${BRAND_DNA}
+\`\`\`
+
+## USE-CASE — ${USE_CASE}
+
+Apply the lens within these scaffolding constraints:
+
+\`\`\`
+${USE_CASE_TEMPLATE}
+\`\`\`
+
+## INSTRUCTIONS
+
+1. Adopt the lens narrative arc, vocabulary register, and signature phrases — but stay within brand DNA constraints
+2. Use brand-specific facts, products, audience details when supplied
+3. Output in language: ${LANGUAGE}
+4. Avoid blocked words from the lens vocabulary section
+5. Match the lens energy_level and humor_register
+6. If brand DNA contradicts the lens (e.g. lens says "high-intensity" but brand DNA says "calm-luxury"), brand DNA wins on tone — but use the lens STRUCTURAL patterns (arc, opening move, framework)
+
+## USER INPUT (what to generate)
+
+${USER_INPUT:-<the user request goes here — describe the specific piece of content to generate>}
+EOF
+)
+
+# ---- 6. Token estimate + emit JSON ----
+TOKEN_EST=$(python3 -c "
+import sys
+text = sys.stdin.read()
+print(len(text) // 4)
+" <<< "$COMPOSED")
+
+echo "$(date +%Y-%m-%dT%H:%M:%S),$LENS,${BRAND:-},$USE_CASE,$TOKEN_EST" >> "$LOG_DIR/lens-apply.log"
+
+META_TMP=$(mktemp -t lens-apply-meta.XXXXXX)
+COMPOSED_TMP=$(mktemp -t lens-apply-composed.XXXXXX)
+printf '%s' "$COMPOSED" > "$COMPOSED_TMP"
+cat > "$META_TMP" << EOF_META
+{
+  "lens_id": "$LENS_ID",
+  "lens_register": "$LENS_REGISTER",
+  "brand": "${BRAND:-}",
+  "brand_dna_path": "${BRAND_DNA_PATH:-(missing)}",
+  "use_case": "$USE_CASE",
+  "use_case_pattern_id": "${USE_CASE_PATTERN_ID:-(none)}",
+  "language": "$LANGUAGE",
+  "composition_token_count": $TOKEN_EST,
+  "gate_warnings": $GATE_WARNINGS_JSON
+}
+EOF_META
+
+python3 - "$COMPOSED_TMP" "$META_TMP" << 'PYEOF'
+import json, sys
+composed = open(sys.argv[1]).read()
+meta = json.load(open(sys.argv[2]))
+meta['composed_prompt'] = composed
+print(json.dumps(meta, indent=2, ensure_ascii=False))
+PYEOF
+rm -f "$COMPOSED_TMP" "$META_TMP"

--- a/skills/persona-lens/scripts/lens-decomposer.sh
+++ b/skills/persona-lens/scripts/lens-decomposer.sh
@@ -1,0 +1,388 @@
+#!/usr/bin/env bash
+# lens-decomposer — URL / transcript → 30-field thought-leader-lens decomposition
+#
+# Input: YouTube URL OR transcript file OR bulk CSV
+# Pipeline:
+#   1. Fetch transcript (yt-dlp for YT auto-subs; curl+strip for other URLs)
+#   2. Send transcript + 30-field schema → LLM (default: gemini-2.5-flash)
+#   3. Receive JSON
+#   4. Append decomposition section to lens markdown + UPSERT registry
+#
+# Usage:
+#   bash lens-decomposer.sh --url "https://youtube.com/watch?v=X" --lens steve-jobs --live
+#   bash lens-decomposer.sh --transcript /path/to/text.txt --lens hormozi --live
+#   bash lens-decomposer.sh --bulk-csv urls.csv --max-cost 1.00 --live
+#
+# Env:
+#   PERSONA_LENS_LLM_API_KEY   — falls back to $GEMINI_API_KEY
+#   PERSONA_LENS_LLM_MODEL     — defaults to gemini-2.5-flash
+#   LENSES_DB_PATH             — registry SQLite. Defaults to <skill>/data/persona-lens.db
+#   LENSES_DIR                 — lens-markdown bodies. Defaults to <skill>/patterns/lenses
+#   LENSES_INTEL_DIR           — decomposition JSON sidecars. Defaults to <skill>/intel
+#   PERSONA_LENS_SCHEMA_PATH   — schema JSON for the decomposition. Defaults to <skill>/schemas/lens-30field.json
+#
+# Cost (rough): ~$0.005/decomposition with Gemini flash · 100-URL bulk ≈ $0.50.
+
+set -uo pipefail
+
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DB="${LENSES_DB_PATH:-$SKILL_DIR/data/persona-lens.db}"
+LENSES_DIR="${LENSES_DIR:-$SKILL_DIR/patterns/lenses}"
+INTEL_DIR="${LENSES_INTEL_DIR:-$SKILL_DIR/intel}"
+LOG_DIR="${LENSES_LOG_DIR:-$SKILL_DIR/logs}"
+SCHEMA="${PERSONA_LENS_SCHEMA_PATH:-$SKILL_DIR/schemas/lens-30field.json}"
+mkdir -p "$INTEL_DIR" "$LOG_DIR" "$LENSES_DIR"
+
+URL=""
+TRANSCRIPT=""
+LENS=""
+BULK_CSV=""
+MAX_FRESH=3
+MAX_COST=1.00
+DRY_RUN=1   # default to dry-run; pass --live to fire LLM
+SELFTEST=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --url)        URL="$2"; shift 2 ;;
+    --transcript) TRANSCRIPT="$2"; shift 2 ;;
+    --lens)       LENS="$2"; shift 2 ;;
+    --bulk-csv)   BULK_CSV="$2"; shift 2 ;;
+    --max-fresh)  MAX_FRESH="$2"; shift 2 ;;
+    --max-cost)   MAX_COST="$2"; shift 2 ;;
+    --live)       DRY_RUN=0; shift ;;
+    --dry-run)    DRY_RUN=1; shift ;;
+    --selftest)   SELFTEST=1; shift ;;
+    --help|-h)    sed -n '2,30p' "$0"; exit 0 ;;
+    *) echo "Unknown: $1" >&2; exit 1 ;;
+  esac
+done
+
+log() { echo "[$(date +%H:%M:%S)] lens-decomposer: $*" >&2; }
+
+# ---- Selftest (no LLM, no network) ----
+if (( SELFTEST )); then
+  echo "[lens-decomposer] selftest: starting (dry-run; no LLM)"
+  st_tmp=$(mktemp -d -t lens-decomp-st.XXXXXX)
+  export LENSES_DB_PATH="$st_tmp/persona-lens.db"
+  export LENSES_DIR="$st_tmp/patterns"
+  export LENSES_INTEL_DIR="$st_tmp/intel"
+  export LENSES_LOG_DIR="$st_tmp/logs"
+  export PERSONA_LENS_SCHEMA_PATH="$st_tmp/schemas/lens-30field.json"
+
+  bash "$SKILL_DIR/scripts/persona-lens.sh" add hormozi \
+    --bucket founders --register direct-blunt \
+    --rationale 'one hundred million offers, LTV, skin in the game' --live >/dev/null
+
+  # Stage a fake transcript
+  transcript_tmp=$(mktemp -t lens-decomp-tr.XXXXXX)
+  echo "First principles thinking. Skin in the game. LTV beats CAC. Print profit." > "$transcript_tmp"
+
+  st_out=$(bash "$SKILL_DIR/scripts/lens-decomposer.sh" --lens hormozi --transcript "$transcript_tmp" --dry-run 2>&1)
+  if echo "$st_out" | grep -q "DRY-RUN: would decompose"; then
+    rm -f "$transcript_tmp"
+    rm -rf "$st_tmp"
+    echo "[lens-decomposer] selftest: PASS"
+    echo "VERDICT: PASS"
+    exit 0
+  else
+    echo "[lens-decomposer] selftest: FAIL — DRY-RUN line not produced"
+    rm -f "$transcript_tmp"
+    rm -rf "$st_tmp"
+    exit 1
+  fi
+fi
+
+# ---- Validation ----
+if [[ -z "$LENS" && -z "$BULK_CSV" ]]; then
+  echo "ERROR: --lens <slug> required (or --bulk-csv path)" >&2
+  exit 1
+fi
+
+# ---- Schema bootstrap (ship default if not present) ----
+if [[ ! -f "$SCHEMA" ]]; then
+  mkdir -p "$(dirname "$SCHEMA")"
+  cat > "$SCHEMA" << 'EOF_SCHEMA'
+{
+  "narrative": {
+    "arc": "what is the story shape?",
+    "opening_move": "how does this speaker open?",
+    "framework_used": "named framework or none",
+    "anti_pattern": "what they explicitly reject",
+    "stakes": "what hangs in the balance",
+    "resolution": "where they leave the audience"
+  },
+  "vocabulary": {
+    "register": "casual | direct-blunt | quiet-mystic | founder-confident | …",
+    "signature_phrases": ["3-7 phrases this speaker uses repeatedly"],
+    "blocked_words": ["words this speaker never uses"],
+    "rhetorical_devices": ["repetition | tricolon | …"],
+    "vocabulary_density": "dense | spare | technical | poetic",
+    "metaphor_source": "domain (sports, war, biology, music, …)"
+  },
+  "design": {
+    "composition_pref": "what visual layouts they favor (if visual)",
+    "typography": "type choices (if cited)",
+    "restraint": "ornate | balanced | minimal",
+    "palette": ["color motifs"],
+    "spacing": "tight | loose",
+    "iconography": "what shapes/icons recur"
+  },
+  "meta_text": {
+    "framework_used": "named framework",
+    "anchor": "one-line first-principle anchor",
+    "contrarian_take": "what mainstream they push back on",
+    "self_revealing_metaphor": "metaphor they apply to themselves",
+    "wisdom_source": "where they say their insights come from",
+    "vulnerability_marker": "what they admit struggling with"
+  },
+  "creative_direction": {
+    "first_principles_anchor": "one-line statement of root belief",
+    "energy_level": "low-still | calm-resolute | high-intense",
+    "humor_register": "none | dry | playful | absurd",
+    "audience_address": "first | second | third person",
+    "pacing": "slow | medium | rapid",
+    "callback_density": "low | medium | high"
+  }
+}
+EOF_SCHEMA
+fi
+
+if [[ -n "$LENS" && -z "$URL" && -z "$TRANSCRIPT" ]]; then
+  log "no --url or --transcript provided"
+  echo "{\"mode\":\"no-input\",\"lens\":\"$LENS\",\"note\":\"Pass --url or --transcript to decompose.\"}"
+  exit 0
+fi
+
+# ---- Source API key ----
+KEY="${PERSONA_LENS_LLM_API_KEY:-${GEMINI_API_KEY:-}}"
+if (( DRY_RUN == 0 )) && [[ -z "$KEY" ]]; then
+  echo "ERROR: PERSONA_LENS_LLM_API_KEY (or GEMINI_API_KEY) not set" >&2
+  exit 2
+fi
+
+MODEL="${PERSONA_LENS_LLM_MODEL:-${GEMINI_MODEL:-gemini-2.5-flash}}"
+
+# ---- Fetch transcript ----
+fetch_transcript() {
+  local src="$1" out_file="$2"
+  src="${src/#\~/$HOME}"
+
+  if [[ -f "$src" ]]; then cp "$src" "$out_file"; return 0; fi
+
+  if [[ "$src" == *"youtube.com"* || "$src" == *"youtu.be"* ]]; then
+    local tmp_dir; tmp_dir=$(mktemp -d -t lens-decompose-yt.XXXXXX)
+    if command -v yt-dlp >/dev/null 2>&1; then
+      yt-dlp --skip-download --write-auto-subs --sub-format vtt --sub-langs en --no-warnings \
+        -o "$tmp_dir/%(id)s.%(ext)s" "$src" 2>/dev/null || true
+      local vtt_file; vtt_file=$(ls "$tmp_dir"/*.en.vtt 2>/dev/null | head -1)
+      if [[ -n "$vtt_file" ]]; then
+        grep -v -E '^WEBVTT|^[0-9:.]+ -->|^$|^[0-9]+$' "$vtt_file" | tr '\n' ' ' | sed 's/  */ /g' > "$out_file"
+        rm -rf "$tmp_dir"
+        return 0
+      fi
+    fi
+    rm -rf "$tmp_dir"
+    log "no yt-dlp or no VTT — trying youtube-transcript-api"
+    python3 - "$src" "$out_file" << 'PYEOF' || return 3
+import re, sys
+try:
+    from youtube_transcript_api import YouTubeTranscriptApi
+except ImportError:
+    print("ERROR: pip install youtube-transcript-api or yt-dlp", file=sys.stderr)
+    sys.exit(3)
+url, out = sys.argv[1], sys.argv[2]
+m = re.search(r'(?:v=|/shorts/|youtu\.be/)([A-Za-z0-9_-]{11})', url)
+vid = m.group(1) if m else None
+if not vid:
+    sys.exit("no video id")
+transcript = YouTubeTranscriptApi().fetch(vid)
+with open(out, 'w') as f:
+    f.write(' '.join(s.text for s in transcript))
+PYEOF
+    return 0
+  fi
+
+  log "non-YouTube URL — using curl + readability extraction"
+  curl -sSL --max-time 30 "$src" 2>/dev/null \
+    | python3 -c "
+import sys, re, html
+t = sys.stdin.read()
+t = re.sub(r'<script[^>]*>.*?</script>', '', t, flags=re.S|re.I)
+t = re.sub(r'<style[^>]*>.*?</style>', '', t, flags=re.S|re.I)
+t = re.sub(r'<[^>]+>', ' ', t)
+t = html.unescape(t)
+t = re.sub(r'\s+', ' ', t).strip()
+print(t)
+" > "$out_file" 2>/dev/null
+  [[ -s "$out_file" ]] || { echo "ERROR: empty content from $src" >&2; return 4; }
+}
+
+# ---- LLM decomposition ----
+decompose_via_llm() {
+  local transcript_file="$1" lens_slug="$2" out_json="$3"
+  local transcript schema prompt payload raw_tmp http_code
+  transcript=$(head -c 8000 "$transcript_file")
+  schema=$(cat "$SCHEMA")
+
+  prompt=$(python3 - "$schema" "$lens_slug" "$transcript" << 'PYEOF'
+import sys, json
+schema, lens, transcript = sys.argv[1], sys.argv[2], sys.argv[3]
+print(f'''You are a cultural decomposition engine. Decompose the speaker into a JSON object matching this schema:
+
+{schema}
+
+Speaker persona slug: {lens}
+Transcript:
+"""
+{transcript}
+"""
+
+Return ONLY a JSON object with the 5 top-level buckets (narrative, vocabulary, design, meta_text, creative_direction). No markdown fence, no commentary, JSON only.''')
+PYEOF
+)
+
+  payload=$(python3 -c "
+import json, sys
+print(json.dumps({
+  'contents': [{'parts': [{'text': sys.argv[1]}]}],
+  'generationConfig': {'response_mime_type': 'application/json', 'temperature': 0.3}
+}))
+" "$prompt")
+
+  raw_tmp=$(mktemp -t lens-llm.XXXXXX)
+  for attempt in 1 2 3; do
+    http_code=$(curl -sS -w '%{http_code}' -o "$raw_tmp" -X POST \
+      "https://generativelanguage.googleapis.com/v1beta/models/${MODEL}:generateContent?key=${KEY}" \
+      -H 'Content-Type: application/json' \
+      -d "$payload" 2>&1) || true
+    [[ "$http_code" == "200" ]] && break
+    [[ "$http_code" =~ ^5 ]] && { log "LLM HTTP $http_code attempt $attempt — backoff"; sleep "$attempt"; } || break
+  done
+
+  if [[ "$http_code" != "200" ]]; then
+    echo "ERROR: LLM HTTP $http_code" >&2
+    head -c 500 "$raw_tmp" >&2; echo >&2
+    return 5
+  fi
+
+  python3 -c "
+import json, sys
+d = json.load(open(sys.argv[1]))
+txt = d.get('candidates',[{}])[0].get('content',{}).get('parts',[{}])[0].get('text','')
+try:
+    print(json.dumps(json.loads(txt), indent=2, ensure_ascii=False))
+except Exception:
+    print(txt)
+" "$raw_tmp" > "$out_json"
+  rm -f "$raw_tmp"
+}
+
+append_to_lens_pattern() {
+  local lens_slug="$1" decomp_json="$2" source_id="$3" source_url="$4"
+  local lens_md="$LENSES_DIR/${lens_slug}-lens-v1.md"
+
+  if [[ ! -f "$lens_md" ]]; then
+    log "WARNING: lens markdown not found: $lens_md — run persona-lens.sh add first"
+    return 7
+  fi
+
+  cat >> "$lens_md" << EOF
+
+---
+
+## Decomposition: $source_id ($(date +%Y-%m-%d))
+
+**Source.** $source_url
+**Decomposed via.** lens-decomposer.sh / $MODEL
+
+\`\`\`json
+$(cat "$decomp_json")
+\`\`\`
+
+EOF
+
+  log "appended decomposition to $lens_md (+$(wc -c < "$decomp_json") bytes)"
+
+  # Re-UPSERT body to DB
+  local body; body=$(cat "$lens_md")
+  _sq() { printf "%s" "$1" | sed "s/'/''/g"; }
+  local id="${lens_slug}-lens-v1"
+  sqlite3 "$DB" "UPDATE patterns SET body='$(_sq "$body")', updated_at=datetime('now') WHERE id='$(_sq "$id")'"
+}
+
+cost_log() {
+  local lens="$1" url="$2" status="$3"
+  echo "$(date +%Y-%m-%dT%H:%M:%S),$lens,$url,$MODEL,$status,0.005" >> "$LOG_DIR/lens-decompose.log"
+}
+
+process_one() {
+  local url="$1" lens="$2"
+  log "process: lens=$lens url=$url"
+
+  local lens_intel="$INTEL_DIR/$lens"
+  mkdir -p "$lens_intel"
+
+  local source_id
+  source_id=$(echo "$url" | sed 's|.*/||; s|[?&].*||; s|[^A-Za-z0-9_-]|_|g' | head -c 30)
+  [[ -z "$source_id" ]] && source_id="src-$(date +%s)"
+
+  local transcript_tmp decomp_out
+  transcript_tmp=$(mktemp -t lens-transcript.XXXXXX)
+  decomp_out="$lens_intel/${source_id}.json"
+
+  if ! fetch_transcript "$url" "$transcript_tmp"; then
+    cost_log "$lens" "$url" "fetch_failed"
+    rm -f "$transcript_tmp"
+    return 1
+  fi
+
+  log "transcript: $(wc -c < "$transcript_tmp") chars"
+
+  if (( DRY_RUN )); then
+    log "DRY-RUN: would decompose via $MODEL → $decomp_out (pass --live to fire)"
+    head -c 200 "$transcript_tmp" >&2; echo "..." >&2
+    rm -f "$transcript_tmp"
+    return 0
+  fi
+
+  if ! decompose_via_llm "$transcript_tmp" "$lens" "$decomp_out"; then
+    cost_log "$lens" "$url" "decompose_failed"
+    rm -f "$transcript_tmp"
+    return 2
+  fi
+
+  cost_log "$lens" "$url" "ok"
+  append_to_lens_pattern "$lens" "$decomp_out" "$source_id" "$url"
+  rm -f "$transcript_tmp"
+  return 0
+}
+
+process_bulk() {
+  local csv="$1"
+  if [[ ! -f "$csv" ]]; then echo "ERROR: bulk CSV not found: $csv" >&2; exit 8; fi
+
+  local total=0 ok=0 fail=0 cost_acc=0
+  while IFS=, read -r url lens; do
+    [[ "$url" == "url" || -z "$url" ]] && continue
+    total=$((total + 1))
+    cost_acc=$(python3 -c "print(round($cost_acc + 0.005, 3))")
+    if (( $(python3 -c "print(1 if $cost_acc > $MAX_COST else 0)") )); then
+      log "BUDGET CAP HIT: \$$cost_acc > \$$MAX_COST — stopping at $total processed"
+      break
+    fi
+    if process_one "$url" "$lens"; then ok=$((ok + 1)); else fail=$((fail + 1)); fi
+  done < "$csv"
+
+  log "BULK DONE: $total · $ok ok · $fail failed · \$${cost_acc}"
+  echo "{\"total\":$total,\"ok\":$ok,\"fail\":$fail,\"cost\":$cost_acc,\"max_cost\":$MAX_COST}"
+}
+
+# ---- Dispatch ----
+if [[ -n "$BULK_CSV" ]]; then
+  process_bulk "$BULK_CSV"
+elif [[ -n "$URL" ]]; then
+  process_one "$URL" "$LENS"
+elif [[ -n "$TRANSCRIPT" ]]; then
+  process_one "$TRANSCRIPT" "$LENS"
+fi

--- a/skills/persona-lens/scripts/lens-wiki-digest.sh
+++ b/skills/persona-lens/scripts/lens-wiki-digest.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# lens-wiki-digest — generate per-lens markdown digest from the registry
+#
+# For each active (and candidate, when included) lens, write:
+#   $LENSES_WIKI_DIR/<slug>.md   — per-lens state snapshot
+#   $LENSES_WIKI_DIR/index.md    — grouped-by-bucket index
+#
+# Usage:
+#   bash lens-wiki-digest.sh                          # all active + candidate
+#   bash lens-wiki-digest.sh --week 2026-W18          # specific ISO week label
+#   bash lens-wiki-digest.sh --lens steve-jobs        # single lens
+#   bash lens-wiki-digest.sh --dry-run                # plan only
+#   bash lens-wiki-digest.sh --selftest
+
+set -uo pipefail
+
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DB="${LENSES_DB_PATH:-$SKILL_DIR/data/persona-lens.db}"
+WIKI_DIR="${LENSES_WIKI_DIR:-$SKILL_DIR/wiki}"
+LOG_DIR="${LENSES_LOG_DIR:-$SKILL_DIR/logs}"
+INTEL_DIR="${LENSES_INTEL_DIR:-$SKILL_DIR/intel}"
+mkdir -p "$WIKI_DIR" "$LOG_DIR"
+
+WEEK=$(date +%G-W%V)
+LENS=""
+DRY_RUN=0
+SELFTEST=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --week)    WEEK="$2"; shift 2 ;;
+    --lens)    LENS="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --selftest) SELFTEST=1; shift ;;
+    --help|-h) sed -n '2,18p' "$0"; exit 0 ;;
+    *) echo "Unknown: $1" >&2; exit 1 ;;
+  esac
+done
+
+log() { echo "[$(date +%H:%M:%S)] lens-wiki-digest: $*" >&2; }
+_sq() { printf "%s" "$1" | sed "s/'/''/g"; }
+
+# ---- Selftest ----
+if (( SELFTEST )); then
+  echo "[lens-wiki-digest] selftest: starting"
+  st_tmp=$(mktemp -d -t lens-wiki-st.XXXXXX)
+  export LENSES_DB_PATH="$st_tmp/persona-lens.db"
+  export LENSES_DIR="$st_tmp/patterns"
+  export LENSES_WIKI_DIR="$st_tmp/wiki"
+  export LENSES_LOG_DIR="$st_tmp/logs"
+  export LENSES_INTEL_DIR="$st_tmp/intel"
+
+  bash "$SKILL_DIR/scripts/persona-lens.sh" add steve-jobs \
+    --bucket founders --register founder-confident --rationale "first principles" --live >/dev/null
+  bash "$SKILL_DIR/scripts/persona-lens.sh" add rick-rubin \
+    --bucket producers --register quiet-mystic --rationale "less but better" --live >/dev/null
+
+  bash "$SKILL_DIR/scripts/lens-wiki-digest.sh" 2>/dev/null
+
+  if [[ -f "$st_tmp/wiki/index.md" && -f "$st_tmp/wiki/steve-jobs.md" && -f "$st_tmp/wiki/rick-rubin.md" ]]; then
+    echo "[lens-wiki-digest] selftest: PASS"
+    echo "  index: $st_tmp/wiki/index.md"
+    rm -rf "$st_tmp"
+    echo "VERDICT: PASS"
+    exit 0
+  else
+    echo "[lens-wiki-digest] selftest: FAIL — missing wiki files"
+    ls -la "$st_tmp/wiki/" 2>&1 || true
+    rm -rf "$st_tmp"
+    exit 1
+  fi
+fi
+
+if [[ ! -f "$DB" ]]; then
+  echo "ERROR: registry DB not found at $DB — add some lenses first" >&2
+  exit 1
+fi
+
+POOL_SH="$SKILL_DIR/scripts/_lens-pool.sh"
+ALL_LENSES=$(bash "$POOL_SH" --include-candidates 2>/dev/null | tr '\n' ' ')
+
+if [[ -n "$LENS" ]]; then
+  TARGET_LENSES="$LENS"
+else
+  TARGET_LENSES="$ALL_LENSES"
+fi
+
+write_lens_digest() {
+  local slug="$1"
+  local out_md="$WIKI_DIR/${slug}.md"
+  local lens_id="${slug}-lens-v1"
+  local lens_name lens_register body_size use_count vlm_avg promo
+  lens_name=$(sqlite3 "$DB" "SELECT name FROM patterns WHERE id='$(_sq "$lens_id")'" 2>/dev/null)
+  lens_register=$(sqlite3 "$DB" "SELECT register FROM patterns WHERE id='$(_sq "$lens_id")'" 2>/dev/null)
+  body_size=$(sqlite3 "$DB" "SELECT length(body) FROM patterns WHERE id='$(_sq "$lens_id")'" 2>/dev/null)
+  use_count=$(sqlite3 "$DB" "SELECT COALESCE(use_count,0) FROM patterns WHERE id='$(_sq "$lens_id")'" 2>/dev/null)
+  vlm_avg=$(sqlite3 "$DB" "SELECT printf('%.2f', COALESCE(vlm_score_avg,0)) FROM patterns WHERE id='$(_sq "$lens_id")'" 2>/dev/null)
+  promo=$(sqlite3 "$DB" "SELECT promotion_status FROM patterns WHERE id='$(_sq "$lens_id")'" 2>/dev/null)
+
+  local sidecar_count=0
+  if [[ -d "$INTEL_DIR/$slug" ]]; then
+    sidecar_count=$(ls "$INTEL_DIR/$slug"/*.json 2>/dev/null | wc -l | tr -d ' ')
+  fi
+
+  local top_brands
+  top_brands=$(sqlite3 "$DB" "SELECT brand, COUNT(*) AS uses FROM use_log WHERE pattern_id='$(_sq "$lens_id")' AND brand != '' GROUP BY brand ORDER BY uses DESC LIMIT 3" 2>/dev/null | sed 's/|/: /g; s/^/  - /')
+  [[ -z "$top_brands" ]] && top_brands="  - (no use_log entries yet — fires when apply usage starts logging)"
+
+  if (( DRY_RUN )); then
+    log "DRY: would write $out_md (lens_name=$lens_name body=${body_size:-0}B sidecars=$sidecar_count)"
+    return 0
+  fi
+
+  cat > "$out_md" << EOF
+# ${lens_name:-$slug} — Lens Digest ${WEEK}
+
+**Generated.** $(date +%Y-%m-%dT%H:%M:%S) by lens-wiki-digest
+**Source.** persona-lens registry where persona_lens=${slug}
+
+## State
+
+| Metric | Value |
+|---|---|
+| Lens ID | \`$lens_id\` |
+| Status | $promo |
+| Register | $lens_register |
+| Pattern body size | ${body_size:-0} bytes |
+| Decompositions | $sidecar_count |
+| Total uses (use_log) | $use_count |
+| Avg VLM score | $vlm_avg |
+
+## Top cross-brand applications
+
+$top_brands
+
+## Decompositions ($INTEL_DIR/${slug}/)
+
+$(if [[ -d "$INTEL_DIR/$slug" ]]; then
+    ls "$INTEL_DIR/$slug"/*.json 2>/dev/null | head -5 | while read -r f; do
+      echo "- \`$(basename "$f")\`"
+    done
+  else
+    echo "- (none yet — run lens-decomposer.sh --lens $slug --url ... --live to add)"
+  fi)
+
+## How to apply this lens
+
+\`\`\`bash
+bash scripts/lens-apply.sh --lens $slug --brand-dna /path/to/BRAND-DNA.md --use-case <slug>
+\`\`\`
+EOF
+
+  echo "$out_md"
+}
+
+write_index() {
+  local index_md="$WIKI_DIR/index.md"
+  if (( DRY_RUN )); then log "DRY: would write $index_md"; return 0; fi
+
+  local sections
+  sections=$(sqlite3 "$DB" "SELECT bucket, persona_lens, promotion_status FROM patterns WHERE persona_lens != '' ORDER BY bucket, persona_lens" -separator '|||' | python3 -c "
+import sys
+from collections import defaultdict
+groups = defaultdict(list)
+for line in sys.stdin:
+    parts = line.strip().split('|||')
+    if len(parts) != 3: continue
+    bucket, slug, status = parts
+    groups[bucket].append((slug, status))
+out = []
+for bucket in sorted(groups.keys()):
+    out.append(f'### {bucket.title()}')
+    for slug, status in groups[bucket]:
+        mark = '[active]' if status == 'active' else ('[candidate]' if status == 'candidate' else '[deprecated]')
+        out.append(f'- {mark} [{slug}]({slug}.md)')
+    out.append('')
+print('\n'.join(out))
+")
+
+  local active_count candidate_count
+  active_count=$(sqlite3 "$DB" "SELECT COUNT(*) FROM patterns WHERE persona_lens != '' AND promotion_status='active'")
+  candidate_count=$(sqlite3 "$DB" "SELECT COUNT(*) FROM patterns WHERE persona_lens != '' AND promotion_status='candidate'")
+
+  cat > "$index_md" << EOF
+# Persona-Lens Wiki — Index ($(date +%Y-%m-%d))
+
+**$active_count active + $candidate_count candidate lenses** queryable.
+
+## Live registry
+
+$sections
+
+**Legend.** [active] in pool · [candidate] awaits promote · [deprecated] out of pool
+
+## Commands
+
+\`\`\`bash
+bash scripts/persona-lens.sh add <slug> --bucket <X> --register <Y> --live
+bash scripts/persona-lens.sh propose <slug> --by agent:scout --evidence <url> --live
+bash scripts/persona-lens.sh promote <slug> --live
+bash scripts/persona-lens.sh fuse <a> <b> --live
+bash scripts/persona-lens.sh digest --bucket <X> --live
+bash scripts/lens-apply.sh --lens <slug> --brand-dna PATH --use-case <X>
+\`\`\`
+EOF
+  echo "$index_md"
+}
+
+log "week=$WEEK target_lenses=$(echo "$TARGET_LENSES" | wc -w | tr -d ' ')"
+
+written=0
+for slug in $TARGET_LENSES; do
+  out=$(write_lens_digest "$slug")
+  [[ -n "$out" ]] && written=$((written + 1))
+done
+
+if [[ -z "$LENS" ]]; then write_index; fi
+log "DONE: $written lens digests written to $WIKI_DIR"
+echo "$WIKI_DIR"

--- a/skills/persona-lens/scripts/persona-lens.sh
+++ b/skills/persona-lens/scripts/persona-lens.sh
@@ -1,0 +1,582 @@
+#!/usr/bin/env bash
+# persona-lens — dynamic lens registry CLI
+#
+# A self-contained lens-decomposition registry: add / propose / promote /
+# deprecate / fuse / digest / list lenses against a local SQLite DB.
+#
+# SAFETY: Mutating verbs (add/propose/promote/deprecate/fuse/digest) default
+# to DRY-RUN. Add --live to actually mutate the DB. Read-only verbs (list,
+# help, --selftest) fire normally.
+#
+# Storage:
+#   $LENSES_DB_PATH   — SQLite path. Default: <skill>/data/persona-lens.db
+#   $LENSES_DIR       — Lens-markdown bodies. Default: <skill>/patterns/lenses/
+#   $LENSES_INTEL_DIR — Digest outputs. Default: <skill>/intel/
+#   $LENSES_LOG_DIR   — Event logs. Default: <skill>/logs/
+#
+# LLM (used by `digest` only):
+#   $PERSONA_LENS_LLM_API_KEY — falls back to $GEMINI_API_KEY
+#   $PERSONA_LENS_LLM_MODEL   — defaults to gemini-2.5-flash
+#
+# Usage:
+#   persona-lens.sh add <slug> --name "X" --bucket founders --register founder-confident --live
+#   persona-lens.sh propose <slug> --by agent:scout --evidence <url> --bucket performers --live
+#   persona-lens.sh promote <slug> --live
+#   persona-lens.sh deprecate <slug> --live
+#   persona-lens.sh fuse <slug-a> <slug-b> [--name "A x B"] [--bucket hybrid] --live
+#   persona-lens.sh digest --bucket founders [--via gemini-2.5-flash] --live
+#   persona-lens.sh list [--bucket X --status Y --proposed-by Z] [--format table|json]
+#   persona-lens.sh --selftest
+#
+# Without --live, mutating verbs print what they WOULD do and exit cleanly.
+
+set -uo pipefail
+
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# --- Paths (env-overridable, default to skill-local) -----------------
+DB="${LENSES_DB_PATH:-$SKILL_DIR/data/persona-lens.db}"
+LENSES_DIR="${LENSES_DIR:-$SKILL_DIR/patterns/lenses}"
+INTEL_DIR="${LENSES_INTEL_DIR:-$SKILL_DIR/intel}"
+LOG_DIR="${LENSES_LOG_DIR:-$SKILL_DIR/logs}"
+mkdir -p "$(dirname "$DB")" "$LENSES_DIR" "$INTEL_DIR" "$LOG_DIR"
+
+# --- DB schema bootstrap ---------------------------------------------
+_ensure_db() {
+  sqlite3 "$DB" <<'SQL'
+CREATE TABLE IF NOT EXISTS patterns (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  pattern_type TEXT NOT NULL DEFAULT 'persona',
+  use_case TEXT,
+  intent_tags TEXT,
+  tool_targets TEXT,
+  language TEXT DEFAULT 'en',
+  register TEXT,
+  director_persona TEXT,
+  era TEXT,
+  persona_lens TEXT NOT NULL,
+  bucket TEXT NOT NULL,
+  promotion_status TEXT NOT NULL DEFAULT 'active',
+  proposed_by TEXT,
+  evidence_url TEXT,
+  source_url TEXT,
+  source_creator TEXT,
+  source_date TEXT,
+  source_provenance TEXT,
+  parent_id TEXT,
+  validated_status TEXT,
+  notes TEXT,
+  body TEXT,
+  body_path TEXT,
+  vlm_score_avg REAL,
+  use_count INTEGER DEFAULT 0,
+  created_at TEXT DEFAULT (datetime('now')),
+  updated_at TEXT DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_patterns_lens   ON patterns(persona_lens);
+CREATE INDEX IF NOT EXISTS idx_patterns_bucket ON patterns(bucket);
+CREATE INDEX IF NOT EXISTS idx_patterns_status ON patterns(promotion_status);
+
+CREATE TABLE IF NOT EXISTS use_log (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  pattern_id TEXT NOT NULL,
+  brand TEXT,
+  use_case TEXT,
+  vlm_score REAL,
+  notes TEXT,
+  at TEXT DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_use_log_pattern ON use_log(pattern_id);
+SQL
+}
+_ensure_db
+
+VERB="${1:-help}"; shift || true
+
+# --- --live opt-in safety guard --------------------------------------
+PL_LIVE=0
+_filtered=()
+for arg in "$@"; do
+  if [[ "$arg" == "--live" ]]; then
+    PL_LIVE=1
+  else
+    _filtered+=("$arg")
+  fi
+done
+set -- ${_filtered[@]+"${_filtered[@]}"}
+
+_pl_is_mutating() {
+  case "$1" in
+    add|propose|promote|deprecate|fuse|digest) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+if _pl_is_mutating "$VERB" && (( PL_LIVE == 0 )); then
+  echo "[persona-lens] MODE: dry-run (add --live to fire)" >&2
+  echo "[persona-lens]   verb: $VERB" >&2
+  echo "[persona-lens]   args: $*" >&2
+  case "$VERB" in
+    digest)  echo "[persona-lens]   estimated cost: ~\$0.005-0.02 (LLM call)" >&2 ;;
+    add|propose|fuse) echo "[persona-lens]   would write: SQLite registry + markdown stub at $LENSES_DIR/" >&2 ;;
+    promote|deprecate) echo "[persona-lens]   would update: patterns.promotion_status in $DB" >&2 ;;
+  esac
+  echo "[persona-lens] No mutation made." >&2
+  exit 0
+fi
+
+(( PL_LIVE == 1 )) && echo "[persona-lens] MODE: LIVE (firing $VERB for real)" >&2
+
+log() { echo "[$(date +%H:%M:%S)] persona-lens: $*" >&2; }
+
+# --- sqlite single-quote escape --------------------------------------
+_sq() { printf "%s" "$1" | sed "s/'/''/g"; }
+
+cmd_help() {
+  sed -n '2,36p' "$0"
+  exit 0
+}
+
+# ---- add ----
+cmd_add() {
+  local slug="${1:-}"; shift || { echo "ERROR: slug required" >&2; exit 1; }
+  local name="" bucket="" register="" intent_tags="[]" rationale=""
+  local promotion_status="active" proposed_by="user:cli" evidence_url=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --name)         name="$2"; shift 2 ;;
+      --bucket)       bucket="$2"; shift 2 ;;
+      --register)     register="$2"; shift 2 ;;
+      --intent-tags)  intent_tags="$2"; shift 2 ;;
+      --rationale)    rationale="$2"; shift 2 ;;
+      --status)       promotion_status="$2"; shift 2 ;;
+      --by)           proposed_by="$2"; shift 2 ;;
+      --evidence)     evidence_url="$2"; shift 2 ;;
+      *) echo "Unknown: $1" >&2; exit 1 ;;
+    esac
+  done
+
+  [[ -z "$name" ]] && name="${slug} — thought-leader lens"
+  [[ -z "$bucket" ]] && { echo "ERROR: --bucket required (founders|storytellers|designers|performers|hybrid|emerging|dtc-playbook|...)" >&2; exit 1; }
+  [[ -z "$register" ]] && { echo "ERROR: --register required" >&2; exit 1; }
+
+  local id="${slug}-lens-v1"
+  local md_file="$LENSES_DIR/${slug}-lens-v1.md"
+  mkdir -p "$(dirname "$md_file")"
+
+  cat > "$md_file" << EOF
+---
+id: ${id}
+name: ${name}
+pattern_type: persona
+use_case: thought-leader-lens
+intent_tags: ${intent_tags}
+tool_targets: ["claude","gpt","headline-gen","copy-rewrite","video-script-gen"]
+language: en
+register: ${register}
+director_persona: ""
+era: ""
+persona_lens: ${slug}
+bucket: ${bucket}
+promotion_status: ${promotion_status}
+proposed_by: ${proposed_by}
+evidence_url: ${evidence_url}
+source_url: ${evidence_url}
+source_creator: persona-lens (registry add)
+source_date: $(date +%Y-%m-%d)
+source_provenance: derived
+validated_status: experimental
+notes: Added via persona-lens.sh add by ${proposed_by}. ${rationale}
+---
+
+# ${name}
+
+**Bucket.** ${bucket}
+**Register.** ${register}
+**Status.** ${promotion_status}
+**Added by.** ${proposed_by}
+**Why.** ${rationale:-Pending decomposition via lens-decomposer.sh}
+
+Body will populate via lens-decomposer.sh on seed URLs.
+EOF
+
+  # UPSERT into SQLite
+  local body
+  body=$(cat "$md_file")
+  local id_sq name_sq register_sq bucket_sq prop_sq pby_sq evid_sq notes_sq body_sq lens_sq
+  id_sq=$(_sq "$id"); name_sq=$(_sq "$name"); register_sq=$(_sq "$register")
+  bucket_sq=$(_sq "$bucket"); prop_sq=$(_sq "$promotion_status")
+  pby_sq=$(_sq "$proposed_by"); evid_sq=$(_sq "$evidence_url")
+  notes_sq=$(_sq "$rationale"); body_sq=$(_sq "$body"); lens_sq=$(_sq "$slug")
+
+  sqlite3 "$DB" <<SQL
+INSERT INTO patterns (id, name, pattern_type, use_case, intent_tags, tool_targets, language, register, persona_lens, bucket, promotion_status, proposed_by, evidence_url, source_url, source_provenance, validated_status, notes, body, body_path)
+VALUES ('$id_sq', '$name_sq', 'persona', 'thought-leader-lens', '$(_sq "$intent_tags")', '["claude","gpt"]', 'en', '$register_sq', '$lens_sq', '$bucket_sq', '$prop_sq', '$pby_sq', '$evid_sq', '$evid_sq', 'derived', 'experimental', '$notes_sq', '$body_sq', '$(_sq "$md_file")')
+ON CONFLICT(id) DO UPDATE SET
+  name=excluded.name,
+  register=excluded.register,
+  bucket=excluded.bucket,
+  promotion_status=excluded.promotion_status,
+  proposed_by=excluded.proposed_by,
+  body=excluded.body,
+  body_path=excluded.body_path,
+  notes=excluded.notes,
+  updated_at=datetime('now');
+SQL
+
+  log "lens added: $slug ($bucket / $register / $promotion_status)"
+  echo "{\"slug\":\"$slug\",\"id\":\"$id\",\"bucket\":\"$bucket\",\"status\":\"$promotion_status\",\"by\":\"$proposed_by\",\"file\":\"$md_file\"}"
+}
+
+# ---- propose (agent path) ----
+cmd_propose() {
+  local slug="${1:-}"; shift || { echo "ERROR: slug required" >&2; exit 1; }
+  local by_arg="agent:unknown"
+
+  local found_by=0
+  for arg in "$@"; do
+    if (( found_by )); then by_arg="$arg"; break; fi
+    if [[ "$arg" == "--by" ]]; then found_by=1; fi
+  done
+  if [[ $# -gt 0 && "$1" != --* && "$found_by" -eq 0 ]]; then
+    by_arg="$1"; shift
+  fi
+  cmd_add "$slug" --status candidate --by "$by_arg" "$@"
+  log "PROPOSED: $slug by $by_arg — promote with: persona-lens.sh promote $slug --live"
+  echo "$(date +%Y-%m-%dT%H:%M:%S),propose,$slug,$by_arg" >> "$LOG_DIR/persona-lens-events.log"
+}
+
+# ---- read current promotion_status ----
+_pl_read_status() {
+  local slug="$1"
+  if [[ ! -f "$DB" ]]; then echo ""; return 0; fi
+  sqlite3 "$DB" "SELECT promotion_status FROM patterns WHERE persona_lens='$(_sq "$slug")' LIMIT 1;" 2>/dev/null
+}
+
+cmd_promote() {
+  local slug="${1:-}"; [[ -z "$slug" ]] && { echo "ERROR: slug required" >&2; exit 1; }
+  local current; current=$(_pl_read_status "$slug")
+  if [[ -z "$current" ]]; then
+    echo "[persona-lens] ERROR: lens not found in registry: $slug" >&2; exit 1
+  fi
+  if [[ "$current" == "active" ]]; then
+    echo "[persona-lens] noop: $slug already active" >&2; exit 0
+  fi
+  if [[ "$current" == "deprecated" ]]; then
+    echo "[persona-lens] ERROR: cannot resurrect deprecated lens $slug — add fresh slug" >&2; exit 1
+  fi
+  sqlite3 "$DB" "UPDATE patterns SET promotion_status='active', updated_at=datetime('now') WHERE persona_lens='$(_sq "$slug")'"
+  echo "$(date +%Y-%m-%dT%H:%M:%S),promote,$slug,from=$current" >> "$LOG_DIR/persona-lens-events.log"
+  log "promoted: $slug ($current → active)"
+  echo "{\"slug\":\"$slug\",\"status\":\"active\",\"from\":\"$current\"}"
+}
+
+cmd_deprecate() {
+  local slug="${1:-}"; [[ -z "$slug" ]] && { echo "ERROR: slug required" >&2; exit 1; }
+  local current; current=$(_pl_read_status "$slug")
+  if [[ -z "$current" ]]; then
+    echo "[persona-lens] ERROR: lens not found in registry: $slug" >&2; exit 1
+  fi
+  if [[ "$current" == "deprecated" ]]; then
+    echo "[persona-lens] noop: $slug already deprecated" >&2; exit 0
+  fi
+  sqlite3 "$DB" "UPDATE patterns SET promotion_status='deprecated', updated_at=datetime('now') WHERE persona_lens='$(_sq "$slug")'"
+  echo "$(date +%Y-%m-%dT%H:%M:%S),deprecate,$slug,from=$current" >> "$LOG_DIR/persona-lens-events.log"
+  log "deprecated: $slug ($current → deprecated)"
+  echo "{\"slug\":\"$slug\",\"status\":\"deprecated\",\"from\":\"$current\"}"
+}
+
+# ---- fuse ----
+cmd_fuse() {
+  local a="${1:-}" b="${2:-}"; shift 2 2>/dev/null || true
+  [[ -z "$a" || -z "$b" ]] && { echo "ERROR: usage: fuse <a> <b> [--name X] [--bucket Y]" >&2; exit 1; }
+
+  local fused_name="${a}-x-${b}" bucket="hybrid"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --name)   fused_name=$(echo "$2" | tr ' ' '-' | tr 'A-Z' 'a-z'); shift 2 ;;
+      --bucket) bucket="$2"; shift 2 ;;
+      *) echo "Unknown: $1" >&2; exit 1 ;;
+    esac
+  done
+
+  local fused_slug="$fused_name"
+  local body_a body_b register_a register_b
+  body_a=$(sqlite3 "$DB" "SELECT body FROM patterns WHERE persona_lens='$(_sq "$a")'")
+  body_b=$(sqlite3 "$DB" "SELECT body FROM patterns WHERE persona_lens='$(_sq "$b")'")
+  register_a=$(sqlite3 "$DB" "SELECT register FROM patterns WHERE persona_lens='$(_sq "$a")'")
+  register_b=$(sqlite3 "$DB" "SELECT register FROM patterns WHERE persona_lens='$(_sq "$b")'")
+
+  [[ -z "$body_a" ]] && { echo "ERROR: lens not found: $a" >&2; exit 1; }
+  [[ -z "$body_b" ]] && { echo "ERROR: lens not found: $b" >&2; exit 1; }
+
+  local md_file="$LENSES_DIR/${fused_slug}-lens-v1.md"
+  cat > "$md_file" << EOF
+---
+id: ${fused_slug}-lens-v1
+name: ${a} × ${b} — hybrid lens
+pattern_type: persona
+use_case: thought-leader-lens
+intent_tags: ["hybrid","fusion","cross-lens"]
+tool_targets: ["claude","gpt","headline-gen","copy-rewrite"]
+language: en
+register: ${register_a}-${register_b}-hybrid
+persona_lens: ${fused_slug}
+bucket: ${bucket}
+promotion_status: candidate
+proposed_by: agent:fusion
+parent_id: ${a}-lens-v1,${b}-lens-v1
+validated_status: experimental
+notes: Fusion lens combining $a and $b.
+---
+
+# ${a} × ${b} — Hybrid Lens
+
+**Composition rule.** Take **${a}**'s structural skeleton (narrative arc, opening
+move, framework_used) and apply **${b}**'s vocabulary register, blocked words,
+and design restraint over it. Energy and humor follow ${b}; framework and
+contrarian-take follow ${a}.
+
+## Component A — ${a} body
+\`\`\`
+${body_a}
+\`\`\`
+
+## Component B — ${b} body
+\`\`\`
+${body_b}
+\`\`\`
+
+## Fusion guidance
+
+When applying via lens-apply.sh:
+1. Use A.narrative.* (arc, opening_move, framework)
+2. Use B.vocabulary.* (register, signature_phrases override A, blocked_words union)
+3. Use B.design.* (composition_pref, typography, restraint principles)
+4. Use B.creative_direction.energy_level + humor_register
+5. Use A.creative_direction.first_principles_anchor + contrarian_take
+EOF
+
+  # Persist fused lens via UPSERT
+  local body_full; body_full=$(cat "$md_file")
+  sqlite3 "$DB" <<SQL
+INSERT INTO patterns (id, name, pattern_type, use_case, language, register, persona_lens, bucket, promotion_status, proposed_by, parent_id, validated_status, notes, body, body_path)
+VALUES ('$(_sq "${fused_slug}-lens-v1")', '$(_sq "${a} × ${b} — hybrid lens")', 'persona', 'thought-leader-lens', 'en', '$(_sq "${register_a}-${register_b}-hybrid")', '$(_sq "$fused_slug")', '$(_sq "$bucket")', 'candidate', 'agent:fusion', '$(_sq "${a}-lens-v1,${b}-lens-v1")', 'experimental', '$(_sq "Fusion lens combining $a and $b.")', '$(_sq "$body_full")', '$(_sq "$md_file")')
+ON CONFLICT(id) DO UPDATE SET
+  body=excluded.body,
+  updated_at=datetime('now');
+SQL
+
+  echo "$(date +%Y-%m-%dT%H:%M:%S),fuse,$fused_slug,parents=$a+$b" >> "$LOG_DIR/persona-lens-events.log"
+  log "fused: $a × $b → $fused_slug (status=candidate)"
+  echo "{\"slug\":\"$fused_slug\",\"parents\":[\"$a\",\"$b\"],\"status\":\"candidate\",\"file\":\"$md_file\"}"
+}
+
+# ---- digest (extract 底层逻辑 via LLM) ----
+cmd_digest() {
+  local bucket="" model="${PERSONA_LENS_LLM_MODEL:-${GEMINI_MODEL:-gemini-2.5-flash}}"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --bucket) bucket="$2"; shift 2 ;;
+      --via)    model="$2"; shift 2 ;;
+      *) echo "Unknown: $1" >&2; exit 1 ;;
+    esac
+  done
+  [[ -z "$bucket" ]] && { echo "ERROR: --bucket required" >&2; exit 1; }
+
+  local key="${PERSONA_LENS_LLM_API_KEY:-${GEMINI_API_KEY:-}}"
+  if [[ -z "$key" ]]; then
+    echo "ERROR: PERSONA_LENS_LLM_API_KEY (or GEMINI_API_KEY) not set" >&2
+    exit 2
+  fi
+
+  log "digesting bucket=$bucket via $model — finding 底层逻辑 (first principles)"
+
+  local bodies
+  bodies=$(sqlite3 "$DB" "SELECT body FROM patterns WHERE bucket='$(_sq "$bucket")' AND promotion_status='active' AND persona_lens != ''" -separator $'\n\n---LENS---\n\n')
+
+  if [[ -z "$bodies" ]]; then
+    echo "ERROR: no active lenses found in bucket=$bucket" >&2
+    exit 3
+  fi
+
+  local out_md="$INTEL_DIR/${bucket}-meta-pattern-$(date +%Y-%m-%d).md"
+  local prompt_tmp raw_tmp
+  prompt_tmp=$(mktemp -t lens-digest-prompt.XXXXXX)
+  raw_tmp=$(mktemp -t lens-digest-raw.XXXXXX)
+
+  cat > "$prompt_tmp" << PROMPTEOF
+You are a meta-pattern extraction engine. Below are the decomposed lenses for the "${bucket}" bucket. Each is decomposed into a 30-field schema (narrative · vocabulary · design · meta_text · creative_direction).
+
+Find the 底层逻辑 (underlying logic / first principles) shared across these lenses. Output as a JSON object:
+
+{
+  "bucket": "${bucket}",
+  "shared_principles": ["3-5 first-principles common to all lenses in this bucket"],
+  "shared_narrative_arcs": ["arc patterns appearing in 3+ lenses"],
+  "shared_vocabulary_register": ["register types overlapping"],
+  "shared_signature_phrases": ["phrases appearing across 2+ lenses"],
+  "differentiators": ["the 1-2 things that distinguish each lens within the bucket"],
+  "meta_template": "A 1-paragraph 'starter template' that any new lens in this bucket should fit.",
+  "candidate_seed_creators": ["3-5 creator names who fit this meta-pattern but aren't yet in registry"]
+}
+
+Decomposed lenses for bucket=${bucket}:
+
+${bodies}
+
+Return JSON only, no commentary.
+PROMPTEOF
+
+  local payload
+  payload=$(python3 -c "
+import json
+text = open('$prompt_tmp').read()
+print(json.dumps({
+  'contents': [{'parts': [{'text': text}]}],
+  'generationConfig': {'response_mime_type': 'application/json', 'temperature': 0.4}
+}))
+")
+
+  local http_code
+  for attempt in 1 2 3; do
+    http_code=$(curl -sS -w '%{http_code}' -o "$raw_tmp" -X POST \
+      "https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${key}" \
+      -H 'Content-Type: application/json' -d "$payload" 2>&1) || true
+    [[ "$http_code" == "200" ]] && break
+    [[ "$http_code" =~ ^5 ]] && { log "LLM $model HTTP $http_code attempt $attempt — backoff"; sleep "$attempt"; }
+  done
+
+  if [[ "$http_code" != "200" ]]; then
+    echo "ERROR: LLM HTTP $http_code" >&2
+    head -c 500 "$raw_tmp" >&2; echo >&2
+    rm -f "$prompt_tmp" "$raw_tmp"
+    exit 5
+  fi
+
+  python3 -c "
+import json
+d = json.load(open('$raw_tmp'))
+txt = d.get('candidates',[{}])[0].get('content',{}).get('parts',[{}])[0].get('text','')
+try:
+    print(json.dumps(json.loads(txt), indent=2, ensure_ascii=False))
+except Exception:
+    print(txt)
+" > "$out_md.json"
+
+  cat > "$out_md" << EOF
+# ${bucket} bucket — 底层逻辑 (meta-pattern) $(date +%Y-%m-%d)
+
+**Generated.** $(date +%Y-%m-%dT%H:%M:%S) by persona-lens.sh digest
+**Model.** ${model}
+**Lenses analyzed.** $(sqlite3 "$DB" "SELECT COUNT(*) FROM patterns WHERE bucket='$(_sq "$bucket")' AND promotion_status='active'")
+
+## Meta-pattern (JSON)
+
+\`\`\`json
+$(cat "$out_md.json")
+\`\`\`
+
+## How to use
+
+When proposing future ${bucket} lenses, inject this meta-pattern as constraint.
+A new ${bucket} lens that doesn't match these shared_principles → low-confidence
+candidate, requires manual review.
+
+When fusing lenses, prefer within-bucket pairs (they share the meta-pattern,
+fusion produces coherent hybrid).
+EOF
+
+  rm -f "$prompt_tmp" "$raw_tmp"
+  echo "$(date +%Y-%m-%dT%H:%M:%S),digest,$bucket,$model" >> "$LOG_DIR/persona-lens-events.log"
+  log "digest written: $out_md (+ $out_md.json)"
+  echo "$out_md"
+}
+
+# ---- list ----
+cmd_list() {
+  local bucket="" status="" proposed_by="" format="table"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --bucket)      bucket="$2"; shift 2 ;;
+      --status)      status="$2"; shift 2 ;;
+      --proposed-by) proposed_by="$2"; shift 2 ;;
+      --format)      format="$2"; shift 2 ;;
+      *) echo "Unknown: $1" >&2; exit 1 ;;
+    esac
+  done
+
+  local where_parts="persona_lens != ''"
+  [[ -n "$bucket" ]]      && where_parts="$where_parts AND bucket='$(_sq "$bucket")'"
+  [[ -n "$status" ]]      && where_parts="$where_parts AND promotion_status='$(_sq "$status")'"
+  [[ -n "$proposed_by" ]] && where_parts="$where_parts AND proposed_by='$(_sq "$proposed_by")'"
+  local where_clause="WHERE $where_parts"
+
+  case "$format" in
+    json)
+      sqlite3 -json "$DB" "SELECT persona_lens, bucket, promotion_status, register, proposed_by, length(body) as body_len, vlm_score_avg, use_count FROM patterns $where_clause ORDER BY bucket, persona_lens"
+      ;;
+    *)
+      sqlite3 -column -header "$DB" "SELECT persona_lens, bucket, promotion_status, register, proposed_by, length(body) as body, vlm_score_avg as vlm, use_count as uses FROM patterns $where_clause ORDER BY bucket, persona_lens"
+      ;;
+  esac
+}
+
+# ---- selftest ----
+cmd_selftest() {
+  echo "[persona-lens] selftest: starting (DB=$DB)"
+  local tmpdb tmpdir
+  tmpdir=$(mktemp -d -t persona-lens-selftest.XXXXXX)
+  tmpdb="$tmpdir/persona-lens.db"
+
+  # Re-invoke this script with overridden paths
+  export LENSES_DB_PATH="$tmpdb"
+  export LENSES_DIR="$tmpdir/patterns"
+  export LENSES_INTEL_DIR="$tmpdir/intel"
+  export LENSES_LOG_DIR="$tmpdir/logs"
+
+  # Re-source the same script (idempotent) — we'll just shell out
+  local self="$0"
+
+  echo "  [1/6] add steve-jobs (dry-run)"
+  bash "$self" add steve-jobs --bucket founders --register founder-confident --rationale "first principles" >/dev/null
+  echo "  [2/6] add steve-jobs (live)"
+  bash "$self" add steve-jobs --bucket founders --register founder-confident --rationale "first principles" --live >/dev/null
+  echo "  [3/6] add rick-rubin (live)"
+  bash "$self" add rick-rubin --bucket producers --register quiet-mystic --rationale "less but better" --live >/dev/null
+  echo "  [4/6] list active (json)"
+  local count; count=$(bash "$self" list --format json 2>/dev/null | python3 -c "import json,sys; print(len(json.load(sys.stdin)))" 2>/dev/null || echo 0)
+  echo "      → $count lenses in registry"
+  if [[ "$count" -lt 2 ]]; then echo "FAIL: expected ≥2 lenses, got $count"; exit 1; fi
+
+  echo "  [5/6] fuse steve-jobs × rick-rubin (live)"
+  bash "$self" fuse steve-jobs rick-rubin --live >/dev/null
+
+  echo "  [6/6] deprecate rick-rubin (live)"
+  bash "$self" deprecate rick-rubin --live >/dev/null
+  local depr; depr=$(bash "$self" list --status deprecated --format json 2>/dev/null | python3 -c "import json,sys; print(len(json.load(sys.stdin)))" 2>/dev/null || echo 0)
+  if [[ "$depr" -lt 1 ]]; then echo "FAIL: expected ≥1 deprecated lens, got $depr"; exit 1; fi
+
+  rm -rf "$tmpdir"
+  echo "[persona-lens] selftest: PASS"
+  echo "VERDICT: PASS"
+}
+
+# ---- dispatch ----
+case "$VERB" in
+  add)        cmd_add "$@" ;;
+  propose)    cmd_propose "$@" ;;
+  promote)    cmd_promote "$@" ;;
+  deprecate)  cmd_deprecate "$@" ;;
+  fuse)       cmd_fuse "$@" ;;
+  digest)     cmd_digest "$@" ;;
+  list)       cmd_list "$@" ;;
+  --selftest|selftest) cmd_selftest ;;
+  help|-h|--help|"") cmd_help ;;
+  *)
+    echo "ERROR: unknown verb '$VERB'" >&2
+    cmd_help
+    ;;
+esac

--- a/skills/persona-lens/smokes/smoke.sh
+++ b/skills/persona-lens/smokes/smoke.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# smoke.sh — F6 minimal smoke for persona-lens
+# Exit 0 if skill is invokable + responds to --help.
+# Generated 2026-05-09 by scaffold_skill_smoke.sh.
+set -euo pipefail
+
+SCRIPT_REL="scripts/persona-lens.sh"
+SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$SKILL_DIR/$SCRIPT_REL"
+
+# Check 1: script exists + executable
+if [ ! -f "$SCRIPT" ]; then
+  echo "FAIL: script missing at $SCRIPT" >&2
+  echo "VERDICT: FAIL"
+  exit 1
+fi
+
+# Check 2: bash syntax-clean
+if ! bash -n "$SCRIPT" 2>/dev/null; then
+  echo "FAIL: bash -n syntax error in $SCRIPT" >&2
+  echo "VERDICT: FAIL"
+  exit 1
+fi
+
+# Check 3: --help responds within 5s and exits cleanly
+HELP_OUT="$(timeout 5 bash "$SCRIPT" --help 2>&1 || true)"
+if [ -z "$HELP_OUT" ]; then
+  echo "WARN: --help produced no output (skill may not implement --help)" >&2
+  # Not a hard fail — many skills don't implement --help
+fi
+
+echo "VERDICT: PASS"
+exit 0


### PR DESCRIPTION
## What this skill does

`persona-lens` is a **self-contained lens-decomposition registry**: a SQLite-backed registry of "lenses" (decomposed perspectives — thought-leaders like Steve Jobs / Rick Rubin / Hormozi, and DTC funnel playbooks like Huel / Hims / AG1) that you can **apply**, **fuse**, and **digest** into the shared first-principles (底层逻辑) of a creative space. The skill ships seven CLIs that turn quantitative decompositions into composable [lens × brand-DNA × use-case × user-input] prompts.

## Why it's useful

You point it at a YouTube talk or essay — the **decomposer** writes a 30-field decomposition (narrative arc, vocabulary register, signature phrases, anti-patterns, etc.) and registers it. Later, **lens-apply** composes that decomposition with any brand's `BRAND-DNA.md` and a use-case (manifesto, ad-headline, email subject, etc.) into a ready prompt. **fuse** combines two lenses into a hybrid. **digest** asks an LLM to extract the shared first-principles across a whole bucket of lenses — the quantitative-to-qualitative meta-pattern.

Concrete use case: you have 20 founder-lens decompositions. `persona-lens.sh digest --bucket founders --live` returns:
```json
{
  "shared_principles": ["First Principles Thinking", "Audacious Vision", "Calm Confident Authority"],
  "meta_template": "...",
  "candidate_seed_creators": ["Jensen Huang", "Reed Hastings", ...]
}
```

## Standalone-ness

Zero external skill dependencies. Only `bash + python3 + sqlite3 + curl`. Optional:
- `yt-dlp` or `youtube-transcript-api` — only for `lens-decomposer.sh --url <youtube-URL>`
- Gemini API key (or any LLM provider key wired via the two `curl` blocks) — only for `digest` + `decomposer` verbs
- A `mempalace-policy.sh`-style gate (entirely opt-in via `MEMPALACE_POLICY_SH`)

All paths are skill-local by default. Override any of: `LENSES_DB_PATH`, `LENSES_DIR`, `LENSES_WIKI_DIR`, `LENSES_INTEL_DIR`, `LENSES_LOG_DIR`, `PERSONA_LENS_BRANDS_DIR`, `PERSONA_LENS_SCHEMA_PATH`, `PERSONA_LENS_LLM_API_KEY`, `PERSONA_LENS_LLM_MODEL`.

## Selftest output

Every script ships a `--selftest` that creates a `mktemp -d` workspace, runs the verb, and cleans up. Real output from a fresh clone:

```
## persona-lens.sh --selftest
[persona-lens] selftest: starting
  [1/6] add steve-jobs (dry-run)
  [2/6] add steve-jobs (live)
  [3/6] add rick-rubin (live)
  [4/6] list active (json) → 2 lenses in registry
  [5/6] fuse steve-jobs × rick-rubin (live)
  [6/6] deprecate rick-rubin (live)
[persona-lens] selftest: PASS
VERDICT: PASS

## lens-apply.sh --selftest
   tokens: 596
   brand_dna: <tmpdir>/brands/example-brand/BRAND-DNA.md
[lens-apply] selftest: PASS
VERDICT: PASS

## brand-to-playbook.sh --selftest
   detected category: food
   candidates: 2
[brand-to-playbook] selftest: PASS
VERDICT: PASS

## lens-decomposer.sh --selftest (dry-run; no LLM)
[lens-decomposer] selftest: PASS
VERDICT: PASS

## lens-wiki-digest.sh --selftest
[lens-wiki-digest] selftest: PASS
VERDICT: PASS

## smokes/smoke.sh
VERDICT: PASS
```

## Example usage

```bash
# 1. Add two lenses
bash scripts/persona-lens.sh add steve-jobs \
  --bucket founders --register founder-confident \
  --rationale "first principles · less but better · demos > slides" --live

bash scripts/persona-lens.sh add huel-funnel \
  --bucket dtc-playbook --register direct-response \
  --rationale "category: food. Science-authority + subscribe-and-save." --live

# 2. Apply Steve Jobs lens × your brand DNA × manifesto use-case
bash scripts/lens-apply.sh \
  --lens steve-jobs \
  --brand-dna /path/to/your-brand/BRAND-DNA.md \
  --use-case manifesto \
  --user-input "We're launching a new pour-over kettle."
# → emits JSON: { composed_prompt, lens_id, brand_dna_path, composition_token_count, ... }

# 3. Auto-route your brand to its best-fit DTC playbook
bash scripts/brand-to-playbook.sh \
  --brand-dna /path/to/your-brand/BRAND-DNA.md \
  --use-case ad-headline \
  --auto-apply
```

## Origin

Ported from **Zennith OS** (Huemankind agency tooling). The original version was tightly coupled to a multi-skill registry and a 7-brand corpus; this PR decouples it into a self-contained skill with env-var-overridable paths, ships a default 30-field schema, and includes per-script `--selftest` mode.

## License

MIT — see `skills/persona-lens/LICENSE.txt`.

## Decoupling LOC delta

Compared to the internal Zennith-OS version:
- Removed 4 zennith-internal scripts (`_ship-chain.sh`, `_gen-lens-stubs.py`, `_import-design-aesthetics.py`, `_build-seed-urls.sh`) — these only made sense against an internal corpus
- Rewrote 5 core scripts (`persona-lens.sh`, `lens-apply.sh`, `brand-to-playbook.sh`, `lens-decomposer.sh`, `lens-wiki-digest.sh`) for self-contained SQLite + env-var paths
- Added bootstrap schema at `schemas/lens-30field.json`
- Added per-script `--selftest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
