### PR TITLE
fix(pdf): create output directory in convert_pdf_to_images.py

### DIFF
--- a/skills/pdf/scripts/convert_pdf_to_images.py
+++ b/skills/pdf/scripts/convert_pdf_to_images.py
@@ -7,6 +7,7 @@ from pdf2image import convert_from_path
 
 
 def convert(pdf_path, output_dir, max_dim=1000):
+    os.makedirs(output_dir, exist_ok=True)
     images = convert_from_path(pdf_path, dpi=200)
 
     for i, image in enumerate(images):


### PR DESCRIPTION
## Summary

Fixes #1025.

`skills/pdf/scripts/convert_pdf_to_images.py` writes PNGs via
`image.save(os.path.join(output_dir, "page_*.png"))`. `image.save()` does
not create parent directories, so when the caller passes a path that
doesn't exist yet (e.g. `/tmp/output_dir/` from a fresh shell), the
script fails on the first page with:

```
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/output_dir/page_1.png'
```

The script is invoked from `skills/pdf/forms.md` as a building block in
several workflows, and the failure mode is unfriendly to agents — the
error doesn't suggest the missing directory as the cause, and re-running
with a different path doesn't help.

## Change

A single line at the top of `convert()`:

```python
def convert(pdf_path, output_dir, max_dim=1000):
    os.makedirs(output_dir, exist_ok=True)
    ...
```

`os` is already imported, so no new dependencies. `exist_ok=True` keeps
the call idempotent for callers who do pre-create the directory.

## Verification

- Python syntax valid.
- `os.makedirs(output_dir, exist_ok=True)` behaviour confirmed:
  creates a missing directory, no-op when the directory already exists,
  supports nested paths.
- No CI / test framework is present in this repository, so verification
  is limited to the smoke checks above.

The issue body proposed the same one-line fix; this PR applies it
directly.