### PR TITLE
Fix model config shape in managed-agents API reference

### DIFF
--- a/skills/claude-api/shared/managed-agents-api-reference.md
+++ b/skills/claude-api/shared/managed-agents-api-reference.md
@@ -38,7 +38,7 @@ All resources are under the `beta` namespace. Python and TypeScript share identi
 
 **Agent shorthand:** `agent` on session create accepts either a bare string (`agent="agent_abc123"` — uses latest version) or the full reference object (`{type: "agent", id: "agent_abc123", version: 123}`).
 
-**Model shorthand:** `model` on agent create accepts either a bare string (`model="claude-opus-4-7"` — uses `standard` speed) or the full config object (`{type: "model_config", id: "claude-opus-4-6", speed: "fast"}`). Note: `speed: "fast"` is only supported on Opus 4.6.
+**Model shorthand:** `model` on agent create accepts either a bare string (`model="claude-opus-4-7"` — uses `standard` speed) or the full config object (`{id: "claude-opus-4-6", speed: "fast"}`). Note: `speed: "fast"` is only supported on Opus 4.6.
 
 ---
 


### PR DESCRIPTION
The `model` field on agent create accepts `{id, speed}`, not `{type: "model_config", id, speed}` — there is no `type` discriminator on that object.

Aligns line 41 with the shape already documented at line 206 and in `managed-agents-core.md`.