### PR TITLE
fix(skill-creator): keep at least one example of each class in train

### DIFF
--- a/skills/skill-creator/scripts/run_loop.py
+++ b/skills/skill-creator/scripts/run_loop.py
@@ -33,9 +33,23 @@ def split_eval_set(eval_set: list[dict], holdout: float, seed: int = 42) -> tupl
     random.shuffle(trigger)
     random.shuffle(no_trigger)
 
-    # Calculate split points
-    n_trigger_test = max(1, int(len(trigger) * holdout))
-    n_no_trigger_test = max(1, int(len(no_trigger) * holdout))
+    # Calculate split points. Clamp so the train set keeps at least one
+    # example from each class when possible: with a single positive (or
+    # negative) example, max(1, int(1*holdout))=1 would put it entirely in
+    # test, leaving train with zero positives/negatives and breaking the
+    # improvement loop (it would never see any failures-to-trigger / false
+    # triggers for that class).
+    def _split_point(n: int) -> int:
+        if n == 0:
+            return 0
+        if n == 1:
+            # Only one example for this class: keep it in train so the
+            # improvement loop can react to it.
+            return 0
+        return min(n - 1, max(1, int(n * holdout)))
+
+    n_trigger_test = _split_point(len(trigger))
+    n_no_trigger_test = _split_point(len(no_trigger))
 
     # Split
     test_set = trigger[:n_trigger_test] + no_trigger[:n_no_trigger_test]


### PR DESCRIPTION
# anthropics/skills — `split_eval_set` can empty a class from train

- **Repo**: [anthropics/skills](https://github.com/anthropics/skills)
- **File**: `skills/skill-creator/scripts/run_loop.py`
- **Status**: VERIFIED

## Symptom

When an eval set contains only a single entry of a class (positive or
negative), `split_eval_set` sends that lone example to the test split and
leaves the train split with no example of that class at all. The
improvement loop can then observe neither false triggers nor missed
triggers for that class, and has no basis to evolve the skill description
on that side.

## Root cause

```python
n_trigger_test = max(1, int(len(trigger) * holdout))
n_no_trigger_test = max(1, int(len(no_trigger) * holdout))
```

With `n = 1`, `max(1, int(1 * holdout)) == 1`, so `train[:n - 1]` is empty
and 100% of the class ends up in test. There is no guard for `n - 1`.

## Patch

Introduces a `_split_point(n)` helper that:

- returns `0` if the class is empty,
- returns `0` if `n == 1` (keeps the example in train so the loop can
  react),
- otherwise clamps the test share into `[1, n - 1]`.

See `archive/iter-002/skills-split-eval-set-zero-train/patch.diff`.

## Verification

`archive/iter-002/skills-split-eval-set-zero-train/verify.log`:

```
1p/5n: train_pos=1 test_pos=0 train_neg=3 test_neg=2
5p/1n: train_neg=1 test_neg=0
10/10: train= 12 test= 8
2/2:   train= 2 test= 2
0p/5n: train= 3 test= 2
100/100: train= 120 test= 80
ALL_OK
```

Every non-empty class keeps at least one example in train; behavior on
"normal" sizes is unchanged.
