### PR TITLE
Add docs-to-course skill

### DIFF
--- a/skills/docs-to-course/LICENSE
+++ b/skills/docs-to-course/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Infoblox, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/docs-to-course/SKILL.md
+++ b/skills/docs-to-course/SKILL.md
@@ -30,120 +30,17 @@ If the user provides a GitHub link, clone or fetch the relevant files first. If 
 
 ---
 
-## Dependency: Firecrawl MCP
-
-This skill requires the Firecrawl MCP server for web crawling. Without it, URL inputs will not work — only local files and GitHub repos are available.
-
-**Setup (one-time):**
-
-1. Get a Firecrawl API key at [firecrawl.dev](https://firecrawl.dev) (free tier: 500 credits)
-2. Add the MCP server to Claude Code:
-
-```bash
-claude mcp add firecrawl -e FIRECRAWL_API_KEY=fc-your-key-here -- npx -y firecrawl-mcp
-```
-
-Or add to `~/.claude/settings.json` manually:
-
-```json
-{
-  "mcpServers": {
-    "firecrawl": {
-      "command": "npx",
-      "args": ["-y", "firecrawl-mcp"],
-      "env": {
-        "FIRECRAWL_API_KEY": "fc-your-key-here"
-      }
-    }
-  }
-}
-```
-
-Verify it's working: restart Claude Code and confirm `mcp__firecrawl__firecrawl_map` appears in available tools.
-
----
-
 ## The Process (5 Phases)
 
 **Phase 0 only runs when the input is a website URL.** For local files or GitHub repos, skip straight to Phase 1.
 
 ### Phase 0: Web Crawl via Firecrawl MCP (URL input only)
 
-When the user provides an `https://` URL, use the Firecrawl MCP to discover and fetch documentation pages. Firecrawl handles JS-rendered sites, robots.txt compliance, rate limiting, and HTML-to-markdown conversion automatically — no custom crawl logic needed.
+When the user provides an `https://` URL, **read `references/firecrawl.md`** before proceeding. It contains the full crawl procedure: site mapping, URL filtering rules, batch scrape arguments, credit accounting, and the exact user-facing messages at each step.
 
-#### 0A: Map the site
+If the Firecrawl tools are not available in your environment, the reference file also has the one-time setup instructions to share with the user. Local files and GitHub repos work without Firecrawl — skip straight to Phase 1 in that case.
 
-Use `firecrawl_map` to discover all URLs at the documentation domain:
-
-```
-Tool: mcp__firecrawl__firecrawl_map
-Arguments: { "url": "<the URL the user provided>" }
-```
-
-`firecrawl_map` returns a list of all URLs Firecrawl can see on the site. It respects robots.txt automatically — if a path is disallowed, those URLs will not appear in the results.
-
-If the map returns zero URLs or only the root URL, the site is likely behind authentication or heavily bot-protected. Tell the user:
-> "Firecrawl couldn't index this site — it may require a login or block automated access. Try downloading the docs locally or finding the source repository."
-
-#### 0B: Filter URLs to documentation pages
-
-From the map results, filter down to documentation-relevant URLs before spending fetch credits. Apply this logic mentally (no code to run — you're reading the URL list):
-
-**Exclude patterns** — drop any URL matching:
-- `/blog/`, `/changelog/`, `/release-notes/`, `/news/`
-- `/legal/`, `/privacy/`, `/terms/`, `/license/`
-- `/tag/`, `/category/`, `/author/`
-- File extensions: `.pdf`, `.zip`, `.png`, `.jpg`, `.svg`, `.css`, `.js`
-
-**Prioritize** shorter paths first — top-level section pages (e.g., `/docs/guide/`) before deep sub-pages (e.g., `/docs/guide/advanced/edge-cases/`).
-
-**Cap at 50 URLs.** If the filtered list exceeds 50, take the 50 with the shortest paths (broadest coverage). If the user's URL already points to a specific sub-section (e.g., `https://docs.example.com/api/`), keep only URLs within that prefix.
-
-Tell the user the filtered count before fetching:
-> "Found 73 pages — scoping to 50 most relevant for the documentation section. Fetching now..."
-
-#### 0C: Fetch all pages as clean markdown
-
-Use `firecrawl_batch_scrape` to fetch all filtered URLs in one call:
-
-```
-Tool: mcp__firecrawl__firecrawl_batch_scrape
-Arguments: {
-  "urls": ["<url1>", "<url2>", ...],   // the filtered list from 0B
-  "options": {
-    "formats": ["markdown"],
-    "onlyMainContent": true
-  }
-}
-```
-
-`onlyMainContent: true` tells Firecrawl to strip navigation, footers, sidebars, and cookie banners — returning only the page body as clean markdown. This is the key advantage over a plain HTTP fetch.
-
-Each result in the response includes:
-- `url` — the source URL (use this in spec citation references)
-- `markdown` — the clean page content
-
-If a batch exceeds Firecrawl's credit limit mid-run, it will return partial results. Proceed with what was returned and note what was skipped.
-
-#### 0D: Hand off to Phase 1
-
-Read the markdown content from the batch scrape results. Phase 1 proceeds identically to the local-files case — treat each page's `markdown` field as a document to analyze.
-
-Tell the user:
-> "Crawled N pages from [domain]. Proceeding to analysis."
-
-**Always record the source `url` for each page** so spec translation blocks can cite the exact page URL rather than a generic domain reference.
-
-#### Credit usage reference
-
-| Operation | Firecrawl credits |
-|---|---|
-| `firecrawl_map` (site discovery) | 1 credit |
-| `firecrawl_batch_scrape` per page | 1 credit per URL |
-| 50-page course crawl (typical) | ~51 credits |
-| Free tier | 500 credits |
-
-A free account covers roughly 9 full course crawls at 50 pages each. Credits reset monthly on paid plans.
+After Phase 0, treat each fetched page's markdown as a document and proceed to Phase 1. Record the source URL for each page so spec translation blocks can cite the exact page later.
 
 ---
 
@@ -573,5 +470,6 @@ Trying to teach all the documentation, producing a course so long it's unusable.
 
 Read these when you reach the relevant phase:
 
+- **`references/firecrawl.md`** — Firecrawl MCP setup instructions and the full Phase 0 crawl procedure (mapping, URL filtering, batch scrape, credit usage). Read when the input is an `https://` URL, or when Firecrawl tools are unavailable and the user needs setup instructions.
 - **`references/design-system.md`** — CSS custom properties, color palette with WCAG contrast ratios, typography scale, spacing, shadows, animations, accessibility notes, scrollbar styling. Read before writing any CSS.
 - **`references/interactive-elements.md`** — Implementation patterns for every interactive element: spec↔plain-English translations, prediction questions, completion problems, mid-module knowledge checks, retrieval callbacks, scenario quizzes with elaborative feedback, decision tree navigators, state machine visualizers, data flow animations, architecture diagrams, drag-and-drop matching, callout boxes, pattern cards, flow diagrams, glossary tooltips. Read before building any interactive elements.

--- a/skills/docs-to-course/SKILL.md
+++ b/skills/docs-to-course/SKILL.md
@@ -165,6 +165,68 @@ Structure the course as 5–7 modules plus a required synthesis module. The arc 
 
 **Do NOT present the curriculum for approval — build it.** Design internally, generate the HTML, let the user react to the result.
 
+#### 2C: Brand Skin (optional — branded courses only)
+
+Skip this sub-phase by default. Run it only when **one of these triggers fires**:
+
+1. The user's request includes a branding phrase: "with our brand," "branded course," "use our brand colors," "apply our corporate branding," "with [company] branding," or similar
+2. A `.brand.json` file exists in the working directory
+
+The brand skin is a thin override layer. It does not replace the design system — typography, layout, warm backgrounds, alternating module rhythm, semantic colors, and voice rules stay under the skill's control. Only the accent color, logo, brand name in the nav, and optionally the actor palette are brand-driven.
+
+**2C-1: Detect or intake**
+
+If `.brand.json` is present, read it and confirm:
+> "Found brand spec for [name] with primary [#hex]. Apply it to this course?"
+
+If not present, prompt the user for:
+
+| Field | Required | Format |
+|---|---|---|
+| Brand name | yes | string |
+| Primary brand color | yes | hex (e.g., `#1A4FBA`) |
+| Logo | optional | local SVG path, PNG/JPG path, or URL |
+| Secondary colors | optional | up to 4 hex values for the actor palette |
+| Co-brand tagline | optional | short string |
+
+Persist the intake as `.brand.json` in the working directory so future runs in the same project don't re-prompt.
+
+**2C-2: Validate the brand color**
+
+Compute the contrast ratio of the brand primary against `#FAF7F2` (the warm off-white background):
+
+- ≥ 4.5:1 — safe for any use
+- 3:1 – 4.5:1 — large text only (acceptable for module numbers and titles)
+- < 3:1 — fails WCAG AA. Report the actual ratio and ask the user for a darker brand variant. Do not silently mutate the brand color.
+
+**2C-3: Embed the logo**
+
+The output must remain self-contained. Inline the logo into the nav:
+
+- **SVG** — paste the SVG markup directly into the nav HTML; strip any external `<image>`, `<use href>`, or web-font refs
+- **PNG/JPG (local)** — base64-encode and embed as a data URI
+- **URL** — fetch at build time, embed as data URI
+
+Render at 24–32px height in the nav (nav-height is 50px). **Logo appears in the nav only** — not in module headers, not in the synthesis reference card. Brand presence stays light.
+
+**2C-4: Apply the override**
+
+See `references/design-system.md` → "Brand Skin Layer" for the exact override mechanism, the full list of skinnable tokens, and the `.brand.json` schema. In short: emit a second `:root` block in the course's `<style>` containing only the overridden accent tokens and the derived radial-gradient tint; CSS cascade picks the brand values.
+
+**Actor palette rule:**
+- 5 secondary colors provided → wholesale replacement of `--color-actor-1..5`
+- 1–4 secondary colors provided → mix: brand colors fill `--color-actor-1..N`, defaults remain for the rest
+- 0 provided → defaults stand
+
+**2C-5: Nav rendering**
+
+Replace the default `.nav-title` text with a logo-plus-name lockup:
+- Logo on the left (24–32px height)
+- Brand name immediately right of the logo as `.nav-title`
+- Course title moves to the right side of the nav or below as a subtitle
+
+If no logo is provided, render brand name only.
+
 ---
 
 ### Phase 3: Build the Course
@@ -375,15 +437,20 @@ Every technical term with a precise meaning in this documentation gets a dashed-
 
 ### Design Identity
 
-Read `references/design-system.md` for the full token system. Non-negotiable principles:
+Read `references/design-system.md` for the full token system. **Immutable principles — never overridden, including by brand skins:**
 
 - **Warm palette**: off-white backgrounds, warm grays — no cold whites or blues
-- **Bold accent**: one confident color (vermillion, coral, teal — not purple gradients). Match to the subject matter's personality.
 - **Distinctive typography**: Bricolage Grotesque for headings — never Inter, Roboto, or Arial
 - **Generous whitespace**: modules breathe; max 3–4 short paragraphs per screen
 - **Alternating backgrounds**: even/odd modules alternate warm tones for visual rhythm
 - **Dark spec blocks**: dark background for spec-language excerpts — signals "official text"
 - **Depth without harshness**: warm RGBA shadows only — never pure black
+
+**Brand-overridable (only when invoked with corporate branding — see Phase 2C):**
+
+- **Bold accent**: one confident color. Defaults to vermillion, coral, teal, amber, or forest (matched to the subject matter's personality). When a brand skin is applied, the brand primary replaces the default accent and the radial-gradient tint is derived from it.
+- **Nav logo and brand name**: only appears when a brand spec is supplied.
+- **Actor palette**: defaults to the five colors in `references/design-system.md`. A brand spec can replace 1–5 of them.
 
 ---
 

--- a/skills/docs-to-course/SKILL.md
+++ b/skills/docs-to-course/SKILL.md
@@ -1,0 +1,577 @@
+---
+name: docs-to-course
+description: "Turn any documentation into a beautiful, interactive single-page HTML training course. Use this skill whenever someone wants to create a course, tutorial, or learning artifact from documentation, specs, RFCs, wikis, API references, whitepapers, or any technical writing. Also trigger when users mention 'turn this doc into a course,' 'make training from this,' 'create a tutorial from this spec,' 'interactive course from documentation,' 'teach this RFC,' 'onboarding from docs,' or 'learn from this documentation.' This skill produces a stunning, self-contained HTML file with scroll-based navigation, animated concept visualizations, embedded quizzes, and spec-language-to-plain-English side-by-side translations."
+license: MIT. LICENSE file has complete terms.
+compatibility: Requires the Firecrawl MCP server (firecrawl-mcp) for URL inputs. Works without it for local files and GitHub repos.
+---
+
+# Docs-to-Course
+
+Transform any documentation into a stunning, interactive single-page HTML training course. The output is a single self-contained HTML file (no dependencies except Google Fonts) that teaches the material through scroll-based modules, animated concept visualizations, formative and summative quizzes, spaced retrieval callbacks, and plain-English translations of dense spec language.
+
+Works with: Markdown files, PDFs, RFCs, API reference docs, architecture decision records, wikis, whitepapers, onboarding guides, standards documents, internal runbooks, product specs — any written documentation. **Also works directly from documentation websites** via built-in crawling (Phase 0).
+
+## First-Run Welcome
+
+When the skill is first triggered and the user hasn't specified documentation yet, introduce yourself:
+
+> **I can turn any documentation into an interactive training course — no teaching experience required.**
+>
+> Just point me at your docs:
+> - **A website URL** — e.g., "make a course from https://docs.example.com" — I'll crawl the site automatically
+> - **A local folder** — e.g., "turn ./docs into a course"
+> - **A single file** — e.g., "make a course from RFC 9460" or "turn this spec.md into a course"
+> - **A GitHub link** — e.g., "make a course from https://github.com/user/repo/wiki"
+> - **The current project** — just say "turn the docs into a course"
+>
+> I'll read the documentation, identify the 20% that provides 80% of the practical value, and generate a beautiful single-page HTML course with concept diagrams, plain-English spec translations, and scenario quizzes. The whole thing runs in your browser — no setup needed.
+
+If the user provides a GitHub link, clone or fetch the relevant files first. If they say "this project's docs," look for a `docs/` folder, `README.md`, wiki pages, or any `.md`/`.rst`/`.txt` files in the current working directory.
+
+---
+
+## Dependency: Firecrawl MCP
+
+This skill requires the Firecrawl MCP server for web crawling. Without it, URL inputs will not work — only local files and GitHub repos are available.
+
+**Setup (one-time):**
+
+1. Get a Firecrawl API key at [firecrawl.dev](https://firecrawl.dev) (free tier: 500 credits)
+2. Add the MCP server to Claude Code:
+
+```bash
+claude mcp add firecrawl -e FIRECRAWL_API_KEY=fc-your-key-here -- npx -y firecrawl-mcp
+```
+
+Or add to `~/.claude/settings.json` manually:
+
+```json
+{
+  "mcpServers": {
+    "firecrawl": {
+      "command": "npx",
+      "args": ["-y", "firecrawl-mcp"],
+      "env": {
+        "FIRECRAWL_API_KEY": "fc-your-key-here"
+      }
+    }
+  }
+}
+```
+
+Verify it's working: restart Claude Code and confirm `mcp__firecrawl__firecrawl_map` appears in available tools.
+
+---
+
+## The Process (5 Phases)
+
+**Phase 0 only runs when the input is a website URL.** For local files or GitHub repos, skip straight to Phase 1.
+
+### Phase 0: Web Crawl via Firecrawl MCP (URL input only)
+
+When the user provides an `https://` URL, use the Firecrawl MCP to discover and fetch documentation pages. Firecrawl handles JS-rendered sites, robots.txt compliance, rate limiting, and HTML-to-markdown conversion automatically — no custom crawl logic needed.
+
+#### 0A: Map the site
+
+Use `firecrawl_map` to discover all URLs at the documentation domain:
+
+```
+Tool: mcp__firecrawl__firecrawl_map
+Arguments: { "url": "<the URL the user provided>" }
+```
+
+`firecrawl_map` returns a list of all URLs Firecrawl can see on the site. It respects robots.txt automatically — if a path is disallowed, those URLs will not appear in the results.
+
+If the map returns zero URLs or only the root URL, the site is likely behind authentication or heavily bot-protected. Tell the user:
+> "Firecrawl couldn't index this site — it may require a login or block automated access. Try downloading the docs locally or finding the source repository."
+
+#### 0B: Filter URLs to documentation pages
+
+From the map results, filter down to documentation-relevant URLs before spending fetch credits. Apply this logic mentally (no code to run — you're reading the URL list):
+
+**Exclude patterns** — drop any URL matching:
+- `/blog/`, `/changelog/`, `/release-notes/`, `/news/`
+- `/legal/`, `/privacy/`, `/terms/`, `/license/`
+- `/tag/`, `/category/`, `/author/`
+- File extensions: `.pdf`, `.zip`, `.png`, `.jpg`, `.svg`, `.css`, `.js`
+
+**Prioritize** shorter paths first — top-level section pages (e.g., `/docs/guide/`) before deep sub-pages (e.g., `/docs/guide/advanced/edge-cases/`).
+
+**Cap at 50 URLs.** If the filtered list exceeds 50, take the 50 with the shortest paths (broadest coverage). If the user's URL already points to a specific sub-section (e.g., `https://docs.example.com/api/`), keep only URLs within that prefix.
+
+Tell the user the filtered count before fetching:
+> "Found 73 pages — scoping to 50 most relevant for the documentation section. Fetching now..."
+
+#### 0C: Fetch all pages as clean markdown
+
+Use `firecrawl_batch_scrape` to fetch all filtered URLs in one call:
+
+```
+Tool: mcp__firecrawl__firecrawl_batch_scrape
+Arguments: {
+  "urls": ["<url1>", "<url2>", ...],   // the filtered list from 0B
+  "options": {
+    "formats": ["markdown"],
+    "onlyMainContent": true
+  }
+}
+```
+
+`onlyMainContent: true` tells Firecrawl to strip navigation, footers, sidebars, and cookie banners — returning only the page body as clean markdown. This is the key advantage over a plain HTTP fetch.
+
+Each result in the response includes:
+- `url` — the source URL (use this in spec citation references)
+- `markdown` — the clean page content
+
+If a batch exceeds Firecrawl's credit limit mid-run, it will return partial results. Proceed with what was returned and note what was skipped.
+
+#### 0D: Hand off to Phase 1
+
+Read the markdown content from the batch scrape results. Phase 1 proceeds identically to the local-files case — treat each page's `markdown` field as a document to analyze.
+
+Tell the user:
+> "Crawled N pages from [domain]. Proceeding to analysis."
+
+**Always record the source `url` for each page** so spec translation blocks can cite the exact page URL rather than a generic domain reference.
+
+#### Credit usage reference
+
+| Operation | Firecrawl credits |
+|---|---|
+| `firecrawl_map` (site discovery) | 1 credit |
+| `firecrawl_batch_scrape` per page | 1 credit per URL |
+| 50-page course crawl (typical) | ~51 credits |
+| Free tier | 500 credits |
+
+A free account covers roughly 9 full course crawls at 50 pages each. Credits reset monthly on paid plans.
+
+---
+
+### Phase 1: Analysis — Learner, Scope, and Content
+
+Do all three sub-phases before writing any HTML or designing any curriculum.
+
+#### 1A: Identify the Primary Learner
+
+Pick **one** primary learner profile. A course designed for everyone serves no one. Common profiles for documentation:
+
+| Profile | What they already know | What they need to leave with |
+|---|---|---|
+| New practitioner | Domain basics, not this system | Mental model + vocabulary to work independently |
+| Adjacent-field expert | Deep expertise nearby, not here | Tradeoffs and key differences from what they know |
+| Implementer | Conceptual understanding | Precise rules, edge cases, failure modes |
+| Decision-maker / lead | Business context | Enough depth to ask the right questions and evaluate options |
+| Operator / oncall | How to use it, not why | Why it works this way + what to do when it breaks |
+
+**Write a one-paragraph learner profile:** who this person is, what they already know confidently, what they don't know, and what they need to be able to do after the course. Every content and design decision flows from this. Post it at the top of your internal curriculum plan before continuing.
+
+If the user has specified an audience, use it. Otherwise, infer from the documentation itself: an RFC is written for implementers, an API reference for integrators, an ADR for team engineers, a runbook for operators.
+
+#### 1B: Scope the Course
+
+Large documentation sets cannot become a single course without scoping. Apply the 80/20 rule: **identify the 20% of the documentation that provides 80% of the practical value** for the primary learner. Everything else is reference material they can look up — don't teach it.
+
+**Scoping heuristics:**
+- A single HTML course should take **15–25 minutes per module** to complete, with 5–7 modules maximum
+- If the documentation has more material than 5–7 modules can cover well, scope to the core flow and note what's excluded
+- Prioritize: concepts required to understand anything else → the main operational flow → the most common edge cases → the most dangerous gotchas
+- Cut: exhaustive option reference, historical rationale that doesn't affect current behavior, content the learner will look up rather than internalize
+
+**Document your scope decision:** write one sentence for each major section of the documentation — "include (core flow)," "include (edge case, high risk)," or "exclude (reference, low teaching value)."
+
+#### 1C: Analyze the Content
+
+Now read the scoped documentation deeply. Extract:
+
+- **The core problem** — what situation or need does this address? What goes wrong without it?
+- **The key concepts** — the 3–7 ideas someone must hold in their head for everything else to make sense
+- **Prerequisite knowledge map** — what does the documentation assume the reader already knows? What gaps might the primary learner have?
+- **The mental model** — how do the pieces fit together? Map the relationships, not just the inventory.
+- **Technical vocabulary** — terms used with a precise meaning in this document, especially terms that look familiar but differ from everyday usage or adjacent-field usage
+- **The tradeoffs** — every design decision trades something. What did the authors choose and why?
+- **The gotchas** — mistakes practitioners commonly make; things the doc warns about; failure modes
+- **The "so what"** — after understanding this, what can the learner now do that they couldn't before?
+
+**Adjust analysis focus by document type:**
+
+| Document type | Primary analysis focus |
+|---|---|
+| RFC / standards document | Problem statement, protocol flow, MUST/SHOULD/MAY distinctions, security considerations, edge cases |
+| API reference | Authentication, core data model, common call patterns, error handling, rate limits |
+| Architecture doc / ADR | Decision made, alternatives considered, tradeoffs, when to revisit |
+| Onboarding guide | System mental model, key operations, common first-week mistakes |
+| Runbook / operational guide | Action sequences, decision points, what can go wrong and how to recover |
+| Whitepaper | The claim, the evidence, the assumptions, the practitioner implications |
+
+---
+
+### Phase 2: Curriculum Design
+
+#### 2A: Write Learning Objectives First
+
+Before designing any module's content, write **1–3 learning objectives** for each module. Objectives must be:
+
+- **Measurable** — start with an action verb from Bloom's taxonomy
+- **Specific** — describe what the learner will be able to do with the knowledge, not just that they'll "understand" it
+- **Pitched at application or above** — avoid "remember" and "understand" objectives; favor "apply," "analyze," "evaluate," and "create"
+
+**Bloom's verb reference (use these):**
+
+| Level | Verbs to use |
+|---|---|
+| Apply (L3) | implement, use, execute, solve, demonstrate, apply |
+| Analyze (L4) | differentiate, compare, distinguish, examine, break down, trace |
+| Evaluate (L5) | judge, justify, defend, critique, assess, select (given criteria) |
+| Create (L6) | design, construct, compose, propose, formulate |
+
+**Avoid:** "understand," "know," "learn," "appreciate," "be familiar with" — these are not measurable.
+
+**Example objectives (from a DNS TTL course):**
+- *Apply*: Given a DNS response with a specific TTL, determine the correct caching behavior at each resolver type.
+- *Analyze*: Given a broken DNS propagation scenario, trace which component is most likely at fault and why.
+- *Evaluate*: Given two TTL strategies for a high-availability service, select the better one and justify the tradeoff.
+
+**Check alignment:** once objectives are written, verify that your planned content actually teaches each objective and that your planned quiz question actually tests it. If content doesn't connect to an objective, cut it or add an objective. If an objective has no quiz question, write one.
+
+#### 2B: Design the Curriculum Arc
+
+Structure the course as 5–7 modules plus a required synthesis module. The arc always starts from **why this matters** and moves toward **how to apply it**, ending with a synthesis that connects all the pieces.
+
+| Module position | Purpose | Instructional strategy |
+|---|---|---|
+| 1 | The problem and the big picture | Hook with a concrete failure scenario; establish why this exists |
+| 2 | Key concepts and vocabulary | Pre-train components in isolation before showing them working together |
+| 3 | The core flow | Trace end-to-end with a worked example; then a faded example |
+| 4 | The important details | Segment into sub-flows; address edge cases that affect the primary learner |
+| 5 | Design decisions and tradeoffs | Evaluate alternatives; build judgment, not just knowledge |
+| 6 | Applying it in practice | Transfer activity: new scenario the learner hasn't seen |
+| 7 (optional) | When things go wrong | Debugging mental model; failure modes; recovery patterns |
+| Final | Synthesis and closure | Reassemble the full mental model; return to Module 1's opening scenario |
+
+**Scaffolding between modules:**
+- End every module with a one-sentence bridge: *"In the next module, we'll see what happens when this mechanism meets [complication]."*
+- Begin every module from Module 2 onward with a **prerequisite signal**: *"This module assumes you understand [concept from previous module]. If that's fuzzy, scroll back to Module N."*
+- From Module 3 onward, include one **retrieval callback** per module — a question or reference that resurfaces a concept from an earlier module in a new context.
+
+**Each module must contain:**
+- 1–3 learning objectives (written in Phase 2A)
+- A **prerequisite signal** (Modules 2+)
+- 3–6 screens, each teaching exactly one idea
+- At least one **spec-to-plain-English translation**
+- At least one **formative check** embedded mid-module (prediction question, inline knowledge check, or completion problem)
+- At least one **interactive element** (see reference files)
+- One or two **"aha!" callout boxes** — insights the doc never states directly but practitioners learn the hard way
+- At least one **metaphor**, followed immediately by its boundary (*"This analogy breaks down when X, because in reality Y"*)
+- A **summative quiz** at the end (3–5 scenario-based questions)
+- A **retrieval callback** (Modules 3+)
+- A **bridge sentence** to the next module
+
+**Do NOT present the curriculum for approval — build it.** Design internally, generate the HTML, let the user react to the result.
+
+---
+
+### Phase 3: Build the Course
+
+Generate a single HTML file with embedded CSS and JavaScript. Read `references/design-system.md` for the complete CSS design tokens, typography, accessibility requirements, and color system. Read `references/interactive-elements.md` for implementation patterns of every interactive element type.
+
+#### 3A: Accessibility baseline (non-negotiable)
+
+Every course must meet WCAG 2.1 AA as a floor. Read the accessibility section of `references/design-system.md` before writing any HTML. Required at minimum:
+
+- All text meets contrast ratio requirements (4.5:1 body, 3:1 large text)
+- All interactive elements have `aria-label` or visible label and correct `role`
+- All diagrams and visual-only content have descriptive `alt` text or `aria-label`
+- All interactive elements are keyboard-operable (tab, enter, space, arrow keys)
+- Focus states are always visible — never `outline: none` without a replacement
+- Drag-and-drop has a keyboard-accessible fallback (click-to-select, click-to-place)
+- Tooltips are dismissible by keyboard (Escape key)
+- Color is never the only means of conveying information (always pair with text or icon)
+
+#### 3B: Build order
+
+1. **Foundation** — HTML shell with all module sections (empty), complete CSS design system, navigation bar with progress tracking, scroll-snap behavior, keyboard navigation, and scroll-triggered animations. After this step, you have a working skeleton.
+
+2. **One module at a time** — For each module:
+   a. Write the prerequisite signal and learning objectives display
+   b. Build the content screens
+   c. Add formative checks (prediction question or completion problem)
+   d. Add the spec translation block(s)
+   e. Add the retrieval callback (Module 3+)
+   f. Add the summative quiz
+   g. Add the bridge sentence
+
+3. **Synthesis module** — Build last, after all content modules exist. See synthesis module spec below.
+
+4. **Polish pass** — transitions, mobile responsiveness, visual consistency, accessibility audit.
+
+#### 3C: The synthesis module (required)
+
+Every course must end with a synthesis module. It is **not** a summary — it is a reassembly. Structure:
+
+1. **Return to the opening scenario** — restate the concrete problem or failure from Module 1. Now ask the learner to solve it with everything they've learned. This is the highest-value transfer activity in the course.
+
+2. **The assembled mental model** — show the complete concept map, architecture diagram, or flow diagram that represents the whole system. Each piece should be recognizable from a specific earlier module. Clicking or hovering a component links back to where it was taught.
+
+3. **What you can now do** — 3–5 concrete capabilities the learner has gained, phrased as actions: *"You can now trace a DNS propagation failure to its source," not "You now understand DNS propagation."*
+
+4. **Where to go next** — a reference card or checklist the learner keeps: the 5 things to remember, the 3 most dangerous gotchas, the 2 tradeoffs to revisit when making a decision.
+
+5. **A final transfer question** — one open-ended scenario the learner should be able to reason through now. No answer provided — this is for reflection, not grading.
+
+#### 3D: Critical implementation rules
+
+- File must be completely self-contained (only external dependency: Google Fonts CDN)
+- Use CSS `scroll-snap-type: y proximity` (NOT `mandatory`)
+- Use `min-height: 100dvh` with `100vh` fallback
+- Only animate `transform` and `opacity` for GPU performance
+- Wrap all JS in an IIFE; use `passive: true` on scroll listeners; throttle with `requestAnimationFrame`
+- Include touch support for drag-and-drop; keyboard nav (arrow keys); ARIA attributes throughout
+
+#### 3E: Voice & writing rules (humanizer pass — required before output)
+
+All prose in the generated HTML must pass these rules. Apply them while writing content, then do a final pass before closing `</body>`. When uncertain, invoke the `humanizer` skill on a draft section.
+
+**Banned constructions — fix every instance:**
+
+| Pattern | Example to avoid | Fix |
+|---|---|---|
+| Em dash in prose | `detects threats — surfacing them as tickets` | Use a colon, comma, or split the sentence |
+| Significance inflation | `pivotal, crucial, key, invaluable, vital, testament, underscores` | Use plain words: important, useful, shows, proves |
+| Copula avoidance | `serves as, stands as, represents, functions as` | Use `is`, `are`, `works as` |
+| Negative parallelism | `not just X, but Y` · `it's not about X, it's about Y` | Say the thing directly |
+| False ranges | `from detection to takedown, from alerts to hunting` | List the items explicitly |
+| Promotional language | `powerful, seamless, stunning, robust, groundbreaking` | Cut it or replace with a specific claim |
+| -ing padding | `...ensuring compliance, highlighting the risk, showcasing how` | Restructure or cut the participial phrase |
+| Generic upbeat endings | `the future looks bright · you're on your way · exciting times ahead` | End with a concrete next action |
+| Vague attributions | `experts argue, research shows, industry consensus` | Cite the actual source or cut |
+| Sycophantic feedback | `Great job! Excellent thinking!` | Just give the feedback |
+
+**Rules for quiz and prediction text specifically:**
+
+- Wrong-answer feedback must never start with "Not quite" or "That's not right" — vary the opening; don't make it sound automated
+- Correct-answer feedback must not start with "Correct!" or "Exactly right!" — just explain the concept directly
+- Prediction commit button text: use "Lock in my answer →" (single select) or "Lock in my answers →" (multi-select). Never "Submit" or "Confirm"
+- Prediction reveals should start with the surprise, not a preamble ("All four — and that's the problem" not "The correct answer is all four")
+
+**Voice baseline for educational content:**
+
+Write like a knowledgeable colleague talking to a smart peer, not like documentation. Sentences can be short. Opinions are allowed. If something has a counterintuitive behavior, say so — "This surprises most people." If something is genuinely tricky, say so — "This is the one that trips up experienced analysts." Avoid sounding assembled.
+
+---
+
+## Content Philosophy
+
+### Objectives-First, Then Content
+
+Every content decision should be traceable to a learning objective. If a screen doesn't help the learner achieve an objective, cut it or reframe it. The discipline of writing objectives before content is what separates a course from a guided tour of the documentation.
+
+### Show, Don't Tell — Aggressively Visual
+
+People's eyes glaze over text blocks. Follow these hard rules:
+
+**Text limits:**
+- Max **2–3 sentences** per text block. Fourth sentence → convert to a visual.
+- Every screen must be **at least 50% visual** (diagrams, translation blocks, cards, animations, badges).
+
+**Convert text to visuals:**
+- A list of 3+ concepts → **cards with icons**
+- A sequence of steps → **flow diagram** or **numbered step cards**
+- "Component A interacts with Component B" → **animated data flow** or **architecture diagram**
+- Dense spec language → **spec ↔ plain-English translation block**
+- Comparing two approaches → **side-by-side columns**
+
+**Visual breathing room:** generous spacing between elements; alternate full-width visuals with narrow text blocks for rhythm; every module has at least one hero visual.
+
+### Spec ↔ Plain English Translations
+
+Left panel: verbatim text from the documentation (as a styled blockquote — never modified, trimmed, or paraphrased). Right panel: a three-part annotation:
+
+1. **What it means** — the plain translation
+2. **Why it matters** — the practical consequence of getting this right or wrong
+3. **Watch out for** — the gotcha, the edge case, the thing everyone gets wrong first
+
+Never modify the spec text. If a passage is too long, *choose* a naturally self-contained excerpt. The learner should be able to open the original document and find the exact text they learned from.
+
+### One Concept Per Screen
+
+Each screen within a module teaches exactly one idea. If you need more space, add a screen — don't cram.
+
+### Metaphors First — With Boundaries
+
+Introduce every new concept with a metaphor. Then immediately ground it: *"In this spec, this looks like..."* Then add the boundary: *"This analogy breaks down when X, because in reality Y."*
+
+The boundary is not optional. Every metaphor has a failure mode — learners who don't know where the metaphor ends form misconceptions that are harder to correct than if you'd used no metaphor at all.
+
+**No recycled metaphors.** Never "restaurant" or "kitchen" more than once. Each concept deserves a metaphor that feels inevitable for that specific idea. The TTL is like a milk expiration date. An authoritative server is like a land registry — the definitive record, not a copy. RFC MUST/SHOULD/MAY is like legal language: MUST means the contract is void if you don't, SHOULD means you'd lose in court if you didn't without good reason, MAY means it's explicitly permitted.
+
+### Cognitive Load Management
+
+**Intrinsic load (complexity of the material itself):**
+- **Pre-train components** before showing them working together. Teach what a resolver does in isolation before showing resolver → authoritative → resolver flows.
+- **Segmentation**: break complex multi-step processes into sub-flows. Teach each sub-flow to completion before connecting them.
+- **Worked examples → faded examples**: for complex processes, show a fully worked example first, then a partially worked one (with blanks), then ask the learner to complete or extend it. Never jump from example to quiz without a faded step.
+
+**Extraneous load (complexity in the presentation):**
+- Max 2–3 sentences per text block
+- One concept per screen
+- Visual over verbal everywhere possible
+- No horizontal scrollbars — ever
+
+### Formative Assessment Throughout
+
+Don't save all assessment for the end of a module. Three formative patterns — use at least one per module:
+
+**Prediction questions** (place before introducing a concept):
+- *"Before we show you how TTL propagation works, what would you expect to happen if an intermediate cache extended a record's TTL? Keep your prediction in mind as you read on."*
+- Creates a curiosity gap; activates prior knowledge; makes the correct answer more memorable when it arrives
+
+**Mid-module knowledge checks** (1 question, embedded in content):
+- Single inline question after a key concept, before moving to the next
+- Low stakes — no score, just "you're tracking" vs "read that screen again"
+- Immediately corrective: the feedback appears inline, not at the end
+
+**Completion problems** (faded worked examples):
+- Show a process with one or two steps left blank for the learner to fill in
+- More challenging than a multiple-choice quiz; more supported than an open question
+- See `references/interactive-elements.md` for the implementation pattern
+
+### Spaced Retrieval — Cross-Module Callbacks
+
+From Module 3 onward, every module begins or ends with a retrieval callback: a question or scenario that requires the learner to use a concept from an earlier module in a new context.
+
+This is not a review question ("What did we say about X?"). It is a *transfer* question ("In Module 2 we learned that resolvers cache responses — given what you now know about authoritative servers, what would happen if an authoritative server returns a response with TTL 0 to a resolver that has already cached that record?").
+
+The callback should feel like the material is building on itself, not testing whether the learner was paying attention.
+
+### Summative Quizzes That Test Application
+
+Placed at the end of each module. 3–5 questions. Every question must present a new situation the learner hasn't seen and ask them to *apply* what they learned — not recite it.
+
+**Question hierarchy (use types 1–2 most):**
+1. **"What would you do?" scenarios** — new situation, apply the knowledge
+2. **Debugging scenarios** — something is broken, trace the cause
+3. **Tradeoff evaluation** — two approaches, select and justify given criteria
+4. **Tracing exercises** — follow the data/control flow through a new example
+
+**Never quiz:** definitions, section numbers, verbatim text recall, anything answerable by scrolling up.
+
+**Elaborative feedback on wrong answers:** don't just reveal the right answer. Explain *why the wrong answer is wrong* — what reasoning flaw it reflects, and what would have to be true for the wrong answer to be correct. This turns an incorrect attempt into a learning event.
+
+Example of weak feedback: *"Not quite — the correct answer is B."*
+Example of elaborative feedback: *"That would be correct if resolvers were allowed to extend TTLs from authoritative sources — but RFC 2181 explicitly forbids this to prevent cache poisoning. The reasoning the spec uses is that only the authoritative source knows how fresh a record actually is."*
+
+**Quiz tone:** non-punitive, no score shown. The quiz is a thinking exercise, not a test.
+
+### Glossary Tooltips — Every Term in Context
+
+Every technical term with a precise meaning in this documentation gets a dashed-underline tooltip on first use in each module. The definition should explain what this term means *in this specific document*, not just the generic definition.
+
+**Be extremely aggressive with tooltips:**
+- Acronyms — ALWAYS on first use
+- RFC normative language ("MUST," "SHOULD," "MAY," "RECOMMENDED," "OPTIONAL")
+- Terms that look familiar but are used technically ("record," "field," "class," "type," "authority")
+- Terms the primary learner's adjacent domain uses differently than this spec does
+
+**Tooltip content structure:** plain-English definition (1–2 sentences) + a phrase on *how you'd use this term when giving instructions* — e.g., *"When asking an engineer about this, you'd say 'Is this a normative MUST or a SHOULD?' to find out how much flexibility there is in the implementation."*
+
+**Cursor:** `cursor: pointer` (never `cursor: help`). **Positioning:** `position: fixed` appended to `document.body` to prevent clipping. See `references/interactive-elements.md`.
+
+### Design Identity
+
+Read `references/design-system.md` for the full token system. Non-negotiable principles:
+
+- **Warm palette**: off-white backgrounds, warm grays — no cold whites or blues
+- **Bold accent**: one confident color (vermillion, coral, teal — not purple gradients). Match to the subject matter's personality.
+- **Distinctive typography**: Bricolage Grotesque for headings — never Inter, Roboto, or Arial
+- **Generous whitespace**: modules breathe; max 3–4 short paragraphs per screen
+- **Alternating backgrounds**: even/odd modules alternate warm tones for visual rhythm
+- **Dark spec blocks**: dark background for spec-language excerpts — signals "official text"
+- **Depth without harshness**: warm RGBA shadows only — never pure black
+
+---
+
+## Gotchas — Common Failure Points
+
+### Teaching the Outline, Not the Understanding
+The most common failure. Writing a course that mirrors the documentation's section structure rather than teaching the mental model. A section-by-section tour is not a course — it's a narrated table of contents. **Fix:** write learning objectives first. If your module structure maps 1:1 to the doc's section structure, you're following the outline, not the learning arc. Reorganize around *what the learner needs to understand first* to make everything else click.
+
+### Objectives Written After Content
+Writing content first, then adding objectives that describe what you already wrote. This is backwards and produces weak objectives. **Fix:** objectives must be written before content. If you catch yourself writing "understand" or "know," stop and rewrite with a Bloom's L3+ verb.
+
+### Monolithic Learner Profile
+Trying to serve multiple audiences (implementer AND decision-maker AND operator) in one course. The result serves none of them. **Fix:** name one primary learner in Phase 1A. Every content decision after that references this person.
+
+### No Metaphor Boundary
+A metaphor without a boundary teaches the concept and a misconception simultaneously. Learners extend metaphors past their valid range. **Fix:** every metaphor is followed immediately by one sentence explaining where it breaks down.
+
+### Formative Assessment Missing
+Quizzes only at module end means learners discover gaps after seeing all the content, not while learning it. **Fix:** include at least one prediction question, inline knowledge check, or completion problem per module, placed *before* the summative quiz.
+
+### No Retrieval Callbacks
+Each module is self-contained with no references back to earlier material. Learning fades quickly when concepts are only encountered once. **Fix:** from Module 3 onward, every module opens or closes with a retrieval callback that applies an earlier concept in a new context.
+
+### No Synthesis Module
+The course ends when the content ends. The learner's working memory never consolidates. **Fix:** always build the synthesis module — return to the opening scenario, show the assembled mental model, give a reference card.
+
+### Weak Wrong-Answer Feedback
+Feedback that just reveals the right answer without explaining why the wrong answer was wrong. **Fix:** for every distractor in a quiz, write what reasoning flaw it represents and what would have to be true for it to be correct.
+
+### Prediction Question Single-Select Mismatch
+Writing a prediction question whose reveal answer is "all of the above" (or any answer requiring multiple options) but using the default single-select (radio-style) interaction — where clicking any option clears the others. The learner is forced to pick one, then sees that every option was correct, making the interaction feel broken and dishonest.
+
+**The root cause:** ask yourself *how many options should the learner have selected when they commit?* If the answer is more than one, single-select is wrong.
+
+**Fix:** add `data-multiselect="true"` to the `prediction-block` div. This switches `selectPrediction()` to toggle-on-click (checkbox-style) rather than clear-all-then-set (radio-style). The commit button appears once at least one option is selected. Update the label to "Select all that apply" and rewrite the question stem to invite multiple selections ("Pick every option you think is plausible" rather than "Which one is most likely").
+
+**Decision rule:**
+- Use **single-select** (default): when exactly one option is most-correct. Stem: "Which one…" or "What would you expect…"
+- Use **multi-select** (`data-multiselect="true"`): when the reveal is "all of these," "several of these," or any combination. Stem: "Select all that apply" / "Pick every option you think is plausible." Button text: "Lock in my answers →" (plural).
+
+```html
+<div class="prediction-block animate-in" id="pred-xyz" data-multiselect="true">
+  <div class="prediction-header">
+    <span aria-hidden="true">🤔</span>
+    <span class="prediction-label">Before we continue — select all that apply</span>
+  </div>
+  <p class="prediction-question">
+    <strong>Pick every option you think is plausible.</strong>
+  </p>
+  <div class="prediction-options">
+    <button class="pred-option" onclick="selectPrediction(this,'pred-xyz')" data-value="a">Option A</button>
+    <button class="pred-option" onclick="selectPrediction(this,'pred-xyz')" data-value="b">Option B</button>
+  </div>
+  <!-- Note: style="display:none" — shown by JS once ≥1 option is selected -->
+  <button class="pred-commit" id="pred-xyz-btn" onclick="commitPrediction('pred-xyz')" style="display:none">Lock in my answers →</button>
+  <div class="pred-reveal" id="pred-xyz-reveal"><!-- reveal --></div>
+</div>
+```
+
+### Tooltip Clipping
+Translation blocks use `overflow: hidden`. Tooltips using `position: absolute` inside the term element get clipped. **Fix:** tooltips must use `position: fixed` and be appended to `document.body`. Calculate position from `getBoundingClientRect()`.
+
+### Accessibility Skipped
+Interactive elements without keyboard operability, diagrams without alt text, color used as the only signal. **Fix:** apply the WCAG 2.1 AA baseline from Phase 3A before writing any interactive elements. Check: every control has an aria-label, every diagram has a description, every color signal has a text/icon pair.
+
+### Walls of Text
+Screens that look like formatted documentation. **Fix:** every screen must be at least 50% visual. Convert any list of 3+ items to cards; any sequence to a flow diagram; any spec excerpt to a translation block.
+
+### Recycled Metaphors
+Using "restaurant" or "kitchen" more than once. **Fix:** each concept gets its own inevitable metaphor. If you reach for the same metaphor twice, stop and find one that fits the specific concept organically.
+
+### Scroll-Snap Mandatory
+`scroll-snap-type: y mandatory` traps users inside long modules. **Fix:** always use `proximity`.
+
+### Module Quality Degradation
+Writing all modules in one pass causes later modules to become thin and rushed. **Fix:** build one module at a time. Verify each before starting the next.
+
+### Scope Ignored
+Trying to teach all the documentation, producing a course so long it's unusable. **Fix:** apply the 80/20 rule in Phase 1B. A course that covers 20% of the documentation well is worth more than one that covers 100% badly.
+
+---
+
+## Reference Files
+
+Read these when you reach the relevant phase:
+
+- **`references/design-system.md`** — CSS custom properties, color palette with WCAG contrast ratios, typography scale, spacing, shadows, animations, accessibility notes, scrollbar styling. Read before writing any CSS.
+- **`references/interactive-elements.md`** — Implementation patterns for every interactive element: spec↔plain-English translations, prediction questions, completion problems, mid-module knowledge checks, retrieval callbacks, scenario quizzes with elaborative feedback, decision tree navigators, state machine visualizers, data flow animations, architecture diagrams, drag-and-drop matching, callout boxes, pattern cards, flow diagrams, glossary tooltips. Read before building any interactive elements.

--- a/skills/docs-to-course/examples/axur-platform-course.html
+++ b/skills/docs-to-course/examples/axur-platform-course.html
@@ -1,0 +1,1907 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Axur Platform — Digital Risk Protection Training</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+:root {
+  --color-bg: #0d1117;
+  --color-surface: #161b27;
+  --color-surface-2: #1e2537;
+  --color-border: #2a3347;
+  --color-accent: #00d4c8;
+  --color-accent-dim: rgba(0,212,200,0.12);
+  --color-accent-secondary: #ff6b35;
+  --color-threat: #ff6b35;
+  --color-threat-dim: rgba(255,107,53,0.12);
+  --color-text: #e6edf3;
+  --color-text-dim: #8b949e;
+  --color-text-muted: #556070;
+  --color-success: #3fb950;
+  --color-success-dim: rgba(63,185,80,0.12);
+  --color-error: #f85149;
+  --color-error-dim: rgba(248,81,73,0.12);
+  --color-warning: #d29922;
+  --color-warning-dim: rgba(210,153,34,0.12);
+  --color-ai-red: #f85149;
+  --color-ai-orange-dark: #ff8c42;
+  --color-ai-orange-light: #ffb347;
+  --color-ai-yellow: #d29922;
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 16px;
+  --radius-xl: 24px;
+  --shadow-sm: 0 1px 3px rgba(0,0,0,0.4);
+  --shadow-md: 0 4px 12px rgba(0,0,0,0.5);
+  --shadow-lg: 0 8px 32px rgba(0,0,0,0.6);
+  --shadow-accent: 0 0 20px rgba(0,212,200,0.2);
+  --transition: 0.2s ease;
+  --font-body: 'Inter', sans-serif;
+  --font-mono: 'JetBrains Mono', monospace;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 3px; border-radius: 2px; }
+:focus:not(:focus-visible) { outline: none; }
+
+html { scroll-behavior: smooth; }
+
+body {
+  font-family: var(--font-body);
+  background: var(--color-bg);
+  color: var(--color-text);
+  line-height: 1.6;
+  overflow-x: hidden;
+}
+
+/* ─── Progress bar ─── */
+#progress-bar-wrap {
+  position: fixed; top: 0; left: 0; right: 0; height: 3px;
+  background: var(--color-border); z-index: 1000;
+}
+#progress-bar {
+  height: 100%; background: var(--color-accent);
+  width: 0%; transition: width 0.3s ease;
+}
+
+/* ─── Nav dots (right side) ─── */
+#nav-dots {
+  position: fixed; right: 20px; top: 50%; transform: translateY(-50%);
+  display: flex; flex-direction: column; gap: 10px; z-index: 999;
+}
+.nav-dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--color-border); border: none; cursor: pointer;
+  transition: all var(--transition); padding: 0;
+}
+.nav-dot.active { background: var(--color-accent); transform: scale(1.4); }
+.nav-dot:hover { background: var(--color-text-dim); }
+.nav-dot-label {
+  position: absolute; right: 18px;
+  background: var(--color-surface); color: var(--color-text);
+  font-size: 11px; white-space: nowrap; padding: 4px 8px;
+  border-radius: var(--radius-sm); border: 1px solid var(--color-border);
+  opacity: 0; pointer-events: none; transition: opacity var(--transition);
+  transform: translateX(-4px);
+}
+#nav-dots:hover .nav-dot-label { opacity: 1; }
+
+/* ─── Modules ─── */
+.module {
+  min-height: 100vh; display: flex; align-items: center; justify-content: center;
+  padding: 80px 24px;
+}
+.module-inner {
+  max-width: 860px; width: 100%;
+}
+.module-badge {
+  display: inline-flex; align-items: center; gap: 8px;
+  font-size: 11px; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--color-accent); background: var(--color-accent-dim);
+  padding: 4px 12px; border-radius: 20px; margin-bottom: 24px;
+}
+.module-title {
+  font-size: clamp(28px, 5vw, 44px); font-weight: 700; line-height: 1.15;
+  margin-bottom: 16px; letter-spacing: -0.02em;
+}
+.module-subtitle {
+  font-size: 18px; color: var(--color-text-dim); margin-bottom: 48px;
+  line-height: 1.6; max-width: 680px;
+}
+
+/* ─── Section headings ─── */
+.section-heading {
+  font-size: 20px; font-weight: 600; margin: 48px 0 20px;
+  color: var(--color-text);
+}
+.section-heading-sm {
+  font-size: 15px; font-weight: 600; color: var(--color-text-dim);
+  text-transform: uppercase; letter-spacing: 0.06em; margin: 32px 0 12px;
+}
+
+/* ─── Callout boxes ─── */
+.callout {
+  border-radius: var(--radius-md); padding: 18px 22px;
+  margin: 24px 0; border-left: 3px solid;
+}
+.callout-info { background: var(--color-accent-dim); border-color: var(--color-accent); }
+.callout-warning { background: var(--color-warning-dim); border-color: var(--color-warning); }
+.callout-danger { background: var(--color-error-dim); border-color: var(--color-error); }
+.callout-success { background: var(--color-success-dim); border-color: var(--color-success); }
+.callout-title { font-weight: 600; font-size: 13px; text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 6px; }
+.callout-info .callout-title { color: var(--color-accent); }
+.callout-warning .callout-title { color: var(--color-warning); }
+.callout-danger .callout-title { color: var(--color-error); }
+.callout-success .callout-title { color: var(--color-success); }
+
+/* ─── Translation blocks ─── */
+.translation-block {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 2px;
+  margin: 28px 0; border-radius: var(--radius-lg); overflow: hidden;
+  border: 1px solid var(--color-border);
+}
+.translation-side {
+  padding: 24px; background: var(--color-surface);
+}
+.translation-side:first-child { border-right: 2px solid var(--color-border); }
+.translation-label {
+  font-size: 10px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase;
+  color: var(--color-text-muted); margin-bottom: 12px;
+}
+.translation-side:first-child .translation-label { color: var(--color-warning); }
+.translation-side:last-child .translation-label { color: var(--color-accent); }
+.translation-text {
+  font-size: 14px; line-height: 1.7; color: var(--color-text);
+}
+.translation-side:first-child .translation-text {
+  font-family: var(--font-mono); font-size: 13px; color: var(--color-text-dim);
+}
+.translation-note {
+  font-size: 12px; color: var(--color-text-dim); margin-top: 12px;
+  padding-top: 10px; border-top: 1px solid var(--color-border);
+}
+.translation-note strong { color: var(--color-warning); }
+
+/* ─── Feature cards ─── */
+.cards-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 16px; margin: 24px 0; }
+.card {
+  background: var(--color-surface); border: 1px solid var(--color-border);
+  border-radius: var(--radius-md); padding: 20px; transition: border-color var(--transition);
+}
+.card:hover { border-color: var(--color-accent); }
+.card-icon { font-size: 28px; margin-bottom: 12px; }
+.card-title { font-weight: 600; font-size: 15px; margin-bottom: 6px; }
+.card-desc { font-size: 13px; color: var(--color-text-dim); line-height: 1.6; }
+.card-stat { font-size: 22px; font-weight: 700; color: var(--color-accent); margin-top: 10px; }
+.card-stat-label { font-size: 11px; color: var(--color-text-muted); }
+
+/* ─── Score badges ─── */
+.score-grid { display: flex; flex-direction: column; gap: 10px; margin: 24px 0; }
+.score-row {
+  display: flex; align-items: center; gap: 16px;
+  background: var(--color-surface); border: 1px solid var(--color-border);
+  border-radius: var(--radius-md); padding: 14px 18px;
+}
+.score-dot { width: 14px; height: 14px; border-radius: 50%; flex-shrink: 0; }
+.score-label { font-weight: 600; font-size: 14px; min-width: 160px; }
+.score-desc { font-size: 13px; color: var(--color-text-dim); }
+
+/* ─── Numbered steps ─── */
+.steps { display: flex; flex-direction: column; gap: 16px; margin: 24px 0; }
+.step {
+  display: flex; gap: 16px; align-items: flex-start;
+  background: var(--color-surface); border: 1px solid var(--color-border);
+  border-radius: var(--radius-md); padding: 18px;
+}
+.step-num {
+  width: 32px; height: 32px; border-radius: 50%;
+  background: var(--color-accent-dim); color: var(--color-accent);
+  font-weight: 700; font-size: 14px; display: flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+}
+.step-content { flex: 1; }
+.step-title { font-weight: 600; font-size: 15px; margin-bottom: 4px; }
+.step-desc { font-size: 13px; color: var(--color-text-dim); line-height: 1.6; }
+
+/* ─── Prediction block ─── */
+.prediction-block {
+  background: var(--color-surface); border: 1px solid var(--color-accent);
+  border-radius: var(--radius-lg); padding: 28px; margin: 32px 0;
+}
+.prediction-header { display: flex; align-items: center; gap: 10px; margin-bottom: 16px; }
+.prediction-label { font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.08em; color: var(--color-accent); }
+.prediction-question { font-size: 16px; line-height: 1.6; margin-bottom: 20px; }
+.prediction-options { display: flex; flex-direction: column; gap: 10px; }
+.pred-option {
+  background: var(--color-surface-2); border: 1px solid var(--color-border);
+  color: var(--color-text); border-radius: var(--radius-md); padding: 12px 16px;
+  text-align: left; cursor: pointer; font-size: 14px; font-family: var(--font-body);
+  transition: all var(--transition);
+}
+.pred-option:hover { border-color: var(--color-accent); }
+.pred-option.selected { border-color: var(--color-accent); background: var(--color-accent-dim); }
+.pred-reveal {
+  margin-top: 20px; padding: 16px; background: var(--color-surface-2);
+  border-radius: var(--radius-md); border-left: 3px solid var(--color-accent);
+  display: none; font-size: 14px; line-height: 1.7;
+}
+.pred-reveal.visible { display: block; }
+.pred-commit {
+  margin-top: 16px; background: var(--color-accent); color: #000;
+  border: none; border-radius: var(--radius-md); padding: 10px 20px;
+  font-weight: 600; font-size: 14px; cursor: pointer; transition: opacity var(--transition);
+  display: none;
+}
+.pred-commit:hover { opacity: 0.85; }
+.pred-commit.visible { display: block; }
+
+/* ─── Quiz ─── */
+.quiz-container {
+  background: var(--color-surface); border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg); padding: 28px; margin: 32px 0;
+}
+.quiz-title { font-weight: 700; font-size: 18px; margin-bottom: 8px; }
+.quiz-q { font-size: 15px; line-height: 1.7; margin-bottom: 20px; color: var(--color-text-dim); }
+.quiz-options { display: flex; flex-direction: column; gap: 10px; margin-bottom: 20px; }
+.quiz-option {
+  display: flex; align-items: flex-start; gap: 12px;
+  background: var(--color-surface-2); border: 1px solid var(--color-border);
+  border-radius: var(--radius-md); padding: 14px 16px; cursor: pointer;
+  transition: all var(--transition); font-size: 14px; text-align: left;
+  font-family: var(--font-body); color: var(--color-text); width: 100%;
+}
+.quiz-option:hover { border-color: var(--color-accent); }
+.quiz-option.selected { border-color: var(--color-accent); background: var(--color-accent-dim); }
+.quiz-option.correct { border-color: var(--color-success); background: var(--color-success-dim); }
+.quiz-option.incorrect { border-color: var(--color-error); background: var(--color-error-dim); }
+.quiz-icon { width: 18px; flex-shrink: 0; margin-top: 1px; }
+.quiz-check {
+  background: var(--color-accent); color: #000; border: none;
+  border-radius: var(--radius-md); padding: 10px 20px;
+  font-weight: 600; cursor: pointer; font-family: var(--font-body);
+}
+.quiz-check:disabled { opacity: 0.5; cursor: not-allowed; }
+.quiz-feedback {
+  margin-top: 16px; padding: 16px; border-radius: var(--radius-md);
+  font-size: 14px; line-height: 1.7; display: none;
+}
+.quiz-feedback.correct { background: var(--color-success-dim); border-left: 3px solid var(--color-success); display: block; }
+.quiz-feedback.incorrect { background: var(--color-error-dim); border-left: 3px solid var(--color-error); display: block; }
+.quiz-reset { margin-top: 12px; background: none; border: 1px solid var(--color-border); color: var(--color-text-dim); border-radius: var(--radius-md); padding: 8px 16px; cursor: pointer; font-size: 13px; }
+.quiz-reset:hover { border-color: var(--color-accent); }
+
+/* ─── Decision tree ─── */
+.dt-container {
+  background: var(--color-surface); border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg); padding: 28px; margin: 32px 0;
+}
+.dt-title { font-weight: 700; font-size: 16px; margin-bottom: 20px; color: var(--color-accent); }
+.dt-node { display: none; }
+.dt-node.active { display: block; }
+.dt-question { font-size: 17px; font-weight: 600; line-height: 1.5; margin-bottom: 18px; }
+.dt-choices { display: flex; flex-direction: column; gap: 10px; }
+.dt-choice {
+  background: var(--color-surface-2); border: 1px solid var(--color-border);
+  border-radius: var(--radius-md); padding: 14px 18px; cursor: pointer;
+  text-align: left; font-size: 14px; color: var(--color-text);
+  font-family: var(--font-body); transition: all var(--transition);
+}
+.dt-choice:hover { border-color: var(--color-accent); color: var(--color-accent); }
+.dt-outcome {
+  border-radius: var(--radius-md); padding: 18px; margin-top: 10px;
+  font-size: 14px; line-height: 1.7;
+}
+.dt-outcome.success { background: var(--color-success-dim); border: 1px solid var(--color-success); }
+.dt-outcome.warning { background: var(--color-warning-dim); border: 1px solid var(--color-warning); }
+.dt-outcome.info { background: var(--color-accent-dim); border: 1px solid var(--color-accent); }
+.dt-outcome-title { font-weight: 700; margin-bottom: 6px; font-size: 15px; }
+.dt-breadcrumb { font-size: 12px; color: var(--color-text-muted); margin-bottom: 16px; }
+.dt-reset { margin-top: 16px; background: none; border: 1px solid var(--color-border); color: var(--color-text-dim); border-radius: var(--radius-md); padding: 8px 16px; cursor: pointer; font-size: 13px; }
+.dt-reset:hover { border-color: var(--color-accent); }
+
+/* ─── State machine ─── */
+.sm-container {
+  background: var(--color-surface); border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg); padding: 28px; margin: 32px 0;
+}
+.sm-title { font-weight: 700; font-size: 16px; margin-bottom: 20px; color: var(--color-accent); }
+.sm-states { display: flex; flex-wrap: wrap; gap: 12px; margin-bottom: 20px; }
+.sm-state {
+  background: var(--color-surface-2); border: 2px solid var(--color-border);
+  border-radius: var(--radius-md); padding: 14px 20px; min-width: 130px;
+  text-align: center; transition: all var(--transition);
+}
+.sm-state.active {
+  border-color: var(--color-accent);
+  box-shadow: var(--shadow-accent);
+}
+.sm-state-name { font-weight: 600; font-size: 14px; }
+.sm-state-desc { font-size: 11px; color: var(--color-text-dim); margin-top: 4px; }
+.sm-arrow { color: var(--color-text-muted); font-size: 20px; line-height: 44px; }
+.sm-triggers { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 16px; }
+.sm-trigger {
+  background: var(--color-accent-dim); border: 1px solid var(--color-accent);
+  color: var(--color-accent); border-radius: 20px; padding: 6px 16px;
+  cursor: pointer; font-size: 13px; font-family: var(--font-body); font-weight: 500;
+  transition: all var(--transition);
+}
+.sm-trigger:hover { background: var(--color-accent); color: #000; }
+.sm-info { font-size: 14px; color: var(--color-text-dim); line-height: 1.6; padding: 14px; background: var(--color-surface-2); border-radius: var(--radius-md); }
+.sm-reset { margin-top: 12px; background: none; border: 1px solid var(--color-border); color: var(--color-text-dim); border-radius: var(--radius-md); padding: 8px 16px; cursor: pointer; font-size: 13px; }
+
+/* ─── Glossary tooltips ─── */
+.term {
+  border-bottom: 1px dashed var(--color-accent); cursor: help;
+  color: var(--color-accent); position: relative; display: inline-block;
+}
+.term:focus { outline: 2px solid var(--color-accent); outline-offset: 2px; }
+.term-tooltip {
+  position: absolute; bottom: calc(100% + 8px); left: 50%; transform: translateX(-50%);
+  background: var(--color-surface-2); border: 1px solid var(--color-accent);
+  border-radius: var(--radius-md); padding: 10px 14px; width: 260px;
+  font-size: 13px; line-height: 1.5; color: var(--color-text);
+  z-index: 100; pointer-events: none; opacity: 0; transition: opacity var(--transition);
+  box-shadow: var(--shadow-md);
+}
+.term:hover .term-tooltip,
+.term:focus .term-tooltip { opacity: 1; }
+
+/* ─── Inline knowledge check ─── */
+.kcheck {
+  background: var(--color-surface); border: 1px solid var(--color-border);
+  border-radius: var(--radius-md); padding: 20px; margin: 24px 0;
+}
+.kcheck-q { font-size: 15px; font-weight: 500; margin-bottom: 14px; }
+.kcheck-options { display: flex; flex-direction: column; gap: 8px; }
+.kcheck-opt {
+  background: var(--color-surface-2); border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm); padding: 10px 14px; cursor: pointer;
+  text-align: left; font-size: 13px; color: var(--color-text); font-family: var(--font-body);
+  transition: all var(--transition);
+}
+.kcheck-opt:hover { border-color: var(--color-accent); }
+.kcheck-opt.correct { border-color: var(--color-success); background: var(--color-success-dim); }
+.kcheck-opt.incorrect { border-color: var(--color-error); background: var(--color-error-dim); }
+.kcheck-feedback { font-size: 13px; margin-top: 10px; padding: 10px 14px; border-radius: var(--radius-sm); display: none; }
+.kcheck-feedback.show { display: block; }
+.kcheck-feedback.ok { background: var(--color-success-dim); color: var(--color-success); }
+.kcheck-feedback.no { background: var(--color-error-dim); color: var(--color-error); }
+
+/* ─── Table ─── */
+.data-table { width: 100%; border-collapse: collapse; margin: 24px 0; font-size: 14px; }
+.data-table th {
+  background: var(--color-surface-2); color: var(--color-text-dim);
+  font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em;
+  padding: 12px 16px; text-align: left; border-bottom: 1px solid var(--color-border);
+}
+.data-table td { padding: 12px 16px; border-bottom: 1px solid var(--color-border); vertical-align: top; }
+.data-table tr:hover td { background: var(--color-surface); }
+
+/* ─── Tag / badge ─── */
+.tag {
+  display: inline-block; font-size: 11px; font-weight: 600; padding: 3px 10px;
+  border-radius: 20px; letter-spacing: 0.04em;
+}
+.tag-accent { background: var(--color-accent-dim); color: var(--color-accent); }
+.tag-threat { background: var(--color-threat-dim); color: var(--color-threat); }
+.tag-success { background: var(--color-success-dim); color: var(--color-success); }
+.tag-warning { background: var(--color-warning-dim); color: var(--color-warning); }
+
+/* ─── AQL code blocks ─── */
+.aql-block {
+  background: #0a0f1a; border: 1px solid var(--color-border);
+  border-radius: var(--radius-md); padding: 20px; margin: 16px 0;
+  font-family: var(--font-mono); font-size: 14px; line-height: 1.8;
+}
+.aql-kw { color: #ff79c6; }
+.aql-val { color: var(--color-accent); }
+.aql-op { color: var(--color-warning); }
+.aql-comment { color: var(--color-text-muted); }
+.aql-wild { color: var(--color-ai-orange-light); }
+
+/* ─── Divider ─── */
+.divider { border: none; border-top: 1px solid var(--color-border); margin: 40px 0; }
+
+/* ─── Animate in ─── */
+.animate-in { opacity: 0; transform: translateY(20px); transition: opacity 0.5s ease, transform 0.5s ease; }
+.animate-in.visible { opacity: 1; transform: translateY(0); }
+
+/* ─── Reduced motion ─── */
+@media (prefers-reduced-motion: reduce) {
+  .animate-in { opacity: 1; transform: none; transition: none; }
+  * { transition-duration: 0.001ms !important; }
+}
+
+/* ─── Responsive ─── */
+@media (max-width: 640px) {
+  .translation-block { grid-template-columns: 1fr; }
+  .translation-side:first-child { border-right: none; border-bottom: 2px solid var(--color-border); }
+  #nav-dots { right: 8px; }
+  .module { padding: 60px 16px; }
+}
+
+/* ─── Hero (module 0) ─── */
+.hero { text-align: center; }
+.hero .module-title { font-size: clamp(32px, 6vw, 54px); }
+.hero-tags { display: flex; gap: 10px; justify-content: center; flex-wrap: wrap; margin-bottom: 40px; }
+.hero-cta {
+  background: var(--color-accent); color: #000; font-weight: 700; font-size: 16px;
+  padding: 14px 32px; border-radius: var(--radius-lg); border: none; cursor: pointer;
+  transition: opacity var(--transition);
+}
+.hero-cta:hover { opacity: 0.85; }
+.hero-meta { font-size: 13px; color: var(--color-text-muted); margin-top: 12px; }
+
+/* ─── Completion banner ─── */
+.completion-banner {
+  text-align: center; padding: 60px 24px;
+  background: linear-gradient(135deg, var(--color-accent-dim), var(--color-threat-dim));
+  border-radius: var(--radius-xl); border: 1px solid var(--color-accent); margin-top: 40px;
+}
+.completion-banner h2 { font-size: 32px; margin-bottom: 12px; }
+.completion-banner p { color: var(--color-text-dim); font-size: 16px; }
+</style>
+</head>
+<body>
+
+<div id="progress-bar-wrap" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" aria-label="Course progress">
+  <div id="progress-bar"></div>
+</div>
+
+<nav id="nav-dots" aria-label="Module navigation">
+  <!-- dots injected by JS -->
+</nav>
+
+<!-- ══════════════════════════════════════════════════════════
+     MODULE 0 — HERO
+══════════════════════════════════════════════════════════ -->
+<section class="module hero" id="mod-0" data-module="0">
+  <div class="module-inner animate-in">
+    <div class="hero-tags">
+      <span class="tag tag-accent">Digital Risk Protection</span>
+      <span class="tag tag-threat">Threat Intelligence</span>
+      <span class="tag tag-warning">7 Modules</span>
+    </div>
+    <h1 class="module-title">Master the Axur Platform</h1>
+    <p class="module-subtitle">
+      From brand monitoring to takedowns: detect, triage, and eliminate
+      digital threats against your organization using Axur's full threat intelligence platform.
+    </p>
+    <button class="hero-cta" onclick="goToModule(1)">Start Learning →</button>
+    <p class="hero-meta">~25 min · Self-paced · No login required</p>
+  </div>
+</section>
+
+<!-- ══════════════════════════════════════════════════════════
+     MODULE 1 — THE DIGITAL THREAT LANDSCAPE
+══════════════════════════════════════════════════════════ -->
+<section class="module" id="mod-1" data-module="1">
+  <div class="module-inner">
+    <div class="module-badge animate-in">Module 1 of 7</div>
+    <h2 class="module-title animate-in">The Digital Threat Landscape</h2>
+    <p class="module-subtitle animate-in">
+      Before you can protect a brand, you need to see it through an attacker's eyes.
+      What are they building, where, and how fast?
+    </p>
+
+    <!-- Prediction question -->
+    <div class="prediction-block animate-in" id="pred-m1" data-multiselect="true">
+      <div class="prediction-header">
+        <span aria-hidden="true">🤔</span>
+        <span class="prediction-label">Before we continue — select all that apply</span>
+      </div>
+      <p class="prediction-question">
+        A customer receives a convincing email claiming their bank account is locked.
+        They click a link and enter their password on what looks exactly like the bank's login page.
+        <strong>Where could the attacker have hosted this fake page? Pick every option you think is plausible.</strong>
+      </p>
+      <div class="prediction-options">
+        <button class="pred-option" onclick="selectPrediction(this,'pred-m1')" data-value="a">On a look-alike domain (e.g. bank-secure-login.com) registered for ~$10</button>
+        <button class="pred-option" onclick="selectPrediction(this,'pred-m1')" data-value="b">On shared hosting linked from a fake social media profile</button>
+        <button class="pred-option" onclick="selectPrediction(this,'pred-m1')" data-value="c">Via a fraudulent Google Ad pointing to a third-party hosting site</button>
+        <button class="pred-option" onclick="selectPrediction(this,'pred-m1')" data-value="d">On infrastructure whose credentials route to a dark web Telegram channel</button>
+      </div>
+      <button class="pred-commit" id="pred-m1-btn" onclick="commitPrediction('pred-m1')" style="display:none">Lock in my answers →</button>
+      <div class="pred-reveal" id="pred-m1-reveal">
+        <strong style="color:var(--color-accent)">All four — and that's the problem.</strong>
+        Attackers use every surface available. A single phishing campaign might serve the fake page from a typo-squatted domain, promote it via fake Google Ads, link it from a fake social media profile, and then route credentials to a Telegram channel on the dark web. Traditional perimeter security sees none of this. That's the gap Axur closes.
+      </div>
+    </div>
+
+    <h3 class="section-heading">The six threat categories Axur monitors</h3>
+
+    <div class="cards-grid animate-in">
+      <div class="card">
+        <div class="card-icon">🎣</div>
+        <div class="card-title">Phishing</div>
+        <div class="card-desc">Fake pages mimicking your brand's login, checkout, or support portals. Distributed via email, ads, social media, and fake apps.</div>
+      </div>
+      <div class="card">
+        <div class="card-icon">📱</div>
+        <div class="card-title">Fake Social &amp; Apps</div>
+        <div class="card-desc">Impersonator accounts on Instagram, Facebook, LinkedIn, X. Counterfeit apps in app stores that steal credentials or spread malware.</div>
+      </div>
+      <div class="card">
+        <div class="card-icon">🏷️</div>
+        <div class="card-title">Brand Abuse</div>
+        <div class="card-desc">Unauthorized use of your logo, name, or visual identity in ads, websites, or domain names to mislead consumers.</div>
+      </div>
+      <div class="card">
+        <div class="card-icon">💳</div>
+        <div class="card-title">Data Leakage</div>
+        <div class="card-desc">Compromised credit card numbers, employee credentials, source code, and confidential documents appearing in underground markets.</div>
+      </div>
+      <div class="card">
+        <div class="card-icon">🌑</div>
+        <div class="card-title">Deep &amp; Dark Web</div>
+        <div class="card-desc">Mentions of your brand, infrastructure, or executives in forums, ransomware leak sites, and encrypted messaging channels inaccessible to search engines.</div>
+      </div>
+      <div class="card">
+        <div class="card-icon">🕵️</div>
+        <div class="card-title">Fraudulent Ads</div>
+        <div class="card-desc">Sponsored search results or display ads using your brand to divert traffic to malicious sites or competitors.</div>
+      </div>
+    </div>
+
+    <!-- Spec ↔ Plain English -->
+    <h3 class="section-heading">Why traditional security misses these threats</h3>
+
+    <div class="translation-block animate-in">
+      <div class="translation-side">
+        <div class="translation-label">Traditional security thinking</div>
+        <div class="translation-text">"We have a firewall, endpoint protection, and a SIEM. Our perimeter is secured."</div>
+        <div class="translation-note"><strong>The gap:</strong> All these tools protect your infrastructure. None of them watch what attackers build <em>outside</em> your network.</div>
+      </div>
+      <div class="translation-side">
+        <div class="translation-label">What this actually means</div>
+        <div class="translation-text">
+          An attacker can register <code style="background:var(--color-surface-2);padding:2px 6px;border-radius:4px;font-family:var(--font-mono)">yourbank-secure.com</code> today, clone your login page, run a Google Ad pointing to it, and harvest credentials — without ever touching your network. Your firewall has nothing to inspect.
+          <br><br>
+          Digital risk protection is the discipline of monitoring the <em>external attack surface</em>: what exists about your brand on the open web, dark web, app stores, and social media that you don't control.
+        </div>
+      </div>
+    </div>
+
+    <div class="callout callout-info animate-in">
+      <div class="callout-title">The Axur approach</div>
+      Axur continuously crawls the open web, deep web, dark web, Telegram channels, app stores, social networks, and domain registrations. Anything matching your monitored assets — brand names, domains, BINs, executives — becomes an actionable ticket.
+    </div>
+
+    <hr class="divider">
+
+    <h3 class="section-heading">How fast does a phishing site get weaponized?</h3>
+    <div class="steps animate-in">
+      <div class="step">
+        <div class="step-num">1</div>
+        <div class="step-content">
+          <div class="step-title">Domain registered (~$10, minutes)</div>
+          <div class="step-desc">Attacker buys a typo-squatted or brand-matching domain. Often dozens per campaign.</div>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-num">2</div>
+        <div class="step-content">
+          <div class="step-title">Fake page deployed (hours)</div>
+          <div class="step-desc">Clones your brand's visual identity using publicly available CSS and images. SSL certificates are free via Let's Encrypt — the padlock is no longer a trust signal.</div>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-num">3</div>
+        <div class="step-content">
+          <div class="step-title">Campaign launched (same day)</div>
+          <div class="step-desc">Phishing emails, social ads, or SMS blasts drive victims to the fake page. Credentials harvested in real-time to a Telegram bot.</div>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-num">4</div>
+        <div class="step-content">
+          <div class="step-title">Accounts drained (within hours)</div>
+          <div class="step-desc">Stolen credentials are tested immediately against banking and e-commerce accounts, or sold in underground markets.</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="callout callout-warning animate-in">
+      <div class="callout-title">Time is the critical variable</div>
+      The sooner a phishing site is detected and taken down, the fewer victims it reaches. Axur's takedown service sends the first extrajudicial notification in <strong>under 4 minutes</strong> on average, and resolves <strong>70%</strong> of cases on that first contact.
+    </div>
+
+    <!-- Knowledge check -->
+    <div class="kcheck animate-in">
+      <div class="kcheck-q">Quick check: A user reports that a Google Ad for "MyBank login" is pointing to a suspicious domain. What type of threat is this?</div>
+      <div class="kcheck-options">
+        <button class="kcheck-opt" onclick="checkKC(this,'right','kc-m1')">Fraudulent Brand Use in Advertising</button>
+        <button class="kcheck-opt" onclick="checkKC(this,'wrong','kc-m1')">Data Leakage</button>
+        <button class="kcheck-opt" onclick="checkKC(this,'wrong','kc-m1')">Deep &amp; Dark Web mention</button>
+        <button class="kcheck-opt" onclick="checkKC(this,'wrong','kc-m1')">Credential exposure</button>
+      </div>
+      <div class="kcheck-feedback ok" id="kc-m1-ok" style="display:none">Correct. Fraudulent ads using a brand's name to divert traffic to a malicious site fall under "Fraudulent Brand Use" in advertising. Axur monitors sponsored search results and display ads specifically for this pattern.</div>
+      <div class="kcheck-feedback no" id="kc-m1-no" style="display:none">Not quite. This is a fraudulent ad — the attacker is using paid search to impersonate the brand. Data leakage and dark web mentions are separate threat categories. Credential exposure would be a downstream effect after victims fall for the phishing.</div>
+    </div>
+
+    <button class="hero-cta" style="margin-top:24px" onclick="goToModule(2)">Next: Navigate Your Workspace →</button>
+  </div>
+</section>
+
+<!-- ══════════════════════════════════════════════════════════
+     MODULE 2 — NAVIGATING YOUR WORKSPACE
+══════════════════════════════════════════════════════════ -->
+<section class="module" id="mod-2" data-module="2">
+  <div class="module-inner">
+    <div class="module-badge animate-in">Module 2 of 7</div>
+    <h2 class="module-title animate-in">Navigating Your Workspace</h2>
+    <p class="module-subtitle animate-in">
+      Axur organizes every detected threat as a ticket inside workspace-specific lists.
+      Get this structure down and everything else follows.
+    </p>
+
+    <h3 class="section-heading">Platform structure at a glance</h3>
+
+    <div class="cards-grid animate-in">
+      <div class="card">
+        <div class="card-icon">🏢</div>
+        <div class="card-title">Workspaces</div>
+        <div class="card-desc">Each threat type has its own workspace: Phishing, Fake Social Media, Fake Mobile App, Fraudulent Brand Use, Data Leakage, Deep &amp; Dark Web. Navigate between them in the left sidebar.</div>
+      </div>
+      <div class="card">
+        <div class="card-icon">🎫</div>
+        <div class="card-title">Tickets</div>
+        <div class="card-desc">Every detected threat becomes a ticket: a structured record with evidence, metadata, AI scoring, and action history. Tickets are the unit of work in Axur.</div>
+      </div>
+      <div class="card">
+        <div class="card-icon">📋</div>
+        <div class="card-title">Work Lists</div>
+        <div class="card-desc">Within each workspace, tickets live in one of five lists that reflect their current stage in your treatment workflow.</div>
+      </div>
+      <div class="card">
+        <div class="card-icon">📊</div>
+        <div class="card-title">Stats Page</div>
+        <div class="card-desc">Platform-wide metrics on coverage, active threats, incidents, and treatment rates, with industry benchmarking.</div>
+      </div>
+    </div>
+
+    <h3 class="section-heading">The five work lists: your ticket pipeline</h3>
+
+    <div class="translation-block animate-in">
+      <div class="translation-side">
+        <div class="translation-label">Platform language</div>
+        <div class="translation-text">Open → Quarantine / Incidents → Treatment → Closed</div>
+        <div class="translation-note"><strong>Key insight:</strong> Incidents and Treatment are both active stages, but with different owners.</div>
+      </div>
+      <div class="translation-side">
+        <div class="translation-label">What it actually means</div>
+        <div class="translation-text">
+          <strong>Open</strong> — New tickets detected by Axur's monitoring. Your inbox: requires your first decision.<br><br>
+          <strong>Quarantine</strong> — "Watch and wait." The URL shows brand misuse but no active fraud yet. Axur checks it daily at 6 a.m. and alerts you if content changes.<br><br>
+          <strong>Incidents</strong> — Confirmed threats requiring action. A transitional list — a ticket here must move forward (takedown, treat internally, or discard).<br><br>
+          <strong>Treatment</strong> — Takedown requested OR being handled internally. Axur is working the takedown; you're monitoring progress.<br><br>
+          <strong>Closed</strong> — Resolved (Solved or Discarded). Quarantine tickets auto-close 6 months after last detection.
+        </div>
+      </div>
+    </div>
+
+    <div class="callout callout-warning animate-in">
+      <div class="callout-title">Quarantine auto-discard</div>
+      Starting November 3, 2025, quarantine tickets are automatically discarded when the last detection date exceeds <strong>6 months</strong>. This runs daily. If a quarantined URL becomes active again, reopen it before the deadline or it will close without action.
+    </div>
+
+    <h3 class="section-heading">AI fraud probability scoring</h3>
+    <p style="color:var(--color-text-dim);font-size:14px;margin-bottom:20px">
+      Axur's AI assigns a fraud probability score to each ticket. Use it to prioritize, but don't let the score replace your judgment on high-stakes tickets.
+    </p>
+
+    <div class="score-grid animate-in">
+      <div class="score-row">
+        <div class="score-dot" style="background:var(--color-ai-red)"></div>
+        <div class="score-label">Red · ≥ 80% probability</div>
+        <div class="score-desc">High confidence of active fraud. Address immediately. These should move from Open → Incident → Takedown the same day.</div>
+      </div>
+      <div class="score-row">
+        <div class="score-dot" style="background:var(--color-ai-orange-dark)"></div>
+        <div class="score-label">Dark orange · 60–79.9%</div>
+        <div class="score-desc">Likely fraud, but review before escalating. Could be a test site or early-stage page not yet collecting credentials.</div>
+      </div>
+      <div class="score-row">
+        <div class="score-dot" style="background:var(--color-ai-orange-light)"></div>
+        <div class="score-label">Light orange · 40–59.9%</div>
+        <div class="score-desc">Ambiguous. May warrant quarantine while you gather more evidence, especially if the domain is very new.</div>
+      </div>
+      <div class="score-row">
+        <div class="score-dot" style="background:var(--color-ai-yellow)"></div>
+        <div class="score-label">Yellow · &lt; 40%</div>
+        <div class="score-desc">Low fraud signal. Review quickly — most will be discarded, but check before closing in case of false negatives on sophisticated pages.</div>
+      </div>
+    </div>
+
+    <div class="kcheck animate-in">
+      <div class="kcheck-q">A ticket arrives with an AI score of 72% (dark orange). The URL is three days old and clearly clones your checkout page, but hasn't appeared in any phishing report yet. What's your best first move?</div>
+      <div class="kcheck-options">
+        <button class="kcheck-opt" onclick="checkKC(this,'wrong','kc-m2')">Discard it — not enough evidence yet</button>
+        <button class="kcheck-opt" onclick="checkKC(this,'right','kc-m2')">Create an incident and request takedown — the visual clone is sufficient evidence</button>
+        <button class="kcheck-opt" onclick="checkKC(this,'wrong','kc-m2')">Put it in quarantine and wait for the AI score to reach 80%</button>
+        <button class="kcheck-opt" onclick="checkKC(this,'wrong','kc-m2')">Treat internally — the AI score is not high enough for takedown</button>
+      </div>
+      <div class="kcheck-feedback ok" id="kc-m2-ok" style="display:none">Right. The AI score is a signal, not a threshold. A visual clone of your checkout page is clear evidence of intent to defraud. Waiting for the score to climb or for reports to accumulate means more victims. Create an incident and request the takedown immediately — you can cancel it within 3 minutes if you change your mind.</div>
+      <div class="kcheck-feedback no" id="kc-m2-no" style="display:none">The AI score guides priority, but doesn't gate your decisions. A visual clone of your checkout page is compelling evidence regardless of score. You have 3 minutes to cancel a takedown request after submitting it, so the cost of acting is very low. Discarding or waiting lets a live phishing page collect more credentials.</div>
+    </div>
+
+    <h3 class="section-heading">Filtering your ticket list</h3>
+    <p style="color:var(--color-text-dim);font-size:14px;margin-bottom:16px">
+      With hundreds of tickets, filters are how you find what matters. Common filter combinations:
+    </p>
+
+    <table class="data-table animate-in">
+      <thead>
+        <tr>
+          <th>Goal</th>
+          <th>Filter to use</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>See only high-priority new threats</td>
+          <td>List: Open · AI Score: Red</td>
+        </tr>
+        <tr>
+          <td>Find all tickets for a specific brand asset</td>
+          <td>Asset filter → select brand name</td>
+        </tr>
+        <tr>
+          <td>Review stale quarantine items before auto-discard</td>
+          <td>List: Quarantine · Sort by: Oldest detection</td>
+        </tr>
+        <tr>
+          <td>Track takedowns in progress</td>
+          <td>List: Treatment · Status: Takedown requested</td>
+        </tr>
+        <tr>
+          <td>Search by URL or domain keyword</td>
+          <td>Manual search bar (supports partial matches)</td>
+        </tr>
+        <tr>
+          <td>Find historical detections for a new BIN</td>
+          <td>Data Leakage · Credit Cards · <code style="font-family:var(--font-mono)">isHistory:true</code></td>
+        </tr>
+      </tbody>
+    </table>
+
+    <button class="hero-cta" style="margin-top:24px" onclick="goToModule(3)">Next: Reading a Ticket →</button>
+  </div>
+</section>
+
+<!-- ══════════════════════════════════════════════════════════
+     MODULE 3 — READING A TICKET
+══════════════════════════════════════════════════════════ -->
+<section class="module" id="mod-3" data-module="3">
+  <div class="module-inner">
+    <div class="module-badge animate-in">Module 3 of 7</div>
+    <h2 class="module-title animate-in">Reading a Ticket</h2>
+    <p class="module-subtitle animate-in">
+      Every threat Axur detects becomes a ticket. Knowing what each field means, and what it doesn't tell you, cuts triage time and reduces wrong calls.
+    </p>
+
+    <h3 class="section-heading">Ticket types across workspaces</h3>
+
+    <table class="data-table animate-in">
+      <thead>
+        <tr><th>Workspace</th><th>Ticket type</th><th>What it detects</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Phishing</td>
+          <td><span class="tag tag-threat">Phishing</span></td>
+          <td>Fake pages mimicking your brand to steal credentials or payments</td>
+        </tr>
+        <tr>
+          <td>Fake Social Media</td>
+          <td><span class="tag tag-threat">Fake Social Media Profile</span></td>
+          <td>Impersonator accounts on major platforms misrepresenting your brand</td>
+        </tr>
+        <tr>
+          <td>Fake Mobile App</td>
+          <td><span class="tag tag-threat">Fake Mobile App</span></td>
+          <td>Counterfeit apps in app stores using your branding</td>
+        </tr>
+        <tr>
+          <td>Fraudulent Brand Use</td>
+          <td><span class="tag tag-threat">Fraudulent Brand Use</span></td>
+          <td>Unauthorized use of name, logo, or visual identity in ads, domains, or sites</td>
+        </tr>
+        <tr>
+          <td>Data Leakage</td>
+          <td><span class="tag tag-accent">Credit Cards · Credentials · Code · Breach Mentions</span></td>
+          <td>Your data appearing in underground markets, paste sites, or ransomware leaks</td>
+        </tr>
+        <tr>
+          <td>Deep &amp; Dark Web</td>
+          <td><span class="tag tag-warning">Dark Web Mention</span></td>
+          <td>References to your brand, employees, or infrastructure in dark web forums and channels</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3 class="section-heading">Anatomy of a ticket: what each field actually means</h3>
+
+    <div class="translation-block animate-in">
+      <div class="translation-side">
+        <div class="translation-label">Platform field</div>
+        <div class="translation-text">AI fraud probability score — 87% (🔴 red)</div>
+        <div class="translation-note"><strong>Watch out:</strong> Score reflects structural and visual signals, not confirmed victim data. A 55% score on a brand-new domain registered yesterday can still be extremely high risk.</div>
+      </div>
+      <div class="translation-side">
+        <div class="translation-label">What it means</div>
+        <div class="translation-text">
+          Axur's model analyzed the page's visual similarity to your brand assets, the domain age and registration pattern, presence of credential-capture forms, URL structure, and SSL certificate. It synthesized these into a single probability.
+          <br><br>
+          87% means: if you showed 100 similar pages to an experienced analyst, roughly 87 would be confirmed phishing. <strong>It's a priority signal, not a certainty.</strong>
+        </div>
+      </div>
+    </div>
+
+    <div class="translation-block animate-in">
+      <div class="translation-side">
+        <div class="translation-label">Platform field</div>
+        <div class="translation-text">Detection date vs. Last detection date</div>
+        <div class="translation-note"><strong>Key distinction:</strong> A site detected 30 days ago with a last detection from yesterday is still active and dangerous.</div>
+      </div>
+      <div class="translation-side">
+        <div class="translation-label">What it means</div>
+        <div class="translation-text">
+          <strong>Detection date</strong> — when Axur first found this threat.<br><br>
+          <strong>Last detection date</strong> — the most recent time Axur confirmed the threat is still live.<br><br>
+          The gap between these tells you how long the threat has been active. A long-running phishing site that survived undetected has likely already victimized many users. Prioritize takedown and check whether credential reset communications are needed.
+        </div>
+      </div>
+    </div>
+
+    <div class="translation-block animate-in">
+      <div class="translation-side">
+        <div class="translation-label">Platform field</div>
+        <div class="translation-text">Evidence: Screenshot + HTML + Links</div>
+        <div class="translation-note"><strong>More evidence = higher takedown success rate.</strong> ISPs and registrars respond faster with clear proof.</div>
+      </div>
+      <div class="translation-side">
+        <div class="translation-label">What it means</div>
+        <div class="translation-text">
+          Axur automatically captures visual evidence of the fraudulent page at detection time. This matters because phishing sites are often gone within hours.
+          <br><br>
+          For manually created tickets, you can add: screenshots, HTML source, and .zip files with full repository captures. Each additional piece of evidence strengthens the extrajudicial notification sent during takedown.
+        </div>
+      </div>
+    </div>
+
+    <h3 class="section-heading">The Details panel: what most people miss</h3>
+    <div class="steps animate-in">
+      <div class="step">
+        <div class="step-num">1</div>
+        <div class="step-content">
+          <div class="step-title">Source &amp; Group (Data Leakage tickets)</div>
+          <div class="step-desc">Where the data was found (Telegram, dark web forum, Mega.io) and the specific group or community. Critical for understanding blast radius — a Telegram channel with 50,000 members means broad exposure.</div>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-num">2</div>
+        <div class="step-content">
+          <div class="step-title">File name &amp; File Information</div>
+          <div class="step-desc">For breach detections, the file containing the exposed data is available for download. Files remain accessible for one year. Always investigate in a sandbox — files come as collected and may contain malware.</div>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-num">3</div>
+        <div class="step-content">
+          <div class="step-title">Events history</div>
+          <div class="step-desc">A full audit trail of every action taken on the ticket: who moved it, when, and what was added. Essential for team handoffs and post-incident review.</div>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-num">4</div>
+        <div class="step-content">
+          <div class="step-title">Tags &amp; Notes</div>
+          <div class="step-desc">Internal-only fields. Notes are never seen by Axur teams. Use them for internal tracking, investigation progress, and cross-team handoff context. Tags enable bulk filtering and reporting.</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="callout callout-info animate-in">
+      <div class="callout-title">Reclassification</div>
+      Analysts, Specialists, and Managers can reclassify Phishing, Fraudulent Brand Use, Fake Social Media Profile, and Fake Mobile App tickets, changing the brand and/or ticket type. Useful when automated classification gets it wrong. You cannot reclassify to a brand or ticket type you don't have access to.
+    </div>
+
+    <!-- Prediction before working a ticket -->
+    <div class="prediction-block animate-in" id="pred-m3">
+      <div class="prediction-header">
+        <span aria-hidden="true">🤔</span>
+        <span class="prediction-label">Think ahead to the next module</span>
+      </div>
+      <p class="prediction-question">
+        You open a new ticket: a domain registered 2 days ago, visual clone of your payment portal, AI score 91% (red). The URL currently returns a 200 OK with credential capture form.
+        <strong>How many actions could you legitimately take on this ticket?</strong>
+      </p>
+      <div class="prediction-options">
+        <button class="pred-option" onclick="selectPrediction(this,'pred-m3')" data-value="a">One — request takedown immediately</button>
+        <button class="pred-option" onclick="selectPrediction(this,'pred-m3')" data-value="b">Two — create incident, then request takedown</button>
+        <button class="pred-option" onclick="selectPrediction(this,'pred-m3')" data-value="c">Six — incident, quarantine, takedown, treat internally, discard, or safelist</button>
+        <button class="pred-option" onclick="selectPrediction(this,'pred-m3')" data-value="d">Three — incident, takedown, or discard</button>
+      </div>
+      <button class="pred-commit visible" id="pred-m3-btn" onclick="commitPrediction('pred-m3')">Lock in my answer →</button>
+      <div class="pred-reveal" id="pred-m3-reveal">
+        <strong style="color:var(--color-accent)">Six — all actions are technically available.</strong> Whether each makes sense is a different question. You <em>could</em> safelist a confirmed phishing page, but you'd be making a costly mistake. The next module covers the decision logic for each action — and the scenarios where even "obvious" choices have nuances.
+      </div>
+    </div>
+
+    <button class="hero-cta" style="margin-top:24px" onclick="goToModule(4)">Next: Working a Ticket →</button>
+  </div>
+</section>
+
+<!-- ══════════════════════════════════════════════════════════
+     MODULE 4 — WORKING A TICKET: TAKING ACTION
+══════════════════════════════════════════════════════════ -->
+<section class="module" id="mod-4" data-module="4">
+  <div class="module-inner">
+    <div class="module-badge animate-in">Module 4 of 7</div>
+    <h2 class="module-title animate-in">Working a Ticket: Taking Action</h2>
+    <p class="module-subtitle animate-in">
+      Six actions. Each moves a ticket forward differently. Here's when each one makes sense, and where teams typically go wrong.
+    </p>
+
+    <h3 class="section-heading">The six actions: quick reference</h3>
+
+    <div class="cards-grid animate-in">
+      <div class="card">
+        <div class="card-icon">⚠️</div>
+        <div class="card-title">Create Incident</div>
+        <div class="card-desc">Flags ticket as a confirmed potential risk. <em>Transitional</em> — a further action must follow. This is not a resolution.</div>
+      </div>
+      <div class="card">
+        <div class="card-icon">👁️</div>
+        <div class="card-title">Send to Quarantine</div>
+        <div class="card-desc">Monitor URLs showing brand misuse but no active fraud. Axur checks daily at 6 a.m. for content changes. Your team manages quarantine, not Axur.</div>
+      </div>
+      <div class="card">
+        <div class="card-icon">🛡️</div>
+        <div class="card-title">Request Takedown</div>
+        <div class="card-desc">Axur sends extrajudicial notifications to ISP, registrant, and registrar. Cancellable within 3 minutes. Under 4 min to first notification on average.</div>
+      </div>
+      <div class="card">
+        <div class="card-icon">🔧</div>
+        <div class="card-title">Treat Internally</div>
+        <div class="card-desc">Your team handles removal without Axur involvement. Use the ticket to centralize progress. Axur takes no action.</div>
+      </div>
+      <div class="card">
+        <div class="card-icon">🗑️</div>
+        <div class="card-title">Discard</div>
+        <div class="card-desc">False positive or irrelevant. Closes the ticket. Use when the detection clearly does not constitute fraud.</div>
+      </div>
+      <div class="card">
+        <div class="card-icon">✅</div>
+        <div class="card-title">Add to Safelist</div>
+        <div class="card-desc">Mark a URL as authorized to circulate. All safelisted URLs are treated as safe in future detections. Use sparingly — mistakes are hard to catch later.</div>
+      </div>
+    </div>
+
+    <!-- Decision tree -->
+    <h3 class="section-heading">Decision navigator — which action to take</h3>
+
+    <div class="dt-container animate-in" role="region" aria-label="Ticket action decision navigator">
+      <div class="dt-title">Walk through any new ticket →</div>
+
+      <div class="dt-node active" id="dt-0">
+        <div class="dt-question">Is this URL authorized by your organization in any way?</div>
+        <div class="dt-choices">
+          <button class="dt-choice" onclick="dtGo('dt-safelist','dt-0')">Yes — this is a legitimate partner, reseller, or owned property</button>
+          <button class="dt-choice" onclick="dtGo('dt-1','dt-0')">No — this is unauthorized</button>
+        </div>
+      </div>
+
+      <div class="dt-node" id="dt-safelist">
+        <div class="dt-breadcrumb">Authorized URL</div>
+        <div class="dt-outcome info">
+          <div class="dt-outcome-title">Add to Safelist</div>
+          If the URL is genuinely authorized and Axur is detecting it as a false positive, safelist it so future identical detections close automatically. Document the reason in the notes field for your team's reference.
+        </div>
+        <button class="dt-reset" onclick="dtReset()">↩ Start over</button>
+      </div>
+
+      <div class="dt-node" id="dt-1">
+        <div class="dt-breadcrumb">Unauthorized →</div>
+        <div class="dt-question">Is there clear, current evidence of active fraud — credential harvesting, payment capture, or obvious brand impersonation with a live form?</div>
+        <div class="dt-choices">
+          <button class="dt-choice" onclick="dtGo('dt-2','dt-1')">Yes — live threat confirmed</button>
+          <button class="dt-choice" onclick="dtGo('dt-3','dt-1')">No — brand misuse exists but no clear fraud mechanism visible yet</button>
+          <button class="dt-choice" onclick="dtGo('dt-false-positive','dt-1')">No — this appears to be a false positive or unrelated site</button>
+        </div>
+      </div>
+
+      <div class="dt-node" id="dt-2">
+        <div class="dt-breadcrumb">Unauthorized → Active fraud confirmed →</div>
+        <div class="dt-question">Does your organization have legal or process reasons to handle this internally (e.g. specific ISP relationships, ongoing law enforcement coordination)?</div>
+        <div class="dt-choices">
+          <button class="dt-choice" onclick="dtGo('dt-takedown','dt-2')">No — Axur should manage the takedown</button>
+          <button class="dt-choice" onclick="dtGo('dt-internal','dt-2')">Yes — we will handle this ourselves</button>
+        </div>
+      </div>
+
+      <div class="dt-node" id="dt-takedown">
+        <div class="dt-breadcrumb">Unauthorized → Active fraud → Axur takedown</div>
+        <div class="dt-outcome success">
+          <div class="dt-outcome-title">Create Incident → Request Takedown</div>
+          Create the incident first to document the threat formally, then request takedown. Axur sends extrajudicial notifications to the ISP, registrant, and registrar in under 4 minutes on average. You have a 3-minute window to cancel after clicking. Add all available evidence before requesting — more evidence improves success rate. 99% overall resolution rate.
+        </div>
+        <button class="dt-reset" onclick="dtReset()">↩ Start over</button>
+      </div>
+
+      <div class="dt-node" id="dt-internal">
+        <div class="dt-breadcrumb">Unauthorized → Active fraud → Internal handling</div>
+        <div class="dt-outcome info">
+          <div class="dt-outcome-title">Create Incident → Treat Internally</div>
+          Create the incident to document it, then select "Treat Internally." Use the ticket notes field to track your progress, contacts reached, and resolution steps. Axur takes no external action — all removal efforts are yours to execute. Export to PDF for sharing with legal or law enforcement.
+        </div>
+        <button class="dt-reset" onclick="dtReset()">↩ Start over</button>
+      </div>
+
+      <div class="dt-node" id="dt-3">
+        <div class="dt-breadcrumb">Unauthorized → No active fraud →</div>
+        <div class="dt-question">How fresh is the domain or account? Could it become fraudulent imminently?</div>
+        <div class="dt-choices">
+          <button class="dt-choice" onclick="dtGo('dt-quarantine','dt-3')">Very new (days old) — high suspicion, worth watching</button>
+          <button class="dt-choice" onclick="dtGo('dt-quarantine','dt-3')">Established but showing concerning content changes</button>
+          <button class="dt-choice" onclick="dtGo('dt-false-positive','dt-3')">Old, stable, and clearly unrelated to fraud</button>
+        </div>
+      </div>
+
+      <div class="dt-node" id="dt-quarantine">
+        <div class="dt-breadcrumb">Brand misuse, no active fraud</div>
+        <div class="dt-outcome warning">
+          <div class="dt-outcome-title">Send to Quarantine</div>
+          Quarantine lets Axur's automated system watch the URL daily (6 a.m. check) and alert you to content changes. Set a calendar reminder to review it before 6 months — it will auto-discard after that window. If Axur signals a content change, reassess and escalate if fraud evidence appears.
+        </div>
+        <button class="dt-reset" onclick="dtReset()">↩ Start over</button>
+      </div>
+
+      <div class="dt-node" id="dt-false-positive">
+        <div class="dt-breadcrumb">False positive or unrelated</div>
+        <div class="dt-outcome info">
+          <div class="dt-outcome-title">Discard</div>
+          If the detection is a false positive — the site doesn't impersonate your brand and poses no fraud risk — discard it. Only safelist it if it's a legitimate authorized URL that will trigger future detections. Discarding alone is usually sufficient for one-off false positives.
+        </div>
+        <button class="dt-reset" onclick="dtReset()">↩ Start over</button>
+      </div>
+    </div>
+
+    <h3 class="section-heading">The takedown process — what happens after you click</h3>
+
+    <div class="steps animate-in">
+      <div class="step">
+        <div class="step-num">1</div>
+        <div class="step-content">
+          <div class="step-title">Extrajudicial notification sent (under 4 min average)</div>
+          <div class="step-desc">Axur forwards a formal abuse notification to three entities simultaneously: the ISP (hosting the content), the registrant (who owns the domain), and the registrar (where the domain was purchased). Each has different leverage over the content.</div>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-num">2</div>
+        <div class="step-content">
+          <div class="step-title">First-contact resolution (70% of cases)</div>
+          <div class="step-desc">Seven in ten takedowns resolve on this first notification — the hosting provider or registrar disables the content. You'll see the ticket update in the platform as the URL goes dark.</div>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-num">3</div>
+        <div class="step-content">
+          <div class="step-title">Escalation if needed</div>
+          <div class="step-desc">For the 30% that don't resolve immediately, Axur escalates through additional channels. Overall resolution rate: 99%. Some delays occur when content is hosted in jurisdictions with limited cooperation.</div>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-num">4</div>
+        <div class="step-content">
+          <div class="step-title">Post-takedown monitoring</div>
+          <div class="step-desc">Attackers often re-register variants of taken-down domains or move to a new host. Axur continues monitoring for resurfaces. If the same content reappears, a new ticket is created automatically.</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="callout callout-warning animate-in">
+      <div class="callout-title">Takedown interrupted</div>
+      Some takedowns enter an "Interrupted" status. This means Axur could not reach the responsible entity — common reasons include hosting in non-cooperative jurisdictions, invalid WHOIS contact data, or the content moving hosts after notification. You can request a Deep &amp; Dark Web investigation to pursue further if your plan includes research hours.
+    </div>
+
+    <!-- Quiz module 4 -->
+    <div class="quiz-container animate-in" role="group" aria-labelledby="quiz4-title">
+      <div class="quiz-title" id="quiz4-title">Scenario Quiz</div>
+      <div class="quiz-q">
+        A ticket arrives: a Telegram channel sharing what appears to be your company's internal HR documents, including employee salary data. The AI score is 45% (yellow). Your instinct is to discard it because the score is low. What should you actually do?
+      </div>
+      <div class="quiz-options" id="quiz4-opts">
+        <button class="quiz-option" onclick="selectQuiz(this,'quiz4')" data-value="a">
+          <span class="quiz-icon" aria-hidden="true">○</span>
+          Discard — the yellow score means it's probably a false positive
+        </button>
+        <button class="quiz-option" onclick="selectQuiz(this,'quiz4')" data-value="b">
+          <span class="quiz-icon" aria-hidden="true">○</span>
+          Create incident and request Deep &amp; Dark Web investigation, then treat internally while coordinating with HR and legal
+        </button>
+        <button class="quiz-option" onclick="selectQuiz(this,'quiz4')" data-value="c">
+          <span class="quiz-icon" aria-hidden="true">○</span>
+          Request takedown — Axur can remove Telegram channels
+        </button>
+        <button class="quiz-option" onclick="selectQuiz(this,'quiz4')" data-value="d">
+          <span class="quiz-icon" aria-hidden="true">○</span>
+          Put it in quarantine and wait for more evidence
+        </button>
+      </div>
+      <button class="quiz-check" id="quiz4-btn" onclick="checkQuiz('quiz4','b')" disabled>Check answer</button>
+      <div class="quiz-feedback" id="quiz4-feedback"></div>
+      <button class="quiz-reset" onclick="resetQuiz('quiz4')" style="display:none" id="quiz4-reset">Try again</button>
+    </div>
+
+    <button class="hero-cta" style="margin-top:24px" onclick="goToModule(5)">Next: Data Leakage →</button>
+  </div>
+</section>
+
+<!-- ══════════════════════════════════════════════════════════
+     MODULE 5 — DATA LEAKAGE
+══════════════════════════════════════════════════════════ -->
+<section class="module" id="mod-5" data-module="5">
+  <div class="module-inner">
+    <div class="module-badge animate-in">Module 5 of 7</div>
+    <h2 class="module-title animate-in">Data Leakage: Protecting Your Crown Jewels</h2>
+    <p class="module-subtitle animate-in">
+      Card numbers, credentials, source code, internal documents: when they show up somewhere they shouldn't, every minute before you respond is time attackers have to use them.
+    </p>
+
+    <h3 class="section-heading">Four leakage types, four different risk profiles</h3>
+
+    <table class="data-table animate-in">
+      <thead>
+        <tr><th>Type</th><th>What's exposed</th><th>Primary risk</th><th>Key response action</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><span class="tag tag-threat">Credit Card Exposure</span></td>
+          <td>Card numbers, CVVs, expiry dates matched against your BINs</td>
+          <td>Fraudulent transactions before you can block cards</td>
+          <td>Reissue or block affected cards; notify cardholders</td>
+        </tr>
+        <tr>
+          <td><span class="tag tag-threat">Credentials Exposure</span></td>
+          <td>Login pairs (email + password) for employee or customer accounts</td>
+          <td>Account takeover, lateral movement, customer fraud</td>
+          <td>Force password reset; notify affected users; review MFA coverage</td>
+        </tr>
+        <tr>
+          <td><span class="tag tag-warning">Code &amp; Secret Leaks</span></td>
+          <td>Source code, API keys, tokens, private certificates on GitHub or paste sites</td>
+          <td>Credential exposure, IP theft, backdoor creation</td>
+          <td>Revoke secrets immediately; audit for downstream use; DMCA if applicable</td>
+        </tr>
+        <tr>
+          <td><span class="tag tag-warning">Mentions in Data Breach</span></td>
+          <td>Files referencing your brand/domain inside ransomware leak packages</td>
+          <td>Extortion, operational data exposure, third-party breach impact</td>
+          <td>Download file in sandbox; assess scope; engage incident response if live attack</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="callout callout-danger animate-in">
+      <div class="callout-title">Critical: Takedown is not available for data breach files</div>
+      Ransomware groups operate outside legal jurisdictions. Takedown isn't an option. The response is entirely internal: assess, contain, notify, harden. For exposure before monitoring was active, use Threat Hunting to search historical data.
+    </div>
+
+    <h3 class="section-heading">Credit card exposure — what makes it different</h3>
+
+    <div class="translation-block animate-in">
+      <div class="translation-side">
+        <div class="translation-label">Common misconception</div>
+        <div class="translation-text">"We have fraud detection — it will catch fraudulent transactions before they succeed."</div>
+        <div class="translation-note"><strong>The gap:</strong> Transaction-based fraud detection is reactive. Credit card exposure is proactive.</div>
+      </div>
+      <div class="translation-side">
+        <div class="translation-label">What exposure monitoring adds</div>
+        <div class="translation-text">
+          Behavioral fraud detection catches anomalous <em>transactions</em>. Credit card exposure catches compromised cards <em>before any transaction is attempted</em>.<br><br>
+          When Axur finds your card data in a Telegram channel or dark web market, you can reissue those cards before attackers use them. The Luhn algorithm validates every detected card number — invalid numbers are discarded, reducing false positives.<br><br>
+          <strong>Complete cards</strong> (number + expiry + CVV) are the highest risk — they can be used immediately for CNP (card-not-present) fraud. <strong>Incomplete cards</strong> still warrant investigation but carry lower immediate risk.
+        </div>
+      </div>
+    </div>
+
+    <!-- Detection lifecycle state machine -->
+    <h3 class="section-heading">Detection lifecycle — the same workflow across all leakage types</h3>
+
+    <div class="sm-container animate-in" role="region" aria-label="Detection lifecycle state machine">
+      <div class="sm-title">Click a transition to move through the lifecycle →</div>
+      <div class="sm-states">
+        <div class="sm-state active" id="sm-new" aria-current="true">
+          <div class="sm-state-name">New</div>
+          <div class="sm-state-desc">Just identified</div>
+        </div>
+        <div class="sm-arrow" aria-hidden="true">→</div>
+        <div class="sm-state" id="sm-treatment">
+          <div class="sm-state-name">In Treatment</div>
+          <div class="sm-state-desc">Under investigation</div>
+        </div>
+        <div class="sm-arrow" aria-hidden="true">→</div>
+        <div class="sm-state" id="sm-solved">
+          <div class="sm-state-name">Solved</div>
+          <div class="sm-state-desc">Addressed</div>
+        </div>
+        <div class="sm-arrow" aria-hidden="true">/</div>
+        <div class="sm-state" id="sm-discarded">
+          <div class="sm-state-name">Discarded</div>
+          <div class="sm-state-desc">Not relevant</div>
+        </div>
+      </div>
+      <div class="sm-triggers">
+        <button class="sm-trigger" onclick="smTrigger('new','Start triage')">Start triage</button>
+        <button class="sm-trigger" onclick="smTrigger('treatment','Mark resolved')">Mark resolved</button>
+        <button class="sm-trigger" onclick="smTrigger('treatment','Mark irrelevant')">Mark irrelevant</button>
+        <button class="sm-trigger" onclick="smReset()">↩ Reset</button>
+      </div>
+      <div class="sm-info" id="sm-info" aria-live="polite">
+        <strong>New</strong> — A detection just landed. Your job: review the evidence, assess whether the data is real and relevant to your organization, and begin triage. Add tags and notes as you go — all actions are logged in the Events history.
+      </div>
+    </div>
+
+    <h3 class="section-heading">Investigating a breach file — safe procedure</h3>
+
+    <div class="steps animate-in">
+      <div class="step">
+        <div class="step-num">1</div>
+        <div class="step-content">
+          <div class="step-title">Read the detection details first</div>
+          <div class="step-desc">Before downloading anything, read the Source, Group, Context, and Mentioned Sample fields. Often these tell you enough to assess severity without touching the file.</div>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-num">2</div>
+        <div class="step-content">
+          <div class="step-title">Download in a sandbox environment</div>
+          <div class="step-desc">Files come as collected and have not been scanned for malware. Axur explicitly recommends using a sandbox. Never open breach files directly on your work machine or corporate network.</div>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-num">3</div>
+        <div class="step-content">
+          <div class="step-title">Assess scope: what exactly is in the file?</div>
+          <div class="step-desc">Determine: which systems or data types are referenced, whether it's a direct exfiltration or a third-party breach that mentions you, and the volume of records.</div>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-num">4</div>
+        <div class="step-content">
+          <div class="step-title">Escalate and notify internally</div>
+          <div class="step-desc">Notify owners of impacted systems. If the breach indicates an active attack, escalate immediately. Engage legal if regulatory notification (GDPR, PCI-DSS, etc.) may be required.</div>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-num">5</div>
+        <div class="step-content">
+          <div class="step-title">Update the detection status and document</div>
+          <div class="step-desc">Move to "In Treatment," add notes with your findings, and update to "Solved" when remediation is complete. Files are available for download for one year — 1 TB per customer per month limit.</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="quiz-container animate-in" role="group" aria-labelledby="quiz5-title">
+      <div class="quiz-title" id="quiz5-title">Scenario Quiz</div>
+      <div class="quiz-q">
+        Axur detects 847 credit cards matching your BINs in a Telegram channel. The detection shows "Incomplete cards" — card numbers only, no CVV or expiry. A colleague says "incomplete cards can't be used for fraud, we can close this." Is she right?
+      </div>
+      <div class="quiz-options" id="quiz5-opts">
+        <button class="quiz-option" onclick="selectQuiz(this,'quiz5')" data-value="a">
+          <span class="quiz-icon" aria-hidden="true">○</span>
+          Yes — without CVV, the cards can't be used for online transactions, so this is low priority
+        </button>
+        <button class="quiz-option" onclick="selectQuiz(this,'quiz5')" data-value="b">
+          <span class="quiz-icon" aria-hidden="true">○</span>
+          Partially — they're lower immediate risk than complete cards, but still warrant investigation and possible reissuance
+        </button>
+        <button class="quiz-option" onclick="selectQuiz(this,'quiz5')" data-value="c">
+          <span class="quiz-icon" aria-hidden="true">○</span>
+          No — incomplete cards are more dangerous because they're harder to detect as compromised
+        </button>
+        <button class="quiz-option" onclick="selectQuiz(this,'quiz5')" data-value="d">
+          <span class="quiz-icon" aria-hidden="true">○</span>
+          It depends entirely on the source — Telegram is low-risk compared to dark web forums
+        </button>
+      </div>
+      <button class="quiz-check" id="quiz5-btn" onclick="checkQuiz('quiz5','b')" disabled>Check answer</button>
+      <div class="quiz-feedback" id="quiz5-feedback"></div>
+      <button class="quiz-reset" onclick="resetQuiz('quiz5')" style="display:none" id="quiz5-reset">Try again</button>
+    </div>
+
+    <button class="hero-cta" style="margin-top:24px" onclick="goToModule(6)">Next: Threat Hunting →</button>
+  </div>
+</section>
+
+<!-- ══════════════════════════════════════════════════════════
+     MODULE 6 — THREAT HUNTING
+══════════════════════════════════════════════════════════ -->
+<section class="module" id="mod-6" data-module="6">
+  <div class="module-inner">
+    <div class="module-badge animate-in">Module 6 of 7</div>
+    <h2 class="module-title animate-in">Threat Hunting: Searching on Your Terms</h2>
+    <p class="module-subtitle animate-in">
+      Axur's monitoring runs 24/7 in the background and automatically opens tickets when matches surface against your assets. Threat Hunting is the complement: a user-initiated search where you formulate a hypothesis and query the data lake directly.
+    </p>
+
+    <div class="callout callout-info animate-in">
+      <div class="callout-title">Automated monitoring vs. user-initiated Threat Hunting</div>
+      Monitoring is automated and continuous — it runs 24/7 without your input and creates tickets when it finds matches against your configured assets. Threat Hunting is user-initiated and hypothesis-driven: you query the data lake manually when you want to (1) test a specific incident hypothesis, (2) explore historical data from before monitoring was active for an asset, (3) deepen context on an existing ticket, or (4) investigate an angle monitoring isn't configured to cover.
+    </div>
+
+    <h3 class="section-heading">The credit system — what it costs to hunt</h3>
+
+    <div class="cards-grid animate-in">
+      <div class="card">
+        <div class="card-icon">🪙</div>
+        <div class="card-title">1 credit = 100 results</div>
+        <div class="card-desc">Each search query consumes credits based on the number of results returned. A query that returns 500 results costs 5 credits.</div>
+      </div>
+      <div class="card">
+        <div class="card-icon">⏱️</div>
+        <div class="card-title">12-hour retention</div>
+        <div class="card-desc">Hunt results are available for 12 hours after the search completes. Export or save what you need — results disappear after the window closes.</div>
+      </div>
+      <div class="card">
+        <div class="card-icon">🔌</div>
+        <div class="card-title">API available</div>
+        <div class="card-desc">Threat Hunting is accessible via the Axur API, enabling integration into automated investigation workflows and SOAR platforms.</div>
+      </div>
+    </div>
+
+    <h3 class="section-heading">The Axur Query Language (AQL)</h3>
+    <p style="color:var(--color-text-dim);font-size:14px;margin-bottom:20px">
+      AQL is the search language for Threat Hunting. It's designed to be readable — if you've ever used a search engine's advanced operators, most of this will feel familiar.
+    </p>
+
+    <table class="data-table animate-in">
+      <thead>
+        <tr><th>Operator</th><th>Syntax</th><th>What it does</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><span class="tag tag-accent">AND</span></td>
+          <td><code style="font-family:var(--font-mono)">phishing AND mybank</code></td>
+          <td>Both terms must appear in the result</td>
+        </tr>
+        <tr>
+          <td><span class="tag tag-accent">OR</span></td>
+          <td><code style="font-family:var(--font-mono)">mybank OR "my bank"</code></td>
+          <td>Either term matches — useful for brand name variations</td>
+        </tr>
+        <tr>
+          <td><span class="tag tag-accent">NOT</span></td>
+          <td><code style="font-family:var(--font-mono)">mybank NOT official</code></td>
+          <td>Exclude results containing a term — reduces noise</td>
+        </tr>
+        <tr>
+          <td><span class="tag tag-warning">* wildcard</span></td>
+          <td><code style="font-family:var(--font-mono)">mybrank*</code></td>
+          <td>Matches zero or more characters — catches typo-squatting variants</td>
+        </tr>
+        <tr>
+          <td><span class="tag tag-warning">? wildcard</span></td>
+          <td><code style="font-family:var(--font-mono)">mybrank?</code></td>
+          <td>Matches exactly one character — more precise than *</td>
+        </tr>
+        <tr>
+          <td><span class="tag tag-warning">~ fuzzy</span></td>
+          <td><code style="font-family:var(--font-mono)">mybank~</code></td>
+          <td>Fuzzy match — catches misspellings and character substitutions (e.g. mybonk, mYbank)</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3 class="section-heading">Real-world query examples</h3>
+
+    <div class="aql-block animate-in">
+      <span class="aql-comment"># Hunt for similar domain names — classic typosquat detection</span><br>
+      <span class="aql-kw">domain</span>:<span class="aql-val">mybank</span><span class="aql-wild">*</span> <span class="aql-op">NOT</span> <span class="aql-val">mybank.com</span>
+    </div>
+
+    <div class="aql-block animate-in">
+      <span class="aql-comment"># Find credential leaks for your domain</span><br>
+      <span class="aql-kw">email</span>:<span class="aql-val">*@mybank.com</span> <span class="aql-op">AND</span> <span class="aql-kw">type</span>:<span class="aql-val">credential</span>
+    </div>
+
+    <div class="aql-block animate-in">
+      <span class="aql-comment"># Search for dark web mentions with executive names</span><br>
+      (<span class="aql-val">"John Smith"</span> <span class="aql-op">OR</span> <span class="aql-val">"Jane Doe"</span>) <span class="aql-op">AND</span> <span class="aql-val">mybank</span>
+    </div>
+
+    <div class="aql-block animate-in">
+      <span class="aql-comment"># Find phishing kits referencing your brand in ads</span><br>
+      <span class="aql-kw">title</span>:<span class="aql-val">mybank</span><span class="aql-wild">~</span> <span class="aql-op">AND</span> <span class="aql-kw">type</span>:<span class="aql-val">sponsored_ad</span>
+    </div>
+
+    <div class="callout callout-info animate-in">
+      <div class="callout-title">AI Query Builder shortcut</div>
+      Not sure how to write an AQL query? The AI Query Builder translates natural language into valid AQL. Type what you're looking for in plain English and it generates the query. You can edit the generated query before running it.
+    </div>
+
+    <h3 class="section-heading">Search parameter categories</h3>
+    <div class="cards-grid animate-in">
+      <div class="card">
+        <div class="card-icon">🌐</div>
+        <div class="card-title">URL &amp; Domains</div>
+        <div class="card-desc">Search across detected URLs and domain registrations. Primary tool for finding typosquat and look-alike domains before they launch phishing campaigns.</div>
+      </div>
+      <div class="card">
+        <div class="card-icon">💳</div>
+        <div class="card-title">Credit Cards</div>
+        <div class="card-desc">Search by BIN range, card number prefix, or source. Note: Threat Hunting does NOT provide CVV numbers — use Credit Card Exposure for full detection details.</div>
+      </div>
+      <div class="card">
+        <div class="card-icon">🔑</div>
+        <div class="card-title">Credentials</div>
+        <div class="card-desc">Search leaked login pairs by domain, email pattern, or username. Useful for assessing scope before forcing a password reset campaign.</div>
+      </div>
+      <div class="card">
+        <div class="card-icon">📢</div>
+        <div class="card-title">Ads &amp; Sponsored</div>
+        <div class="card-desc">Search for fraudulent sponsored search results or display ads using your brand. Especially useful post-campaign to catch fast-moving ad fraud.</div>
+      </div>
+      <div class="card">
+        <div class="card-icon">🌑</div>
+        <div class="card-title">Deep &amp; Dark Web</div>
+        <div class="card-desc">Search forums, marketplaces, ransomware sites, and Telegram channels for brand mentions, leaked documents, and threat actor chatter.</div>
+      </div>
+    </div>
+
+    <div class="quiz-container animate-in" role="group" aria-labelledby="quiz6-title">
+      <div class="quiz-title" id="quiz6-title">Knowledge Check</div>
+      <div class="quiz-q">
+        You run a Threat Hunting search that returns 1,200 results. You spend 2 hours reviewing them and identify 3 confirmed threats. When you try to export the remaining results the next morning, you find they're gone. What happened, and how do you prevent this next time?
+      </div>
+      <div class="quiz-options" id="quiz6-opts">
+        <button class="quiz-option" onclick="selectQuiz(this,'quiz6')" data-value="a">
+          <span class="quiz-icon" aria-hidden="true">○</span>
+          A system error deleted the results — contact Axur support
+        </button>
+        <button class="quiz-option" onclick="selectQuiz(this,'quiz6')" data-value="b">
+          <span class="quiz-icon" aria-hidden="true">○</span>
+          Results expired after the 12-hour retention window — export immediately after a search or re-run the query
+        </button>
+        <button class="quiz-option" onclick="selectQuiz(this,'quiz6')" data-value="c">
+          <span class="quiz-icon" aria-hidden="true">○</span>
+          Your credits ran out during the session — purchase more and retry
+        </button>
+        <button class="quiz-option" onclick="selectQuiz(this,'quiz6')" data-value="d">
+          <span class="quiz-icon" aria-hidden="true">○</span>
+          Results older than 24 hours require a paid archive access request
+        </button>
+      </div>
+      <button class="quiz-check" id="quiz6-btn" onclick="checkQuiz('quiz6','b')" disabled>Check answer</button>
+      <div class="quiz-feedback" id="quiz6-feedback"></div>
+      <button class="quiz-reset" onclick="resetQuiz('quiz6')" style="display:none" id="quiz6-reset">Try again</button>
+    </div>
+
+    <button class="hero-cta" style="margin-top:24px" onclick="goToModule(7)">Next: Measuring Security Posture →</button>
+  </div>
+</section>
+
+<!-- ══════════════════════════════════════════════════════════
+     MODULE 7 — STATS & SECURITY POSTURE
+══════════════════════════════════════════════════════════ -->
+<section class="module" id="mod-7" data-module="7">
+  <div class="module-inner">
+    <div class="module-badge animate-in">Module 7 of 7</div>
+    <h2 class="module-title animate-in">Measuring Your Security Posture</h2>
+    <p class="module-subtitle animate-in">
+      The Stats page shows whether your program is actually working: response speed and industry benchmarks, not just detection counts.
+    </p>
+
+    <h3 class="section-heading">The four metric categories</h3>
+
+    <div class="cards-grid animate-in">
+      <div class="card">
+        <div class="card-icon">🔭</div>
+        <div class="card-title">Coverage</div>
+        <div class="card-desc">How broad is Axur's monitoring for your assets? Higher coverage means fewer gaps in detection. Driven by your monitored asset list — the richer it is, the better the coverage.</div>
+      </div>
+      <div class="card">
+        <div class="card-icon">⚠️</div>
+        <div class="card-title">Threats</div>
+        <div class="card-desc">Total threats detected across all workspaces. Trend over time tells you if your brand's threat surface is growing, stable, or shrinking.</div>
+      </div>
+      <div class="card">
+        <div class="card-icon">🚨</div>
+        <div class="card-title">Incidents</div>
+        <div class="card-desc">Confirmed threats broken down by type: phishing, fake social, data leakage, etc. Includes segment benchmarking — how your incident rate compares to peers in your industry.</div>
+      </div>
+      <div class="card">
+        <div class="card-icon">✅</div>
+        <div class="card-title">Solved</div>
+        <div class="card-desc">Treatment rate metrics: how many threats were resolved vs. left open, average time-to-resolution, and takedown success rates.</div>
+      </div>
+    </div>
+
+    <h3 class="section-heading">Reading the stats — spec ↔ plain English</h3>
+
+    <div class="translation-block animate-in">
+      <div class="translation-side">
+        <div class="translation-label">Platform metric</div>
+        <div class="translation-text">Industry benchmark: Your phishing incident rate is 23% above segment average</div>
+      </div>
+      <div class="translation-side">
+        <div class="translation-label">What it means for you</div>
+        <div class="translation-text">
+          Your brand is being targeted more aggressively than peers in your sector. This is either because: (a) your brand is more valuable to attackers (higher customer trust = more convincing phishing), (b) your monitoring coverage is higher so you're catching more, or (c) a specific campaign is targeting your industry vertical.
+          <br><br>
+          <strong>The right response:</strong> Don't reduce monitoring to look better in benchmarks. Investigate whether a specific threat actor group is running campaigns against your sector, and tighten takedown response times.
+        </div>
+      </div>
+    </div>
+
+    <div class="translation-block animate-in">
+      <div class="translation-side">
+        <div class="translation-label">Platform metric</div>
+        <div class="translation-text">Takedown resolved: 99% overall · 70% on first notification · Under 4 min to first notification (avg)</div>
+      </div>
+      <div class="translation-side">
+        <div class="translation-label">What it means for you</div>
+        <div class="translation-text">
+          Seven in ten takedowns succeed on the first extrajudicial notification — meaning most phishing sites are down within hours of your request. The remaining 30% require escalation but reach 99% overall.
+          <br><br>
+          <strong>Your time-to-takedown</strong> depends on how fast you move tickets from Open → Incident → Treatment. Axur's speed is fixed; your triage speed is not. A ticket sitting in Open for 48 hours before you request takedown means 48 extra hours of active phishing.
+        </div>
+      </div>
+    </div>
+
+    <h3 class="section-heading">Building monitoring into your workflow</h3>
+
+    <div class="steps animate-in">
+      <div class="step">
+        <div class="step-num">1</div>
+        <div class="step-content">
+          <div class="step-title">Daily: clear the Open queue</div>
+          <div class="step-desc">Start with AI score red tickets. Every new red ticket should be evaluated and actioned (incident or discard) the same day it appears. Set up email alerts for new detections if you don't check daily.</div>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-num">2</div>
+        <div class="step-content">
+          <div class="step-title">Weekly: review quarantine and treatment</div>
+          <div class="step-desc">Check Quarantine for content changes flagged by Axur's daily crawl. Review Treatment tickets for stalled takedowns or "interrupted" statuses that need escalation or internal follow-up.</div>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-num">3</div>
+        <div class="step-content">
+          <div class="step-title">Monthly: proactive Threat Hunting</div>
+          <div class="step-desc">Run at least one proactive hunt per month — search for similar domain names registered in the past 30 days, new credential exposures, or dark web mentions. Find threats before the monitoring pipeline surfaces them.</div>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-num">4</div>
+        <div class="step-content">
+          <div class="step-title">Quarterly: review monitored assets</div>
+          <div class="step-desc">Coverage is only as good as your asset list. Add new brand names, acquired domains, new executive names, BINs for new card products. Remove assets that are no longer monitored. Export Stats for security reporting to leadership.</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="callout callout-success animate-in">
+      <div class="callout-title">What "good" looks like</div>
+      A mature Axur program: red tickets actioned same-day, takedown requests submitted within 2 hours of confirmation, quarantine reviewed weekly, Threat Hunting scheduled monthly, and asset list audited quarterly. Most programs reach this cadence within 60–90 days of onboarding.
+    </div>
+
+    <!-- Final quiz -->
+    <div class="quiz-container animate-in" role="group" aria-labelledby="quiz7-title">
+      <div class="quiz-title" id="quiz7-title">Final Scenario</div>
+      <div class="quiz-q">
+        Your Stats page shows: 340 threats detected last month, 89% treatment rate, but average time-to-treatment of 4.2 days. Your takedown success rate is 97%. Your manager asks what to focus on improving. What's the most impactful recommendation?
+      </div>
+      <div class="quiz-options" id="quiz7-opts">
+        <button class="quiz-option" onclick="selectQuiz(this,'quiz7')" data-value="a">
+          <span class="quiz-icon" aria-hidden="true">○</span>
+          Increase monitored assets to detect more threats — 340 per month seems low
+        </button>
+        <button class="quiz-option" onclick="selectQuiz(this,'quiz7')" data-value="b">
+          <span class="quiz-icon" aria-hidden="true">○</span>
+          Focus on reducing time-to-treatment — 4.2 days means phishing sites are live for days before action
+        </button>
+        <button class="quiz-option" onclick="selectQuiz(this,'quiz7')" data-value="c">
+          <span class="quiz-icon" aria-hidden="true">○</span>
+          Push takedown success from 97% to 100% — no threats should be left unresolved
+        </button>
+        <button class="quiz-option" onclick="selectQuiz(this,'quiz7')" data-value="d">
+          <span class="quiz-icon" aria-hidden="true">○</span>
+          The 89% treatment rate is the most urgent gap — 11% of threats are unresolved
+        </button>
+      </div>
+      <button class="quiz-check" id="quiz7-btn" onclick="checkQuiz('quiz7','b')" disabled>Check answer</button>
+      <div class="quiz-feedback" id="quiz7-feedback"></div>
+      <button class="quiz-reset" onclick="resetQuiz('quiz7')" style="display:none" id="quiz7-reset">Try again</button>
+    </div>
+
+    <div class="completion-banner animate-in">
+      <h2>Course Complete</h2>
+      <p>You've covered the full Axur platform: threat detection, ticket triage, data leakage, takedowns, and threat hunting.</p>
+      <br>
+      <p style="font-size:14px;color:var(--color-text-dim)">
+        <strong style="color:var(--color-accent)">Next steps:</strong>
+        Log in to Axur → clear your Open queue → run your first Threat Hunt.
+      </p>
+    </div>
+  </div>
+</section>
+
+<script>
+// ─── Module data ───────────────────────────────────────────
+const MODULES = [
+  { id: 'mod-0', label: 'Intro' },
+  { id: 'mod-1', label: 'Threat Landscape' },
+  { id: 'mod-2', label: 'Your Workspace' },
+  { id: 'mod-3', label: 'Reading a Ticket' },
+  { id: 'mod-4', label: 'Working a Ticket' },
+  { id: 'mod-5', label: 'Data Leakage' },
+  { id: 'mod-6', label: 'Threat Hunting' },
+  { id: 'mod-7', label: 'Security Posture' },
+];
+
+// ─── Nav dots ──────────────────────────────────────────────
+function buildNavDots() {
+  const nav = document.getElementById('nav-dots');
+  MODULES.forEach((m, i) => {
+    const btn = document.createElement('button');
+    btn.className = 'nav-dot' + (i === 0 ? ' active' : '');
+    btn.setAttribute('aria-label', 'Go to ' + m.label);
+    btn.setAttribute('tabindex', '0');
+    const lbl = document.createElement('span');
+    lbl.className = 'nav-dot-label';
+    lbl.textContent = m.label;
+    btn.appendChild(lbl);
+    btn.addEventListener('click', () => goToModule(i));
+    btn.addEventListener('keydown', e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); goToModule(i); } });
+    nav.appendChild(btn);
+  });
+}
+
+function updateNavDots(activeIdx) {
+  document.querySelectorAll('.nav-dot').forEach((d, i) => {
+    d.classList.toggle('active', i === activeIdx);
+  });
+}
+
+// ─── Progress bar ──────────────────────────────────────────
+function updateProgress() {
+  const modules = document.querySelectorAll('.module');
+  const scrollY = window.scrollY + window.innerHeight * 0.5;
+  let active = 0;
+  modules.forEach((m, i) => {
+    if (m.getBoundingClientRect().top + window.scrollY <= scrollY) active = i;
+  });
+  const pct = (active / (modules.length - 1)) * 100;
+  document.getElementById('progress-bar').style.width = pct + '%';
+  document.getElementById('progress-bar-wrap').setAttribute('aria-valuenow', Math.round(pct));
+  updateNavDots(active);
+}
+
+// ─── Scroll to module ──────────────────────────────────────
+function goToModule(idx) {
+  const el = document.getElementById(MODULES[idx].id);
+  if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}
+
+// ─── Animate-in on scroll ─────────────────────────────────
+function checkAnimations() {
+  document.querySelectorAll('.animate-in:not(.visible)').forEach(el => {
+    const rect = el.getBoundingClientRect();
+    if (rect.top < window.innerHeight * 0.92) el.classList.add('visible');
+  });
+}
+
+window.addEventListener('scroll', () => { updateProgress(); checkAnimations(); }, { passive: true });
+window.addEventListener('resize', updateProgress, { passive: true });
+document.addEventListener('DOMContentLoaded', () => { buildNavDots(); checkAnimations(); updateProgress(); });
+
+// ─── Prediction questions ──────────────────────────────────
+// data-multiselect="true" on the block → toggle behavior (checkbox-style)
+// default (no attribute) → single-select (radio-style)
+function selectPrediction(btn, blockId) {
+  const block = document.getElementById(blockId);
+  const isMulti = block.dataset.multiselect === 'true';
+  if (isMulti) {
+    // Toggle this option; leave others untouched
+    btn.classList.toggle('selected');
+  } else {
+    // Clear all, then select the clicked one
+    block.querySelectorAll('.pred-option').forEach(b => b.classList.remove('selected'));
+    btn.classList.add('selected');
+  }
+  // Show commit button once at least one option is selected
+  const commitBtn = document.getElementById(blockId + '-btn');
+  if (commitBtn) {
+    const anySelected = block.querySelectorAll('.pred-option.selected').length > 0;
+    if (anySelected) {
+      commitBtn.style.display = 'block';
+      commitBtn.classList.add('visible');
+    } else {
+      commitBtn.style.display = 'none';
+      commitBtn.classList.remove('visible');
+    }
+  }
+}
+
+function commitPrediction(blockId) {
+  const reveal = document.getElementById(blockId + '-reveal');
+  const btn = document.getElementById(blockId + '-btn');
+  if (reveal) reveal.classList.add('visible');
+  if (btn) btn.style.display = 'none';
+  document.getElementById(blockId).querySelectorAll('.pred-option').forEach(b => { b.disabled = true; b.style.cursor = 'default'; });
+}
+
+// ─── Inline knowledge check ────────────────────────────────
+function checkKC(btn, result, id) {
+  const parent = btn.closest('.kcheck');
+  parent.querySelectorAll('.kcheck-opt').forEach(b => { b.disabled = true; b.style.cursor = 'default'; });
+  btn.classList.add(result === 'right' ? 'correct' : 'incorrect');
+  const ok = document.getElementById(id + '-ok');
+  const no = document.getElementById(id + '-no');
+  if (result === 'right') { ok.style.display = 'block'; ok.classList.add('show'); }
+  else { no.style.display = 'block'; no.classList.add('show'); }
+}
+
+// ─── Multiple choice quiz ──────────────────────────────────
+function selectQuiz(btn, quizId) {
+  const opts = document.getElementById(quizId + '-opts');
+  opts.querySelectorAll('.quiz-option').forEach(b => b.classList.remove('selected'));
+  btn.classList.add('selected');
+  document.getElementById(quizId + '-btn').disabled = false;
+}
+
+const QUIZ_FEEDBACK = {
+  quiz4: {
+    b: 'Correct. This is a Deep & Dark Web threat — the ticket type matters for choosing the right response. Telegram channels cannot be taken down via Axur\'s standard process, but a Deep & Dark Web investigation can produce intelligence for law enforcement referral. Internal coordination with HR (to assess the authenticity and scope of the documents) and legal (for potential regulatory obligations) is essential. The low AI score reflects that automated systems struggle with context-heavy breach scenarios — your human judgment is critical here.',
+    default: 'Not quite. The AI score of 45% reflects the difficulty of automatically classifying context-rich breach scenarios, not the severity of the threat. Actual HR salary data leaked in a Telegram channel is a serious incident regardless of score. Discarding or quarantining would mean missing a real data exposure. Takedown of Telegram channels via Axur\'s standard process isn\'t available — but a Dark Web investigation is.'
+  },
+  quiz5: {
+    b: 'Correct. Incomplete cards (number only, no CVV/expiry) pose lower immediate risk for CNP fraud but aren\'t harmless. They can be used in fraud scenarios where CVV isn\'t checked, tested via BIN attacks, or combined with other stolen data. 847 cards is a significant volume — investigate the source, assess whether the cards are still valid, and consider whether proactive reissuance is warranted based on your fraud risk tolerance.',
+    default: 'Not exactly right. Incomplete cards are lower immediate risk than complete cards, but they\'re not safe to ignore — especially at 847 cards from a single Telegram channel, which suggests an active breach rather than random noise. The source matters too: Telegram channels can have large audiences who rapidly weaponize leaked data. "B" is the most accurate answer.'
+  },
+  quiz6: {
+    b: 'Correct. Threat Hunting results are retained for only 12 hours after a search completes. This is a hard limit — there\'s no archive or support ticket that recovers expired results. Best practice: export results immediately after a search, or save the query so you can re-run it (which will consume credits again). For large investigations, break your analysis into sessions that fit within the 12-hour window.',
+    default: 'This isn\'t right. The 12-hour retention window is the key concept here. Results don\'t disappear due to errors or credit issues — they simply expire. Axur support cannot recover expired search results. Always export or re-run. This is one of the most common Threat Hunting gotchas for new users.'
+  },
+  quiz7: {
+    b: 'Exactly right. A 4.2-day average time-to-treatment means phishing sites, fake apps, and data leakage are active for over four days before your team acts. That\'s four days of credential harvesting, fraud, and brand damage. Takedown success at 97% is already excellent — marginal gains there won\'t move the needle. The 89% treatment rate sounds decent, but the speed problem is the real bottleneck. Focus on reducing triage time: daily queue review, alert routing, and clearer escalation paths for the team.',
+    default: 'The most impactful lever here is speed, not volume or completeness metrics. A 4.2-day treatment time means threats are live and active for days. Whether it\'s 340 or 400 threats, or 89% vs 95% treatment rate — none of those improvements matter as much as acting faster on the threats you\'re already finding. Option B is the right answer.'
+  }
+};
+
+function checkQuiz(quizId, correctValue) {
+  const opts = document.getElementById(quizId + '-opts');
+  const selected = opts.querySelector('.quiz-option.selected');
+  if (!selected) return;
+  const val = selected.getAttribute('data-value');
+  const isCorrect = val === correctValue;
+  opts.querySelectorAll('.quiz-option').forEach(b => { b.disabled = true; b.style.cursor = 'default'; });
+  selected.classList.add(isCorrect ? 'correct' : 'incorrect');
+  if (isCorrect) {
+    opts.querySelectorAll('.quiz-option').forEach(b => {
+      if (b.getAttribute('data-value') === correctValue) b.classList.add('correct');
+    });
+    selected.querySelector('.quiz-icon').textContent = '✓';
+  } else {
+    selected.querySelector('.quiz-icon').textContent = '✗';
+    opts.querySelectorAll('.quiz-option').forEach(b => {
+      if (b.getAttribute('data-value') === correctValue) b.classList.add('correct');
+    });
+  }
+  document.getElementById(quizId + '-btn').disabled = true;
+  const feedback = document.getElementById(quizId + '-feedback');
+  const fb = QUIZ_FEEDBACK[quizId];
+  feedback.textContent = (fb && fb[val]) ? fb[val] : (fb && fb.default) ? fb.default : '';
+  feedback.className = 'quiz-feedback ' + (isCorrect ? 'correct' : 'incorrect');
+  const reset = document.getElementById(quizId + '-reset');
+  if (reset) reset.style.display = 'inline-block';
+}
+
+function resetQuiz(quizId) {
+  const opts = document.getElementById(quizId + '-opts');
+  opts.querySelectorAll('.quiz-option').forEach(b => {
+    b.classList.remove('selected','correct','incorrect');
+    b.disabled = false; b.style.cursor = 'pointer';
+    const icon = b.querySelector('.quiz-icon');
+    if (icon) icon.textContent = '○';
+  });
+  document.getElementById(quizId + '-btn').disabled = true;
+  document.getElementById(quizId + '-feedback').className = 'quiz-feedback';
+  document.getElementById(quizId + '-feedback').textContent = '';
+  const reset = document.getElementById(quizId + '-reset');
+  if (reset) reset.style.display = 'none';
+}
+
+// ─── Decision tree ─────────────────────────────────────────
+let dtHistory = [];
+
+function dtGo(targetId, fromId) {
+  dtHistory.push(fromId);
+  document.querySelectorAll('.dt-node').forEach(n => n.classList.remove('active'));
+  document.getElementById(targetId).classList.add('active');
+}
+
+function dtReset() {
+  dtHistory = [];
+  document.querySelectorAll('.dt-node').forEach(n => n.classList.remove('active'));
+  document.getElementById('dt-0').classList.add('active');
+}
+
+// ─── State machine ─────────────────────────────────────────
+const smStates = {
+  new: {
+    el: 'sm-new',
+    info: '<strong>New</strong> — A detection just landed. Your job: review the evidence, assess whether the data is real and relevant, and begin triage. Add tags and notes as you go — all actions are logged in Events history.'
+  },
+  treatment: {
+    el: 'sm-treatment',
+    info: '<strong>In Treatment</strong> — You\'ve begun investigating or remediating. For credit cards: reissuing cards. For credentials: forcing resets. For breach files: investigating scope in a sandbox. Keep notes updated so teammates can pick up where you left off.'
+  },
+  solved: {
+    el: 'sm-solved',
+    info: '<strong>Solved</strong> — Remediation is complete. Cards reissued, passwords reset, breach scope documented, internal teams notified. Mark as Solved only when no further action is required. This closes the detection.'
+  },
+  discarded: {
+    el: 'sm-discarded',
+    info: '<strong>Discarded</strong> — The detection is not relevant to your organization, is a false positive, or is an intentional exposure (e.g. a public test). Close the detection without remediation. Document the reason in notes.'
+  }
+};
+
+let smCurrent = 'new';
+
+const smTransitions = {
+  'Start triage': { from: 'new', to: 'treatment' },
+  'Mark resolved': { from: 'treatment', to: 'solved' },
+  'Mark irrelevant': { from: 'treatment', to: 'discarded' }
+};
+
+function smTrigger(fromState, label) {
+  const t = smTransitions[label];
+  if (!t) return;
+  Object.keys(smStates).forEach(k => {
+    const el = document.getElementById(smStates[k].el);
+    el.classList.remove('active');
+    el.removeAttribute('aria-current');
+  });
+  const next = t.to;
+  const el = document.getElementById(smStates[next].el);
+  el.classList.add('active');
+  el.setAttribute('aria-current', 'true');
+  smCurrent = next;
+  document.getElementById('sm-info').innerHTML = smStates[next].info;
+}
+
+function smReset() {
+  Object.keys(smStates).forEach(k => {
+    const el = document.getElementById(smStates[k].el);
+    el.classList.remove('active');
+    el.removeAttribute('aria-current');
+  });
+  document.getElementById(smStates['new'].el).classList.add('active');
+  document.getElementById(smStates['new'].el).setAttribute('aria-current', 'true');
+  smCurrent = 'new';
+  document.getElementById('sm-info').innerHTML = smStates['new'].info;
+}
+
+// ─── Keyboard module navigation ────────────────────────────
+document.addEventListener('keydown', e => {
+  if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+  const modules = document.querySelectorAll('.module');
+  const scrollY = window.scrollY + window.innerHeight * 0.5;
+  let current = 0;
+  modules.forEach((m, i) => { if (m.getBoundingClientRect().top + window.scrollY <= scrollY) current = i; });
+  if (e.key === 'ArrowDown' && current < modules.length - 1) { e.preventDefault(); goToModule(current + 1); }
+  if (e.key === 'ArrowUp' && current > 0) { e.preventDefault(); goToModule(current - 1); }
+});
+</script>
+</body>
+</html>

--- a/skills/docs-to-course/references/design-system.md
+++ b/skills/docs-to-course/references/design-system.md
@@ -574,3 +574,90 @@ For code blocks on the dark `--color-bg-code` background:
 .code-attr     { color: #F9E2AF; }  /* yellow — HTML attributes */
 .code-value    { color: #A6E3A1; }  /* green — attribute values */
 ```
+
+---
+
+## Brand Skin Layer (optional)
+
+When a course is generated with corporate branding (see SKILL.md Phase 2C), a thin override layer adjusts the accent and adds a logo. The layer is opt-in and skin-only — it does not replace the design system.
+
+### Skinnable tokens
+
+| Token | Override source | Notes |
+|---|---|---|
+| `--color-accent` | Brand primary hex | Must pass 3:1 contrast on `#FAF7F2` |
+| `--color-accent-hover` | Derived: brand primary, ~10% darker | Auto-computed |
+| `--color-accent-light` | Derived: brand primary mixed ~10% with `--color-bg` | Auto-computed |
+| `--color-accent-muted` | Derived: brand primary at reduced saturation | Auto-computed |
+| Body radial-gradient tint | Derived: brand primary at ~3% alpha | Replaces the default vermillion tint in [Scrollbar & Background](#scrollbar--background) |
+| `--color-actor-1..5` | Brand secondary colors | Wholesale replacement if 5 provided; otherwise mix with defaults |
+
+### Tokens that are NOT skinnable
+
+- All `--color-bg*` (warm off-white is structural to the aesthetic)
+- All `--font-*` (typography is the skill's identity)
+- All `--space-*`, `--radius-*`, `--shadow-*`
+- Semantic colors (`--color-success`, `--color-error`, `--color-info`) — functional, not branding
+- Dark code background (`--color-bg-code`) and syntax highlighting
+
+### `.brand.json` schema
+
+```json
+{
+  "name": "Acme Corp",
+  "primary": "#1A4FBA",
+  "logo": "./assets/logo.svg",
+  "secondary": ["#FF6B35", "#2D8B55", "#7B6DAA", "#D4A843"],
+  "tagline": "Engineering Excellence"
+}
+```
+
+All fields except `name` and `primary` are optional. Place `.brand.json` in the working directory and the skill auto-detects it on the next run.
+
+### Override pattern
+
+The generated HTML emits two `:root` blocks in `<style>`. The default block (from this file) stays unchanged; the override block appears immediately after and contains only the brand-driven tokens. CSS cascade resolves the conflict to the brand values:
+
+```css
+:root {
+  /* default tokens — copied verbatim from this file */
+  --color-accent: #D94F30;
+  /* ...etc */
+}
+
+:root {
+  /* brand skin overrides — emitted only when a brand spec is supplied */
+  --color-accent:        #1A4FBA;
+  --color-accent-hover:  /* ~10% darker */;
+  --color-accent-light:  /* mixed with --color-bg */;
+  --color-accent-muted:  /* reduced saturation */;
+}
+
+body {
+  background-image: radial-gradient(
+    ellipse at 20% 50%,
+    rgba(26, 79, 186, 0.03) 0%,  /* derived from brand primary */
+    transparent 50%
+  );
+}
+```
+
+### Logo embedding
+
+The course HTML must remain self-contained. Logos are inlined:
+
+- **SVG** — paste markup directly into the nav; strip external `<image>`, `<use href>`, or web-font references
+- **PNG/JPG** — base64 data URI
+- **URL** — fetched once at build time, embedded as a data URI
+
+Render at 24–32px height in the nav (nav-height is 50px). Logo only appears in the nav — never in module headers, synthesis cards, or elsewhere.
+
+### Contrast validation
+
+Before applying the override, compute the contrast ratio of the brand primary against `#FAF7F2`:
+
+| Ratio | Use |
+|---|---|
+| ≥ 4.5:1 | Any use, including body text accents |
+| 3:1 – 4.5:1 | Large text only (module numbers, titles) |
+| < 3:1 | Fails WCAG AA — ask the user for a darker brand variant; do not silently mutate |

--- a/skills/docs-to-course/references/design-system.md
+++ b/skills/docs-to-course/references/design-system.md
@@ -1,0 +1,576 @@
+# Design System Reference
+
+Complete CSS design tokens for the course. Copy this entire `:root` block into the course HTML and adapt the accent color to suit the project's personality.
+
+## Table of Contents
+1. [Accessibility (WCAG 2.1 AA)](#accessibility-wcag-21-aa)
+2. [Color Palette](#color-palette)
+3. [Typography](#typography)
+4. [Spacing & Layout](#spacing--layout)
+5. [Shadows & Depth](#shadows--depth)
+6. [Animations & Transitions](#animations--transitions)
+7. [Navigation & Progress](#navigation--progress)
+8. [Module Structure](#module-structure)
+9. [Responsive Breakpoints](#responsive-breakpoints)
+10. [Scrollbar & Background](#scrollbar--background)
+
+---
+
+## Accessibility (WCAG 2.1 AA)
+
+All courses must meet WCAG 2.1 AA. Apply these rules before writing any interactive element.
+
+### Contrast ratios (non-negotiable)
+
+The default token values meet AA. If you change any color token, verify it still passes:
+
+| Context | Required ratio | Token pairs that meet it |
+|---|---|---|
+| Body text (< 18px) | 4.5 : 1 | `--color-text` on `--color-bg` = ~12:1 ✓ |
+| Large text (≥ 18px or bold ≥ 14px) | 3 : 1 | `--color-accent` on `--color-bg` = ~4.5:1 ✓ |
+| UI components & states | 3 : 1 | Focus ring, button borders |
+
+**Check tool:** use the browser DevTools accessibility panel or [contrast-ratio.com](https://contrast-ratio.com) on any custom color.
+
+**Never use color as the only signal.** Always pair color with a text label, icon, or pattern. Quiz correct/incorrect states use color + checkmark/✕ icon + text feedback. Error states use `--color-error` + `aria-invalid` + visible message.
+
+### Focus states
+
+Never write `outline: none` without a replacement. The default browser outline is ugly but functional — if you override it, replace it with something equally visible:
+
+```css
+:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 3px;
+  border-radius: 2px;
+}
+/* Remove for mouse users only — preserve for keyboard */
+:focus:not(:focus-visible) {
+  outline: none;
+}
+```
+
+Apply `:focus-visible` to all interactive elements: buttons, links, quiz options, drag chips, tooltip terms, nav dots.
+
+### Keyboard operability
+
+Every interactive element must be fully operable with keyboard alone:
+
+| Element | Required keyboard behavior |
+|---|---|
+| Quiz options | Tab to focus, Space/Enter to select |
+| Drag-and-drop | Tab to chip, Space to pick up, Arrow keys to move, Space/Enter to drop; fallback click-to-select |
+| Tooltips | Focusable terms, Enter/Space to show, Escape to dismiss |
+| Chat/flow animations | Buttons for next/play/reset; all focusable |
+| Decision tree | All choice buttons focusable and activatable with Enter |
+| Nav dots | Tab between dots, Enter to navigate |
+| Scroll | Arrow keys (up/down) navigate modules |
+
+### ARIA requirements
+
+```html
+<!-- Progress bar -->
+<div class="progress-bar" role="progressbar"
+     aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"
+     aria-label="Course progress"></div>
+
+<!-- Quiz group -->
+<div class="quiz-container" role="group" aria-labelledby="quiz-heading">
+
+<!-- Quiz radio options -->
+<button class="quiz-option" role="radio" aria-checked="false"
+        aria-describedby="q1-feedback">
+
+<!-- Interactive diagram -->
+<div class="arch-diagram" role="region" aria-label="System architecture diagram">
+
+<!-- Decision tree -->
+<div class="decision-tree" role="region" aria-label="[Descriptive name] decision tree">
+
+<!-- Live feedback regions -->
+<div class="quiz-feedback" aria-live="polite">
+<div class="check-feedback" aria-live="polite">
+<div class="sm-info" aria-live="polite">
+
+<!-- Diagram descriptions (when SVG/canvas not feasible) -->
+<div class="flow-animation" role="img"
+     aria-label="Step-by-step diagram showing [describe the flow]">
+```
+
+### Alt text for all visual-only content
+
+Every diagram, animation, and flow visualization that conveys information visually must have a text alternative:
+
+```html
+<!-- Option 1: aria-label on the container -->
+<div class="arch-diagram" role="img"
+     aria-label="Architecture diagram showing three components: Client, Resolver, and Authoritative Server. Client queries Resolver; Resolver either serves from cache or queries Authoritative Server; Authoritative Server returns the authoritative answer.">
+
+<!-- Option 2: visually-hidden description -->
+<div class="flow-animation">
+  <!-- ...visual content... -->
+  <p class="visually-hidden">
+    This animation shows five steps: (1) Client sends query to resolver...
+  </p>
+</div>
+```
+
+```css
+.visually-hidden {
+  position: absolute;
+  width: 1px; height: 1px;
+  margin: -1px; padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+```
+
+### Drag-and-drop keyboard fallback
+
+The HTML5 drag API does not work reliably on keyboard or mobile assistive technology. All drag-and-drop elements must have a click-based fallback:
+
+```javascript
+// Click-to-select, click-to-place fallback
+let selectedChip = null;
+
+chips.forEach(chip => {
+  chip.addEventListener('click', () => {
+    if (selectedChip === chip) {
+      // Deselect
+      chip.classList.remove('selected');
+      chip.setAttribute('aria-pressed', 'false');
+      selectedChip = null;
+    } else {
+      // Select this chip
+      chips.forEach(c => { c.classList.remove('selected'); c.setAttribute('aria-pressed', 'false'); });
+      chip.classList.add('selected');
+      chip.setAttribute('aria-pressed', 'true');
+      selectedChip = chip;
+    }
+  });
+});
+
+zones.forEach(zone => {
+  zone.addEventListener('click', () => {
+    if (!selectedChip) return;
+    const target = zone.querySelector('.dnd-zone-target');
+    target.textContent = selectedChip.textContent;
+    target.dataset.placed = selectedChip.dataset.answer;
+    selectedChip.classList.add('placed');
+    selectedChip.setAttribute('aria-pressed', 'false');
+    selectedChip = null;
+  });
+});
+```
+
+### Reduced motion
+
+Respect the user's motion preference. All animations should degrade gracefully:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+  .animate-in {
+    opacity: 1 !important;
+    transform: none !important;
+  }
+}
+```
+
+---
+
+## Color Palette
+
+```css
+:root {
+  /* --- BACKGROUNDS --- */
+  --color-bg:             #FAF7F2;       /* warm off-white, like aged paper */
+  --color-bg-warm:        #F5F0E8;       /* slightly warmer for alternating modules */
+  --color-bg-code:        #1E1E2E;       /* deep indigo-charcoal for code blocks */
+  --color-text:           #2C2A28;       /* dark charcoal, easy on eyes */
+  --color-text-secondary: #6B6560;       /* warm gray for secondary text */
+  --color-text-muted:     #9E9790;       /* muted for timestamps, labels */
+  --color-border:         #E5DFD6;       /* subtle warm border */
+  --color-border-light:   #EEEBE5;       /* even lighter border */
+  --color-surface:        #FFFFFF;       /* card surfaces */
+  --color-surface-warm:   #FDF9F3;       /* warm card surface */
+
+  /* --- ACCENT (adapt per project — pick ONE bold color) ---
+     Default: vermillion. Alternatives: coral (#E06B56), teal (#2A7B9B),
+     amber (#D4A843), forest (#2D8B55). Avoid purple gradients. */
+  --color-accent:         #D94F30;
+  --color-accent-hover:   #C4432A;
+  --color-accent-light:   #FDEEE9;
+  --color-accent-muted:   #E8836C;
+
+  /* --- SEMANTIC --- */
+  --color-success:        #2D8B55;
+  --color-success-light:  #E8F5EE;
+  --color-error:          #C93B3B;
+  --color-error-light:    #FDE8E8;
+  --color-info:           #2A7B9B;
+  --color-info-light:     #E4F2F7;
+
+  /* --- ACTOR COLORS (assign to main components) ---
+     Each major "character" in the codebase gets a distinct color
+     for chat bubbles, diagrams, and highlights */
+  --color-actor-1:        #D94F30;       /* vermillion */
+  --color-actor-2:        #2A7B9B;       /* teal */
+  --color-actor-3:        #7B6DAA;       /* muted plum */
+  --color-actor-4:        #D4A843;       /* golden */
+  --color-actor-5:        #2D8B55;       /* forest */
+}
+```
+
+**Rules:**
+- Even-numbered modules use `--color-bg`, odd-numbered use `--color-bg-warm` (alternating backgrounds create visual rhythm)
+- Actor colors should be visually distinct from each other and from the accent
+- Code blocks always use `--color-bg-code` with light text
+
+---
+
+## Typography
+
+```css
+:root {
+  /* --- FONTS ---
+     Display: bold, geometric, personality-driven. NOT Inter/Roboto/Arial.
+     Body: readable with character. NOT system fonts.
+     Mono: developer-friendly with clear character distinction. */
+  --font-display:  'Bricolage Grotesque', Georgia, serif;
+  --font-body:     'DM Sans', -apple-system, sans-serif;
+  --font-mono:     'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
+
+  /* --- TYPE SCALE (1.25 ratio) --- */
+  --text-xs:   0.75rem;    /* 12px — labels, badges */
+  --text-sm:   0.875rem;   /* 14px — secondary text, code */
+  --text-base: 1rem;       /* 16px — body text */
+  --text-lg:   1.125rem;   /* 18px — lead paragraphs */
+  --text-xl:   1.25rem;    /* 20px — screen headings */
+  --text-2xl:  1.5rem;     /* 24px — sub-module titles */
+  --text-3xl:  1.875rem;   /* 30px — module subtitles */
+  --text-4xl:  2.25rem;    /* 36px — module titles */
+  --text-5xl:  3rem;       /* 48px — hero text */
+  --text-6xl:  3.75rem;    /* 60px — module numbers */
+
+  /* --- LINE HEIGHTS --- */
+  --leading-tight:  1.15;  /* headings */
+  --leading-snug:   1.3;   /* subheadings */
+  --leading-normal: 1.6;   /* body text */
+  --leading-loose:  1.8;   /* relaxed reading */
+}
+```
+
+**Google Fonts link (put in `<head>`):**
+```html
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,600;12..96,700;12..96,800&family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400;1,9..40,500&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+```
+
+**Rules:**
+- Module numbers: `--text-6xl`, font-display, weight 800, `--color-accent` with 15% opacity
+- Module titles: `--text-4xl`, font-display, weight 700
+- Screen headings: `--text-xl` or `--text-2xl`, font-display, weight 600
+- Body text: `--text-base` or `--text-lg`, font-body, `--leading-normal`
+- Code: `--text-sm`, font-mono
+- Labels/badges: `--text-xs`, font-mono, uppercase, letter-spacing 0.05em
+
+---
+
+## Spacing & Layout
+
+```css
+:root {
+  --space-1:  0.25rem;   /* 4px */
+  --space-2:  0.5rem;    /* 8px */
+  --space-3:  0.75rem;   /* 12px */
+  --space-4:  1rem;      /* 16px */
+  --space-5:  1.25rem;   /* 20px */
+  --space-6:  1.5rem;    /* 24px */
+  --space-8:  2rem;      /* 32px */
+  --space-10: 2.5rem;    /* 40px */
+  --space-12: 3rem;      /* 48px */
+  --space-16: 4rem;      /* 64px */
+  --space-20: 5rem;      /* 80px */
+  --space-24: 6rem;      /* 96px */
+
+  --content-width:     800px;   /* standard reading width */
+  --content-width-wide: 1000px; /* for side-by-side layouts */
+  --nav-height:        50px;
+  --radius-sm:  8px;
+  --radius-md:  12px;
+  --radius-lg:  16px;
+  --radius-full: 9999px;
+}
+```
+
+**Module layout:**
+```css
+.module {
+  min-height: 100dvh;       /* fallback: 100vh */
+  scroll-snap-align: start;
+  padding: var(--space-16) var(--space-6);
+  padding-top: calc(var(--nav-height) + var(--space-12));
+}
+.module-content {
+  max-width: var(--content-width);
+  margin: 0 auto;
+}
+```
+
+---
+
+## Shadows & Depth
+
+```css
+:root {
+  --shadow-sm:  0 1px 2px rgba(44, 42, 40, 0.05);
+  --shadow-md:  0 4px 12px rgba(44, 42, 40, 0.08);
+  --shadow-lg:  0 8px 24px rgba(44, 42, 40, 0.1);
+  --shadow-xl:  0 16px 48px rgba(44, 42, 40, 0.12);
+}
+```
+
+Use warm-tinted RGBA (44, 42, 40) — never pure black shadows.
+
+---
+
+## Animations & Transitions
+
+```css
+:root {
+  --ease-out:    cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
+  --duration-fast:   150ms;
+  --duration-normal: 300ms;
+  --duration-slow:   500ms;
+  --stagger-delay:   120ms;
+}
+```
+
+**Scroll-triggered reveal pattern:**
+```css
+.animate-in {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity var(--duration-slow) var(--ease-out),
+              transform var(--duration-slow) var(--ease-out);
+}
+.animate-in.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* Stagger children */
+.stagger-children > .animate-in {
+  transition-delay: calc(var(--stagger-index, 0) * var(--stagger-delay));
+}
+```
+
+**JS setup for stagger:**
+```javascript
+document.querySelectorAll('.stagger-children').forEach(parent => {
+  Array.from(parent.children).forEach((child, i) => {
+    child.style.setProperty('--stagger-index', i);
+  });
+});
+```
+
+**Intersection Observer (trigger reveals):**
+```javascript
+const observer = new IntersectionObserver((entries) => {
+  entries.forEach(entry => {
+    if (entry.isIntersecting) {
+      entry.target.classList.add('visible');
+      observer.unobserve(entry.target); // animate only once
+    }
+  });
+}, { rootMargin: '0px 0px -10% 0px', threshold: 0.1 });
+
+document.querySelectorAll('.animate-in').forEach(el => observer.observe(el));
+```
+
+---
+
+## Navigation & Progress
+
+**HTML structure:**
+```html
+<nav class="nav">
+  <div class="progress-bar" role="progressbar" aria-valuenow="0"></div>
+  <div class="nav-inner">
+    <span class="nav-title">Course Title</span>
+    <div class="nav-dots">
+      <button class="nav-dot" data-target="module-1" data-tooltip="Module 1 Name"
+              role="tab" aria-label="Module 1"></button>
+      <!-- one per module -->
+    </div>
+  </div>
+</nav>
+```
+
+**Progress bar (CSS-only where possible, JS fallback):**
+```javascript
+function updateProgressBar() {
+  const scrollTop = window.scrollY;
+  const scrollHeight = document.documentElement.scrollHeight - window.innerHeight;
+  const progress = (scrollTop / scrollHeight) * 100;
+  progressBar.style.width = progress + '%';
+}
+window.addEventListener('scroll', () => {
+  requestAnimationFrame(updateProgressBar);
+}, { passive: true });
+```
+
+**Nav dot states:**
+- Default: `border: 2px solid var(--color-text-muted)`, empty center
+- Current: `border-color: var(--color-accent)`, filled center, subtle glow shadow
+- Visited: `background: var(--color-accent)`, filled solid
+
+**Keyboard navigation:**
+```javascript
+document.addEventListener('keydown', (e) => {
+  if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) return;
+  if (e.key === 'ArrowDown' || e.key === 'ArrowRight') { nextModule(); e.preventDefault(); }
+  if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') { prevModule(); e.preventDefault(); }
+});
+```
+
+---
+
+## Module Structure
+
+**HTML template for each module:**
+```html
+<section class="module" id="module-N" style="background: var(--color-bg or --color-bg-warm)">
+  <div class="module-content">
+    <header class="module-header animate-in">
+      <span class="module-number">0N</span>
+      <h1 class="module-title">Module Title</h1>
+      <p class="module-subtitle">One-line description of what this module teaches</p>
+    </header>
+
+    <div class="module-body">
+      <section class="screen animate-in">
+        <h2 class="screen-heading">Screen Title</h2>
+        <p>Content...</p>
+        <!-- Interactive elements, code translations, etc. -->
+      </section>
+
+      <section class="screen animate-in">
+        <!-- Next screen -->
+      </section>
+    </div>
+  </div>
+</section>
+```
+
+---
+
+## Responsive Breakpoints
+
+```css
+/* Tablet */
+@media (max-width: 768px) {
+  :root {
+    --text-4xl: 1.875rem;
+    --text-5xl: 2.25rem;
+    --text-6xl: 3rem;
+  }
+  .translation-block { grid-template-columns: 1fr; } /* stack code/english */
+  .pattern-cards { grid-template-columns: 1fr 1fr; }
+}
+
+/* Mobile */
+@media (max-width: 480px) {
+  :root {
+    --text-4xl: 1.5rem;
+    --text-5xl: 1.875rem;
+    --text-6xl: 2.25rem;
+  }
+  .module { padding: var(--space-8) var(--space-4); }
+  .pattern-cards { grid-template-columns: 1fr; }
+  .flow-steps { flex-direction: column; }
+  .flow-arrow { transform: rotate(90deg); }
+}
+```
+
+---
+
+## Scrollbar & Background
+
+```css
+/* Custom scrollbar */
+::-webkit-scrollbar { width: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb {
+  background: var(--color-border);
+  border-radius: var(--radius-full);
+}
+
+/* Subtle atmospheric background */
+body {
+  background: var(--color-bg);
+  background-image: radial-gradient(
+    ellipse at 20% 50%,
+    rgba(217, 79, 48, 0.03) 0%,
+    transparent 50%
+  );
+}
+
+/* Page scroll setup */
+html {
+  scroll-snap-type: y proximity;
+  scroll-behavior: smooth;
+}
+```
+
+---
+
+## Code Block Globals
+
+All code blocks in the course — whether inside translation blocks, standalone snippets, or quiz challenges — must wrap text and never show a horizontal scrollbar. This is a teaching tool, not an IDE.
+
+```css
+pre, code {
+  white-space: pre-wrap;       /* wrap long lines */
+  word-break: break-word;      /* break mid-word if absolutely needed */
+  overflow-x: hidden;          /* no horizontal scrollbar — ever */
+}
+/* Hide scrollbars on code containers */
+.translation-code::-webkit-scrollbar,
+pre::-webkit-scrollbar {
+  display: none;
+}
+```
+
+Code snippets must be **exact copies** from the real codebase — never modified, trimmed, or simplified. Instead, choose naturally short (5-10 line) sections from the code that illustrate the concept well. If a longer block is needed, show it all — the wrapping CSS will handle readability.
+
+---
+
+## Syntax Highlighting (Catppuccin-inspired)
+
+For code blocks on the dark `--color-bg-code` background:
+
+```css
+.code-keyword  { color: #CBA6F7; }  /* purple — if, else, return, function */
+.code-string   { color: #A6E3A1; }  /* green — "strings" */
+.code-function { color: #89B4FA; }  /* blue — function names */
+.code-comment  { color: #6C7086; }  /* muted gray — // comments */
+.code-number   { color: #FAB387; }  /* peach — numbers */
+.code-property { color: #F9E2AF; }  /* yellow — object keys */
+.code-operator { color: #94E2D5; }  /* teal — =, =>, +, etc. */
+.code-tag      { color: #F38BA8; }  /* pink — HTML tags */
+.code-attr     { color: #F9E2AF; }  /* yellow — HTML attributes */
+.code-value    { color: #A6E3A1; }  /* green — attribute values */
+```

--- a/skills/docs-to-course/references/firecrawl.md
+++ b/skills/docs-to-course/references/firecrawl.md
@@ -1,0 +1,115 @@
+# Firecrawl MCP — setup and Phase 0 crawl procedure
+
+This skill uses the Firecrawl MCP server to crawl documentation websites. Read this file when the user provides an `https://` URL as input, or when Firecrawl tools are unavailable and you need to tell the user how to install them.
+
+Firecrawl handles JS-rendered sites (Docusaurus, Mintlify, Nextra, hosted GitBook), robots.txt compliance, rate limiting, and HTML-to-markdown conversion automatically. No custom crawl logic is needed.
+
+## Setup (one-time, user-facing)
+
+If the Firecrawl tools (e.g. `mcp__firecrawl__firecrawl_map`) are not available, stop and tell the user:
+
+> This skill needs the Firecrawl MCP server for URL inputs. One-time setup:
+>
+> 1. Get a Firecrawl API key at [firecrawl.dev](https://firecrawl.dev) (free tier: 500 credits — about 9 full course crawls)
+> 2. Add the MCP server to Claude Code:
+>
+>    ```bash
+>    claude mcp add firecrawl -e FIRECRAWL_API_KEY=fc-your-key-here -- npx -y firecrawl-mcp
+>    ```
+>
+>    Or add to `~/.claude/settings.json` manually:
+>
+>    ```json
+>    {
+>      "mcpServers": {
+>        "firecrawl": {
+>          "command": "npx",
+>          "args": ["-y", "firecrawl-mcp"],
+>          "env": {
+>            "FIRECRAWL_API_KEY": "fc-your-key-here"
+>          }
+>        }
+>      }
+>    }
+>    ```
+>
+> Restart Claude Code and confirm `mcp__firecrawl__firecrawl_map` appears in available tools. Local files and GitHub repos work without Firecrawl.
+
+## Phase 0: Web crawl procedure
+
+### 0A: Map the site
+
+Use `firecrawl_map` to discover all URLs at the documentation domain:
+
+```
+Tool: mcp__firecrawl__firecrawl_map
+Arguments: { "url": "<the URL the user provided>" }
+```
+
+`firecrawl_map` returns a list of all URLs Firecrawl can see on the site. It respects robots.txt automatically — if a path is disallowed, those URLs will not appear in the results.
+
+If the map returns zero URLs or only the root URL, the site is likely behind authentication or heavily bot-protected. Tell the user:
+
+> "Firecrawl couldn't index this site — it may require a login or block automated access. Try downloading the docs locally or finding the source repository."
+
+### 0B: Filter URLs to documentation pages
+
+From the map results, filter down to documentation-relevant URLs before spending fetch credits. Apply this logic mentally (no code to run — you're reading the URL list):
+
+**Exclude patterns** — drop any URL matching:
+- `/blog/`, `/changelog/`, `/release-notes/`, `/news/`
+- `/legal/`, `/privacy/`, `/terms/`, `/license/`
+- `/tag/`, `/category/`, `/author/`
+- File extensions: `.pdf`, `.zip`, `.png`, `.jpg`, `.svg`, `.css`, `.js`
+
+**Prioritize** shorter paths first — top-level section pages (e.g., `/docs/guide/`) before deep sub-pages (e.g., `/docs/guide/advanced/edge-cases/`).
+
+**Cap at 50 URLs.** If the filtered list exceeds 50, take the 50 with the shortest paths (broadest coverage). If the user's URL already points to a specific sub-section (e.g., `https://docs.example.com/api/`), keep only URLs within that prefix.
+
+Tell the user the filtered count before fetching:
+
+> "Found 73 pages — scoping to 50 most relevant for the documentation section. Fetching now..."
+
+### 0C: Fetch all pages as clean markdown
+
+Use `firecrawl_batch_scrape` to fetch all filtered URLs in one call:
+
+```
+Tool: mcp__firecrawl__firecrawl_batch_scrape
+Arguments: {
+  "urls": ["<url1>", "<url2>", ...],   // the filtered list from 0B
+  "options": {
+    "formats": ["markdown"],
+    "onlyMainContent": true
+  }
+}
+```
+
+`onlyMainContent: true` tells Firecrawl to strip navigation, footers, sidebars, and cookie banners — returning only the page body as clean markdown. This is the key advantage over a plain HTTP fetch.
+
+Each result in the response includes:
+- `url` — the source URL (use this in spec citation references)
+- `markdown` — the clean page content
+
+If a batch exceeds Firecrawl's credit limit mid-run, it will return partial results. Proceed with what was returned and note what was skipped.
+
+### 0D: Hand off to Phase 1
+
+Read the markdown content from the batch scrape results. Phase 1 proceeds identically to the local-files case — treat each page's `markdown` field as a document to analyze.
+
+Tell the user:
+
+> "Crawled N pages from [domain]. Proceeding to analysis."
+
+**Always record the source `url` for each page** so spec translation blocks can cite the exact page URL rather than a generic domain reference.
+
+## Credit usage reference
+
+| Operation | Firecrawl credits |
+|---|---|
+| `firecrawl_map` (site discovery) | 1 credit |
+| `firecrawl_batch_scrape` per page | 1 credit per URL |
+| 50-page course crawl (typical) | ~51 credits |
+| Free tier | 500 credits |
+
+A free account covers roughly 9 full course crawls at 50 pages each. Credits reset monthly on paid plans.

--- a/skills/docs-to-course/references/interactive-elements.md
+++ b/skills/docs-to-course/references/interactive-elements.md
@@ -1,0 +1,2215 @@
+# Interactive Elements Reference
+
+Implementation patterns for every interactive element type used in courses. Pick the elements that best serve each module's teaching goal.
+
+**Formative elements** (embed mid-module, before summative quiz):
+- Prediction Questions — activate prior knowledge before introducing a concept
+- Mid-Module Knowledge Checks — single inline question after a key concept
+- Completion Problems — faded worked examples with blanks to fill
+- Retrieval Callbacks — cross-module transfer questions (Module 3+)
+
+**Primary teaching elements:**
+- Spec ↔ Plain English Translation Blocks — the core teaching tool
+- Code ↔ English Translation Blocks — for code/config examples in docs
+- Decision Tree Navigator — for conditional logic and decision points
+- State Machine Visualizer — for protocols and stateful systems
+
+**Assessment elements:**
+- Multiple-Choice Quizzes (with elaborative feedback)
+- Scenario Quiz
+- Drag-and-Drop Matching
+- "Spot the Bug" Challenge
+
+**Visual elements:**
+- Message Flow / Data Flow Animation
+- Interactive Architecture Diagram
+- Group Chat Animation
+- Layer Toggle Demo
+- Callout Boxes
+- Pattern/Feature Cards
+- Flow Diagrams
+- Permission/Config Badges
+- Glossary Tooltips
+- Visual File Tree
+- Icon-Label Rows
+- Numbered Step Cards
+
+## Table of Contents
+### Formative
+1. [Prediction Questions](#prediction-questions)
+2. [Mid-Module Knowledge Check](#mid-module-knowledge-check)
+3. [Completion Problems](#completion-problems)
+4. [Retrieval Callbacks](#retrieval-callbacks)
+
+### Teaching
+5. [Spec ↔ Plain English Translation Blocks](#spec--plain-english-translation-blocks)
+6. [Code ↔ English Translation Blocks](#code--english-translation-blocks)
+7. [Decision Tree Navigator](#decision-tree-navigator)
+8. [State Machine Visualizer](#state-machine-visualizer)
+
+### Assessment
+9. [Multiple-Choice Quizzes (with elaborative feedback)](#multiple-choice-quizzes)
+10. [Scenario Quiz](#scenario-quiz)
+11. [Drag-and-Drop Matching](#drag-and-drop-matching)
+12. ["Spot the Bug" Challenge](#spot-the-bug-challenge)
+
+### Visual
+13. [Message Flow / Data Flow Animation](#message-flow--data-flow-animation)
+14. [Interactive Architecture Diagram](#interactive-architecture-diagram)
+15. [Group Chat Animation](#group-chat-animation)
+16. [Layer Toggle Demo](#layer-toggle-demo)
+17. [Callout Boxes](#callout-boxes)
+18. [Pattern/Feature Cards](#patternfeature-cards)
+19. [Flow Diagrams](#flow-diagrams)
+20. [Permission/Config Badges](#permissionconfig-badges)
+21. [Glossary Tooltips](#glossary-tooltips)
+22. [Visual File Tree](#visual-file-tree)
+23. [Icon-Label Rows](#icon-label-rows)
+24. [Numbered Step Cards](#numbered-step-cards)
+
+---
+
+## Prediction Questions
+
+Place **before** introducing a concept. Activates prior knowledge, creates a curiosity gap, and makes the correct answer more memorable when it arrives. The prediction is never graded — it's a thinking prompt.
+
+**When to use:** any time you're about to introduce a mechanism, rule, or behavior that has a non-obvious outcome. Ask the learner what they'd expect before showing them what actually happens.
+
+**HTML:**
+```html
+<div class="prediction-block animate-in" id="pred-ttl">
+  <div class="prediction-header">
+    <span class="prediction-icon" aria-hidden="true">🤔</span>
+    <span class="prediction-label">Before we continue — make a prediction</span>
+  </div>
+  <p class="prediction-question">
+    An intermediate DNS resolver receives a response where the authoritative server set a TTL of 300 seconds.
+    The resolver has been caching this record for 120 seconds already.
+    <strong>What TTL should the resolver report to the client that just asked for this record?</strong>
+  </p>
+  <div class="prediction-options">
+    <button class="pred-option" onclick="selectPrediction(this, 'pred-ttl')" data-value="a">
+      300 seconds — pass through the original TTL
+    </button>
+    <button class="pred-option" onclick="selectPrediction(this, 'pred-ttl')" data-value="b">
+      180 seconds — subtract the time already cached
+    </button>
+    <button class="pred-option" onclick="selectPrediction(this, 'pred-ttl')" data-value="c">
+      120 seconds — the time it has held the record
+    </button>
+    <button class="pred-option" onclick="selectPrediction(this, 'pred-ttl')" data-value="d">
+      It depends on the resolver implementation
+    </button>
+  </div>
+  <div class="prediction-reveal" id="pred-ttl-reveal" aria-live="polite">
+    <p class="pred-reveal-text" style="display:none"></p>
+  </div>
+  <button class="pred-commit-btn" onclick="commitPrediction('pred-ttl')"
+          aria-label="Lock in prediction and see the answer">
+    Lock in my prediction →
+  </button>
+</div>
+```
+
+**JS:**
+```javascript
+const predictionAnswers = {
+  'pred-ttl': {
+    correct: 'b',
+    reveal: `The correct answer is <strong>180 seconds</strong> — and this is actually a normative requirement in RFC 2181. The resolver must decrement the TTL by the time it has held the record. The reason: TTL is a freshness guarantee from the <em>authoritative source</em>. If a resolver passed through 300 seconds to every client regardless of how long it had cached the record, a client could receive a record that expires sooner than the TTL suggests — breaking the freshness contract. Keep this in mind as we look at the spec language.`
+  }
+};
+
+window.selectPrediction = function(btn, id) {
+  const block = document.getElementById(id);
+  block.querySelectorAll('.pred-option').forEach(b => b.classList.remove('selected'));
+  btn.classList.add('selected');
+  btn.dataset.selected = 'true';
+};
+
+window.commitPrediction = function(id) {
+  const block = document.getElementById(id);
+  const selected = block.querySelector('.pred-option.selected');
+  if (!selected) return;
+
+  const data = predictionAnswers[id];
+  const isCorrect = selected.dataset.value === data.correct;
+  const revealEl = document.getElementById(`${id}-reveal`);
+  const textEl = revealEl.querySelector('.pred-reveal-text');
+
+  // Mark all options — correct answer always highlighted
+  block.querySelectorAll('.pred-option').forEach(b => {
+    b.disabled = true;
+    if (b.dataset.value === data.correct) b.classList.add('pred-correct');
+    else if (b.dataset.selected) b.classList.add('pred-incorrect');
+  });
+
+  textEl.innerHTML = (isCorrect
+    ? '<strong>Good intuition!</strong> '
+    : '<strong>Interesting — here\'s what the spec requires:</strong> ')
+    + data.reveal;
+  textEl.style.display = 'block';
+  revealEl.style.display = 'block';
+
+  block.querySelector('.pred-commit-btn').style.display = 'none';
+};
+```
+
+**CSS:**
+```css
+.prediction-block {
+  background: var(--color-surface-warm);
+  border: 2px dashed var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  margin: var(--space-8) 0;
+}
+.prediction-header {
+  display: flex; align-items: center; gap: var(--space-3);
+  margin-bottom: var(--space-4);
+}
+.prediction-label {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-secondary);
+}
+.prediction-question {
+  margin-bottom: var(--space-5);
+  line-height: var(--leading-normal);
+}
+.prediction-options {
+  display: flex; flex-direction: column; gap: var(--space-2);
+  margin-bottom: var(--space-5);
+}
+.pred-option {
+  text-align: left;
+  padding: var(--space-3) var(--space-4);
+  border: 2px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  cursor: pointer;
+  transition: border-color var(--duration-fast), background var(--duration-fast);
+  font-size: var(--text-sm);
+}
+.pred-option:hover:not(:disabled) { border-color: var(--color-accent-muted); }
+.pred-option.selected { border-color: var(--color-accent); background: var(--color-accent-light); }
+.pred-option.pred-correct { border-color: var(--color-success); background: var(--color-success-light); }
+.pred-option.pred-incorrect { border-color: var(--color-error); background: var(--color-error-light); }
+.pred-commit-btn {
+  background: var(--color-accent); color: white;
+  border: none; border-radius: var(--radius-sm);
+  padding: var(--space-3) var(--space-6);
+  cursor: pointer; font-weight: 600;
+  transition: background var(--duration-fast);
+}
+.pred-commit-btn:hover { background: var(--color-accent-hover); }
+.prediction-reveal {
+  display: none;
+  background: var(--color-info-light);
+  border-left: 3px solid var(--color-info);
+  border-radius: var(--radius-sm);
+  padding: var(--space-4);
+  margin-top: var(--space-4);
+  font-size: var(--text-sm);
+  line-height: var(--leading-normal);
+}
+```
+
+**Rules:**
+- The question must have a definite answer in the documentation — don't use this for genuinely ambiguous scenarios
+- All options should be plausible — avoid obvious wrong answers
+- The reveal should reference the spec language the learner is about to see, creating a bridge
+- Never grade or score predictions; the point is engagement and curiosity, not assessment
+
+---
+
+## Mid-Module Knowledge Check
+
+A single inline question placed immediately after a key concept is introduced, before moving to the next screen. Catches misunderstanding early. Low stakes — feedback is immediate and non-judgmental.
+
+**When to use:** after introducing any concept that subsequent content builds on. If the learner misunderstands X and you introduce Y that depends on X, you compound the confusion. The check gives them a chance to self-correct.
+
+**HTML:**
+```html
+<div class="inline-check animate-in" role="group" aria-labelledby="check-q1-label">
+  <div class="inline-check-header">
+    <span class="check-icon" aria-hidden="true">✓</span>
+    <span class="check-label" id="check-q1-label">Quick check</span>
+  </div>
+  <p class="check-question">
+    A resolver receives a NOERROR response with an empty answer section. What does this mean?
+  </p>
+  <div class="check-options">
+    <button class="check-option" onclick="checkInline(this, false, 'check-q1')"
+            aria-describedby="check-q1-feedback">
+      The record doesn't exist
+    </button>
+    <button class="check-option" onclick="checkInline(this, true, 'check-q1')"
+            aria-describedby="check-q1-feedback">
+      The record doesn't exist <em>in the queried name</em>, but the response is valid
+    </button>
+    <button class="check-option" onclick="checkInline(this, false, 'check-q1')"
+            aria-describedby="check-q1-feedback">
+      An error occurred on the server
+    </button>
+  </div>
+  <div class="check-feedback" id="check-q1-feedback" aria-live="polite"></div>
+</div>
+```
+
+**JS:**
+```javascript
+window.checkInline = function(btn, isCorrect, checkId) {
+  const container = btn.closest('.inline-check');
+  const feedback = document.getElementById(`${checkId}-feedback`);
+
+  container.querySelectorAll('.check-option').forEach(b => b.disabled = true);
+  btn.classList.add(isCorrect ? 'check-correct' : 'check-incorrect');
+
+  if (isCorrect) {
+    feedback.innerHTML = '<strong>Exactly.</strong> NOERROR with an empty answer is called NODATA — it means the name exists but has no records of the requested type. This is distinct from NXDOMAIN (name doesn\'t exist at all). Keep the distinction in mind for the next section.';
+    feedback.className = 'check-feedback show success';
+  } else {
+    // Highlight the correct one
+    container.querySelectorAll('.check-option').forEach(b => {
+      if (b.textContent.trim() !== btn.textContent.trim()) {
+        b.classList.add('check-hint');
+      }
+    });
+    feedback.innerHTML = '<strong>Not quite.</strong> NOERROR means the query was processed successfully — the server isn\'t reporting an error. But the empty answer section does have a specific meaning. Look at the highlighted option and read on to see why the distinction matters.';
+    feedback.className = 'check-feedback show error';
+  }
+};
+```
+
+**CSS:**
+```css
+.inline-check {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-5);
+  margin: var(--space-6) 0;
+}
+.inline-check-header {
+  display: flex; align-items: center; gap: var(--space-2);
+  margin-bottom: var(--space-3);
+}
+.check-label {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-secondary);
+}
+.check-question { margin-bottom: var(--space-4); font-size: var(--text-base); }
+.check-options { display: flex; flex-direction: column; gap: var(--space-2); }
+.check-option {
+  text-align: left; padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-sm); background: var(--color-surface);
+  cursor: pointer; font-size: var(--text-sm);
+  transition: border-color var(--duration-fast);
+}
+.check-option:hover:not(:disabled) { border-color: var(--color-accent-muted); }
+.check-option.check-correct { border-color: var(--color-success); background: var(--color-success-light); }
+.check-option.check-incorrect { border-color: var(--color-error); background: var(--color-error-light); }
+.check-option.check-hint { border-color: var(--color-success); }
+.check-feedback {
+  max-height: 0; overflow: hidden; opacity: 0;
+  transition: max-height var(--duration-normal), opacity var(--duration-normal);
+  margin-top: var(--space-3); font-size: var(--text-sm);
+  border-radius: var(--radius-sm); padding: 0;
+}
+.check-feedback.show {
+  max-height: 200px; opacity: 1;
+  padding: var(--space-3) var(--space-4);
+}
+.check-feedback.success { background: var(--color-success-light); color: var(--color-success); }
+.check-feedback.error { background: var(--color-error-light); color: var(--color-error); }
+```
+
+---
+
+## Completion Problems
+
+A faded worked example — the learner sees a process partially complete and must fill in the missing steps. More challenging than multiple-choice; more supported than open-ended. Bridges the gap between "follow this worked example" and "now do it yourself."
+
+**When to use:** after a fully worked example has been shown. The completion problem uses the same process but with a different input or scenario, with 1–2 steps left blank. Place before the module's summative quiz.
+
+**HTML:**
+```html
+<div class="completion-problem animate-in" id="cp-ttl-calc">
+  <div class="cp-header">
+    <span class="cp-badge">Completion Problem</span>
+    <p class="cp-instruction">
+      A resolver receives a cached record. Fill in the blanks to trace the correct TTL behavior.
+    </p>
+  </div>
+
+  <div class="cp-scenario">
+    <div class="cp-given">
+      <strong>Given:</strong> Authoritative server returned TTL = 600s.
+      Resolver has held the record for 400s. Client requests the record.
+    </div>
+  </div>
+
+  <div class="cp-steps">
+    <!-- Completed step (shown) -->
+    <div class="cp-step completed">
+      <div class="cp-step-num" aria-label="Step 1">1</div>
+      <div class="cp-step-body">
+        <strong>Check cache freshness</strong>
+        <p>600s − 400s = 200s remaining. Record is still fresh (> 0).</p>
+      </div>
+    </div>
+
+    <!-- Blank step (learner fills) -->
+    <div class="cp-step blank">
+      <div class="cp-step-num" aria-label="Step 2">2</div>
+      <div class="cp-step-body">
+        <strong>Determine TTL to return to client</strong>
+        <div class="cp-input-group">
+          <label class="cp-label" for="cp-ttl-input">Return TTL =</label>
+          <input type="number" id="cp-ttl-input" class="cp-input"
+                 placeholder="?" aria-describedby="cp-ttl-hint" min="0">
+          <span class="cp-unit">seconds</span>
+        </div>
+        <p id="cp-ttl-hint" class="cp-hint">Hint: RFC 2181 §8 — resolvers must decrement TTL by time held</p>
+      </div>
+    </div>
+
+    <!-- Blank step -->
+    <div class="cp-step blank">
+      <div class="cp-step-num" aria-label="Step 3">3</div>
+      <div class="cp-step-body">
+        <strong>What happens when the client caches this response?</strong>
+        <div class="cp-choices">
+          <label class="cp-choice">
+            <input type="radio" name="cp-client-cache" value="a">
+            <span>The client may cache for up to 600 seconds</span>
+          </label>
+          <label class="cp-choice">
+            <input type="radio" name="cp-client-cache" value="b">
+            <span>The client may cache for up to 200 seconds</span>
+          </label>
+          <label class="cp-choice">
+            <input type="radio" name="cp-client-cache" value="c">
+            <span>The client must not cache — TTL has been altered</span>
+          </label>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <button class="cp-check-btn" onclick="checkCompletion('cp-ttl-calc')"
+          aria-label="Check my answers">Check answers</button>
+  <div class="cp-feedback" id="cp-ttl-calc-feedback" aria-live="polite"></div>
+</div>
+```
+
+**JS:**
+```javascript
+const completionAnswers = {
+  'cp-ttl-calc': {
+    checks: [
+      {
+        type: 'number',
+        inputId: 'cp-ttl-input',
+        correct: 200,
+        tolerance: 0,
+        correctMsg: 'Correct — 200 seconds. The resolver subtracts the time held (400s) from the original TTL (600s).',
+        wrongMsg: (val) => `Not quite. The resolver held the record for 400s of a 600s TTL — so ${600 - 400}s remain. You entered ${val}s.`
+      },
+      {
+        type: 'radio',
+        name: 'cp-client-cache',
+        correct: 'b',
+        correctMsg: 'Correct. The client receives a TTL of 200s and may cache for up to that long. This preserves the authoritative server\'s freshness guarantee end-to-end.',
+        wrongMsg: 'Not quite. The client should respect the TTL the resolver returned (200s), not the original TTL from the authoritative server. The resolver already decremented it.'
+      }
+    ]
+  }
+};
+
+window.checkCompletion = function(id) {
+  const data = completionAnswers[id];
+  const feedback = document.getElementById(`${id}-feedback`);
+  const results = [];
+
+  data.checks.forEach(check => {
+    if (check.type === 'number') {
+      const input = document.getElementById(check.inputId);
+      const val = parseInt(input.value, 10);
+      const correct = Math.abs(val - check.correct) <= check.tolerance;
+      input.classList.add(correct ? 'cp-correct' : 'cp-incorrect');
+      results.push({ correct, msg: correct ? check.correctMsg : check.wrongMsg(val) });
+    } else if (check.type === 'radio') {
+      const selected = document.querySelector(`input[name="${check.name}"]:checked`);
+      const correct = selected && selected.value === check.correct;
+      results.push({ correct, msg: correct ? check.correctMsg : check.wrongMsg });
+    }
+  });
+
+  const allCorrect = results.every(r => r.correct);
+  feedback.innerHTML = results.map((r, i) =>
+    `<div class="cp-result ${r.correct ? 'success' : 'error'}">
+      <strong>Step ${i + 2}:</strong> ${r.msg}
+    </div>`
+  ).join('');
+  feedback.className = 'cp-feedback show';
+};
+```
+
+**CSS:**
+```css
+.completion-problem {
+  background: var(--color-surface-warm);
+  border: 2px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  margin: var(--space-8) 0;
+}
+.cp-badge {
+  display: inline-block;
+  font-family: var(--font-mono); font-size: var(--text-xs);
+  text-transform: uppercase; letter-spacing: 0.08em;
+  background: var(--color-accent); color: white;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-full);
+  margin-bottom: var(--space-3);
+}
+.cp-scenario {
+  background: var(--color-bg-code); color: #CDD6F4;
+  border-radius: var(--radius-sm);
+  padding: var(--space-4) var(--space-5);
+  margin: var(--space-4) 0;
+  font-size: var(--text-sm);
+}
+.cp-steps { display: flex; flex-direction: column; gap: var(--space-4); margin: var(--space-5) 0; }
+.cp-step { display: flex; gap: var(--space-4); align-items: flex-start; }
+.cp-step-num {
+  width: 32px; height: 32px; border-radius: 50%; flex-shrink: 0;
+  display: flex; align-items: center; justify-content: center;
+  font-weight: 700; font-family: var(--font-display);
+}
+.cp-step.completed .cp-step-num { background: var(--color-success); color: white; }
+.cp-step.blank .cp-step-num { background: var(--color-accent); color: white; }
+.cp-step.completed .cp-step-body { opacity: 0.8; }
+.cp-input-group { display: flex; align-items: center; gap: var(--space-3); margin: var(--space-3) 0; }
+.cp-input {
+  width: 80px; padding: var(--space-2) var(--space-3);
+  border: 2px solid var(--color-border); border-radius: var(--radius-sm);
+  font-size: var(--text-base); font-family: var(--font-mono); text-align: center;
+}
+.cp-input:focus { outline: 2px solid var(--color-accent); outline-offset: 2px; border-color: transparent; }
+.cp-input.cp-correct { border-color: var(--color-success); background: var(--color-success-light); }
+.cp-input.cp-incorrect { border-color: var(--color-error); background: var(--color-error-light); }
+.cp-hint { font-size: var(--text-xs); color: var(--color-text-muted); margin: var(--space-1) 0 0; }
+.cp-choices { display: flex; flex-direction: column; gap: var(--space-2); margin-top: var(--space-3); }
+.cp-choice { display: flex; align-items: flex-start; gap: var(--space-3); cursor: pointer; font-size: var(--text-sm); }
+.cp-check-btn {
+  background: var(--color-accent); color: white; border: none;
+  border-radius: var(--radius-sm); padding: var(--space-3) var(--space-6);
+  cursor: pointer; font-weight: 600; margin-top: var(--space-4);
+}
+.cp-feedback { display: none; margin-top: var(--space-4); }
+.cp-feedback.show { display: flex; flex-direction: column; gap: var(--space-3); }
+.cp-result {
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-sm); font-size: var(--text-sm);
+}
+.cp-result.success { background: var(--color-success-light); color: var(--color-success); }
+.cp-result.error { background: var(--color-error-light); color: var(--color-error); }
+```
+
+---
+
+## Retrieval Callbacks
+
+A question at the start or end of a module (Module 3+) that asks the learner to apply a concept from an earlier module in a new context. Not a review question — a *transfer* question. The callback makes learning feel cumulative.
+
+**When to use:** once per module from Module 3 onward. Place at the top of the module (before new content) or at the bottom (after the summative quiz, as a bridge to the next module).
+
+**Structure:**
+- Name the earlier module/concept explicitly ("In Module 2 we saw that...")
+- Present a new scenario that requires applying that concept alongside the new content
+- Reveal the answer only after the learner commits
+- Bridge to the current module's content ("This connects to what we're about to learn about X")
+
+**HTML:**
+```html
+<div class="retrieval-callback animate-in" id="rcb-m4">
+  <div class="rcb-header">
+    <span class="rcb-tag" aria-label="Builds on Module 2">↩ Building on Module 2</span>
+    <span class="rcb-label">Retrieval challenge</span>
+  </div>
+  <p class="rcb-context">
+    In Module 2 we learned that resolvers cache responses and decrement TTL as time passes.
+  </p>
+  <p class="rcb-question">
+    <strong>New scenario:</strong> A resolver has a cached record with 50 seconds remaining.
+    It receives a new query for the same name but a <em>different record type</em>.
+    Must it return the cached record? What should it do?
+  </p>
+  <div class="rcb-options">
+    <button class="rcb-option" onclick="commitRcb(this, 'rcb-m4', false)">
+      Yes — the name is the same, so the cache entry applies
+    </button>
+    <button class="rcb-option" onclick="commitRcb(this, 'rcb-m4', false)">
+      No — it must discard the cache and query fresh
+    </button>
+    <button class="rcb-option" onclick="commitRcb(this, 'rcb-m4', true)">
+      No — cache entries are keyed by name <em>and</em> type; this is a cache miss
+    </button>
+  </div>
+  <div class="rcb-reveal" id="rcb-m4-reveal" aria-live="polite" style="display:none">
+    <p>Cache entries are keyed by the tuple (name, type, class). A query for <code>example.com A</code> and <code>example.com AAAA</code> are separate cache entries even though the name is identical. This matters for Module 4 because...</p>
+    <p class="rcb-bridge">This module explores exactly how that tuple works and what happens when it collides. Keep this scenario in mind as we go.</p>
+  </div>
+</div>
+```
+
+**JS:**
+```javascript
+window.commitRcb = function(btn, id, isCorrect) {
+  const block = document.getElementById(id);
+  block.querySelectorAll('.rcb-option').forEach(b => {
+    b.disabled = true;
+    if (b === btn) b.classList.add(isCorrect ? 'rcb-correct' : 'rcb-incorrect');
+    if (isCorrect && b !== btn) b.classList.add('rcb-dim');
+    if (!isCorrect && b.dataset.correct) b.classList.add('rcb-correct');
+  });
+  // Mark correct option if wrong
+  if (!isCorrect) {
+    block.querySelectorAll('.rcb-option').forEach(b => {
+      if (b.textContent.includes('name and type')) b.classList.add('rcb-correct');
+    });
+  }
+  document.getElementById(`${id}-reveal`).style.display = 'block';
+};
+```
+
+**CSS:**
+```css
+.retrieval-callback {
+  background: linear-gradient(135deg, var(--color-bg-warm), var(--color-surface-warm));
+  border-left: 4px solid var(--color-accent);
+  border-radius: 0 var(--radius-md) var(--radius-md) 0;
+  padding: var(--space-5) var(--space-6);
+  margin: var(--space-8) 0;
+}
+.rcb-header {
+  display: flex; align-items: center; gap: var(--space-3);
+  margin-bottom: var(--space-4);
+}
+.rcb-tag {
+  font-family: var(--font-mono); font-size: var(--text-xs);
+  text-transform: uppercase; letter-spacing: 0.06em;
+  background: var(--color-accent-light); color: var(--color-accent);
+  border: 1px solid var(--color-accent-muted);
+  padding: var(--space-1) var(--space-3); border-radius: var(--radius-full);
+}
+.rcb-label {
+  font-size: var(--text-xs); text-transform: uppercase; letter-spacing: 0.06em;
+  color: var(--color-text-muted);
+}
+.rcb-context { color: var(--color-text-secondary); font-size: var(--text-sm); margin-bottom: var(--space-3); }
+.rcb-question { margin-bottom: var(--space-4); }
+.rcb-options { display: flex; flex-direction: column; gap: var(--space-2); }
+.rcb-option {
+  text-align: left; padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--color-border); border-radius: var(--radius-sm);
+  background: var(--color-surface); cursor: pointer; font-size: var(--text-sm);
+}
+.rcb-option:hover:not(:disabled) { border-color: var(--color-accent-muted); }
+.rcb-option.rcb-correct { border-color: var(--color-success); background: var(--color-success-light); }
+.rcb-option.rcb-incorrect { border-color: var(--color-error); background: var(--color-error-light); }
+.rcb-option.rcb-dim { opacity: 0.45; }
+.rcb-reveal {
+  margin-top: var(--space-4); padding: var(--space-4);
+  background: var(--color-surface); border-radius: var(--radius-sm);
+  font-size: var(--text-sm); line-height: var(--leading-normal);
+}
+.rcb-bridge {
+  margin-top: var(--space-3); font-style: italic;
+  color: var(--color-text-secondary);
+}
+```
+
+---
+
+## Decision Tree Navigator
+
+For documentation that describes conditional logic — "if X, do A; if Y, do B; unless Z, in which case..." A clickable decision tree where the learner navigates a real scenario step by step, making choices and seeing the consequences.
+
+**When to use:** any time the documentation contains decision logic, routing rules, priority tables, or "it depends" scenarios. Much more effective than a list of rules.
+
+**HTML:**
+```html
+<div class="decision-tree" id="dt-rcode" role="region" aria-label="DNS RCODE decision tree">
+  <div class="dt-header">
+    <span class="dt-label">Interactive: Handling DNS Response Codes</span>
+    <button class="dt-reset" onclick="resetDT('dt-rcode')"
+            aria-label="Reset decision tree">Start over</button>
+  </div>
+
+  <!-- Scenario context -->
+  <div class="dt-scenario">
+    <strong>Scenario:</strong> Your resolver just received a DNS response.
+    Walk through how to handle it correctly.
+  </div>
+
+  <!-- Node 0: root -->
+  <div class="dt-node active" id="dt-rcode-0" aria-live="polite">
+    <p class="dt-question">What is the RCODE in the response header?</p>
+    <div class="dt-choices">
+      <button class="dt-choice" onclick="dtNavigate('dt-rcode', 0, 'noerror')"
+              aria-label="RCODE is NOERROR (0)">
+        <span class="dt-choice-label">NOERROR (0)</span>
+        <span class="dt-choice-hint">Query processed successfully</span>
+      </button>
+      <button class="dt-choice" onclick="dtNavigate('dt-rcode', 0, 'nxdomain')"
+              aria-label="RCODE is NXDOMAIN (3)">
+        <span class="dt-choice-label">NXDOMAIN (3)</span>
+        <span class="dt-choice-hint">Name does not exist</span>
+      </button>
+      <button class="dt-choice" onclick="dtNavigate('dt-rcode', 0, 'servfail')"
+              aria-label="RCODE is SERVFAIL (2)">
+        <span class="dt-choice-label">SERVFAIL (2)</span>
+        <span class="dt-choice-hint">Server could not complete the query</span>
+      </button>
+    </div>
+  </div>
+
+  <!-- Node: NOERROR branch -->
+  <div class="dt-node" id="dt-rcode-noerror" hidden>
+    <div class="dt-breadcrumb">NOERROR →</div>
+    <p class="dt-question">Does the Answer section contain records?</p>
+    <div class="dt-choices">
+      <button class="dt-choice" onclick="dtNavigate('dt-rcode', 'noerror', 'answer-yes')">
+        <span class="dt-choice-label">Yes — records present</span>
+      </button>
+      <button class="dt-choice" onclick="dtNavigate('dt-rcode', 'noerror', 'answer-no')">
+        <span class="dt-choice-label">No — answer section is empty</span>
+      </button>
+    </div>
+  </div>
+
+  <!-- Terminal nodes -->
+  <div class="dt-node dt-terminal" id="dt-rcode-answer-yes" hidden>
+    <div class="dt-breadcrumb">NOERROR → Records present →</div>
+    <div class="dt-outcome success">
+      <strong>Cache and return the records.</strong>
+      <p>Cache each RR respecting its TTL. Return the answer to the client. This is the happy path.</p>
+      <div class="dt-spec-ref">RFC 1035 §3.2 — each resource record is cached independently with its own TTL.</div>
+    </div>
+  </div>
+
+  <div class="dt-node dt-terminal" id="dt-rcode-answer-no" hidden>
+    <div class="dt-breadcrumb">NOERROR → Empty answer →</div>
+    <div class="dt-outcome warning">
+      <strong>This is NODATA — cache the negative response.</strong>
+      <p>The name exists but has no records of the requested type. Cache this negative result using the SOA TTL from the authority section to prevent hammering the authoritative server.</p>
+      <div class="dt-spec-ref">RFC 2308 §3 — negative caching of NODATA responses.</div>
+    </div>
+  </div>
+
+  <div class="dt-node dt-terminal" id="dt-rcode-nxdomain" hidden>
+    <div class="dt-breadcrumb">NXDOMAIN →</div>
+    <div class="dt-outcome warning">
+      <strong>Cache the negative response, return NXDOMAIN to client.</strong>
+      <p>The name does not exist. Cache for the SOA minimum TTL. Distinguish from NODATA: NXDOMAIN means the name is gone entirely — not just this record type.</p>
+      <div class="dt-spec-ref">RFC 2308 §2 — NXDOMAIN caching and SOA TTL.</div>
+    </div>
+  </div>
+
+  <div class="dt-node dt-terminal" id="dt-rcode-servfail" hidden>
+    <div class="dt-breadcrumb">SERVFAIL →</div>
+    <div class="dt-outcome error">
+      <strong>Do not cache. Retry with backoff or return error to client.</strong>
+      <p>SERVFAIL indicates a server-side failure — the authoritative server may be temporarily unreachable or misconfigured. Caching this would poison the cache.</p>
+      <div class="dt-spec-ref">RFC 4035 §5.3 — SERVFAIL is used by DNSSEC validators to signal validation failure; behavior varies by context.</div>
+    </div>
+  </div>
+
+  <!-- Path history -->
+  <div class="dt-path" id="dt-rcode-path" aria-live="polite"></div>
+</div>
+```
+
+**JS:**
+```javascript
+const dtGraphs = {
+  'dt-rcode': {
+    // adjacency: nodeId → { choiceValue: nextNodeId }
+    0: { noerror: 'noerror', nxdomain: 'nxdomain', servfail: 'servfail' },
+    noerror: { 'answer-yes': 'answer-yes', 'answer-no': 'answer-no' },
+  }
+};
+
+const dtPaths = {};
+
+window.dtNavigate = function(treeId, fromNode, choice) {
+  const tree = document.getElementById(treeId);
+  const graph = dtGraphs[treeId];
+  const nextId = graph[fromNode]?.[choice];
+  if (!nextId) return;
+
+  // Hide current node
+  const current = tree.querySelector('.dt-node.active');
+  if (current) current.classList.remove('active');
+
+  // Show next node
+  const next = document.getElementById(`${treeId}-${nextId}`);
+  if (next) {
+    next.hidden = false;
+    next.classList.add('active');
+    next.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  }
+
+  // Track path
+  if (!dtPaths[treeId]) dtPaths[treeId] = [];
+  dtPaths[treeId].push(choice);
+  const pathEl = document.getElementById(`${treeId}-path`);
+  if (pathEl) pathEl.textContent = 'Your path: ' + dtPaths[treeId].join(' → ');
+};
+
+window.resetDT = function(treeId) {
+  const tree = document.getElementById(treeId);
+  tree.querySelectorAll('.dt-node').forEach(n => {
+    n.hidden = true;
+    n.classList.remove('active');
+  });
+  const root = document.getElementById(`${treeId}-0`);
+  root.hidden = false;
+  root.classList.add('active');
+  dtPaths[treeId] = [];
+  const pathEl = document.getElementById(`${treeId}-path`);
+  if (pathEl) pathEl.textContent = '';
+};
+```
+
+**CSS:**
+```css
+.decision-tree {
+  background: var(--color-surface-warm);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  margin: var(--space-8) 0;
+}
+.dt-header {
+  display: flex; justify-content: space-between; align-items: center;
+  margin-bottom: var(--space-5);
+}
+.dt-label {
+  font-family: var(--font-mono); font-size: var(--text-xs);
+  text-transform: uppercase; letter-spacing: 0.08em;
+  color: var(--color-text-secondary);
+}
+.dt-reset {
+  font-size: var(--text-xs); padding: var(--space-1) var(--space-3);
+  border: 1px solid var(--color-border); border-radius: var(--radius-sm);
+  background: var(--color-surface); cursor: pointer;
+}
+.dt-scenario {
+  background: var(--color-bg-code); color: #CDD6F4;
+  padding: var(--space-3) var(--space-4); border-radius: var(--radius-sm);
+  font-size: var(--text-sm); margin-bottom: var(--space-5);
+}
+.dt-node { animation: fadeSlideUp 0.25s var(--ease-out); }
+.dt-question { font-weight: 600; margin-bottom: var(--space-4); }
+.dt-choices { display: flex; flex-direction: column; gap: var(--space-2); }
+.dt-choice {
+  display: flex; flex-direction: column; gap: var(--space-1);
+  text-align: left; padding: var(--space-4);
+  border: 2px solid var(--color-border); border-radius: var(--radius-sm);
+  background: var(--color-surface); cursor: pointer;
+  transition: border-color var(--duration-fast), transform var(--duration-fast);
+}
+.dt-choice:hover { border-color: var(--color-accent); transform: translateX(4px); }
+.dt-choice:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 2px; }
+.dt-choice-label { font-weight: 600; font-family: var(--font-mono); font-size: var(--text-sm); }
+.dt-choice-hint { font-size: var(--text-xs); color: var(--color-text-secondary); }
+.dt-breadcrumb {
+  font-family: var(--font-mono); font-size: var(--text-xs);
+  color: var(--color-text-muted); margin-bottom: var(--space-3);
+}
+.dt-outcome {
+  padding: var(--space-5); border-radius: var(--radius-md);
+  border-left: 4px solid;
+}
+.dt-outcome.success { background: var(--color-success-light); border-color: var(--color-success); }
+.dt-outcome.warning { background: var(--color-accent-light); border-color: var(--color-accent); }
+.dt-outcome.error { background: var(--color-error-light); border-color: var(--color-error); }
+.dt-spec-ref {
+  margin-top: var(--space-3); font-size: var(--text-xs);
+  font-family: var(--font-mono); color: var(--color-text-muted);
+}
+.dt-path {
+  margin-top: var(--space-4); font-size: var(--text-xs);
+  color: var(--color-text-muted); font-family: var(--font-mono);
+}
+@keyframes fadeSlideUp {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+```
+
+---
+
+## State Machine Visualizer
+
+For documentation describing protocols, lifecycle states, or any system with explicit states and transitions (connection states, record lifecycle, authentication flows). Shows states as nodes and transitions as labeled edges. The learner triggers transitions by clicking.
+
+**When to use:** any time the documentation has a state diagram, lifecycle table, or "when in state X, upon event Y, transition to state Z" language.
+
+**HTML:**
+```html
+<div class="state-machine" id="sm-tcp" role="region" aria-label="TCP connection state machine">
+  <div class="sm-header">
+    <span class="sm-label">TCP Connection States (simplified)</span>
+    <div class="sm-controls">
+      <button class="sm-trigger" onclick="smTrigger('sm-tcp', 'syn_sent')"
+              aria-label="Send SYN">Send SYN</button>
+      <button class="sm-trigger" onclick="smTrigger('sm-tcp', 'established')"
+              aria-label="Receive SYN-ACK">SYN-ACK received</button>
+      <button class="sm-trigger" onclick="smTrigger('sm-tcp', 'fin_wait')"
+              aria-label="Send FIN">Send FIN</button>
+      <button class="sm-trigger" onclick="smTrigger('sm-tcp', 'closed')"
+              aria-label="Close">Close</button>
+      <button class="sm-reset-btn" onclick="smReset('sm-tcp')"
+              aria-label="Reset to initial state">Reset</button>
+    </div>
+  </div>
+
+  <div class="sm-canvas">
+    <div class="sm-state" id="sm-tcp-closed" data-state="closed" aria-current="true">
+      <span class="sm-state-name">CLOSED</span>
+      <span class="sm-state-desc">No connection</span>
+    </div>
+    <div class="sm-arrow sm-arrow-right" aria-hidden="true">→<span class="sm-arrow-label">SYN</span></div>
+    <div class="sm-state" id="sm-tcp-syn_sent" data-state="syn_sent">
+      <span class="sm-state-name">SYN_SENT</span>
+      <span class="sm-state-desc">Waiting for SYN-ACK</span>
+    </div>
+    <div class="sm-arrow sm-arrow-right" aria-hidden="true">→<span class="sm-arrow-label">SYN-ACK</span></div>
+    <div class="sm-state" id="sm-tcp-established" data-state="established">
+      <span class="sm-state-name">ESTABLISHED</span>
+      <span class="sm-state-desc">Data transfer active</span>
+    </div>
+    <div class="sm-arrow sm-arrow-down" aria-hidden="true">↓<span class="sm-arrow-label">FIN</span></div>
+    <div class="sm-state" id="sm-tcp-fin_wait" data-state="fin_wait">
+      <span class="sm-state-name">FIN_WAIT_1</span>
+      <span class="sm-state-desc">Closing initiated</span>
+    </div>
+    <div class="sm-arrow sm-arrow-right" aria-hidden="true">→<span class="sm-arrow-label">ACK + FIN</span></div>
+    <div class="sm-state" id="sm-tcp-closed2" data-state="closed">
+      <span class="sm-state-name">CLOSED</span>
+      <span class="sm-state-desc">Connection terminated</span>
+    </div>
+  </div>
+
+  <div class="sm-info" id="sm-tcp-info" aria-live="polite">
+    <strong>Current state: CLOSED</strong>
+    <p>No active connection. Waiting for either a passive open (listen) or an active open (connect).</p>
+  </div>
+</div>
+```
+
+**JS:**
+```javascript
+const smDefinitions = {
+  'sm-tcp': {
+    states: {
+      closed:      { label: 'CLOSED',      desc: 'No active connection. Waiting for passive or active open.' },
+      syn_sent:    { label: 'SYN_SENT',    desc: 'Active open initiated. SYN sent, waiting for SYN-ACK from the server.' },
+      established: { label: 'ESTABLISHED', desc: 'Three-way handshake complete. Data transfer is active. This is the normal operating state.' },
+      fin_wait:    { label: 'FIN_WAIT_1',  desc: 'Close initiated by this side. FIN sent, waiting for acknowledgement.' },
+    },
+    current: 'closed'
+  }
+};
+
+window.smTrigger = function(machineId, targetState) {
+  const sm = smDefinitions[machineId];
+  const stateData = sm.states[targetState];
+  if (!stateData) return;
+
+  // Deactivate current
+  const machine = document.getElementById(machineId);
+  machine.querySelectorAll('.sm-state').forEach(el => {
+    el.classList.remove('sm-active');
+    el.removeAttribute('aria-current');
+  });
+
+  // Activate new state
+  const stateEl = document.getElementById(`${machineId}-${targetState}`);
+  if (stateEl) {
+    stateEl.classList.add('sm-active');
+    stateEl.setAttribute('aria-current', 'true');
+  }
+
+  sm.current = targetState;
+
+  // Update info panel
+  const info = document.getElementById(`${machineId}-info`);
+  info.innerHTML = `<strong>Current state: ${stateData.label}</strong><p>${stateData.desc}</p>`;
+};
+
+window.smReset = function(machineId) {
+  smTrigger(machineId, 'closed');
+};
+```
+
+**CSS:**
+```css
+.state-machine {
+  background: var(--color-surface-warm);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  margin: var(--space-8) 0;
+}
+.sm-header {
+  display: flex; flex-wrap: wrap; gap: var(--space-4);
+  justify-content: space-between; align-items: center;
+  margin-bottom: var(--space-5);
+}
+.sm-label {
+  font-family: var(--font-mono); font-size: var(--text-xs);
+  text-transform: uppercase; letter-spacing: 0.08em;
+  color: var(--color-text-secondary);
+}
+.sm-controls { display: flex; flex-wrap: wrap; gap: var(--space-2); }
+.sm-trigger {
+  padding: var(--space-2) var(--space-4);
+  border: 1px solid var(--color-accent-muted); border-radius: var(--radius-sm);
+  background: var(--color-accent-light); color: var(--color-accent);
+  cursor: pointer; font-size: var(--text-xs); font-weight: 600;
+  transition: background var(--duration-fast), border-color var(--duration-fast);
+}
+.sm-trigger:hover { background: var(--color-accent); color: white; }
+.sm-trigger:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 2px; }
+.sm-reset-btn {
+  padding: var(--space-2) var(--space-4);
+  border: 1px solid var(--color-border); border-radius: var(--radius-sm);
+  background: var(--color-surface); cursor: pointer; font-size: var(--text-xs);
+}
+.sm-canvas {
+  display: flex; flex-wrap: wrap; align-items: center;
+  gap: var(--space-2); margin: var(--space-5) 0;
+  overflow-x: auto; padding-bottom: var(--space-2);
+}
+.sm-state {
+  display: flex; flex-direction: column; align-items: center;
+  padding: var(--space-4) var(--space-5);
+  border: 2px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  min-width: 120px; text-align: center;
+  transition: all var(--duration-normal) var(--ease-out);
+}
+.sm-state.sm-active {
+  border-color: var(--color-accent);
+  background: var(--color-accent-light);
+  box-shadow: 0 0 0 3px var(--color-accent-light), var(--shadow-md);
+  transform: scale(1.04);
+}
+.sm-state-name {
+  font-family: var(--font-mono); font-size: var(--text-xs);
+  font-weight: 700; letter-spacing: 0.05em;
+}
+.sm-state-desc { font-size: var(--text-xs); color: var(--color-text-secondary); margin-top: var(--space-1); }
+.sm-arrow {
+  display: flex; flex-direction: column; align-items: center;
+  color: var(--color-text-muted); font-size: 1.25rem; position: relative;
+}
+.sm-arrow-label {
+  font-size: var(--text-xs); font-family: var(--font-mono);
+  color: var(--color-text-muted); white-space: nowrap;
+}
+.sm-info {
+  background: var(--color-surface); border-radius: var(--radius-sm);
+  padding: var(--space-4); margin-top: var(--space-4); font-size: var(--text-sm);
+  border-left: 3px solid var(--color-accent);
+}
+```
+
+---
+
+## Spec ↔ Plain English Translation Blocks
+
+The primary teaching element for docs-to-course. Shows verbatim text from the documentation on the left (styled as a blockquote to signal "official language") and a plain-English translation on the right that explains what it means, why it matters, and what to watch out for.
+
+**HTML:**
+```html
+<div class="translation-block animate-in">
+  <div class="translation-spec">
+    <span class="translation-label">SPEC</span>
+    <blockquote class="spec-excerpt">
+      <p>Each RR in the answer section MUST have a TTL no greater than the TTL field in the original record set, and MUST NOT have a TTL of zero unless the original record set had a TTL of zero.</p>
+    </blockquote>
+    <cite class="spec-cite">RFC 2181, Section 5.2</cite>
+  </div>
+  <div class="translation-english">
+    <span class="translation-label">PLAIN ENGLISH</span>
+    <div class="translation-lines">
+      <p class="tl"><strong>What it means:</strong> When a DNS server passes along an answer, it can't extend how long that answer lives — only shorten it or keep it the same.</p>
+      <p class="tl"><strong>Why it matters:</strong> This prevents "TTL inflation" where a middleman could make a record appear fresher than the authority intended, undermining cache poisoning defenses.</p>
+      <p class="tl"><strong>Watch out for:</strong> A TTL of zero is special — it means "don't cache this at all." The spec protects this signal from being stripped by intermediaries.</p>
+    </div>
+  </div>
+</div>
+```
+
+**CSS:**
+```css
+.translation-block {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  box-shadow: var(--shadow-md);
+  margin: var(--space-8) 0;
+}
+.translation-spec {
+  background: var(--color-bg-code);
+  color: #CDD6F4;
+  padding: var(--space-6);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  line-height: 1.8;
+  position: relative;
+}
+.spec-excerpt {
+  margin: var(--space-4) 0 var(--space-3);
+  padding-left: var(--space-4);
+  border-left: 3px solid var(--color-accent-muted);
+  font-style: italic;
+  color: #CDD6F4;
+}
+.spec-cite {
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-text-muted);
+  letter-spacing: 0.03em;
+}
+.translation-english {
+  background: var(--color-surface-warm);
+  padding: var(--space-6);
+  font-size: var(--text-sm);
+  line-height: 1.7;
+  border-left: 3px solid var(--color-accent);
+}
+.translation-label {
+  position: absolute;
+  top: var(--space-2);
+  right: var(--space-3);
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  opacity: 0.5;
+}
+.translation-english .translation-label {
+  position: static;
+  display: block;
+  margin-bottom: var(--space-3);
+  color: var(--color-text-muted);
+}
+.tl { margin: var(--space-3) 0; }
+.tl:first-child { margin-top: 0; }
+/* Responsive: stack vertically on mobile */
+@media (max-width: 768px) {
+  .translation-block { grid-template-columns: 1fr; }
+  .translation-english { border-left: none; border-top: 3px solid var(--color-accent); }
+}
+```
+
+**Rules:**
+- Show the spec text **verbatim** — never paraphrase or condense the left panel
+- Choose **naturally self-contained** passages (2-5 sentences) rather than truncating longer sections
+- The right panel has three parts: **What it means** (the plain translation), **Why it matters** (the practical consequence), and optionally **Watch out for** (the gotcha)
+- Keep each panel to about the same visual height — if the spec excerpt is short, keep the translation concise too
+
+---
+
+## Code ↔ English Translation Blocks
+
+Used when the documentation contains code examples, configuration snippets, or protocol message formats. Shows the code on the left and a plain English translation on the right, line by line.
+
+**HTML:**
+```html
+<div class="translation-block animate-in">
+  <div class="translation-code">
+    <span class="translation-label">CODE</span>
+    <pre><code>
+<span class="code-line"><span class="code-keyword">const</span> response = <span class="code-keyword">await</span> <span class="code-function">fetch</span>(url, {</span>
+<span class="code-line">  <span class="code-property">method</span>: <span class="code-string">'POST'</span>,</span>
+<span class="code-line">  <span class="code-property">headers</span>: { <span class="code-string">'Authorization'</span>: apiKey }</span>
+<span class="code-line">});</span>
+    </code></pre>
+  </div>
+  <div class="translation-english">
+    <span class="translation-label">PLAIN ENGLISH</span>
+    <div class="translation-lines">
+      <p class="tl">Send a request to the URL and wait for a response...</p>
+      <p class="tl">We're sending data (POST), not just asking for it (GET)...</p>
+      <p class="tl">Include our API key so the server knows who we are...</p>
+      <p class="tl">End of the request setup.</p>
+    </div>
+  </div>
+</div>
+```
+
+**CSS:**
+```css
+.translation-block {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  box-shadow: var(--shadow-md);
+  margin: var(--space-8) 0;
+}
+.translation-code {
+  background: var(--color-bg-code);
+  color: #CDD6F4;
+  padding: var(--space-6);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  line-height: 1.7;
+  position: relative;
+  overflow-x: hidden;  /* NO horizontal scrollbar — ever */
+}
+.translation-code pre,
+.translation-code code {
+  white-space: pre-wrap;       /* wrap long lines instead of scrolling */
+  word-break: break-word;      /* break mid-word if needed */
+  overflow-x: hidden;
+}
+.translation-english {
+  background: var(--color-surface-warm);
+  padding: var(--space-6);
+  font-size: var(--text-sm);
+  line-height: 1.7;
+  border-left: 3px solid var(--color-accent);
+}
+.translation-label {
+  position: absolute;
+  top: var(--space-2);
+  right: var(--space-3);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  opacity: 0.5;
+}
+.translation-english .translation-label {
+  color: var(--color-text-muted);
+}
+/* Responsive: stack vertically on mobile */
+@media (max-width: 768px) {
+  .translation-block { grid-template-columns: 1fr; }
+  .translation-english { border-left: none; border-top: 3px solid var(--color-accent); }
+}
+```
+
+**Rules:**
+- Each English line should correspond to 1-2 code lines
+- Use conversational language, not technical jargon
+- Highlight the "why" not just the "what" — e.g., "Include our API key so the server knows who we are" not "Set the Authorization header"
+
+---
+
+## Multiple-Choice Quizzes
+
+Summative assessment placed at the end of each module. 3–5 scenario-based questions. Every question presents a new situation the learner hasn't seen and asks them to *apply* knowledge — not recite it.
+
+**Elaborative feedback is required for every distractor.** Do not just reveal the correct answer. For each wrong option, write:
+1. Why this answer is wrong — what reasoning flaw it represents
+2. What would have to be true for this answer to be correct
+
+This turns wrong attempts into learning events. See the data structure below for how to store per-option feedback.
+
+**HTML:**
+```html
+<div class="quiz-container" role="group" aria-labelledby="quiz-m3-heading">
+  <h3 class="quiz-heading" id="quiz-m3-heading">Module 3 Quiz</h3>
+
+  <div class="quiz-question-block" data-question="q1" data-correct="option-b">
+    <div class="quiz-scenario-tag" aria-label="Scenario question">Scenario</div>
+    <h4 class="quiz-question">
+      A client receives a DNS response with TTL 0 for a record it previously cached with TTL 300.
+      The client cached the record 60 seconds ago. What should it do?
+    </h4>
+    <div class="quiz-options" role="radiogroup" aria-label="Answer options">
+      <button class="quiz-option" data-value="option-a" onclick="selectOption(this)"
+              role="radio" aria-checked="false">
+        <div class="quiz-option-radio" aria-hidden="true"></div>
+        <span>Keep the cached record — 240 seconds remain on the original TTL</span>
+      </button>
+      <button class="quiz-option" data-value="option-b" onclick="selectOption(this)"
+              role="radio" aria-checked="false">
+        <div class="quiz-option-radio" aria-hidden="true"></div>
+        <span>Discard the cached record immediately — TTL 0 means do not cache</span>
+      </button>
+      <button class="quiz-option" data-value="option-c" onclick="selectOption(this)"
+              role="radio" aria-checked="false">
+        <div class="quiz-option-radio" aria-hidden="true"></div>
+        <span>Cache the record with the new TTL of 0, expiring it at the next query</span>
+      </button>
+    </div>
+    <div class="quiz-feedback" id="q1-feedback" aria-live="polite"></div>
+  </div>
+
+  <button class="quiz-check-btn" onclick="checkQuiz('module-3-quiz')"
+          aria-label="Check answers">Check Answers</button>
+  <button class="quiz-reset-btn" onclick="resetQuiz('module-3-quiz')"
+          aria-label="Try again">Try Again</button>
+</div>
+```
+
+**JS pattern — with elaborative feedback per distractor:**
+```javascript
+// Define elaborative feedback for every option, not just the correct one
+const quizData = {
+  'module-3-quiz': {
+    q1: {
+      correct: 'option-b',
+      feedback: {
+        'option-a': {
+          // Explain the reasoning flaw, not just "wrong"
+          wrong: `This would be correct if TTL 0 were simply a lower TTL than the cached value. But TTL 0 has a specific normative meaning in RFC 1035: the record MUST NOT be cached. It's a signal from the authoritative server, not a duration. The new response supersedes the cached entry regardless of remaining TTL.`,
+          correctReinforcement: null
+        },
+        'option-b': {
+          wrong: null,
+          correctReinforcement: `Exactly. TTL 0 is a normative "do not cache" signal from the authoritative server. RFC 1035 §3.2.1 states that TTL 0 means the RR can only be used for the transaction in progress. Any cached copy must be discarded.`
+        },
+        'option-c': {
+          wrong: `Close, but caching a record with TTL 0 contradicts what TTL 0 means. A cached record with TTL 0 would expire immediately on the next query — effectively not caching it — but the spec is more direct: TTL 0 means the record MUST NOT be stored in cache at all. The distinction matters when a record has been deliberately made uncacheable for security reasons.`,
+          correctReinforcement: null
+        }
+      }
+    }
+  }
+};
+
+window.selectOption = function(btn) {
+  const block = btn.closest('.quiz-question-block');
+  block.querySelectorAll('.quiz-option').forEach(o => {
+    o.classList.remove('selected');
+    o.setAttribute('aria-checked', 'false');
+  });
+  btn.classList.add('selected');
+  btn.setAttribute('aria-checked', 'true');
+};
+
+window.checkQuiz = function(quizId) {
+  const container = document.getElementById(quizId) ||
+    document.querySelector(`[data-quiz-id="${quizId}"]`);
+  const data = quizData[quizId];
+  if (!container || !data) return;
+
+  container.querySelectorAll('.quiz-question-block').forEach(q => {
+    const qId = q.dataset.question;
+    const selected = q.querySelector('.quiz-option.selected');
+    const feedback = q.querySelector('.quiz-feedback');
+    if (!selected || !data[qId]) return;
+
+    const selectedValue = selected.dataset.value;
+    const correctValue = data[qId].correct;
+    const isCorrect = selectedValue === correctValue;
+    const feedbackData = data[qId].feedback[selectedValue];
+
+    selected.classList.add(isCorrect ? 'correct' : 'incorrect');
+    if (!isCorrect) {
+      q.querySelector(`[data-value="${correctValue}"]`).classList.add('correct');
+    }
+
+    feedback.innerHTML = isCorrect
+      ? `<strong>Correct.</strong> ${feedbackData.correctReinforcement}`
+      : `<strong>Not quite.</strong> ${feedbackData.wrong}`;
+    feedback.className = `quiz-feedback show ${isCorrect ? 'success' : 'error'}`;
+    q.querySelectorAll('.quiz-option').forEach(o => o.disabled = true);
+  });
+};
+
+window.resetQuiz = function(quizId) {
+  const container = document.getElementById(quizId) ||
+    document.querySelector(`[data-quiz-id="${quizId}"]`);
+  if (!container) return;
+  container.querySelectorAll('.quiz-option').forEach(o => {
+    o.classList.remove('selected', 'correct', 'incorrect');
+    o.setAttribute('aria-checked', 'false');
+    o.disabled = false;
+  });
+  container.querySelectorAll('.quiz-feedback').forEach(f => {
+    f.className = 'quiz-feedback';
+    f.innerHTML = '';
+  });
+};
+```
+
+**CSS for quiz states:**
+```css
+.quiz-option {
+  display: flex; align-items: center; gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border: 2px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  cursor: pointer; width: 100%;
+  transition: border-color var(--duration-fast), background var(--duration-fast);
+}
+.quiz-option:hover { border-color: var(--color-accent-muted); }
+.quiz-option.selected { border-color: var(--color-accent); background: var(--color-accent-light); }
+.quiz-option.correct { border-color: var(--color-success); background: var(--color-success-light); }
+.quiz-option.incorrect { border-color: var(--color-error); background: var(--color-error-light); }
+.quiz-option-radio {
+  width: 18px; height: 18px; border-radius: 50%;
+  border: 2px solid var(--color-border);
+  transition: all var(--duration-fast);
+}
+.quiz-option.selected .quiz-option-radio {
+  border-color: var(--color-accent);
+  background: var(--color-accent);
+  box-shadow: inset 0 0 0 3px white;
+}
+.quiz-feedback {
+  max-height: 0; overflow: hidden; opacity: 0;
+  transition: max-height var(--duration-normal), opacity var(--duration-normal);
+}
+.quiz-feedback.show { max-height: 200px; opacity: 1; padding: var(--space-3); margin-top: var(--space-2); border-radius: var(--radius-sm); }
+.quiz-feedback.success { background: var(--color-success-light); color: var(--color-success); }
+.quiz-feedback.error { background: var(--color-error-light); color: var(--color-error); }
+```
+
+---
+
+## Drag-and-Drop Matching
+
+For matching concepts to descriptions. Supports both mouse (HTML5 Drag API) and touch.
+
+**HTML:**
+```html
+<div class="dnd-container">
+  <div class="dnd-chips">
+    <div class="dnd-chip" draggable="true" data-answer="actor-a">Actor A</div>
+    <div class="dnd-chip" draggable="true" data-answer="actor-b">Actor B</div>
+    <div class="dnd-chip" draggable="true" data-answer="actor-c">Actor C</div>
+  </div>
+  <div class="dnd-zones">
+    <div class="dnd-zone" data-correct="actor-a">
+      <p class="dnd-zone-label">Description for Actor A</p>
+      <div class="dnd-zone-target">Drop here</div>
+    </div>
+    <!-- more zones -->
+  </div>
+  <button onclick="checkDnD()">Check Matches</button>
+  <button onclick="resetDnD()">Reset</button>
+</div>
+```
+
+**JS (mouse + touch):**
+```javascript
+// MOUSE: HTML5 Drag API
+chips.forEach(chip => {
+  chip.addEventListener('dragstart', (e) => {
+    e.dataTransfer.setData('text/plain', chip.dataset.answer);
+    chip.classList.add('dragging');
+  });
+  chip.addEventListener('dragend', () => chip.classList.remove('dragging'));
+});
+
+zones.forEach(zone => {
+  const target = zone.querySelector('.dnd-zone-target');
+  target.addEventListener('dragover', (e) => { e.preventDefault(); target.classList.add('drag-over'); });
+  target.addEventListener('dragleave', () => target.classList.remove('drag-over'));
+  target.addEventListener('drop', (e) => {
+    e.preventDefault();
+    target.classList.remove('drag-over');
+    const answer = e.dataTransfer.getData('text/plain');
+    const chip = document.querySelector(`[data-answer="${answer}"]`);
+    target.textContent = chip.textContent;
+    target.dataset.placed = answer;
+    chip.classList.add('placed');
+  });
+});
+
+// TOUCH: Custom implementation (HTML5 drag doesn't work on mobile)
+chips.forEach(chip => {
+  chip.addEventListener('touchstart', (e) => {
+    e.preventDefault();
+    const touch = e.touches[0];
+    const clone = chip.cloneNode(true);
+    clone.classList.add('touch-ghost');
+    clone.style.cssText = `position:fixed; z-index:1000; pointer-events:none;
+      left:${touch.clientX - 40}px; top:${touch.clientY - 20}px;`;
+    document.body.appendChild(clone);
+    chip._ghost = clone;
+    chip._answer = chip.dataset.answer;
+  }, { passive: false });
+
+  chip.addEventListener('touchmove', (e) => {
+    e.preventDefault();
+    const touch = e.touches[0];
+    if (chip._ghost) {
+      chip._ghost.style.left = (touch.clientX - 40) + 'px';
+      chip._ghost.style.top = (touch.clientY - 20) + 'px';
+    }
+    // Highlight zone under finger
+    const el = document.elementFromPoint(touch.clientX, touch.clientY);
+    zones.forEach(z => z.querySelector('.dnd-zone-target').classList.remove('drag-over'));
+    if (el && el.closest('.dnd-zone-target')) {
+      el.closest('.dnd-zone-target').classList.add('drag-over');
+    }
+  }, { passive: false });
+
+  chip.addEventListener('touchend', (e) => {
+    if (chip._ghost) { chip._ghost.remove(); chip._ghost = null; }
+    const touch = e.changedTouches[0];
+    const el = document.elementFromPoint(touch.clientX, touch.clientY);
+    if (el && el.closest('.dnd-zone-target')) {
+      const target = el.closest('.dnd-zone-target');
+      target.textContent = chip.textContent;
+      target.dataset.placed = chip._answer;
+      chip.classList.add('placed');
+    }
+  });
+});
+```
+
+---
+
+## Group Chat Animation
+
+iMessage/WeChat-style chat showing components "talking" to each other. Messages appear one by one with typing indicators.
+
+**HTML:**
+```html
+<div class="chat-window">
+  <div class="chat-messages" id="chat-messages">
+    <div class="chat-message" data-msg="0" data-sender="actor-a" style="display:none">
+      <div class="chat-avatar" style="background: var(--color-actor-1)">A</div>
+      <div class="chat-bubble">
+        <span class="chat-sender" style="color: var(--color-actor-1)">Actor A</span>
+        <p>Hey Background, I need the data for this item.</p>
+      </div>
+    </div>
+    <!-- more messages... -->
+  </div>
+
+  <div class="chat-typing" id="chat-typing" style="display:none">
+    <div class="chat-avatar" id="typing-avatar">?</div>
+    <div class="chat-typing-dots">
+      <span class="typing-dot"></span>
+      <span class="typing-dot"></span>
+      <span class="typing-dot"></span>
+    </div>
+  </div>
+
+  <div class="chat-controls">
+    <button onclick="playChatNext()">Next Message</button>
+    <button onclick="playChatAll()">Play All</button>
+    <button onclick="resetChat()">Replay</button>
+    <span class="chat-progress">0 / N messages</span>
+  </div>
+</div>
+```
+
+**JS:**
+```javascript
+let chatIndex = 0;
+const chatMessages = document.querySelectorAll('#chat-messages .chat-message');
+
+// Actor color/avatar mapping
+const actors = {
+  'actor-a': { initials: 'A', color: 'var(--color-actor-1)' },
+  'actor-b': { initials: 'B', color: 'var(--color-actor-2)' },
+  'actor-c': { initials: 'C', color: 'var(--color-actor-3)' },
+};
+
+window.playChatNext = function() {
+  if (chatIndex >= chatMessages.length) return;
+  const msg = chatMessages[chatIndex];
+  const sender = msg.dataset.sender;
+
+  // Show typing indicator with correct avatar
+  const typing = document.getElementById('chat-typing');
+  const avatar = document.getElementById('typing-avatar');
+  avatar.textContent = actors[sender].initials;
+  avatar.style.background = actors[sender].color;
+  typing.style.display = 'flex';
+
+  setTimeout(() => {
+    typing.style.display = 'none';
+    msg.style.display = 'flex';
+    msg.style.animation = 'fadeSlideUp 0.3s var(--ease-out)';
+    chatIndex++;
+    updateChatProgress();
+  }, 800);
+};
+
+window.playChatAll = function() {
+  const interval = setInterval(() => {
+    if (chatIndex >= chatMessages.length) { clearInterval(interval); return; }
+    playChatNext();
+  }, 1200);
+};
+```
+
+**CSS for typing dots:**
+```css
+.typing-dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--color-text-muted);
+  animation: typingBounce 1.4s infinite;
+}
+.typing-dot:nth-child(2) { animation-delay: 0.2s; }
+.typing-dot:nth-child(3) { animation-delay: 0.4s; }
+@keyframes typingBounce {
+  0%, 60%, 100% { transform: translateY(0); }
+  30% { transform: translateY(-6px); }
+}
+```
+
+---
+
+## Message Flow / Data Flow Animation
+
+Step-by-step visualization of data moving between components. User clicks "Next Step" to advance.
+
+**HTML:**
+```html
+<div class="flow-animation">
+  <div class="flow-actors">
+    <div class="flow-actor" id="flow-actor-1">
+      <div class="flow-actor-icon">A</div>
+      <span>Actor 1</span>
+    </div>
+    <div class="flow-actor" id="flow-actor-2">
+      <div class="flow-actor-icon">B</div>
+      <span>Actor 2</span>
+    </div>
+    <div class="flow-actor" id="flow-actor-3">
+      <div class="flow-actor-icon">C</div>
+      <span>Actor 3</span>
+    </div>
+  </div>
+
+  <div class="flow-packet" id="flow-packet"></div>
+
+  <div class="flow-step-label" id="flow-label">Click "Next Step" to begin</div>
+
+  <div class="flow-controls">
+    <button onclick="flowNext()">Next Step</button>
+    <button onclick="flowReset()">Restart</button>
+    <span class="flow-progress">Step 0 / N</span>
+  </div>
+</div>
+```
+
+**JS pattern:**
+```javascript
+const flowSteps = [
+  { from: 'actor-1', to: 'actor-2', label: 'User clicks button → Actor 1 detects click event', highlight: 'actor-1' },
+  { from: 'actor-1', to: 'actor-2', label: 'Actor 1 sends message to Actor 2', highlight: 'actor-2', packet: true },
+  { from: 'actor-2', to: 'external', label: 'Actor 2 calls external API', highlight: 'actor-2', cloud: true },
+  // etc.
+];
+
+let flowStep = 0;
+window.flowNext = function() {
+  if (flowStep >= flowSteps.length) return;
+  const step = flowSteps[flowStep];
+
+  // Remove previous highlights
+  document.querySelectorAll('.flow-actor').forEach(a => a.classList.remove('active'));
+
+  // Highlight current actor
+  document.getElementById(`flow-${step.highlight}`).classList.add('active');
+
+  // Animate packet if needed
+  if (step.packet) {
+    animatePacket(step.from, step.to);
+  }
+
+  // Update label
+  document.getElementById('flow-label').textContent = step.label;
+  flowStep++;
+};
+```
+
+**CSS for active actor glow:**
+```css
+.flow-actor.active {
+  box-shadow: 0 0 0 3px var(--color-accent), 0 0 20px rgba(217, 79, 48, 0.2);
+  transform: scale(1.05);
+  transition: all var(--duration-normal) var(--ease-out);
+}
+```
+
+---
+
+## Interactive Architecture Diagram
+
+Full-system diagram where hovering/clicking a component shows a description tooltip.
+
+**HTML:**
+```html
+<div class="arch-diagram">
+  <div class="arch-zone arch-zone-browser">
+    <h4 class="arch-zone-label">Browser</h4>
+    <div class="arch-component" data-desc="Injects UI into the web page, reads DOM, captures user actions"
+         onclick="showArchDesc(this)">
+      <div class="arch-icon">📄</div>
+      <span>Component A</span>
+    </div>
+    <!-- more components -->
+  </div>
+  <div class="arch-zone arch-zone-external">
+    <h4 class="arch-zone-label">External Services</h4>
+    <!-- API cards -->
+  </div>
+  <div class="arch-description" id="arch-desc">Click any component to learn what it does</div>
+</div>
+```
+
+---
+
+## Layer Toggle Demo
+
+Shows how different layers (e.g., HTML/CSS/JS, or data/logic/UI) build on each other. Three tabs switch between views.
+
+**HTML:**
+```html
+<div class="layer-demo">
+  <div class="layer-tabs">
+    <button class="layer-tab active" onclick="showLayer('html')">HTML</button>
+    <button class="layer-tab" onclick="showLayer('css')">+ CSS</button>
+    <button class="layer-tab" onclick="showLayer('js')">+ JS</button>
+  </div>
+  <div class="layer-viewport">
+    <div class="layer" id="layer-html" style="display:block">
+      <!-- Raw unstyled version -->
+    </div>
+    <div class="layer" id="layer-css" style="display:none">
+      <!-- Styled version -->
+    </div>
+    <div class="layer" id="layer-js" style="display:none">
+      <!-- Interactive version -->
+    </div>
+  </div>
+  <p class="layer-description" id="layer-desc">This is the raw HTML...</p>
+</div>
+```
+
+---
+
+## "Spot the Bug" Challenge
+
+Show code with a deliberate bug. User clicks the buggy line. Reveal explains the issue.
+
+**HTML:**
+```html
+<div class="bug-challenge">
+  <h3>Find the bug in this code:</h3>
+  <div class="bug-code">
+    <div class="bug-line" data-line="1" onclick="checkBugLine(this, false)">
+      <span class="line-num">1</span>
+      <code>chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {</code>
+    </div>
+    <div class="bug-line" data-line="2" onclick="checkBugLine(this, false)">
+      <span class="line-num">2</span>
+      <code>  if (msg.action === 'fetchData') {</code>
+    </div>
+    <div class="bug-line bug-target" data-line="3" onclick="checkBugLine(this, true)">
+      <span class="line-num">3</span>
+      <code>    fetch(url).then(r => r.json()).then(data => sendResponse(data));</code>
+    </div>
+    <div class="bug-line" data-line="4" onclick="checkBugLine(this, false)">
+      <span class="line-num">4</span>
+      <code>  }</code>
+    </div>
+    <div class="bug-line" data-line="5" onclick="checkBugLine(this, false)">
+      <span class="line-num">5</span>
+      <code>});</code>
+    </div>
+  </div>
+  <div class="bug-feedback" id="bug-feedback"></div>
+</div>
+```
+
+**JS:**
+```javascript
+window.checkBugLine = function(el, isCorrect) {
+  const feedback = el.closest('.bug-challenge').querySelector('.bug-feedback');
+  if (isCorrect) {
+    el.classList.add('correct');
+    feedback.innerHTML = '<strong>Found it!</strong> The listener uses an async operation (fetch) but doesn\'t return true. Chrome closes the message channel before the response can be sent. Fix: add <code>return true;</code> at the end.';
+    feedback.className = 'bug-feedback show success';
+  } else {
+    el.classList.add('incorrect');
+    feedback.innerHTML = 'Not this line — look for where the async timing might cause problems...';
+    feedback.className = 'bug-feedback show error';
+    setTimeout(() => { el.classList.remove('incorrect'); feedback.className = 'bug-feedback'; }, 2000);
+  }
+};
+```
+
+---
+
+## Scenario Quiz
+
+"What would a senior engineer do?" — situational questions with explanations.
+
+Same HTML/CSS/JS pattern as Multiple-Choice Quizzes, but with longer scenario descriptions and more detailed explanations. Wrap each question in a scenario context block:
+
+```html
+<div class="scenario-block">
+  <div class="scenario-context">
+    <span class="scenario-label">Scenario</span>
+    <p>Your app processes a 3-hour podcast transcript. The API has a 16,000 token limit. What do you do?</p>
+  </div>
+  <!-- quiz-options here -->
+</div>
+```
+
+---
+
+## Callout Boxes
+
+"Aha!" moments — universal CS insights. Max 2 per module.
+
+```html
+<div class="callout callout-accent">
+  <div class="callout-icon">💡</div>
+  <div class="callout-content">
+    <strong class="callout-title">Key Insight</strong>
+    <p>This pattern — splitting responsibilities into focused roles — is one of the most important ideas in software engineering. Engineers call it "separation of concerns."</p>
+  </div>
+</div>
+```
+
+**Variants:**
+- `callout-accent`: vermillion left border, light accent background (for CS insights)
+- `callout-info`: teal left border, light info background (for "good to know")
+- `callout-warning`: red left border, light error background (for common mistakes)
+
+---
+
+## Pattern/Feature Cards
+
+Grid of cards highlighting engineering patterns, tech stack components, or key concepts.
+
+```html
+<div class="pattern-cards">
+  <div class="pattern-card" style="border-top: 3px solid var(--color-actor-1)">
+    <div class="pattern-icon" style="background: var(--color-actor-1)">🔄</div>
+    <h4 class="pattern-title">Caching</h4>
+    <p class="pattern-desc">Store results to avoid redundant work — like keeping leftovers instead of cooking a new meal every time.</p>
+  </div>
+  <!-- more cards -->
+</div>
+```
+
+```css
+.pattern-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-4);
+}
+.pattern-card {
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  padding: var(--space-6);
+  box-shadow: var(--shadow-sm);
+  transition: transform var(--duration-normal) var(--ease-out), box-shadow var(--duration-normal);
+}
+.pattern-card:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-md);
+}
+```
+
+---
+
+## Flow Diagrams
+
+**Horizontal flow (desktop):**
+```html
+<div class="flow-steps">
+  <div class="flow-step">
+    <div class="flow-step-num">1</div>
+    <p>User clicks button</p>
+  </div>
+  <div class="flow-arrow">→</div>
+  <div class="flow-step">
+    <div class="flow-step-num">2</div>
+    <p>Component A detects click</p>
+  </div>
+  <div class="flow-arrow">→</div>
+  <!-- more steps -->
+</div>
+```
+
+Arrows rotate to `↓` on mobile via CSS transform.
+
+---
+
+## Permission/Config Badges
+
+For annotating config files, permissions, or settings:
+
+```html
+<div class="badge-list">
+  <div class="badge-item">
+    <code class="badge-code">storage</code>
+    <span class="badge-desc">Save data between sessions (like browser bookmarks)</span>
+  </div>
+  <div class="badge-item">
+    <code class="badge-code">activeTab</code>
+    <span class="badge-desc">Access the currently open tab (only when the user clicks)</span>
+  </div>
+</div>
+```
+
+```css
+.badge-item {
+  display: flex; align-items: center; gap: var(--space-4);
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-sm);
+  transition: border-color var(--duration-fast);
+}
+.badge-item:hover { border-color: var(--color-accent-muted); }
+.badge-code {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  background: var(--color-bg-code);
+  color: #CBA6F7;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  white-space: nowrap;
+}
+```
+
+---
+
+## Glossary Tooltips
+
+The most important accessibility feature for non-technical learners. Any technical term in the course text should be wrapped in a tooltip that shows a plain-English definition on hover (desktop) or tap (mobile). The learner never has to leave the page or Google anything.
+
+**HTML — mark up terms inline:**
+```html
+<p>The extension uses a
+  <span class="term" data-definition="A service worker is a background script that runs independently of the web page — like a behind-the-scenes assistant that's always on, even when you're not looking at the page.">service worker</span>
+  to handle API calls.
+</p>
+```
+
+**CSS:**
+```css
+.term {
+  border-bottom: 1.5px dashed var(--color-accent-muted);
+  cursor: pointer;    /* NOT cursor: help — pointer feels clickable and inviting */
+  position: relative;
+}
+.term:hover, .term.active {
+  border-bottom-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+/* The tooltip bubble — uses position: fixed and is appended to document.body
+   via JS so it is NEVER clipped by ancestor overflow: hidden containers
+   (like translation blocks). See JS section below for positioning logic. */
+.term-tooltip {
+  position: fixed;        /* CRITICAL: fixed, not absolute — prevents clipping */
+  background: var(--color-bg-code);
+  color: #CDD6F4;
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
+  font-family: var(--font-body);
+  line-height: var(--leading-normal);
+  width: max(200px, min(320px, 80vw));
+  box-shadow: var(--shadow-lg);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity var(--duration-fast);
+  z-index: 10000;        /* Above everything, including nav */
+}
+/* Arrow pointing down */
+.term-tooltip::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 6px solid transparent;
+  border-top-color: var(--color-bg-code);
+}
+.term-tooltip.visible {
+  opacity: 1;
+}
+
+/* If tooltip goes off-screen top, flip to below */
+.term-tooltip.flip {
+  bottom: auto;
+  top: calc(100% + 8px);
+}
+.term-tooltip.flip::after {
+  top: auto;
+  bottom: 100%;
+  border-top-color: transparent;
+  border-bottom-color: var(--color-bg-code);
+}
+```
+
+**JS — position: fixed tooltips appended to body (never clipped by overflow):**
+```javascript
+// Tooltip container — appended to body so it's never clipped
+let activeTooltip = null;
+
+function positionTooltip(term, tip) {
+  const rect = term.getBoundingClientRect();
+  const tipWidth = 300; // approximate
+  let left = rect.left + rect.width / 2 - tipWidth / 2;
+  // Clamp to viewport
+  left = Math.max(8, Math.min(left, window.innerWidth - tipWidth - 8));
+
+  // Try above first
+  let top = rect.top - 8;
+  tip.style.left = left + 'px';
+
+  // Position above by default, flip below if no room
+  document.body.appendChild(tip);
+  const tipHeight = tip.offsetHeight;
+  if (rect.top - tipHeight - 8 < 0) {
+    // Flip below
+    tip.style.top = (rect.bottom + 8) + 'px';
+    tip.classList.add('flip');
+  } else {
+    tip.style.top = (rect.top - tipHeight - 8) + 'px';
+    tip.classList.remove('flip');
+  }
+}
+
+document.querySelectorAll('.term').forEach(term => {
+  const tip = document.createElement('span');
+  tip.className = 'term-tooltip';
+  tip.textContent = term.dataset.definition;
+
+  // Hover for desktop
+  term.addEventListener('mouseenter', () => {
+    if (activeTooltip && activeTooltip !== tip) {
+      activeTooltip.classList.remove('visible');
+      activeTooltip.remove();
+    }
+    positionTooltip(term, tip);
+    requestAnimationFrame(() => tip.classList.add('visible'));
+    activeTooltip = tip;
+  });
+
+  term.addEventListener('mouseleave', () => {
+    tip.classList.remove('visible');
+    setTimeout(() => { if (!tip.classList.contains('visible')) tip.remove(); }, 150);
+    activeTooltip = null;
+  });
+
+  // Tap for mobile
+  term.addEventListener('click', (e) => {
+    e.stopPropagation();
+    if (activeTooltip && activeTooltip !== tip) {
+      activeTooltip.classList.remove('visible');
+      activeTooltip.remove();
+    }
+    if (tip.classList.contains('visible')) {
+      tip.classList.remove('visible');
+      tip.remove();
+      activeTooltip = null;
+    } else {
+      positionTooltip(term, tip);
+      requestAnimationFrame(() => tip.classList.add('visible'));
+      activeTooltip = tip;
+    }
+  });
+});
+
+// Close tooltips when clicking elsewhere
+document.addEventListener('click', () => {
+  if (activeTooltip) {
+    activeTooltip.classList.remove('visible');
+    activeTooltip.remove();
+    activeTooltip = null;
+  }
+});
+```
+
+**Rules:**
+- Mark up EVERY technical term on first use in each module (API, DOM, callback, async, endpoint, middleware, etc.)
+- Keep definitions to 1-2 sentences max, in everyday language
+- Use a metaphor in the definition when it helps — e.g., "A **callback** is like leaving your phone number at a restaurant so they can call you when your table is ready"
+- Don't mark the same term twice within the same screen — only on first appearance per module
+- The dashed underline should be subtle enough not to distract but visible enough that curious learners discover it
+
+---
+
+## Visual File Tree
+
+Use instead of paragraphs listing "this folder does X, that folder does Y." Much easier to scan.
+
+```html
+<div class="file-tree">
+  <div class="ft-folder open">
+    <span class="ft-name">app/</span>
+    <span class="ft-desc">Pages and API routes</span>
+    <div class="ft-children">
+      <div class="ft-folder">
+        <span class="ft-name">api/</span>
+        <span class="ft-desc">Backend endpoints the frontend calls</span>
+      </div>
+      <div class="ft-file">
+        <span class="ft-name">layout.tsx</span>
+        <span class="ft-desc">The shell that wraps every page</span>
+      </div>
+    </div>
+  </div>
+  <div class="ft-folder">
+    <span class="ft-name">components/</span>
+    <span class="ft-desc">Reusable UI building blocks</span>
+  </div>
+  <div class="ft-folder">
+    <span class="ft-name">lib/</span>
+    <span class="ft-desc">Shared logic and utilities</span>
+  </div>
+</div>
+```
+
+```css
+.file-tree { font-family: var(--font-mono); font-size: var(--text-sm); }
+.ft-folder, .ft-file {
+  padding: var(--space-2) var(--space-3);
+  border-left: 2px solid var(--color-border-light);
+  margin-left: var(--space-4);
+}
+.ft-folder > .ft-name { color: var(--color-accent); font-weight: 600; }
+.ft-folder > .ft-name::before { content: '📁 '; }
+.ft-file > .ft-name::before { content: '📄 '; }
+.ft-desc {
+  color: var(--color-text-secondary);
+  font-family: var(--font-body);
+  margin-left: var(--space-2);
+  font-size: var(--text-xs);
+}
+.ft-children { margin-left: var(--space-4); }
+```
+
+---
+
+## Icon-Label Rows
+
+For listing components, features, or concepts visually. Replaces bullet-point paragraphs.
+
+```html
+<div class="icon-rows">
+  <div class="icon-row">
+    <div class="icon-circle" style="background: var(--color-actor-1)">🖥️</div>
+    <div>
+      <strong>Frontend (Next.js)</strong>
+      <p>What the user sees and interacts with</p>
+    </div>
+  </div>
+  <div class="icon-row">
+    <div class="icon-circle" style="background: var(--color-actor-2)">⚡</div>
+    <div>
+      <strong>API Routes</strong>
+      <p>Backend logic that runs on the server</p>
+    </div>
+  </div>
+  <div class="icon-row">
+    <div class="icon-circle" style="background: var(--color-actor-3)">🗄️</div>
+    <div>
+      <strong>Database (Supabase)</strong>
+      <p>Where all the data is stored permanently</p>
+    </div>
+  </div>
+</div>
+```
+
+```css
+.icon-rows { display: flex; flex-direction: column; gap: var(--space-4); }
+.icon-row {
+  display: flex; align-items: center; gap: var(--space-4);
+  padding: var(--space-4);
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+}
+.icon-row p { margin: 0; color: var(--color-text-secondary); font-size: var(--text-sm); }
+.icon-circle {
+  width: 48px; height: 48px; border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 1.25rem; flex-shrink: 0;
+}
+```
+
+---
+
+## Numbered Step Cards
+
+For sequences that would otherwise be a numbered paragraph list. Visual, scannable, and each step stands alone.
+
+```html
+<div class="step-cards">
+  <div class="step-card">
+    <div class="step-num">1</div>
+    <div class="step-body">
+      <strong>User pastes a YouTube URL</strong>
+      <p>The frontend captures the URL and extracts the video ID</p>
+    </div>
+  </div>
+  <div class="step-card">
+    <div class="step-num">2</div>
+    <div class="step-body">
+      <strong>API fetches the transcript</strong>
+      <p>A server-side route calls an external service to get the video's text</p>
+    </div>
+  </div>
+  <div class="step-card">
+    <div class="step-num">3</div>
+    <div class="step-body">
+      <strong>AI analyzes the content</strong>
+      <p>The transcript is sent to an AI model that extracts key moments</p>
+    </div>
+  </div>
+</div>
+```
+
+```css
+.step-cards { display: flex; flex-direction: column; gap: var(--space-3); }
+.step-card {
+  display: flex; align-items: flex-start; gap: var(--space-4);
+  padding: var(--space-4) var(--space-5);
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  border-left: 3px solid var(--color-accent);
+  box-shadow: var(--shadow-sm);
+}
+.step-num {
+  width: 32px; height: 32px; border-radius: 50%;
+  background: var(--color-accent);
+  color: white; font-weight: 700;
+  display: flex; align-items: center; justify-content: center;
+  font-family: var(--font-display);
+  flex-shrink: 0;
+}
+.step-body p { margin: var(--space-1) 0 0; color: var(--color-text-secondary); font-size: var(--text-sm); }
+```


### PR DESCRIPTION
## Summary

Adds **docs-to-course**, a skill that turns any documentation — local files, GitHub repos, or live documentation websites — into a stunning, self-contained single-page HTML training course with scroll-based modules, animated visualizations, embedded quizzes, spec ↔ plain-English translation blocks, and spaced retrieval callbacks.

Designed around a documented pedagogy: 80/20 scoping, Bloom-aligned objectives written before content, prediction questions and completion problems for formative assessment, elaborative wrong-answer feedback, and a required synthesis module that returns to the opening scenario.

## What's in the submission

| File | Purpose |
|---|---|
| `skills/docs-to-course/SKILL.md` | Five-phase skill (web crawl → analysis → curriculum design → build → polish) |
| `skills/docs-to-course/references/design-system.md` | CSS tokens, WCAG 2.1 AA accessibility baseline, typography, color, optional brand-skin layer |
| `skills/docs-to-course/references/interactive-elements.md` | Implementation patterns for every interactive element (translations, quizzes, drag-and-drop, decision trees, etc.) |
| `skills/docs-to-course/references/firecrawl.md` | Web crawl procedure (called only when input is a URL) |
| `skills/docs-to-course/examples/axur-platform-course.html` | Full working example (1900-line standalone HTML course) |
| `skills/docs-to-course/LICENSE` | MIT |

## Dependencies

- **Firecrawl MCP** (optional) — required only when users supply a URL. Local files and GitHub repos work without it. Setup instructions live in `references/firecrawl.md`.

## Try it

```
make a course from RFC 9460
turn ./docs into a course
make a course from https://docs.example.com
```

For corporate-branded output, drop a `.brand.json` in the working directory or add a phrase like "with our brand" — Phase 2C applies a thin accent + logo skin without overriding the skill's core design identity.

## Accessibility

Every interactive element ships with keyboard operability, ARIA labels, focus-visible states, reduced-motion fallbacks, drag-and-drop keyboard alternatives, and WCAG 2.1 AA contrast on all default tokens. See the Accessibility section in `references/design-system.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)