### PR TITLE
Add email-bridge skill

### DIFF
--- a/skills/email-bridge/.gitignore
+++ b/skills/email-bridge/.gitignore
@@ -1,0 +1,5 @@
+*.json
+!email-config.example.json
+.email-seen.json
+__pycache__/
+.ipynb_checkpoints/

--- a/skills/email-bridge/LICENSE
+++ b/skills/email-bridge/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/email-bridge/SKILL.md
+++ b/skills/email-bridge/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: email-bridge
+description: Communicate with Claude Code via email. Send task results, receive and execute instructions from email via SMTP/POP3. Supports 163.com, QQ Mail, Gmail. Ideal for long-running tasks and remote control.
+---
+
+# Email Bridge Skill
+
+Communicate with Claude Code via email — send task results, receive and execute instructions from email.
+
+## Setup
+
+1. Copy `email-config.example.json` to `email-config.json` and fill in credentials
+2. Copy all files into your Claude Code project
+3. Set optional env vars (see Environment Variables)
+4. Start the background poller: `nohup ./email-poll-loop.sh &>/dev/null &`
+
+## Configuration (`email-config.json`)
+
+```json
+{
+  "sender": "your_email@163.com",
+  "receiver": "your_receiver@qq.com",
+  "smtp_server": "smtp.163.com",
+  "smtp_port": 465,
+  "smtp_auth": "YOUR_SMTP_AUTH_CODE",
+  "pop_server": "pop.163.com",
+  "pop_port": 995
+}
+```
+
+To get an SMTP/POP3 auth code for 163.com:
+- Settings → POP3/SMTP/IMAP → Enable SMTP and POP3
+- Copy the generated authorization code
+
+## Commands
+
+```bash
+# Send an email
+python3 email-bridge.py send "<subject>" "<body>"
+
+# Check for new emails (manual)
+python3 email-bridge.py check [limit]
+```
+
+## Smart Session Routing
+
+The background poller intelligently decides whether to continue an existing
+conversation or start a new one, based on email content:
+
+| Trigger | Mode | Behavior |
+|---------|------|----------|
+| Subject starts with `Re:` | `--resume` | Continue existing session |
+| Body contains `继续`/`接着`/`上次`/`刚才`/`之前` | `--resume` | Continue existing session |
+| Body contains `!new`/`新对话`/`新任务` | `-p` | Force new session |
+| Default (no keywords) | `-p` | New standalone session |
+
+Session ID is persisted across emails. Continued emails share Claude context.
+
+## Architecture
+
+```
+You ──email──> POP3 inbox
+                  │
+Bash poller (3min) │  free, zero LLM cost
+                  │  email-decision.py classifies intent
+                  ▼
+           ┌──────────────┐
+           │ continue? ──── claude --resume (same session, full context)
+           │ new?      ──── claude -p      (fresh session)
+           └──────────────┘
+                  │
+             SMTP reply
+```
+
+## File Structure
+
+```
+email-bridge/
+├── email-bridge.py              # Send/check emails
+├── email-poll-loop.sh           # Background poller with smart routing
+├── email-decision.py            # Keyword classifier (continue vs new)
+├── SKILL.md                     # This file
+├── email-config.example.json    # Config template
+├── .gitignore
+├── LICENSE
+└── README.md
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `EMAIL_PROJECT_DIR` | script directory | Project root where `claude` CLI runs |
+| `EMAIL_QUEUE_FILE` | `/tmp/email-pending-queue.txt` | Email queue file path |
+
+## Supported Providers
+
+| Provider | SMTP Server | POP3 Server |
+|----------|-------------|-------------|
+| 163.com  | smtp.163.com:465 | pop.163.com:995 |
+| QQ Mail  | smtp.qq.com:465 | pop.qq.com:995 |
+| Gmail    | smtp.gmail.com:465 | pop.gmail.com:995 |
+
+## Security
+
+- `email-config.json` is gitignored — never commit auth codes
+- `.email-seen.json` tracks processed email UIDs locally
+- Auth codes stay in local config only
+
+## License
+
+MIT

--- a/skills/email-bridge/email-bridge.py
+++ b/skills/email-bridge/email-bridge.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Email Bridge for Claude Code — send via SMTP, receive via POP3.
+
+Setup:
+  1. Copy email-config.example.json to email-config.json
+  2. Fill in your sender email, SMTP auth code, and receiver email
+  3. Place this script and SKILL.md in your Claude Code project
+
+Usage:
+  python3 email-bridge.py send "<subject>" "<body>"
+  python3 email-bridge.py check [limit]
+"""
+
+import sys
+import json
+import os
+import poplib
+import email
+import smtplib
+from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+CONFIG_PATH = SCRIPT_DIR / "email-config.json"
+SEEN_PATH = SCRIPT_DIR / ".email-seen.json"
+
+
+def load_config():
+    if not CONFIG_PATH.exists():
+        print(f"ERROR: Config not found at {CONFIG_PATH}")
+        print("Copy email-config.example.json to email-config.json and fill in your credentials.")
+        sys.exit(1)
+    return json.loads(CONFIG_PATH.read_text())
+
+
+def load_seen():
+    if SEEN_PATH.exists():
+        return set(json.loads(SEEN_PATH.read_text()))
+    return set()
+
+
+def save_seen(seen):
+    SEEN_PATH.write_text(json.dumps(list(seen)))
+
+
+def send(subject, body):
+    cfg = load_config()
+    msg = MIMEMultipart()
+    msg['From'] = cfg['sender']
+    msg['To'] = cfg['receiver']
+    msg['Subject'] = subject
+    msg.attach(MIMEText(body, 'plain', 'utf-8'))
+
+    try:
+        smtp_server = cfg.get('smtp_server', 'smtp.163.com')
+        smtp_port = cfg.get('smtp_port', 465)
+        server = smtplib.SMTP_SSL(smtp_server, smtp_port)
+        server.login(cfg['sender'], cfg['smtp_auth'])
+        server.sendmail(cfg['sender'], cfg['receiver'], msg.as_string())
+        server.quit()
+        print("OK: email sent")
+    except Exception as e:
+        print(f"FAIL: {e}")
+        sys.exit(1)
+
+
+def check(limit=5):
+    cfg = load_config()
+    seen = load_seen()
+    try:
+        pop_server = cfg.get('pop_server', 'pop.163.com')
+        pop_port = cfg.get('pop_port', 995)
+        pop = poplib.POP3_SSL(pop_server, pop_port)
+        pop.user(cfg['sender'])
+        pop.pass_(cfg['smtp_auth'])  # 163 uses same auth code for SMTP and POP3
+        total, _ = pop.stat()
+        resp, uid_list, _ = pop.uidl()
+        if not uid_list:
+            print("No emails")
+            pop.quit()
+            return
+
+        new = []
+        for line in uid_list:
+            uid = line.decode().split()[1]
+            if uid not in seen:
+                new.append(uid)
+
+        if not new:
+            print("No new emails")
+        else:
+            print(f"New: {len(new)} (total: {total})")
+            for uid in new[-limit:]:
+                idx = None
+                for line in uid_list:
+                    parts = line.decode().split()
+                    if parts[1] == uid:
+                        idx = int(parts[0])
+                        break
+                if idx is None:
+                    continue
+                resp, lines, _ = pop.retr(idx)
+                raw = email.message_from_bytes(b'\n'.join(lines))
+                print("---EMAIL---")
+                print(f"UID: {uid}")
+                print(f"From: {raw['From']}")
+                print(f"Subject: {raw['Subject']}")
+                print(f"Date: {raw['Date']}")
+                body = ""
+                if raw.is_multipart():
+                    for part in raw.walk():
+                        ctype = part.get_content_type()
+                        if ctype == 'text/plain':
+                            body += part.get_payload(decode=True).decode('utf-8', errors='replace')
+                else:
+                    body = raw.get_payload(decode=True).decode('utf-8', errors='replace')
+                print(f"Body: {body.strip()}")
+                print("---END---")
+                seen.add(uid)
+
+        pop.quit()
+        save_seen(seen)
+    except Exception as e:
+        print(f"FAIL: {e}")
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print("Usage: email-bridge.py send <subject> <body>")
+        print("       email-bridge.py check [limit]")
+        sys.exit(1)
+
+    cmd = sys.argv[1]
+    if cmd == 'send':
+        if len(sys.argv) < 4:
+            print("Usage: email-bridge.py send <subject> <body>")
+            sys.exit(1)
+        send(sys.argv[2], sys.argv[3])
+    elif cmd == 'check':
+        limit = int(sys.argv[2]) if len(sys.argv) > 2 else 5
+        check(limit)
+    else:
+        print(f"Unknown command: {cmd}")
+        sys.exit(1)

--- a/skills/email-bridge/email-config.example.json
+++ b/skills/email-bridge/email-config.example.json
@@ -1,0 +1,9 @@
+{
+  "sender": "your_email@163.com",
+  "receiver": "your_receiver@qq.com",
+  "smtp_server": "smtp.163.com",
+  "smtp_port": 465,
+  "smtp_auth": "YOUR_SMTP_AUTH_CODE",
+  "pop_server": "pop.163.com",
+  "pop_port": 995
+}

--- a/skills/email-bridge/email-decision.py
+++ b/skills/email-bridge/email-decision.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Classify an email: should it continue an existing session or start a new one?"""
+
+import sys
+import json
+from pathlib import Path
+
+# Keywords that signal "continue the existing conversation"
+CONTINUE_KEYWORDS = [
+    "继续", "接着", "上次", "刚才", "之前", "上面", "前面",
+    "follow up", "continue", "as we discussed", "你刚才",
+    "再帮我", "接着做", "继续做", "还是那个", "刚才那个",
+    "之前那个", "接着聊", "继续聊",
+]
+
+# Keywords that signal "start a fresh session"
+NEW_KEYWORDS = [
+    "!new", "新对话", "新任务", "新话题", "换个话题",
+    "fresh start", "new task", "new topic",
+]
+
+
+def classify(email_body):
+    body_lower = email_body.lower()
+
+    # Explicit new session signal
+    for kw in NEW_KEYWORDS:
+        if kw in body_lower:
+            return "new"
+
+    # Explicit continue signal
+    for kw in CONTINUE_KEYWORDS:
+        if kw in body_lower:
+            return "continue"
+
+    # Subject-based: if it's a reply (Re:), likely continuation
+    # (handled by caller since subject is separate)
+
+    # Default: start new session for standalone tasks
+    return "new"
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        # Read from stdin
+        body = sys.stdin.read()
+    else:
+        body = sys.argv[1]
+
+    result = classify(body)
+    print(result)

--- a/skills/email-bridge/email-poll-loop.sh
+++ b/skills/email-bridge/email-poll-loop.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Smart email poller with intelligent session routing.
+# Polls POP3 every 3 min. When new email arrives, classifies intent:
+#   "continue" → claude --resume (same session, preserves context)
+#   "new"      → claude -p (fresh session, standalone task)
+# Auto-expires after 24 hours.
+
+QUEUE_FILE="${EMAIL_QUEUE_FILE:-/tmp/email-pending-queue.txt}"
+LOCK_FILE="/tmp/email-poll.lock"
+CLAUDE_LOCK="/tmp/email-claude.lock"
+SESSION_FILE="/tmp/email-claude-session.txt"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BRIDGE="$SCRIPT_DIR/email-bridge.py"
+DECIDE="$SCRIPT_DIR/email-decision.py"
+PROJECT_DIR="${EMAIL_PROJECT_DIR:-$SCRIPT_DIR}"
+SYS_SENDERS="service.netease.com|club@service.netease.com|safe@service.netease.com"
+
+# Read receiver from config
+RECEIVER=$(python3 -c "import json; print(json.load(open('$SCRIPT_DIR/email-config.json'))['receiver'])" 2>/dev/null || echo "")
+
+PROMPT_CONTINUE="You are continuing a previous conversation via email.
+Process the email content below and reply:
+1. Read the email body as a command/instruction
+2. Execute it, maintaining context from prior conversation
+3. Reply via: python3 $BRIDGE send \"Re: <subject>\" \"<result>\"
+Do not ask for confirmation. Work efficiently."
+
+PROMPT_NEW="Process this email as a new standalone task:
+1. Read the email body as a command/instruction
+2. Execute it fully
+3. Reply via: python3 $BRIDGE send \"Re: <subject>\" \"<result>\"
+Do not ask for confirmation. Work efficiently."
+
+exec 200>"$LOCK_FILE"
+flock -n 200 || exit 0
+
+END_TIME=$(($(date +%s) + 86400))
+
+while [ $(date +%s) -lt $END_TIME ]; do
+    OUTPUT=$(cd "$PROJECT_DIR" && python3 "$BRIDGE" check 3 2>/dev/null)
+    if echo "$OUTPUT" | grep -q "^New:"; then
+        HAS_USER=$(echo "$OUTPUT" | grep -vE "$SYS_SENDERS" | grep "$RECEIVER")
+        if [ -n "$HAS_USER" ]; then
+            # Extract email body for classification
+            BODY=$(echo "$OUTPUT" | sed -n '/^Body: /,/^---END---/p' | sed '1s/^Body: //' | head -n -1)
+            SUBJECT=$(echo "$OUTPUT" | grep "^Subject:" | head -1)
+
+            # Classify intent
+            MODE="new"
+            # Check subject for Re:
+            if echo "$SUBJECT" | grep -qi "Re:"; then
+                MODE="continue"
+            fi
+            # Run keyword classifier
+            DECISION=$(echo "$BODY" | python3 "$DECIDE" 2>/dev/null)
+            if [ "$DECISION" = "continue" ]; then
+                MODE="continue"
+            fi
+
+            # Write to queue as backup
+            {
+                echo "=== $(date '+%Y-%m-%d %H:%M:%S') [mode=$MODE] ==="
+                echo "$OUTPUT"
+            } >> "$QUEUE_FILE"
+
+            # Process with appropriate session mode
+            (
+                exec 201>"$CLAUDE_LOCK"
+                if flock -n 201; then
+                    cd "$PROJECT_DIR"
+
+                    if [ "$MODE" = "continue" ] && [ -f "$SESSION_FILE" ]; then
+                        RESUME_FLAG="--resume $(cat "$SESSION_FILE")"
+                        PROMPT="$PROMPT_CONTINUE"
+                        echo "[email-poll] Continue session $(cat "$SESSION_FILE")"
+                    else
+                        RESUME_FLAG=""
+                        PROMPT="$PROMPT_NEW"
+                        echo "[email-poll] New session"
+                    fi
+
+                    RESULT=$(claude -p "$PROMPT
+
+Email content:
+$OUTPUT" \
+                        --max-turns 8 \
+                        --dangerously-skip-permissions \
+                        --output-format json \
+                        $RESUME_FLAG \
+                        2>&1)
+
+                    # Save session ID for future continuation
+                    echo "$RESULT" | python3 -c "
+import sys, json
+for line in sys.stdin:
+    line = line.strip()
+    if line.startswith('{'):
+        d = json.loads(line)
+        sid = d.get('session_id','')
+        if sid:
+            open('$SESSION_FILE','w').write(sid)
+            print(f'Saved session: {sid}')
+        break
+" 2>/dev/null
+
+                    echo "$RESULT" > /tmp/email-claude-output.json
+                fi
+            ) &
+        fi
+    fi
+    sleep 180
+done
+
+rm -f "$LOCK_FILE"


### PR DESCRIPTION
## Summary

Add `email-bridge` — a skill for communicating with Claude Code via email.

## Features

- **Send/receive** emails via SMTP/POP3 (163.com, QQ Mail, Gmail)
- **Smart session routing** — `email-decision.py` keyword classifier distinguishes "continue" vs "new" session intent
- **Zero-waste polling** — `email-poll-loop.sh` background poller checks POP3 without consuming LLM tokens; only invokes Claude when a real email arrives
- **Session continuity** — `--resume` support preserves context across emails

## Files

| File | Purpose |
|------|---------|
| `SKILL.md` | Skill definition with YAML frontmatter |
| `email-bridge.py` | Send/check emails via SMTP/POP3 |
| `email-decision.py` | Keyword classifier for session routing |
| `email-poll-loop.sh` | Background polling daemon |
| `email-config.example.json` | Config template |
| `.gitignore` | Excludes real credentials |

## Security

- `email-config.json` is gitignored — auth codes stay local
- `.email-seen.json` tracks processed email UIDs locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)