### PR TITLE
Add obsidian-cli skill for Obsidian vault CLI interaction

### DIFF
--- a/skills/obsidian-cli/LICENSE.txt
+++ b/skills/obsidian-cli/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/obsidian-cli/SKILL.md
+++ b/skills/obsidian-cli/SKILL.md
@@ -1,0 +1,309 @@
+---
+name: obsidian-cli
+description: >-
+  Interact with Obsidian vaults via the built-in Obsidian CLI (v1.12+).
+  Create, read, search, and manage notes, daily notes, tasks, tags, properties,
+  templates, plugins, themes, and more. Activate when the user mentions Obsidian,
+  their vault, notes, or asks to interact with their knowledge base using the CLI.
+allowed-tools: Bash, Read, Write
+user-invocable: true
+shell: bash
+---
+
+# Obsidian CLI Skill
+
+This skill enables Claude to use the **Obsidian CLI** — the command-line interface
+built into Obsidian v1.12+ — to interact with your Obsidian vault(s).
+
+## Prerequisites
+
+- **Obsidian v1.12 or later** installed
+- **Obsidian app must be running** (the CLI communicates via local IPC)
+- **CLI enabled** in Obsidian: *Settings → General → Command line interface → Register CLI*
+- **`obsidian` command available** in your shell PATH
+
+To verify:
+```bash
+obsidian version
+```
+
+If not found, add the Obsidian binary to your PATH:
+- **macOS**: `/Applications/Obsidian.app/Contents/MacOS/obsidian`
+- **Windows**: Typically added automatically after registering in settings
+- **Linux**: Depends on installation method (AppImage, Snap, etc.)
+
+## Syntax
+
+```
+obsidian <command> [options]
+```
+
+### Global Options
+
+| Option | Description |
+|--------|-------------|
+| `vault=<name>` | Target a specific vault by name (required if multiple vaults) |
+| `file=<name>` | Refer to a file by its name (wikilink-style resolution) |
+| `path=<path>` | Refer to a file by its exact path (`folder/note.md`) |
+
+### Important Rules
+
+1. **File resolution**: `file=` resolves like wikilinks (by note name, first match wins);
+   `path=` uses exact file paths. Most commands default to the **active file** when omitted.
+2. **Quoting**: Wrap values containing spaces in quotes: `name="My Note"`.
+3. **Escape sequences**: Use `\n` for newlines, `\t` for tabs in content values.
+4. **Vault targeting**: If you have only one vault, `vault=` is usually optional.
+
+## Command Reference
+
+See `references/commands.md` for the complete list of all commands with their options.
+
+### Complete Command List by Category
+
+#### File Operations
+| Command | Description |
+|---------|-------------|
+| `create name=<name> [content=] [template=] [open] [newtab] [overwrite]` | Create a new note |
+| `read [file=] [path=]` | Read a note's contents |
+| `append [file=] [path=] content= [inline]` | Append content to a note |
+| `prepend [file=] [path=] content= [inline]` | Prepend content (after frontmatter) |
+| `delete [file=] [path=] [permanent]` | Delete a note |
+| `move [file=] [path=] to=<path>` | Move a note to another folder |
+| `rename [file=] [path=] name=<name>` | Rename a note |
+| `file [file=] [path=]` | Show file info |
+
+#### Search & Navigation
+| Command | Description |
+|---------|-------------|
+| `search query=<text> [path=] [limit=] [total] [case] [format=]` | Search vault contents |
+| `search:context query=<text> [path=] [limit=] [case] [format=]` | Search with surrounding context |
+| `search:open [query=]` | Open search view in Obsidian |
+| `open [file=] [path=] [newtab]` | Open a file in Obsidian |
+| `random [folder=] [newtab]` | Open a random note |
+| `random:read [folder=]` | Read a random note |
+| `recents [total]` | List recently opened files |
+| `tabs [ids]` | List open tabs |
+| `tab:open [group=] [file=] [view=]` | Open a new tab |
+
+#### Daily Notes
+| Command | Description |
+|---------|-------------|
+| `daily [paneType=tab\|split\|window]` | Open today's daily note |
+| `daily:read` | Read today's daily note |
+| `daily:append content= [inline] [open] [paneType=]` | Append to daily note |
+| `daily:prepend content= [inline] [open] [paneType=]` | Prepend to daily note |
+| `daily:path` | Get path to daily note |
+
+#### Properties & Tags
+| Command | Description |
+|---------|-------------|
+| `property:set name= value= [type=] [file=] [path=]` | Set a property |
+| `property:read name= [file=] [path=]` | Read a property value |
+| `property:remove name= [file=] [path=]` | Remove a property |
+| `properties [file=] [path=] [name=] [total] [counts] [sort=] [active] [format=]` | List properties in vault |
+| `tags [file=] [path=] [total] [counts] [sort=] [active] [format=]` | List tags |
+| `tag name=<tag> [total] [verbose]` | Get tag info |
+
+#### Tasks
+| Command | Description |
+|---------|-------------|
+| `tasks [file=] [path=] [total] [done] [todo] [status=] [verbose] [active] [daily] [format=]` | List tasks |
+| `task [ref=] [file=] [path=] [line=] [toggle\|done\|todo] [daily] [status=]` | Show or update a task |
+
+#### Templates
+| Command | Description |
+|---------|-------------|
+| `templates [total]` | List available templates |
+| `template:read name= [resolve] [title=]` | Read template content |
+| `template:insert name=` | Insert template into active file |
+
+#### Links
+| Command | Description |
+|---------|-------------|
+| `backlinks [file=] [path=] [counts] [total] [format=]` | List backlinks to a file |
+| `links [file=] [path=] [total]` | List outgoing links from a file |
+| `unresolved [total] [counts] [verbose] [format=]` | List unresolved links |
+| `deadends [total] [all]` | Files with no outgoing links |
+| `orphans [total] [all]` | Files with no incoming links |
+
+#### Vault Info
+| Command | Description |
+|---------|-------------|
+| `files [folder=] [ext=] [total]` | List vault files |
+| `folders [folder=] [total]` | List vault folders |
+| `folder path= [info=files\|folders\|size]` | Show folder info |
+| `vault [info=name\|path\|files\|folders\|size]` | Show vault info |
+| `vaults [total] [verbose]` | List known vaults |
+| `wordcount [file=] [path=] [words] [characters]` | Count words and characters |
+| `outline [file=] [path=] [format=tree\|md\|json] [total]` | Show file headings |
+
+#### Plugin & Theme Management
+| Command | Description |
+|---------|-------------|
+| `plugins [filter=core\|community] [versions] [format=]` | List installed plugins |
+| `plugins:enabled [filter=core\|community] [versions] [format=]` | List enabled plugins |
+| `plugins:restrict [on\|off]` | Toggle or check restricted mode |
+| `plugin id=<plugin-id>` | Get plugin info |
+| `plugin:enable id= [filter=core\|community]` | Enable a plugin |
+| `plugin:disable id= [filter=core\|community]` | Disable a plugin |
+| `plugin:install id= [enable]` | Install a community plugin |
+| `plugin:uninstall id=` | Uninstall a community plugin |
+| `plugin:reload id=` | Reload a plugin (developer use) |
+| `themes [versions]` | List installed themes |
+| `theme [name=]` | Show active theme or get theme info |
+| `theme:set name=` | Set active theme |
+| `theme:install name= [enable]` | Install a community theme |
+| `theme:uninstall name=` | Uninstall a theme |
+
+#### History, Sync & Diff
+| Command | Description |
+|---------|-------------|
+| `history [file=] [path=]` | List file history versions |
+| `history:list` | List files with history |
+| `history:open [file=] [path=]` | Open file recovery |
+| `history:read [file=] [path=] [version=]` | Read a specific history version |
+| `history:restore [file=] [path=] version=<n>` | Restore a specific version |
+| `diff [file=] [path=] [from=] [to=] [filter=local\|sync]` | List or diff versions |
+| `sync:status` | Show sync status |
+| `sync [on\|off]` | Pause or resume sync |
+| `sync:deleted [total]` | List deleted files in sync |
+| `sync:history [file=] [path=] [total]` | List sync version history |
+| `sync:open [file=] [path=]` | Open sync history |
+| `sync:read [file=] [path=] version=<n>` | Read a sync version |
+| `sync:restore [file=] [path=] version=<n>` | Restore a sync version |
+
+#### Commands & Automation
+| Command | Description |
+|---------|-------------|
+| `help [<command>]` | Show list of all commands or help for a specific one |
+| `command id=<command-id>` | Execute any Obsidian command by ID |
+| `commands [filter=]` | List all available commands |
+| `workspace [ids]` | Show workspace tree |
+| `reload` | Reload the vault |
+| `restart` | Restart Obsidian |
+
+#### Aliases
+| Command | Description |
+|---------|-------------|
+| `aliases [file=] [path=] [total] [verbose] [active]` | List aliases in the vault |
+
+#### Bases (Databases)
+| Command | Description |
+|---------|-------------|
+| `bases` | List all base files in vault |
+| `base:create [file=] [path=] [view=] [name=] [content=] [open] [newtab]` | Create a new item in a base |
+| `base:query [file=] [path=] [view=] [format=]` | Query a base and return results |
+| `base:views [file=] [path=]` | List views in a base file |
+
+#### Bookmarks
+| Command | Description |
+|---------|-------------|
+| `bookmarks [total] [verbose] [format=]` | List bookmarks |
+| `bookmark [file=] [subpath=] [folder=] [search=] [url=] [title=]` | Add a bookmark |
+
+#### CSS Snippets
+| Command | Description |
+|---------|-------------|
+| `snippets` | List installed CSS snippets |
+| `snippets:enabled` | List enabled CSS snippets |
+| `snippet:enable name=` | Enable a CSS snippet |
+| `snippet:disable name=` | Disable a CSS snippet |
+
+#### Hotkeys
+| Command | Description |
+|---------|-------------|
+| `hotkeys [total] [verbose] [all] [format=]` | List hotkeys |
+| `hotkey id=<command-id> [verbose]` | Get hotkey for a command |
+
+#### Other
+| Command | Description |
+|---------|-------------|
+| `web url=<url> [newtab]` | Open URL in Obsidian web viewer |
+| `version` | Show Obsidian version |
+
+#### Developer Tools
+| Command | Description |
+|---------|-------------|
+| `eval code=<javascript>` | Execute JavaScript and return result |
+| `devtools` | Toggle Electron dev tools |
+| `dev:cdp method=<CDP.method> [params=]` | Run Chrome DevTools Protocol command |
+| `dev:console [clear] [limit=] [level=]` | Show captured console messages |
+| `dev:css selector= [prop=]` | Inspect CSS with source locations |
+| `dev:debug [on\|off]` | Attach/detach CDP debugger |
+| `dev:dom selector= [total] [text] [inner] [all] [attr=] [css=]` | Query DOM elements |
+| `dev:errors [clear]` | Show captured errors |
+| `dev:mobile [on\|off]` | Toggle mobile emulation |
+| `dev:screenshot [path=]` | Take a screenshot |
+
+## Common Usage Patterns
+
+### Creating notes
+```bash
+# Simple note
+obsidian create name="Meeting Notes" content="Discussed Q4 roadmap"
+
+# Note from a template
+obsidian create name="Daily Journal" template="Journal Template" open
+
+# Note in a specific vault
+obsidian vault="Work" create name="Sprint Review" content="Sprint 42 completed"
+```
+
+### Reading and searching
+```bash
+# Read a specific file
+obsidian read file="Meeting Notes"
+
+# Search vault
+obsidian search query="Q4 roadmap" limit=10
+
+# Search with context
+obsidian search:context query="action items" format=text
+```
+
+### Managing tasks
+```bash
+# List all incomplete tasks
+obsidian tasks todo
+
+# List tasks in a specific file
+obsidian tasks file="Project Plan" done
+
+# Toggle task status
+obsidian task file="Project Plan" line=12 toggle
+```
+
+### Daily notes workflow
+```bash
+# Log to today's daily note
+obsidian daily:append content="- Reviewed PR #42" inline
+
+# Read yesterday's daily note
+obsidian vault="Personal" daily:read
+```
+
+### Properties
+```bash
+# Add a property
+obsidian property:set file="Meeting Notes" name="Status" value="Done" type=text
+
+# Read a property
+obsidian property:read file="Meeting Notes" name="Status"
+
+# Remove a property
+obsidian property:remove file="Meeting Notes" name="Old-Prop"
+```
+
+## Error Handling Tips
+
+- **"Command not found"**: The Obsidian CLI is not in PATH or not enabled in Settings
+- **"No vault specified"**: Use `vault=<name>` when multiple vaults exist or the active vault is unclear
+- **"File not found"**: The file name/path doesn't exist. Try using `path=` with the full path if `file=` fails
+- **"Obsidian is not running"**: The CLI requires the Obsidian desktop app to be open
+- **"Cannot find file"**: Check spelling or use `files` to list available files first
+
+## Slash Commands
+
+When invoked via `/obsidian-cli`, the skill provides general guidance on using the
+Obsidian CLI. For specific operations, just describe what you want to do in natural
+language — the skill will determine the correct command automatically.

--- a/skills/obsidian-cli/references/commands.md
+++ b/skills/obsidian-cli/references/commands.md
@@ -1,0 +1,481 @@
+Obsidian CLI
+
+Usage: obsidian <command> [options]
+
+Options:
+  vault=<name>          Target a specific vault by name
+
+Notes:
+  file resolves by name (like wikilinks), path is exact (folder/note.md)
+  Most commands default to the active file when file/path is omitted
+  Quote values with spaces: name="My Note"
+  Use \n for newline, \t for tab in content values
+
+Commands:
+  aliases               List aliases in the vault
+    file=<name>         - File name
+    path=<path>         - File path
+    total               - Return alias count
+    verbose             - Include file paths
+    active              - Show aliases for active file
+
+  append                Append content to a file
+    file=<name>         - File name
+    path=<path>         - File path
+    content=<text>      - Content to append (required)
+    inline              - Append without newline
+
+  backlinks             List backlinks to a file
+    file=<name>         - Target file name
+    path=<path>         - Target file path
+    counts              - Include link counts
+    total               - Return backlink count
+    format=json|tsv|csv - Output format (default: tsv)
+
+  base:create           Create a new item in a base
+    file=<name>         - Base file name
+    path=<path>         - Base file path
+    view=<name>         - View name
+    name=<name>         - New file name
+    content=<text>      - Initial content
+    open                - Open file after creating
+    newtab              - Open in new tab
+
+  base:query            Query a base and return results
+    file=<name>         - Base file name
+    path=<path>         - Base file path
+    view=<name>         - View name to query
+    format=json|csv|tsv|md|paths  - Output format (default: json)
+
+  base:views            List views in the current base file
+
+  bases                 List all base files in vault
+
+  bookmark              Add a bookmark
+    file=<path>         - File to bookmark
+    subpath=<subpath>   - Subpath (heading or block) within file
+    folder=<path>       - Folder to bookmark
+    search=<query>      - Search query to bookmark
+    url=<url>           - URL to bookmark
+    title=<title>       - Bookmark title
+
+  bookmarks             List bookmarks
+    total               - Return bookmark count
+    verbose             - Include bookmark types
+    format=json|tsv|csv - Output format (default: tsv)
+
+  command               Execute an Obsidian command
+    id=<command-id>     - Command ID to execute (required)
+
+  commands              List available commands
+    filter=<prefix>     - Filter by ID prefix
+
+  create                Create a new file
+    name=<name>         - File name
+    path=<path>         - File path
+    content=<text>      - Initial content
+    template=<name>     - Template to use
+    overwrite           - Overwrite if file exists
+    open                - Open file after creating
+    newtab              - Open in new tab
+
+  daily                 Open daily note
+    paneType=tab|split|window  - Pane type to open in
+
+  daily:append          Append content to daily note
+    content=<text>      - Content to append (required)
+    inline              - Append without newline
+    open                - Open file after adding
+    paneType=tab|split|window  - Pane type to open in
+
+  daily:path            Get daily note path
+
+  daily:prepend         Prepend content to daily note
+    content=<text>      - Content to prepend (required)
+    inline              - Prepend without newline
+    open                - Open file after adding
+    paneType=tab|split|window  - Pane type to open in
+
+  daily:read            Read daily note contents
+
+  deadends              List files with no outgoing links
+    total               - Return dead-end count
+    all                 - Include non-markdown files
+
+  delete                Delete a file
+    file=<name>         - File name
+    path=<path>         - File path
+    permanent           - Skip trash, delete permanently
+
+  diff                  List or diff local/sync versions
+    file=<name>         - File name
+    path=<path>         - File path
+    from=<n>            - Version number to diff from
+    to=<n>              - Version number to diff to
+    filter=local|sync   - Filter by version source
+
+  file                  Show file info
+    file=<name>         - File name
+    path=<path>         - File path
+
+  files                 List files in the vault
+    folder=<path>       - Filter by folder
+    ext=<extension>     - Filter by extension
+    total               - Return file count
+
+  folder                Show folder info
+    path=<path>         - Folder path (required)
+    info=files|folders|size  - Return specific info only
+
+  folders               List folders in the vault
+    folder=<path>       - Filter by parent folder
+    total               - Return folder count
+
+  help                  Show list of all available commands
+    <command>           - Show help for a specific command
+
+  history               List file history versions
+    file=<name>         - File name
+    path=<path>         - File path
+
+  history:list          List files with history
+
+  history:open          Open file recovery
+    file=<name>         - File name
+    path=<path>         - File path
+
+  history:read          Read a file history version
+    file=<name>         - File name
+    path=<path>         - File path
+    version=<n>         - Version number (default: 1)
+
+  history:restore       Restore a file history version
+    file=<name>         - File name
+    path=<path>         - File path
+    version=<n>         - Version number (required)
+
+  hotkey                Get hotkey for a command
+    id=<command-id>     - Command ID (required)
+    verbose             - Show if custom or default
+
+  hotkeys               List hotkeys
+    total               - Return hotkey count
+    verbose             - Show if hotkey is custom
+    format=json|tsv|csv - Output format (default: tsv)
+    all                 - Include commands without hotkeys
+
+  links                 List outgoing links from a file
+    file=<name>         - File name
+    path=<path>         - File path
+    total               - Return link count
+
+  move                  Move or rename a file
+    file=<name>         - File name
+    path=<path>         - File path
+    to=<path>           - Destination folder or path (required)
+
+  open                  Open a file
+    file=<name>         - File name
+    path=<path>         - File path
+    newtab              - Open in new tab
+
+  orphans               List files with no incoming links
+    total               - Return orphan count
+    all                 - Include non-markdown files
+
+  outline               Show headings for the current file
+    file=<name>         - File name
+    path=<path>         - File path
+    format=tree|md|json - Output format (default: tree)
+    total               - Return heading count
+
+  plugin                Get plugin info
+    id=<plugin-id>      - Plugin ID (required)
+
+  plugin:disable        Disable a plugin
+    id=<id>             - Plugin ID (required)
+    filter=core|community  - Plugin type
+
+  plugin:enable         Enable a plugin
+    id=<id>             - Plugin ID (required)
+    filter=core|community  - Plugin type
+
+  plugin:install        Install a community plugin
+    id=<id>             - Plugin ID (required)
+    enable              - Enable after install
+
+  plugin:reload         Reload a plugin (for developers)
+    id=<id>             - Plugin ID (required)
+
+  plugin:uninstall      Uninstall a community plugin
+    id=<id>             - Plugin ID (required)
+
+  plugins               List installed plugins
+    filter=core|community  - Filter by plugin type
+    versions            - Include version numbers
+    format=json|tsv|csv - Output format (default: tsv)
+
+  plugins:enabled       List enabled plugins
+    filter=core|community  - Filter by plugin type
+    versions            - Include version numbers
+    format=json|tsv|csv - Output format (default: tsv)
+
+  plugins:restrict      Toggle or check restricted mode
+    on                  - Enable restricted mode
+    off                 - Disable restricted mode
+
+  prepend               Prepend content to a file
+    file=<name>         - File name
+    path=<path>         - File path
+    content=<text>      - Content to prepend (required)
+    inline              - Prepend without newline
+
+  properties            List properties in the vault
+    file=<name>         - Show properties for file
+    path=<path>         - Show properties for path
+    name=<name>         - Get specific property count
+    total               - Return property count
+    sort=count          - Sort by count (default: name)
+    counts              - Include occurrence counts
+    format=yaml|json|tsv  - Output format (default: yaml)
+    active              - Show properties for active file
+
+  property:read         Read a property value from a file
+    name=<name>         - Property name (required)
+    file=<name>         - File name
+    path=<path>         - File path
+
+  property:remove       Remove a property from a file
+    name=<name>         - Property name (required)
+    file=<name>         - File name
+    path=<path>         - File path
+
+  property:set          Set a property on a file
+    name=<name>         - Property name (required)
+    value=<value>       - Property value (required)
+    type=text|list|number|checkbox|date|datetime  - Property type
+    file=<name>         - File name
+    path=<path>         - File path
+
+  random                Open a random note
+    folder=<path>       - Limit to folder
+    newtab              - Open in new tab
+
+  random:read           Read a random note
+    folder=<path>       - Limit to folder
+
+  read                  Read file contents
+    file=<name>         - File name
+    path=<path>         - File path
+
+  recents               List recently opened files
+    total               - Return recent file count
+
+  reload                Reload the vault
+
+  rename                Rename a file
+    file=<name>         - File name
+    path=<path>         - File path
+    name=<name>         - New file name (required)
+
+  restart               Restart the app
+
+  search                Search vault for text
+    query=<text>        - Search query (required)
+    path=<folder>       - Limit to folder
+    limit=<n>           - Max files
+    total               - Return match count
+    case                - Case sensitive
+    format=text|json    - Output format (default: text)
+
+  search:context        Search with matching line context
+    query=<text>        - Search query (required)
+    path=<folder>       - Limit to folder
+    limit=<n>           - Max files
+    case                - Case sensitive
+    format=text|json    - Output format (default: text)
+
+  search:open           Open search view
+    query=<text>        - Initial search query
+
+  snippet:disable       Disable a CSS snippet
+    name=<name>         - Snippet name (required)
+
+  snippet:enable        Enable a CSS snippet
+    name=<name>         - Snippet name (required)
+
+  snippets              List installed CSS snippets
+
+  snippets:enabled      List enabled CSS snippets
+
+  sync                  Pause or resume sync
+    on                  - Resume sync
+    off                 - Pause sync
+
+  sync:deleted          List deleted files in sync
+    total               - Return deleted file count
+
+  sync:history          List sync version history for a file
+    file=<name>         - File name
+    path=<path>         - File path
+    total               - Return version count
+
+  sync:open             Open sync history
+    file=<name>         - File name
+    path=<path>         - File path
+
+  sync:read             Read a sync version
+    file=<name>         - File name
+    path=<path>         - File path
+    version=<n>         - Version number (required)
+
+  sync:restore          Restore a sync version
+    file=<name>         - File name
+    path=<path>         - File path
+    version=<n>         - Version number (required)
+
+  sync:status           Show sync status
+
+  tab:open              Open a new tab
+    group=<id>          - Tab group ID
+    file=<path>         - File to open
+    view=<type>         - View type to open
+
+  tabs                  List open tabs
+    ids                 - Include tab IDs
+
+  tag                   Get tag info
+    name=<tag>          - Tag name (required)
+    total               - Return occurrence count
+    verbose             - Include file list and count
+
+  tags                  List tags in the vault
+    file=<name>         - File name
+    path=<path>         - File path
+    total               - Return tag count
+    counts              - Include tag counts
+    sort=count          - Sort by count (default: name)
+    format=json|tsv|csv - Output format (default: tsv)
+    active              - Show tags for active file
+
+  task                  Show or update a task
+    ref=<path:line>     - Task reference (path:line)
+    file=<name>         - File name
+    path=<path>         - File path
+    line=<n>            - Line number
+    toggle              - Toggle task status
+    done                - Mark as done
+    todo                - Mark as todo
+    daily               - Use daily note
+    status="<char>"     - Set status character
+
+  tasks                 List tasks in the vault
+    file=<name>         - Filter by file name
+    path=<path>         - Filter by file path
+    total               - Return task count
+    done                - Show completed tasks
+    todo                - Show incomplete tasks
+    status="<char>"     - Filter by status character
+    verbose             - Group by file with line numbers
+    format=json|tsv|csv - Output format (default: text)
+    active              - Show tasks for active file
+    daily               - Show tasks from daily note
+
+  template:insert       Insert template into active file
+    name=<template>     - Template name (required)
+
+  template:read         Read template content
+    name=<template>     - Template name (required)
+    resolve             - Resolve template variables
+    title=<title>       - Title for variable resolution
+
+  templates             List templates
+    total               - Return template count
+
+  theme                 Show active theme or get info
+    name=<name>         - Theme name for details
+
+  theme:install         Install a community theme
+    name=<name>         - Theme name (required)
+    enable              - Activate after install
+
+  theme:set             Set active theme
+    name=<name>         - Theme name (empty for default) (required)
+
+  theme:uninstall       Uninstall a theme
+    name=<name>         - Theme name (required)
+
+  themes                List installed themes
+    versions            - Include version numbers
+
+  unresolved            List unresolved links in vault
+    total               - Return unresolved link count
+    counts              - Include link counts
+    verbose             - Include source files
+    format=json|tsv|csv - Output format (default: tsv)
+
+  vault                 Show vault info
+    info=name|path|files|folders|size  - Return specific info only
+
+  vaults                List known vaults
+    total               - Return vault count
+    verbose             - Include vault paths
+
+  version               Show Obsidian version
+
+  web                   Open URL in web viewer
+    url=<url>           - URL to open (required)
+    newtab              - Open in new tab
+
+  wordcount             Count words and characters
+    file=<name>         - File name
+    path=<path>         - File path
+    words               - Return word count only
+    characters          - Return character count only
+
+  workspace             Show workspace tree
+    ids                 - Include workspace item IDs
+
+
+Developer:
+  dev:cdp               Run a Chrome DevTools Protocol command
+    method=<CDP.method> - CDP method to call (required)
+    params=<json>       - Method parameters as JSON
+
+  dev:console           Show captured console messages
+    clear               - Clear the console buffer
+    limit=<n>           - Max messages to show (default 50)
+    level=log|warn|error|info|debug  - Filter by log level
+
+  dev:css               Inspect CSS with source locations
+    selector=<css>      - CSS selector (required)
+    prop=<name>         - Filter by property name
+
+  dev:debug             Attach/detach Chrome DevTools Protocol debugger
+    on                  - Attach debugger
+    off                 - Detach debugger
+
+  dev:dom               Query DOM elements
+    selector=<css>      - CSS selector (required)
+    total               - Return element count
+    text                - Return text content
+    inner               - Return innerHTML instead of outerHTML
+    all                 - Return all matches instead of first
+    attr=<name>         - Get attribute value
+    css=<prop>          - Get CSS property value
+
+  dev:errors            Show captured errors
+    clear               - Clear the error buffer
+
+  dev:mobile            Toggle mobile emulation
+    on                  - Enable mobile emulation
+    off                 - Disable mobile emulation
+
+  dev:screenshot        Take a screenshot
+    path=<filename>     - Output file path
+
+  devtools              Toggle Electron dev tools
+
+  eval                  Execute JavaScript and return result
+    code=<javascript>   - JavaScript code to execute (required)
+


### PR DESCRIPTION
## Summary

Adds the **obsidian-cli** skill — a comprehensive Claude Code skill for interacting with Obsidian vaults via the built-in Obsidian CLI (v1.12+).

## Features

- **80+ commands** across file operations, search, daily notes, properties, tags, tasks, templates, links, plugins, themes, history, sync, and more
- Full command reference with all options documented
- Usage patterns and examples for common workflows
- Progressive disclosure: SKILL.md (core instructions) + references/commands.md (detailed reference)

## Structure

```
skills/obsidian-cli/
├── SKILL.md                    # Core skill definition with YAML frontmatter
├── LICENSE.txt                 # MIT License
└── references/
    └── commands.md             # Complete command reference (80+ commands)
```

## Testing

After installation, users can verify with:
```bash
obsidian --version  # Verify Obsidian CLI is available
```

Then ask Claude: 'Create a new note in my Obsidian vault' to test basic functionality.