### PR TITLE
fix(skill-creator): map trigger slash commands and guide relative path resolution

### DIFF
--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -96,6 +96,7 @@ These word counts are approximate and you can feel free to go longer if needed.
 - Keep SKILL.md under 500 lines; if you're approaching this limit, add an additional layer of hierarchy along with clear pointers about where the model using the skill should go next to follow up.
 - Reference files clearly from SKILL.md with guidance on when to read them
 - For large reference files (>300 lines), include a table of contents
+- **Path resolution for references**: Relative paths (like `references/aws.md`) do not resolve automatically from the skill's own directory because the process current working directory (CWD) is the active workspace. Furthermore, some platforms (like Claude.ai) reject relative paths entirely. To ensure compatibility across platforms, always instruct the model to construct the absolute path to files in `references/` or other bundled directories. Direct the model to locate the injected header (e.g., `Base directory for this skill: <path>`) or find the skill directory, and combine it with the relative path to form a complete absolute path (e.g., `<base_directory>/references/aws.md`) before executing file reads or writes.
 
 **Domain organization**: When a skill supports multiple domains/frameworks, organize by variant:
 ```

--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -67,9 +67,13 @@ def run_single_query(
         )
         command_file.write_text(command_content)
 
+        # Substitute the skill name slash command in the query if it exists
+        # e.g., /triage-issue -> /triage-issue-skill-<unique_id>
+        modified_query = query.replace(f"/{skill_name}", f"/{clean_name}")
+
         cmd = [
             "claude",
-            "-p", query,
+            "-p", modified_query,
             "--output-format", "stream-json",
             "--verbose",
             "--include-partial-messages",
@@ -138,7 +142,8 @@ def run_single_query(
                                     pending_tool_name = tool_name
                                     accumulated_json = ""
                                 else:
-                                    return False
+                                    # Do not return False immediately; the model might run other helper tools first
+                                    pass
 
                         elif se_type == "content_block_delta" and pending_tool_name:
                             delta = se.get("delta", {})
@@ -163,9 +168,12 @@ def run_single_query(
                             tool_input = content_item.get("input", {})
                             if tool_name == "Skill" and clean_name in tool_input.get("skill", ""):
                                 triggered = True
+                                return True
                             elif tool_name == "Read" and clean_name in tool_input.get("file_path", ""):
                                 triggered = True
-                            return triggered
+                                return True
+                        # If the assistant message finishes and has no matches, return False
+                        return False
 
                     elif event.get("type") == "result":
                         return triggered


### PR DESCRIPTION
## Summary
This PR fixes two open issues in the `skill-creator` tool:
1. **Issue #1169:** The description optimization loop fails to trigger renamed candidate skills (scoring recall=0% across iterations) because trigger queries matching the original slash-command name (e.g. `/{skill_name}`) are not mapped to the clean renamed candidate command name (`/{clean_name}`).
2. **Issue #1153:** Relative paths inside skill bundles (like `references/`) do not resolve relative to the skill directory because path resolution is performed against the workspace CWD.

## Changes
- **run_eval.py:**
  - Dynamically replace `/{skill_name}` occurrences in the query with `/{clean_name}` to allow the renamed candidate command to trigger.
  - Remove the early-exit `return False` in the stream parser when the model invokes other non-Skill/Read tools first.
  - Correct the fallback assistant parsing to return `True` only when a match is found, and `False` otherwise.
- **SKILL.md:**
  - Added documentation explaining the path resolution pitfall for progressive disclosure bundles and instructing authors to guide models to construct absolute paths at runtime.