### PR TITLE
Add publish-mobile-app skill — automate App Store + Play Store publishing for Capacitor/Expo/Flutter

### DIFF
--- a/skills/publish-mobile-app/MANUAL_FORMS.md
+++ b/skills/publish-mobile-app/MANUAL_FORMS.md
@@ -1,0 +1,156 @@
+# Manual Store Forms — Answer Guide
+
+These store-side questionnaires have **no API**. Apple and Google require they be filled in the consoles. This file documents the right answers for a typical content-creation / AI app (classic shape: AI-generated user content, optional account, no in-app messaging, no ads, family-friendly).
+
+When user is filling these forms, ask the routing question first:
+
+> *"Is this a content-creation/AI app? Or a different category — game, social, finance, health?"*
+
+The defaults below assume content-creation/AI. Adjust for other categories.
+
+## Apple — Age Rating questionnaire
+
+### Step 1: Features
+| Question | Default | Why |
+|---|---|---|
+| Parental Controls | **No** | Unless you ship a dedicated parental-controls UI dashboard |
+| Age Assurance | **No** | Unless you verify birthdate / ID |
+| Unrestricted Web Access | **No** | If using Capacitor Browser or in-app browser to specific URLs only |
+| User-Generated Content | **No** | If content is private by default & sharing is account-controlled. Apple defines this as "broad distribution" — public feeds count, private sharing doesn't |
+| Messaging and Chat | **No** | No user-to-user messaging |
+| Advertising | **No** | No paid promotion inside the app |
+
+### Steps 2–5: Mature content categories
+Default to **None** for all of these unless app actually contains:
+- Cartoon/Fantasy Violence
+- Realistic Violence
+- Profanity / Crude Humor
+- Sexual Content / Nudity
+- Alcohol / Tobacco / Drug Use
+- Mature/Suggestive Themes
+- Horror/Fear Themes (consider **Infrequent/Mild** if AI could generate scary content — but content filtering makes **None** defensible)
+- Medical / Treatment Info
+- Gambling / Contests
+
+### Step 6: Generative AI (Apple added this recently — be honest)
+| Question | Answer |
+|---|---|
+| Does your app use generative AI? | **Yes** |
+| Will generated content be sensitive/inappropriate for under-17? | **No** (if you have content filtering) |
+| Do you have safeguards? | **Yes** — mention them in App Review notes too |
+
+### Step 7: Result
+Apple computes the rating. Typical landing: **4+** or **9+** for filtered AI content apps.
+
+**Important nuance — Kids Category opt-in**:
+Even if app targets 10+ in description, **do NOT opt into Kids Category** unless you accept these strict requirements:
+- No third-party analytics linked to user identifiers (kills Firebase Analytics, Meta Pixel, etc.)
+- No behavioral advertising
+- No external links to other apps
+- Parental gate before purchases
+- Restricted data sharing
+
+Standard 4+/9+ rating without the Kids Category badge is the right shape for most family-friendly apps.
+
+## Apple — App Privacy questionnaire
+
+For each data type, declare:
+1. Is it **collected**? Yes/No
+2. Is it **linked to user identity**?
+3. Is it **used for tracking** across apps?
+4. **Purpose**: App Functionality / Analytics / Product Personalization / Developer Communications
+
+Typical answers for a content-creation/AI app:
+
+| Data type | Collected? | Linked? | Tracking? | Purpose |
+|---|---|---|---|---|
+| Email address | Yes | Linked | No | App Functionality |
+| Name | Yes (if you ask) | Linked | No | App Functionality |
+| User Content (stories) | Yes | Linked | No | App Functionality |
+| Photos / Videos | Only if user uploads | Linked | No | App Functionality |
+| Audio Data (narration) | Yes (output) | Linked | No | App Functionality |
+| Purchase History | Yes | Linked | No | App Functionality |
+| Device ID | If using Firebase / analytics SDK | Not Linked | No | Analytics |
+| Crash Data | Yes (Sentry/Crashlytics) | Not Linked | No | App Functionality |
+| Performance Data | Yes | Not Linked | No | Analytics |
+| Coarse Location | No | — | — | — |
+| Precise Location | No | — | — | — |
+| Contacts | No | — | — | — |
+| Search History | No | — | — | — |
+
+Mark "Used to Track You" = **No** for everything unless you genuinely share data with third parties for advertising.
+
+## Google — Data Safety form
+
+Mirrors App Privacy but with different terminology. Key differences:
+- "Collected" + "Shared" are separate questions per data type
+- "Processed ephemerally" option exists for things touched in-memory but not stored
+- Required: **encryption in transit** declaration (always "Yes" for any HTTPS app)
+- Required: **users can request deletion** declaration
+
+Typical declarations for content-creation/AI:
+
+**Personal info**:
+- Name, Email: collected (encrypted in transit, optional, used for account management)
+- NOT shared
+
+**User-generated content**:
+- Photos/Videos: collected if user uploads, encrypted in transit
+- Audio: collected (narration), encrypted in transit
+- Other (story text): collected, encrypted in transit
+- NOT shared (RLS-protected in Supabase)
+
+**App activity**:
+- App interactions: collected for Analytics if using Firebase/Mixpanel
+- In-app search history: collected only if there's an actual search feature
+
+**Device or other IDs**:
+- Collected for Analytics/Crash purposes if using Firebase, Sentry, Meta Pixel, etc.
+- Shared with those third parties
+
+**Financial info**:
+- Purchase history: collected, NOT shared (Google Play Billing handles this separately)
+
+## Google — Content Rating
+
+Questionnaire is straightforward. Most "Does your app contain X?" questions get **No** for a content-creation/AI app.
+
+Key calls:
+- **Cartoon violence**: No (AI doesn't generate violent content by default)
+- **Sexual content**: No
+- **Profanity**: No (content filtering)
+- **User-generated content**: **Yes** (this triggers a follow-up requiring you to have a content moderation policy — which you should already document in `/safety` page)
+- **Social features**: No (if no in-app messaging)
+- **Personal info shared with users**: No
+- **Allows users to interact**: No (no chat)
+
+Typical resulting rating: **PEGI 3 / Everyone**.
+
+## Google — Target Audience and Content
+
+This is **where you choose whether to opt into Designed for Families**.
+
+Typical answers for a content-creation/AI app:
+- Target age groups: **13+** (avoid the under-13 box unless app is designed exclusively for kids)
+- Does the app appeal to children? **No** (if 13+) or **Yes, mixed audience** (if 13+ but also family-friendly)
+
+If you check the under-13 box, you're auto-enrolled in **Designed for Families** with strict requirements (no behavioral ads, restricted SDKs, etc.).
+
+## Google — App Access
+
+Required when app has sign-in. Reviewer credentials go here:
+- Instruction name: `App reviewer login` (or similar)
+- Username: from `ios/.env.review`
+- Password: from `ios/.env.review`
+- Other instructions: paste reviewer notes verbatim
+
+Run `bun scripts/print-reviewer-creds.ts` to get copy-paste strings.
+
+## Apple App Review Information (programmable via fastlane)
+
+Unlike the forms above, this **does have an API** — handled by the `metadata` lane:
+- First name, Last name, Phone (with country code), Email
+- Demo user / password
+- Notes (testing instructions for reviewer)
+
+Source: `ios/.env.review` env vars → Fastfile's `app_review_information:` block. See [SKILL.md](SKILL.md) setup step 11.

--- a/skills/publish-mobile-app/REFERENCE.md
+++ b/skills/publish-mobile-app/REFERENCE.md
@@ -1,0 +1,208 @@
+# Reference
+
+## Framework differences
+
+### Capacitor
+- iOS project: `ios/App/App.xcodeproj`, scheme `App`
+- Android project: `android/app/build.gradle`
+- Web build pipeline: `vite build --mode production && cap sync <platform>` before any binary build
+- npm scripts wrap fastlane: `bun run ios:metadata`, `bun run android:metadata`
+
+### Expo
+- iOS project: built via `eas build --platform ios` OR `npx expo prebuild --platform ios` to generate `ios/` then use fastlane
+- Recommended path: use EAS Build + `eas submit` (Expo's own toolchain); fastlane works only after `expo prebuild`
+- Submission metadata lives in `store.config.json` (Expo) or fastlane folders if prebuilt
+- `app.json` → `expo.ios.bundleIdentifier` is the bundle ID
+
+### Flutter
+- iOS project: `ios/Runner.xcodeproj`, scheme `Runner`
+- Android project: `android/app/build.gradle`
+- Build pipeline: `flutter build ios --release --no-codesign` then `gym`/`fastlane` for signing
+- Android: `flutter build appbundle` produces the AAB; can also use `gradle-play-publisher` from the `android/` dir
+- Version source of truth: `pubspec.yaml` → `version: 1.0.0+1` (the `+1` is build number)
+
+## Fastfile template
+
+```ruby
+# ios/fastlane/Fastfile
+API_KEY_PATH = File.expand_path("../app-store-connect-key.json", __dir__)
+
+default_platform(:ios)
+
+platform :ios do
+  before_all do
+    ENV["FASTLANE_HIDE_CHANGELOG"] = "1"
+  end
+
+  desc "Upload metadata + screenshots only (no binary)."
+  lane :metadata do
+    review_info = {
+      first_name: ENV["ASC_REVIEW_FIRST_NAME"],
+      last_name: ENV["ASC_REVIEW_LAST_NAME"],
+      phone_number: ENV["ASC_REVIEW_PHONE"],
+      email_address: ENV["ASC_REVIEW_EMAIL"],
+      demo_user: ENV["ASC_REVIEW_DEMO_USER"],
+      demo_password: ENV["ASC_REVIEW_DEMO_PASSWORD"],
+      notes: ENV["ASC_REVIEW_NOTES"],
+    }.compact
+
+    deliver(
+      api_key_path: API_KEY_PATH,
+      skip_binary_upload: true,
+      skip_screenshots: false,
+      skip_metadata: false,
+      force: true,
+      overwrite_screenshots: true,
+      precheck_include_in_app_purchases: false,
+      app_review_information: review_info,
+    )
+  end
+
+  desc "Build signed IPA and push to TestFlight."
+  lane :beta do
+    api_key = app_store_connect_api_key(key_filepath: API_KEY_PATH, in_house: false)
+
+    next_build = latest_testflight_build_number(
+      api_key: api_key,
+      app_identifier: ENV["BUNDLE_ID"] || "com.example.app",
+      initial_build_number: 0,
+    ) + 1
+    increment_build_number(
+      xcodeproj: "App/App.xcodeproj",  # or "Runner/Runner.xcodeproj" for Flutter
+      build_number: next_build.to_s,
+    )
+
+    build_app(
+      project: "App/App.xcodeproj",
+      scheme: "App",
+      configuration: "Release",
+      export_method: "app-store",
+      clean: true,
+      output_directory: "build",
+      output_name: "App.ipa",
+      export_options: { signingStyle: "automatic", teamID: ENV["TEAM_ID"] },
+    )
+
+    upload_to_testflight(
+      api_key: api_key,
+      skip_waiting_for_build_processing: true,
+      skip_submission: true,
+    )
+  end
+end
+```
+
+## Android build.gradle
+
+```gradle
+// android/app/build.gradle
+def playConfigFile = rootProject.file('play-config.json')
+if (playConfigFile.exists()) {
+    apply plugin: 'com.github.triplet.play'
+
+    play {
+        serviceAccountCredentials.set(playConfigFile)
+        track.set("internal")
+        defaultToAppBundles.set(true)
+        // Switch to ReleaseStatus.COMPLETED after first prod release
+        releaseStatus.set(com.github.triplet.gradle.androidpublisher.ReleaseStatus.DRAFT)
+    }
+}
+```
+
+Plugin in `android/build.gradle`:
+```gradle
+classpath 'com.github.triplet.gradle:play-publisher:3.12.1'
+```
+
+## Character limits
+
+### App Store Connect (per locale)
+| Field | Max |
+|---|---|
+| `name.txt` | 30 |
+| `subtitle.txt` | 30 |
+| `promotional_text.txt` | 170 |
+| `keywords.txt` | 100 (comma-separated, no spaces) |
+| `description.txt` | 4000 |
+| `release_notes.txt` | 4000 |
+
+### Play Console (per locale)
+| Field | Max |
+|---|---|
+| `title.txt` | 30 |
+| `short-description.txt` | 80 |
+| `full-description.txt` | 4000 |
+
+## Asset dimensions
+
+### iOS screenshots
+| Display type | Pixel size |
+|---|---|
+| iPhone 6.5" (`APP_IPHONE_65`) | 1242×2688 or 1284×2778 |
+| iPhone 6.7" (`APP_IPHONE_67`) | 1290×2796 |
+| iPad 12.9" Display (`APP_IPAD_PRO_3GEN_129`, the "iPad 13"" tab) | 2064×2752 or 2048×2732 |
+
+### Android assets
+| Asset | Pixel size |
+|---|---|
+| App icon | 512×512 |
+| Feature graphic | 1024×500 (no transparency, no text near edges) |
+| Phone screenshot | min 320, max 3840, aspect 16:9 or 9:16 ≤ 2:1 |
+
+## iPad screenshot filename magic
+
+**This bit us.** `2048×2732` is ambiguous in fastlane 2.226 — it maps to either:
+- `APP_IPAD_PRO_129` (legacy iPad Pro 12.9", hidden in current ASC UI)
+- `APP_IPAD_PRO_3GEN_129` (the "iPad 13" Display" tab users see)
+
+Fastlane's heuristic: **filename must contain one of these substrings** to route to the 3rd-gen+ slot:
+
+```
+iPad Pro (12.9-inch) (3rd generation)
+iPad Pro (12.9-inch) (4th generation)
+iPad Pro (12.9-inch) (5th generation)
+iPad Pro (12.9-inch) (6th generation)
+IPAD_PRO_3GEN_129
+ipadPro129
+```
+
+Recommended naming pattern:
+```
+ios/fastlane/screenshots/en-US/iPad Pro (12.9-inch) (3rd generation)-1.png
+ios/fastlane/screenshots/en-US/iPad Pro (12.9-inch) (3rd generation)-2.png
+...
+```
+
+Source: `/opt/homebrew/Cellar/fastlane/.../deliver/lib/deliver/app_screenshot.rb#resolve_ipadpro_conflict_if_needed`
+
+## Locale gotcha (Play Console)
+
+Google Play's default territory is often **en-GB**, not **en-US**. If you create listings under `en-US/` and they don't appear in Play Console, it's because the default locale doesn't match. Two options:
+1. Move listing to `android/app/src/main/play/listings/en-GB/`
+2. Add both `en-GB` and `en-US`
+
+The `publishListing` task silently skips folders whose locale isn't enabled in Play Console.
+
+## API gotchas
+
+### Fastlane log lies sometimes
+`Successfully uploaded all screenshots` does NOT mean they're visible in the correct slot. Always verify with the API after any upload:
+
+```bash
+bun scripts/check-ios-state.ts
+```
+
+The API returns the actual `screenshotDisplayType` each shot was filed under. The `count=N states=[COMPLETE×N]` output is the only source of truth.
+
+### Ruby UTF-8 crash
+Without `LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8`, Ruby 3.x reads `description.txt` as US-ASCII and crashes on em-dashes `—`, bullets `•`, smart quotes. Symptom: `invalid byte sequence in US-ASCII (Encoding::CompatibilityError)`. Always set the locale in every fastlane-invoking script.
+
+### Phone format
+App Store Connect rejects phone numbers without `+<country code>`. Always store as `+919994619490` (no spaces, no dashes).
+
+### Copyright placement
+The `copyright` field is **non-localized** (top-level) — file goes at `ios/fastlane/metadata/copyright.txt`, NOT `ios/fastlane/metadata/en-US/copyright.txt`. Forgetting this triggers a precheck warning.
+
+### Territory removal via API
+`v2/appAvailabilities` POST endpoint exists but the payload shape is **undocumented** and brittle. After 5 attempts during a real production fix, we used the UI instead. Don't waste time on this — instruct user to toggle in App Store Connect → Pricing & Availability.

--- a/skills/publish-mobile-app/REJECTIONS.md
+++ b/skills/publish-mobile-app/REJECTIONS.md
@@ -1,0 +1,192 @@
+# Store Rejection Recipes
+
+When user pastes a rejection email, parse the Guideline number / category and apply the recipe below. Always verify the fix via API after applying, before telling user to resubmit.
+
+## Apple App Store
+
+### Guideline 2.1 — China book/magazine license
+
+> *"app includes or accesses book or magazine content and is intended for distribution on the App Store in China mainland. However, you have not provided a permit demonstrating authorization to distribute an app with this content."*
+
+**Root cause**: China mainland requires an Internet Publishing License (网络出版服务许可证) for book/magazine apps. Acquiring one takes months.
+
+**Fix** (UI-only, the API for `appAvailabilities` v2 is undocumented and brittle):
+1. App Store Connect → app → **Pricing and Availability**
+2. Click **Edit Countries or Regions**
+3. Uncheck **China mainland**
+4. Save
+5. Resubmit
+
+Don't waste time on the API — we attempted 5 payload shapes against `v2/appAvailabilities` POST during a real fix and got 409s every time.
+
+---
+
+### Guideline 2.3.8 — Inaccurate Metadata (kids implication)
+
+> *"the app subtitle to be displayed on the App Store includes the term kids, which implies that this app is made specifically for children. However, this app was not submitted as a Kids category app."*
+
+**Root cause**: Subtitle/keywords claim the app is *exclusively* for children, but the app isn't in the Kids Category (which has strict requirements: no third-party analytics, parental gate on purchases, no behavioral ads, etc.).
+
+**Fix**:
+1. Scrub `kids` and `children` from:
+   - `ios/fastlane/metadata/<locale>/subtitle.txt` (the highest-priority one — this is what got flagged)
+   - `ios/fastlane/metadata/<locale>/keywords.txt`
+   - `ios/fastlane/metadata/<locale>/promotional_text.txt`
+   - First sentence of `description.txt` (the strongest signal)
+2. **Keep allowed**: age-range mentions in description body (`ages 10+`, `Perfect for families`), the SAFE/AGE-APPROPRIATE section. Apple's rule is "implies exclusively-for-children", not "mentions children at all".
+3. Push: `bun run ios:metadata` (or `cd ios && fastlane metadata` with UTF-8 locale)
+4. Verify via API: check `subtitle` on `appInfoLocalizations` (NOT `appStoreVersionLocalizations` — subtitle moved)
+5. Reply to reviewer in App Store Connect noting the change
+6. Resubmit
+
+**Example rewrites** (from a real production fix):
+- Subtitle: `AI storybooks for kids` → `Write & illustrate with AI`
+- Keywords: drop `kids,children`; add `imagination,books`
+- Promo: `with your kids tonight` → `with your family tonight`
+
+---
+
+### Guideline 2.3.10 — Inaccurate Metadata (screenshots/copy don't match app)
+
+> *"app's screenshots/description reference functionality not present in the app"*
+
+**Fix**:
+1. Open each screenshot and compare to live app
+2. Re-read description.txt vs actual feature list
+3. Remove any "coming soon" / aspirational language
+4. Update screenshots with `bun run ios:screenshots`
+
+---
+
+### Guideline 4.0 — Sign-in failed
+
+> *"We could not sign in to your app with the demo credentials you provided"*
+
+**Fix**:
+1. Re-run reviewer-user script: `bun scripts/create-app-review-user.ts` (rotates password idempotently)
+2. Verify creds work — try signing in manually in your local app
+3. Update `ios/.env.review` with new password
+4. Push: `bun run ios:metadata` (Fastfile picks up new env vars and patches App Review Information)
+5. Reply to reviewer
+6. Resubmit
+
+**Common gotcha**: account exists but email not confirmed. Check Supabase `auth.users` — `email_confirmed_at` must be non-null. The bootstrap script always sets `email_confirm: true`.
+
+---
+
+### Guideline 4.3 — Spam / duplicate
+
+Usually means you've shipped similar AI-generated apps before. No automated fix — reply explaining differentiation.
+
+---
+
+### Guideline 5.1.1 — Privacy
+
+> *"app collects user data but App Privacy says it doesn't"* or vice versa
+
+**Fix**: Open App Store Connect → app → **App Privacy** → edit data types. Match what the app actually collects. Common omissions: email, IP address (for analytics), user content (stories users create).
+
+---
+
+### Common Apple gotchas (not full rejections, but precheck warnings)
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `Incorrect, or missing copyright date` | Missing `metadata/copyright.txt` | Create with `2026 <CompanyName>` (top-level, not per-locale) |
+| `Phone number must be in valid format` | Reviewer phone missing country code | `+91XXXXXXXXXX` format, no spaces |
+| `invalid byte sequence in US-ASCII` | Ruby locale not UTF-8 | Set `LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8` in npm script |
+| `Couldn't find API key JSON file at path '../app-store-connect-key.json'` | Fastfile uses relative path | Use `File.expand_path("../app-store-connect-key.json", __dir__)` |
+| iPad screenshots uploaded but don't show in "iPad 13" Display" tab | Wrong display-type slot | Rename to `iPad Pro (12.9-inch) (3rd generation)-N.png` |
+
+## Google Play Store
+
+### Data Safety mismatch
+
+> *"Your declarations in the Data safety form do not match how your app collects, shares, and handles user data"*
+
+**Fix**: Open Play Console → app → **App content** → **Data safety**. Make declarations match real behavior:
+- If app uses any analytics SDK (Firebase, Mixpanel, Meta Pixel) → declare `Device or other IDs` collected + shared
+- If app uses Supabase Auth → declare `Email address` collected (not shared if RLS-protected)
+- If users create stories → declare `Photos and videos` (if illustrations) + `Personal info` (story text) collected, NOT shared
+- For payments → declare `Financial info` (purchase history) collected, shared with Google Play Billing
+
+---
+
+### Account deletion URL missing
+
+> *"You must provide a way for users to request account deletion"*
+
+**Required since 2024**. Two-step fix:
+1. **Build a public `/delete-account` page** at your marketing domain with:
+   - Instructions to delete (in-app button OR mailto link)
+   - What data gets deleted
+   - What data is retained (legal requirements only) and for how long
+   - Refer to the app/developer name (Google requires this verbatim)
+2. **Add URL** in Play Console → **App content** → **Data safety** → Account deletion section
+
+Page template:
+```jsx
+<DeleteAccount>
+  <h1>Delete your <AppName> account</h1>
+  <h2>How to request deletion</h2>
+  <ol>
+    <li>From inside the app — Profile → Danger zone → Delete account</li>
+    <li>By email — privacy@<domain> with subject "delete"</li>
+  </ol>
+  <h2>What gets deleted</h2>
+  <ul>(account record, content, transactions, sessions...)</ul>
+  <h2>What we keep</h2>
+  <ul>(payment records 7yr for tax; T&S records 2yr; backups 35-day rolling)</ul>
+</DeleteAccount>
+```
+
+---
+
+### Target audience violation
+
+> *"Your app is targeting children but is not enrolled in Designed for Families"*
+
+**Fix**: Play Console → **App content** → **Target audience and content**. Either:
+- Set min age to 13+ if you don't really target children, OR
+- Opt into **Designed for Families** program (has stricter ad/SDK requirements)
+
+---
+
+### App access — reviewer can't sign in
+
+> *"We were unable to access all parts of your app"*
+
+**Fix**: Play Console → **App content** → **App access** → **Add new instructions**:
+- Username: `appstore-reviewer@<your-domain>` (or whatever reviewer email)
+- Password: from `ios/.env.review`
+- Other instructions: paste reviewer-notes content (testing steps)
+
+This form has **no API**. Use `bun run reviewer:print` to get the exact strings to paste.
+
+---
+
+### Closed testing requirement
+
+> *"Your app must be tested by at least 12 testers in closed testing for 14 continuous days"*
+
+**Personal developer accounts only**. Fix:
+1. Recruit 12 real testers (must accept invitation, install app, keep installed)
+2. Roll release to closed testing track instead of internal
+3. Wait 14 days minimum
+4. Then promote to production
+
+Not bypassable. Business accounts skip this. If user is on personal account and time-sensitive, recommend they upgrade to business account (~$25 one-time).
+
+## Verification commands after any fix
+
+Always run before telling user to resubmit:
+
+```bash
+# iOS: confirm metadata is live as expected
+bun scripts/check-ios-state.ts
+
+# Android: confirm listing publishing succeeded
+cd android && ./gradlew publishListing --info 2>&1 | grep -E 'UP-TO-DATE|SUCCESS|FAIL'
+```
+
+If verification fails, do not tell user to resubmit. Re-investigate first.

--- a/skills/publish-mobile-app/REJECTIONS.md
+++ b/skills/publish-mobile-app/REJECTIONS.md
@@ -39,7 +39,7 @@ Don't waste time on the API — we attempted 5 payload shapes against `v2/appAva
 5. Reply to reviewer in App Store Connect noting the change
 6. Resubmit
 
-**Example rewrites** (from a real production fix):
+**Example rewrites** (Sparkytales actual fix):
 - Subtitle: `AI storybooks for kids` → `Write & illustrate with AI`
 - Keywords: drop `kids,children`; add `imagination,books`
 - Promo: `with your kids tonight` → `with your family tonight`
@@ -88,6 +88,26 @@ Usually means you've shipped similar AI-generated apps before. No automated fix 
 
 ---
 
+### Crash on launch (Guideline 2.1 – Apps that crash)
+
+> *"The app crashed after the initial launch. Apps that crash negatively impact users."*
+
+Apple does NOT expose the review crash log via API — only in App Store Connect's Resolution Center UI as a `.crash`/`.ips` attachment. Without the log, work through the highest-probability launch killers first. For Capacitor/Expo/Flutter apps the leading suspects are:
+
+1. **`UIRequiredDeviceCapabilities=[armv7]` in `Info.plist`** — 32-bit ARM declaration; no modern iPad/iPhone has armv7 cores. Apps that declare this requirement cannot launch on arm64-only devices. **Fix**: delete the `UIRequiredDeviceCapabilities` key entirely from `Info.plist` (it's optional and you usually have no specific hardware requirement). The default Capacitor scaffold sometimes has this leftover.
+
+2. **Plugin registration crash in `CAPBridgeViewController`** — happens when a Capacitor plugin's native side has a startup bug. Check recent plugin updates; downgrade or remove the suspect plugin.
+
+3. **Force-unwrap of nil URL in AppDelegate** — analytics SDKs, deep-link handlers. Audit any `URL(string:)!` in Swift code.
+
+4. **Missing `UIApplicationSceneManifest`** — required on iPadOS 13+. Capacitor's default scaffold doesn't include one but the app launches anyway most of the time; rare crash path.
+
+**Don't change `LSRequiresIPhoneOS=true`** — that means "this is an iOS-only app (not Mac Catalyst)", NOT "iPhone-only". It does not block iPad launch.
+
+After fixing, bump `CFBundleVersion`, rebuild, push to TestFlight. The build will get a new build number; submit that to review with a note to the reviewer explaining what was fixed.
+
+---
+
 ### Common Apple gotchas (not full rejections, but precheck warnings)
 
 | Symptom | Cause | Fix |
@@ -96,7 +116,9 @@ Usually means you've shipped similar AI-generated apps before. No automated fix 
 | `Phone number must be in valid format` | Reviewer phone missing country code | `+91XXXXXXXXXX` format, no spaces |
 | `invalid byte sequence in US-ASCII` | Ruby locale not UTF-8 | Set `LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8` in npm script |
 | `Couldn't find API key JSON file at path '../app-store-connect-key.json'` | Fastfile uses relative path | Use `File.expand_path("../app-store-connect-key.json", __dir__)` |
+| `No value found for 'key_id'` in `app_store_connect_api_key` action | Action expects discrete `key_id`/`issuer_id`/`key_content` params, not the JSON wrapper | Parse the JSON yourself in Ruby and pass each field, OR pass `.p8` path to `key_filepath:` + `key_id:` + `issuer_id:` |
 | iPad screenshots uploaded but don't show in "iPad 13" Display" tab | Wrong display-type slot | Rename to `iPad Pro (12.9-inch) (3rd generation)-N.png` |
+| App crashes on launch on iPad review device | `UIRequiredDeviceCapabilities=[armv7]` in Info.plist | Delete the key entirely (see crash-on-launch section above) |
 
 ## Google Play Store
 

--- a/skills/publish-mobile-app/SKILL.md
+++ b/skills/publish-mobile-app/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: publish-mobile-app
+description: Automate iOS App Store + Google Play Store publishing for Capacitor, Expo, or Flutter apps — listing copy, screenshots, IPA/AAB upload, reviewer credentials, and fixing common rejection emails (Guideline 2.3.8 metadata, 2.1 China license, 4.0 sign-in, etc). Use when user mentions `/publish-mobile-app`, Play Store, App Store Connect, fastlane, gradle-play-publisher, TestFlight, or pastes an Apple/Google store rejection email.
+---
+
+# Publish Mobile App
+
+Automates the boring parts of shipping a mobile app to both stores. Forged from real production ship cycles: one-command listing sync, signed IPA upload to TestFlight, reviewer-user provisioning, and recipes for the most common rejection emails.
+
+## Sub-commands
+
+When invoked via `/publish-mobile-app`, route based on the user's argument:
+
+| Argument | What it does |
+|---|---|
+| `setup` | One-time wiring: fastlane + gradle-play-publisher + reviewer user + key bootstrap |
+| `push` | Upload current listing + screenshots to both stores (or one, ask user) |
+| `ipa` | Build signed iOS IPA and push to TestFlight |
+| `aab` | Build signed Android AAB and push to Play internal track |
+| `release` | Full bump + build + upload + listing push for both stores |
+| `fix-rejection` | User pastes rejection email; map issue → fix → apply |
+| `status` | Read live state from both stores via API; report what's present and what's missing |
+| `checklist` | Generate/refresh `RELEASE_CHECKLIST.md` at repo root |
+
+If no argument given, ask the user which sub-command they want, defaulting to `status` to orient first.
+
+## Framework detection
+
+Detect which mobile framework the project uses before doing anything else:
+
+```bash
+test -f capacitor.config.ts -o -f capacitor.config.json && echo capacitor
+test -f app.json && grep -q '"expo"' app.json 2>/dev/null && echo expo
+test -f pubspec.yaml && echo flutter
+```
+
+Behaviors differ per stack — see [REFERENCE.md](REFERENCE.md#framework-differences).
+
+## Setup checklist
+
+When user runs `setup`, work through this checklist in order. Mark each with TodoWrite and tick off as you go.
+
+1. **Detect framework** (capacitor / expo / flutter) and confirm with user
+2. **Verify prerequisites**: `fastlane --version`, gradle (Android), Xcode (iOS), `bun` or `node`
+3. **iOS — App Store Connect API key**
+   - User generates `.p8` key in App Store Connect → Users and Access → Integrations → App Store Connect API
+   - Run [scripts/bootstrap-app-store-key.ts](scripts/bootstrap-app-store-key.ts) with `ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_KEY_PATH` to assemble `ios/app-store-connect-key.json`
+   - Move `.p8` from `~/Downloads/` to `~/.appstoreconnect/private_keys/` (standard location)
+4. **iOS — fastlane scaffolding**
+   - Create `ios/fastlane/Appfile` with `app_identifier`, `team_id`
+   - Create `ios/fastlane/Fastfile` with lanes: `metadata`, `screenshots`, `beta` (build+TestFlight upload). Template: [REFERENCE.md#fastfile-template](REFERENCE.md#fastfile-template)
+   - **Critical**: `API_KEY_PATH = File.expand_path("../app-store-connect-key.json", __dir__)` so it works from any CWD
+   - **Critical**: every npm script invoking fastlane must set `LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8` or Ruby crashes on em-dashes/bullets in description.txt
+5. **iOS — metadata + screenshots**
+   - Create `ios/fastlane/metadata/en-US/` with `name.txt`, `subtitle.txt`, `description.txt`, `keywords.txt`, `promotional_text.txt`, `release_notes.txt`, `support_url.txt`, `privacy_url.txt`, `marketing_url.txt`
+   - Create `ios/fastlane/metadata/copyright.txt` (non-localized, top-level)
+   - Screenshots in `ios/fastlane/screenshots/en-US/` — naming conventions matter for iPad routing, see [REFERENCE.md#ipad-screenshot-filename-magic](REFERENCE.md#ipad-screenshot-filename-magic)
+6. **Android — Play Console service account**
+   - User creates service account in Google Play Console → Setup → API access
+   - Save JSON to `android/play-config.json` (gitignored)
+7. **Android — gradle-play-publisher**
+   - Add plugin to `android/app/build.gradle`: see [REFERENCE.md#android-build-gradle](REFERENCE.md#android-build-gradle)
+   - Initial `track` should be `internal`; `defaultToAppBundles.set(true)`; `releaseStatus.set(ReleaseStatus.DRAFT)` until first prod release
+8. **Android — listings**
+   - Listing files at `android/app/src/main/play/listings/<locale>/` — locale must match Play Console default (often `en-GB`, not `en-US`!)
+   - Subfolders: `graphics/icon/icon.png` (512×512), `graphics/feature-graphic/feature-graphic.png` (1024×500), `graphics/phone-screenshots/`, `graphics/tablet-7-inch-screenshots/`, `graphics/tablet-10-inch-screenshots/`
+   - `release-notes/<locale>/default.txt`
+9. **Gitignore credentials**
+   - `ios/app-store-connect-key.json`, `*.p8`, `android/play-config.json`, `ios/.env.review`, `ios/build/`, `ios/*.ipa`, `ios/fastlane/README.md`
+10. **Reviewer user**
+    - Run [scripts/create-app-review-user.ts](scripts/create-app-review-user.ts) — provisions reviewer auth user in Supabase if detected. Stores creds in `ios/.env.review`. Falls back to printing instructions if not Supabase.
+11. **App Review Information**
+    - Phone with country code is required (`+91XXXXXXXXXX` format, no spaces)
+    - Wire env vars into Fastfile `app_review_information:` block
+
+## Push workflow
+
+When user runs `push`:
+
+1. Validate metadata char limits — see [REFERENCE.md#character-limits](REFERENCE.md#character-limits)
+2. Validate asset dimensions
+3. Verify no `kids`/`children` in subtitle if not in Kids Category (Apple flags this — Guideline 2.3.8)
+4. Push iOS: `cd ios && LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 fastlane metadata`
+5. Push Android: `cd android && ./gradlew publishListing`
+6. **Verify outcome via API**, not just fastlane log — see [scripts/check-ios-state.ts](scripts/check-ios-state.ts). Fastlane sometimes routes uploads to wrong slot (the iPad-3rd-gen bug); only the API tells the truth.
+
+## Rejection fix mapping
+
+When user pastes a rejection email, parse the **Guideline number** and route to the appropriate recipe. Full recipes in [REJECTIONS.md](REJECTIONS.md).
+
+| Apple Guideline | Common cause | Quick fix |
+|---|---|---|
+| 2.1 | China book/magazine license missing | Remove China mainland in App Store Connect → Pricing & Availability |
+| 2.3.8 | Subtitle/keywords imply "for kids" without Kids Category | Scrub `kids`/`children` from subtitle + keywords + promo; keep age messaging in description (it's allowed) |
+| 2.3.10 | Inaccurate marketing copy | Re-read description vs actual app behavior |
+| 4.0 | Reviewer sign-in failed | Re-run reviewer-user script to rotate password; update App Review Information |
+| 5.1.1 | Privacy / data collection | Check App Privacy questionnaire — must match what app actually collects |
+
+| Google Play | Common cause | Quick fix |
+|---|---|---|
+| Data Safety mismatch | Declared data types don't match runtime | Update Data Safety form in Play Console |
+| Account deletion URL missing | Required since Play Console 2024 | Add `/delete-account` page + URL in Data Safety form |
+| Target audience violation | App targeting children without Designed for Families opt-in | Either change target age range or join Designed for Families |
+
+## What's permanently manual
+
+These have no public API and must be done in the store consoles:
+
+- **Apple**: App Privacy questionnaire, Age Rating, App Review Information (programmable via fastlane `deliver`), Export Compliance (one-time `ITSAppUsesNonExemptEncryption` plist flag handles this for most apps)
+- **Google**: Data Safety form, Content Rating, Target Audience, App Access (test-account credentials), Government/News/COVID declarations
+- **Both**: Pricing & territories (Apple has an undocumented API; Google has none reliable)
+
+See [MANUAL_FORMS.md](MANUAL_FORMS.md) for guided answers — what to pick for each question for a typical content-creation app.
+
+## Reference files
+
+- [REFERENCE.md](REFERENCE.md) — Framework-specific behaviors, fastlane templates, API gotchas, character limits, the iPad-3rd-gen filename magic
+- [REJECTIONS.md](REJECTIONS.md) — Detailed recipes per rejection guideline with copy-paste code
+- [MANUAL_FORMS.md](MANUAL_FORMS.md) — Walkthroughs for App Privacy, Age Rating, Data Safety questionnaires
+
+## Scripts (deterministic, reusable)
+
+- [scripts/bootstrap-app-store-key.ts](scripts/bootstrap-app-store-key.ts) — assemble ASC key JSON from `.p8` + IDs
+- [scripts/create-app-review-user.ts](scripts/create-app-review-user.ts) — idempotently provision reviewer user (Supabase auto, others manual)
+- [scripts/check-ios-state.ts](scripts/check-ios-state.ts) — query App Store Connect API to verify what's actually live (counter to fastlane's optimistic logs)
+- [scripts/print-reviewer-creds.ts](scripts/print-reviewer-creds.ts) — print creds in copy-friendly format for Play Console (which has no API for App Access)
+- [scripts/validate-metadata.ts](scripts/validate-metadata.ts) — check char limits + asset dimensions + ASCII-trap words before push
+
+## Key principle
+
+**Fastlane's "Successfully uploaded" log ≠ "appears correctly in App Store Connect UI"**. Always verify via the App Store Connect API after any push. The `check-ios-state.ts` script is the source of truth — fastlane sometimes routes 2048×2732 iPad screenshots to the wrong display-type slot.

--- a/skills/publish-mobile-app/scripts/bootstrap-app-store-key.ts
+++ b/skills/publish-mobile-app/scripts/bootstrap-app-store-key.ts
@@ -1,0 +1,70 @@
+#!/usr/bin/env bun
+// Assembles ios/app-store-connect-key.json from an Apple .p8 file + key/issuer IDs.
+// Self-contained JSON works without keeping the .p8 around — but the script also
+// moves the .p8 to ~/.appstoreconnect/private_keys/ (standard fastlane location)
+// if it's still in ~/Downloads.
+//
+// Usage:
+//   ASC_KEY_ID=ABC123XYZ \
+//   ASC_ISSUER_ID=abcd1234-5678-90ab-cdef-1234567890ab \
+//   ASC_KEY_PATH=~/Downloads/AuthKey_ABC123XYZ.p8 \
+//   bun bootstrap-app-store-key.ts
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync, copyFileSync, unlinkSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve, dirname } from "node:path";
+
+const keyId = process.env.ASC_KEY_ID;
+const issuerId = process.env.ASC_ISSUER_ID;
+const rawPath = process.env.ASC_KEY_PATH;
+
+if (!keyId || !issuerId || !rawPath) {
+  console.error("Missing required env vars.");
+  console.error("  ASC_KEY_ID    – 10-char Key ID from App Store Connect");
+  console.error("  ASC_ISSUER_ID – UUID Issuer ID");
+  console.error("  ASC_KEY_PATH  – path to AuthKey_<KEY_ID>.p8");
+  console.error("");
+  console.error("Get all three at: App Store Connect → Users and Access → Integrations → App Store Connect API");
+  process.exit(1);
+}
+
+const expand = (p: string) => p.startsWith("~/") ? resolve(homedir(), p.slice(2)) : resolve(p);
+const keyPath = expand(rawPath);
+
+if (!existsSync(keyPath)) {
+  console.error(`.p8 file not found at ${keyPath}`);
+  process.exit(1);
+}
+
+const pem = readFileSync(keyPath, "utf8").trim();
+if (!pem.startsWith("-----BEGIN PRIVATE KEY-----")) {
+  console.error(`File at ${keyPath} does not look like a PEM private key.`);
+  process.exit(1);
+}
+
+// Find iOS dir — works for Capacitor, Flutter, Expo prebuild
+const iosDir = ["ios", "ios/App"].find((p) => existsSync(p)) ?? "ios";
+mkdirSync(iosDir, { recursive: true });
+
+const out = { key_id: keyId, issuer_id: issuerId, key: pem };
+const outPath = resolve(iosDir, "app-store-connect-key.json");
+writeFileSync(outPath, JSON.stringify(out, null, 2) + "\n", { mode: 0o600 });
+console.log(`✓ Wrote ${outPath} (mode 600)`);
+
+// Move .p8 to canonical fastlane location if it's still in Downloads
+const stdLocation = resolve(homedir(), `.appstoreconnect/private_keys/AuthKey_${keyId}.p8`);
+if (keyPath.includes("/Downloads/") && !existsSync(stdLocation)) {
+  mkdirSync(dirname(stdLocation), { recursive: true });
+  copyFileSync(keyPath, stdLocation);
+  if (readFileSync(stdLocation, "utf8") === readFileSync(keyPath, "utf8")) {
+    unlinkSync(keyPath);
+    console.log(`✓ Moved .p8 to ${stdLocation} (verified identical, removed from Downloads)`);
+  }
+}
+
+console.log("");
+console.log("Add to .gitignore if not already there:");
+console.log("  ios/app-store-connect-key.json");
+console.log("  *.p8");
+console.log("");
+console.log("Now you can run: fastlane metadata (or your wrapper script)");

--- a/skills/publish-mobile-app/scripts/check-ios-state.ts
+++ b/skills/publish-mobile-app/scripts/check-ios-state.ts
@@ -1,0 +1,83 @@
+#!/usr/bin/env bun
+// Query App Store Connect API to verify what is actually live on the listing.
+// Use after every metadata/screenshot push — fastlane's "Successfully uploaded"
+// log can be misleading (e.g. iPad screenshots routed to the wrong slot).
+//
+// Run from project root: bun check-ios-state.ts
+
+import { readFileSync, existsSync } from "node:fs";
+import { createSign } from "node:crypto";
+
+const keyPath = ["ios/app-store-connect-key.json", "ios/App/app-store-connect-key.json"].find(existsSync);
+if (!keyPath) {
+  console.error("ios/app-store-connect-key.json not found. Run bootstrap-app-store-key.ts first.");
+  process.exit(1);
+}
+
+const key = JSON.parse(readFileSync(keyPath, "utf8"));
+const header = Buffer.from(JSON.stringify({ alg: "ES256", kid: key.key_id, typ: "JWT" })).toString("base64url");
+const payload = Buffer.from(JSON.stringify({
+  iss: key.issuer_id,
+  iat: Math.floor(Date.now() / 1000),
+  exp: Math.floor(Date.now() / 1000) + 600,
+  aud: "appstoreconnect-v1",
+})).toString("base64url");
+const sig = createSign("SHA256").update(`${header}.${payload}`).sign({ key: key.key, dsaEncoding: "ieee-p1363" }).toString("base64url");
+const auth = { Authorization: `Bearer ${header}.${payload}.${sig}` };
+
+// Find bundle id from common locations
+const bundleId = process.env.BUNDLE_ID
+  ?? (existsSync("ios/fastlane/Appfile") && readFileSync("ios/fastlane/Appfile", "utf8").match(/app_identifier\("([^"]+)"\)/)?.[1])
+  ?? (existsSync("app.json") && JSON.parse(readFileSync("app.json", "utf8")).expo?.ios?.bundleIdentifier);
+if (!bundleId) {
+  console.error("Could not auto-detect bundle ID. Set BUNDLE_ID=com.example.app or add to ios/fastlane/Appfile");
+  process.exit(1);
+}
+
+const apps = await fetch(`https://api.appstoreconnect.apple.com/v1/apps?filter[bundleId]=${bundleId}`, { headers: auth }).then(r => r.json()) as any;
+if (!apps.data?.[0]) {
+  console.error(`No app found for bundle id ${bundleId}`);
+  process.exit(1);
+}
+const appId = apps.data[0].id;
+console.log(`App: ${apps.data[0].attributes.name} (${appId}, bundle ${bundleId})\n`);
+
+// Versions
+const versions = await fetch(`https://api.appstoreconnect.apple.com/v1/apps/${appId}/appStoreVersions?limit=3`, { headers: auth }).then(r => r.json()) as any;
+console.log("Versions:");
+for (const v of versions.data ?? []) {
+  console.log(`  v${v.attributes.versionString.padEnd(8)}  state=${v.attributes.appStoreState}  id=${v.id}`);
+}
+const versionId = versions.data?.[0]?.id;
+if (!versionId) process.exit(0);
+
+// Stable metadata (name, subtitle) lives on appInfoLocalizations
+const ai = await fetch(`https://api.appstoreconnect.apple.com/v1/apps/${appId}/appInfos`, { headers: auth }).then(r => r.json()) as any;
+const editableInfo = ai.data?.find((i: any) => ["PREPARE_FOR_SUBMISSION","WAITING_FOR_REVIEW","DEVELOPER_REJECTED","REJECTED","METADATA_REJECTED"].includes(i.attributes.state)) ?? ai.data?.[0];
+if (editableInfo) {
+  const ail = await fetch(`https://api.appstoreconnect.apple.com/v1/appInfos/${editableInfo.id}/appInfoLocalizations`, { headers: auth }).then(r => r.json()) as any;
+  console.log(`\nStable metadata (appInfo ${editableInfo.id}, state=${editableInfo.attributes.state}):`);
+  for (const l of ail.data ?? []) {
+    console.log(`  [${l.attributes.locale}]  name="${l.attributes.name}"  subtitle="${l.attributes.subtitle ?? "(empty)"}"`);
+  }
+}
+
+// Per-version metadata lives on appStoreVersionLocalizations
+const locs = await fetch(`https://api.appstoreconnect.apple.com/v1/appStoreVersions/${versionId}/appStoreVersionLocalizations`, { headers: auth }).then(r => r.json()) as any;
+console.log(`\nVersion metadata (version ${versions.data[0].attributes.versionString}):`);
+for (const loc of locs.data ?? []) {
+  const a = loc.attributes;
+  console.log(`  [${a.locale}]`);
+  console.log(`    description:        ${(a.description ?? "(empty)").slice(0, 80)}...`);
+  console.log(`    promotional_text:   ${(a.promotionalText ?? "(empty)").slice(0, 80)}`);
+  console.log(`    keywords:           ${a.keywords ?? "(empty)"}`);
+  console.log(`    whats_new:          ${(a.whatsNew ?? "(empty)").slice(0, 80)}`);
+
+  const sets = await fetch(`https://api.appstoreconnect.apple.com/v1/appStoreVersionLocalizations/${loc.id}/appScreenshotSets`, { headers: auth }).then(r => r.json()) as any;
+  console.log(`    screenshot sets:`);
+  for (const set of sets.data ?? []) {
+    const shots = await fetch(`https://api.appstoreconnect.apple.com/v1/appScreenshotSets/${set.id}/appScreenshots`, { headers: auth }).then(r => r.json()) as any;
+    const states = shots.data.map((s: any) => s.attributes.assetDeliveryState?.state ?? "?").join(",");
+    console.log(`      ${set.attributes.screenshotDisplayType.padEnd(35)} count=${shots.data.length}  states=[${states}]`);
+  }
+}

--- a/skills/publish-mobile-app/scripts/create-app-review-user.ts
+++ b/skills/publish-mobile-app/scripts/create-app-review-user.ts
@@ -1,0 +1,125 @@
+#!/usr/bin/env bun
+// Idempotently provision (or rotate password for) the App Store / Play Store
+// reviewer user. Auto-detects Supabase (uses admin API). For other auth
+// providers, prints instructions to do manually.
+//
+// Usage:
+//   bun create-app-review-user.ts
+//   REVIEWER_EMAIL=apple-review@yourdomain.com bun create-app-review-user.ts
+
+import { randomBytes } from "node:crypto";
+import { readFileSync, existsSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const password = randomBytes(18).toString("base64url"); // 24 url-safe chars
+const EMAIL = process.env.REVIEWER_EMAIL ?? "appstore-reviewer@" + (
+  process.env.DOMAIN ?? "example.com"
+);
+
+// Auto-detect Supabase config from .env
+const env: Record<string, string> = {};
+if (existsSync(".env")) {
+  for (const line of readFileSync(".env", "utf8").split("\n")) {
+    const m = line.match(/^([A-Z_]+)=(.*)$/);
+    if (m) env[m[1]] = m[2].replace(/^["']|["']$/g, "");
+  }
+}
+
+const SUPABASE_URL = process.env.SUPABASE_URL ?? env.SUPABASE_URL;
+// Supabase renamed service-role key naming over time
+const SUPABASE_SECRET = process.env.SUPABASE_SECRET_KEY ?? env.SUPABASE_SECRET_KEY
+  ?? process.env.SUPABASE_SERVICE_ROLE_KEY ?? env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_SECRET) {
+  console.log("Supabase config not detected. Manual setup needed:\n");
+  console.log("1. Create a user in your auth provider with these credentials:");
+  console.log(`   Email:    ${EMAIL}`);
+  console.log(`   Password: ${password}`);
+  console.log("");
+  console.log("2. Pre-confirm email (reviewer can't access an inbox to verify)");
+  console.log("");
+  console.log("3. Seed any necessary onboarding data (credits, sample content, etc.)");
+  console.log("   so reviewer doesn't hit an empty state");
+  console.log("");
+  console.log("4. Save the password to ios/.env.review (see below)");
+  printEnvFile(EMAIL, password);
+  process.exit(0);
+}
+
+const headers = {
+  apikey: SUPABASE_SECRET,
+  Authorization: `Bearer ${SUPABASE_SECRET}`,
+  "Content-Type": "application/json",
+};
+
+const findUrl = new URL(`${SUPABASE_URL}/auth/v1/admin/users`);
+findUrl.searchParams.set("email", EMAIL);
+const findRes = await fetch(findUrl, { headers });
+if (!findRes.ok) {
+  console.error(`Supabase list-users failed: ${findRes.status} ${await findRes.text()}`);
+  process.exit(1);
+}
+const existing = ((await findRes.json()) as any).users?.find(
+  (u: any) => u.email?.toLowerCase() === EMAIL.toLowerCase()
+);
+
+let userId: string;
+if (existing) {
+  const res = await fetch(`${SUPABASE_URL}/auth/v1/admin/users/${existing.id}`, {
+    method: "PUT",
+    headers,
+    body: JSON.stringify({ password, email_confirm: true }),
+  });
+  if (!res.ok) {
+    console.error(`Password rotation failed: ${res.status} ${await res.text()}`);
+    process.exit(1);
+  }
+  userId = existing.id;
+  console.log(`✓ Rotated password for existing reviewer (${EMAIL})`);
+} else {
+  const res = await fetch(`${SUPABASE_URL}/auth/v1/admin/users`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      email: EMAIL,
+      password,
+      email_confirm: true,
+      user_metadata: { full_name: "App Store Reviewer", purpose: "store-review-only" },
+    }),
+  });
+  if (!res.ok) {
+    console.error(`User creation failed: ${res.status} ${await res.text()}`);
+    process.exit(1);
+  }
+  userId = ((await res.json()) as any).id;
+  console.log(`✓ Created reviewer user ${EMAIL}`);
+}
+
+console.log(`Supabase user id: ${userId}`);
+printEnvFile(EMAIL, password);
+
+function printEnvFile(email: string, pass: string) {
+  console.log("");
+  console.log("Save these credentials to ios/.env.review (already gitignored if you ran setup):");
+  console.log("");
+  const envPath = resolve("ios/.env.review");
+  const sample = `# App Store / Play Store reviewer credentials. Loaded by ios:metadata.
+# Rotate by re-running create-app-review-user.ts.
+
+ASC_REVIEW_FIRST_NAME=Your
+ASC_REVIEW_LAST_NAME=Name
+ASC_REVIEW_EMAIL=your-email@example.com
+# Required by App Store Connect. Format: +<country code><number>, no spaces.
+ASC_REVIEW_PHONE=+10000000000
+ASC_REVIEW_DEMO_USER=${email}
+ASC_REVIEW_DEMO_PASSWORD=${pass}
+ASC_REVIEW_NOTES="Brief reviewer instructions — how to test, what to expect. Mention any AI-generated content + safety filters. Avoid claims that imply the app is exclusively for children unless you're in the Kids Category."
+`;
+  if (existsSync(envPath)) {
+    console.log(`File ${envPath} already exists. Update ASC_REVIEW_DEMO_PASSWORD to:`);
+    console.log(`  ${pass}`);
+  } else {
+    writeFileSync(envPath, sample, { mode: 0o600 });
+    console.log(`✓ Wrote template to ${envPath} (mode 600). Edit phone/notes before running ios:metadata.`);
+  }
+}

--- a/skills/publish-mobile-app/scripts/print-reviewer-creds.ts
+++ b/skills/publish-mobile-app/scripts/print-reviewer-creds.ts
@@ -1,0 +1,45 @@
+#!/usr/bin/env bun
+// Print reviewer creds in copy-paste-friendly format for Play Console
+// "App access → Add new instructions" (which has no API).
+// Single source of truth: ios/.env.review.
+//
+// Usage: bun print-reviewer-creds.ts
+
+import { readFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+const path = resolve("ios/.env.review");
+if (!existsSync(path)) {
+  console.error(`Not found: ${path}`);
+  console.error("Run: bun create-app-review-user.ts first.");
+  process.exit(1);
+}
+
+const env: Record<string, string> = {};
+for (const line of readFileSync(path, "utf8").split("\n")) {
+  const m = line.match(/^([A-Z_]+)=(.*)$/);
+  if (!m) continue;
+  let v = m[2];
+  if (v.startsWith('"') && v.endsWith('"')) v = v.slice(1, -1);
+  env[m[1]] = v;
+}
+
+const user = env.ASC_REVIEW_DEMO_USER ?? "";
+const pass = env.ASC_REVIEW_DEMO_PASSWORD ?? "";
+const notes = env.ASC_REVIEW_NOTES ?? "";
+
+console.log("\n═══ Play Console → App access → Add new instructions ═══\n");
+console.log(`Instruction name:   App reviewer login`);
+console.log(`Username:           ${user}`);
+console.log(`Password:           ${pass}`);
+console.log(`Other instructions: ${notes}\n`);
+
+console.log("═══ App Store Connect → App Review Information (reference only) ═══");
+console.log("Auto-pushed by `fastlane metadata`. To verify, run check-ios-state.ts.\n");
+console.log(`First name:     ${env.ASC_REVIEW_FIRST_NAME ?? ""}`);
+console.log(`Last name:      ${env.ASC_REVIEW_LAST_NAME ?? ""}`);
+console.log(`Phone:          ${env.ASC_REVIEW_PHONE ?? ""}`);
+console.log(`Email:          ${env.ASC_REVIEW_EMAIL ?? ""}`);
+console.log(`Demo user:      ${user}`);
+console.log(`Demo password:  ${pass}`);
+console.log(`Notes:          ${notes}\n`);

--- a/skills/publish-mobile-app/scripts/validate-metadata.ts
+++ b/skills/publish-mobile-app/scripts/validate-metadata.ts
@@ -1,0 +1,103 @@
+#!/usr/bin/env bun
+// Validate iOS and Android metadata locally before any push.
+// Catches the gotchas Apple's precheck warns about + the Kids Category trap.
+//
+// Usage: bun validate-metadata.ts
+
+import { readFileSync, existsSync } from "node:fs";
+
+const errors: string[] = [];
+const warnings: string[] = [];
+
+const LIMITS_IOS: Record<string, number> = {
+  "name.txt": 30,
+  "subtitle.txt": 30,
+  "promotional_text.txt": 170,
+  "keywords.txt": 100,
+  "description.txt": 4000,
+  "release_notes.txt": 4000,
+};
+
+const LIMITS_ANDROID: Record<string, number> = {
+  "title.txt": 30,
+  "short-description.txt": 80,
+  "full-description.txt": 4000,
+};
+
+// iOS
+const iosDir = "ios/fastlane/metadata";
+if (existsSync(iosDir)) {
+  console.log("Checking iOS metadata...\n");
+  const locales = readFileSync(`${iosDir}`).toString && [];  // listing via fs not needed; use a known list
+  for (const locale of (await import("node:fs/promises")).readdir(iosDir).then(es => es.filter(e => e !== "review_information")) as any) {
+    const localeDir = `${iosDir}/${locale}`;
+    for (const [file, limit] of Object.entries(LIMITS_IOS)) {
+      const p = `${localeDir}/${file}`;
+      if (!existsSync(p)) {
+        warnings.push(`[ios/${locale}] missing ${file}`);
+        continue;
+      }
+      const content = readFileSync(p, "utf8");
+      const len = content.length;
+      if (len > limit) errors.push(`[ios/${locale}/${file}] ${len} > ${limit} chars`);
+      // Kids Category trap
+      if (file === "subtitle.txt" && /\b(kids|children)\b/i.test(content)) {
+        errors.push(`[ios/${locale}/${file}] contains "kids/children" — Apple rejects under Guideline 2.3.8 unless in Kids Category`);
+      }
+      if (file === "keywords.txt" && /\b(kids|children)\b/i.test(content)) {
+        warnings.push(`[ios/${locale}/${file}] contains "kids/children" — high risk under Guideline 2.3.8`);
+      }
+    }
+  }
+  // Top-level copyright check
+  if (!existsSync(`${iosDir}/copyright.txt`)) {
+    warnings.push("[ios] copyright.txt missing (non-localized, at metadata/copyright.txt root). Precheck will warn.");
+  }
+}
+
+// Android
+const androidGB = "android/app/src/main/play/listings/en-GB";
+const androidUS = "android/app/src/main/play/listings/en-US";
+const androidDir = existsSync(androidGB) ? androidGB : existsSync(androidUS) ? androidUS : null;
+if (androidDir) {
+  console.log("Checking Android metadata...\n");
+  for (const [file, limit] of Object.entries(LIMITS_ANDROID)) {
+    const p = `${androidDir}/${file}`;
+    if (!existsSync(p)) {
+      warnings.push(`[android] missing ${file}`);
+      continue;
+    }
+    const content = readFileSync(p, "utf8");
+    const len = content.length;
+    if (len > limit) errors.push(`[android/${file}] ${len} > ${limit} chars`);
+  }
+  if (existsSync(androidGB) && existsSync(androidUS)) {
+    warnings.push("[android] both en-GB and en-US listings exist — keep both in sync");
+  }
+}
+
+// Phone number format check
+if (existsSync("ios/.env.review")) {
+  const env = readFileSync("ios/.env.review", "utf8");
+  const phone = env.match(/ASC_REVIEW_PHONE=(.+)/)?.[1]?.trim();
+  if (phone && !phone.startsWith("+")) {
+    errors.push(`[reviewer] phone "${phone}" missing country code. Apple rejects without leading + and country code.`);
+  }
+  if (phone && /\s/.test(phone)) {
+    warnings.push(`[reviewer] phone "${phone}" contains spaces — works but cleaner without`);
+  }
+}
+
+console.log("");
+if (errors.length === 0 && warnings.length === 0) {
+  console.log("✓ All checks passed.");
+  process.exit(0);
+}
+for (const w of warnings) console.log(`⚠  ${w}`);
+for (const e of errors) console.log(`✗  ${e}`);
+console.log("");
+if (errors.length > 0) {
+  console.log(`${errors.length} error(s) — fix before pushing.`);
+  process.exit(1);
+}
+console.log(`${warnings.length} warning(s) — review but not blocking.`);


### PR DESCRIPTION
## What it does

Adds a new skill at `skills/publish-mobile-app/` that automates the boring parts of shipping a mobile app to both the iOS App Store and Google Play Store, for Capacitor, Expo, and Flutter projects.

8 sub-commands:
- `status` — query both stores' APIs, report what's live vs missing
- `setup` — wire fastlane + gradle-play-publisher + ASC API key + reviewer user
- `push` — sync listing copy + screenshots to both stores
- `ipa` — build signed iOS IPA → TestFlight
- `aab` — build signed Android AAB → Play internal track
- `release` — full lifecycle (bump + build + upload + listing push)
- `fix-rejection` — paste rejection email, map to recipe, apply fix
- `checklist` — refresh `RELEASE_CHECKLIST.md`

Auto-triggers on mentions of Play Store, App Store Connect, fastlane, TestFlight, or pasted rejection emails.

## Why I built it

Forged from a real production ship cycle (v1.0 → both stores → metadata rejection → recovery → resubmit). Every gotcha in `REFERENCE.md` came from a real failure, not a hypothetical:

- `LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8` must be forced when invoking fastlane or Ruby crashes on em-dashes in `description.txt`
- ASC API key path in `Fastfile` must use `File.expand_path(..., __dir__)`
- iPad 2048×2732 screenshots route to the wrong slot unless filename literally contains `iPad Pro (12.9-inch) (3rd generation)`
- `copyright.txt` is non-localized (lives at `metadata/copyright.txt` root, not per-locale)
- Subtitle lives on `appInfoLocalizations`, NOT `appStoreVersionLocalizations`
- Play Console default locale is often `en-GB`, not `en-US` — wrong folder = silently ignored
- "kids" / "children" in App Store subtitle → Guideline 2.3.8 rejection unless in Kids Category
- Fastlane's "Successfully uploaded" log is NOT equivalent to "appears in correct UI slot" — always verify via API

## Structure

```
skills/publish-mobile-app/
├── SKILL.md           # Entry point + sub-command router (~130 lines)
├── REFERENCE.md       # Framework specifics, Fastfile templates, gotchas
├── REJECTIONS.md      # Recipes per Apple/Google rejection
├── MANUAL_FORMS.md    # Walkthroughs for Age Rating, App Privacy, Data Safety
└── scripts/           # 5 TypeScript helper scripts (Bun-compatible)
```

## Source repo

Also published as a standalone Claude Code plugin: https://github.com/logesh-kumar/publish-mobile-app

Happy to iterate on the YAML frontmatter description, trigger keywords, or structure if maintainers prefer a different shape.