### PR TITLE
ISS-1149 Fix eval framework crashes from credential errors and silent failures

### DIFF
--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -19,6 +19,43 @@ from pathlib import Path
 from scripts.utils import parse_skill_md
 
 
+def preflight_check(model: str | None = None) -> None:
+    """Run a trivial claude -p call to verify credentials and environment.
+
+    Catches missing API keys, bad auth, and broken CLI installations before
+    the expensive evaluation suite starts.
+    """
+    cmd = ["claude", "-p", "Respond with exactly: ok", "--output-format", "text"]
+    if model:
+        cmd.extend(["--model", model])
+    env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, env=env, timeout=30,
+        )
+    except FileNotFoundError:
+        print(
+            "Error: 'claude' CLI not found on PATH. Install it or check your PATH.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    except subprocess.TimeoutExpired:
+        print(
+            "Error: Pre-flight check timed out after 30 s — is the Claude CLI responsive?",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if result.returncode != 0:
+        print(
+            f"Error: Pre-flight credential check failed (exit code {result.returncode}).\n"
+            f"stderr: {result.stderr.strip()}\n"
+            f"Fix your credentials / environment variables before running the eval suite.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
 def find_project_root() -> Path:
     """Find the project root by walking up from cwd looking for .claude/.
 
@@ -85,7 +122,7 @@ def run_single_query(
         process = subprocess.Popen(
             cmd,
             stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
             cwd=project_root,
             env=env,
         )
@@ -175,6 +212,16 @@ def run_single_query(
                 process.kill()
                 process.wait()
 
+        # Surface non-zero exit codes instead of silently returning False
+        if process.returncode and process.returncode != 0:
+            stderr_output = ""
+            if process.stderr:
+                stderr_output = process.stderr.read().decode("utf-8", errors="replace").strip()
+            raise RuntimeError(
+                f"claude -p exited with code {process.returncode}"
+                + (f": {stderr_output}" if stderr_output else "")
+            )
+
         return triggered
     finally:
         if command_file.exists():
@@ -220,6 +267,14 @@ def run_eval(
                 query_triggers[query] = []
             try:
                 query_triggers[query].append(future.result())
+            except RuntimeError as e:
+                # Surface CLI/credential errors loudly — these corrupt data if
+                # silently treated as "did not trigger".
+                raise RuntimeError(
+                    f"Evaluation query failed due to a CLI error (not a "
+                    f"trigger miss). This likely indicates a credential or "
+                    f"environment problem. Query: {query!r}\nError: {e}"
+                ) from e
             except Exception as e:
                 print(f"Warning: query failed: {e}", file=sys.stderr)
                 query_triggers[query].append(False)
@@ -268,6 +323,8 @@ def main():
     parser.add_argument("--model", default=None, help="Model to use for claude -p (default: user's configured model)")
     parser.add_argument("--verbose", action="store_true", help="Print progress to stderr")
     args = parser.parse_args()
+
+    preflight_check(model=args.model)
 
     eval_set = json.loads(Path(args.eval_set).read_text())
     skill_path = Path(args.skill_path)

--- a/skills/skill-creator/scripts/run_loop.py
+++ b/skills/skill-creator/scripts/run_loop.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 from scripts.generate_report import generate_html
 from scripts.improve_description import improve_description
-from scripts.run_eval import find_project_root, run_eval
+from scripts.run_eval import find_project_root, preflight_check, run_eval
 from scripts.utils import parse_skill_md
 
 
@@ -190,23 +190,33 @@ def run_loop(
         if verbose:
             print(f"\nImproving description...", file=sys.stderr)
 
-        t0 = time.time()
-        # Strip test scores from history so improvement model can't see them
-        blinded_history = [
-            {k: v for k, v in h.items() if not k.startswith("test_")}
-            for h in history
-        ]
-        new_description = improve_description(
-            skill_name=name,
-            skill_content=content,
-            current_description=current_description,
-            eval_results=train_results,
-            history=blinded_history,
-            model=model,
-            log_dir=log_dir,
-            iteration=iteration,
-        )
-        improve_elapsed = time.time() - t0
+        try:
+            t0 = time.time()
+            # Strip test scores from history so improvement model can't see them
+            blinded_history = [
+                {k: v for k, v in h.items() if not k.startswith("test_")}
+                for h in history
+            ]
+            new_description = improve_description(
+                skill_name=name,
+                skill_content=content,
+                current_description=current_description,
+                eval_results=train_results,
+                history=blinded_history,
+                model=model,
+                log_dir=log_dir,
+                iteration=iteration,
+            )
+            improve_elapsed = time.time() - t0
+        except Exception as e:
+            exit_reason = f"improve_description crashed on iteration {iteration}: {e}"
+            if verbose:
+                print(
+                    f"\nError during description improvement — saving partial "
+                    f"results and exiting loop.\n  {e}",
+                    file=sys.stderr,
+                )
+            break
 
         if verbose:
             print(f"Proposed ({improve_elapsed:.1f}s): {new_description}", file=sys.stderr)
@@ -257,6 +267,8 @@ def main():
     parser.add_argument("--report", default="auto", help="Generate HTML report at this path (default: 'auto' for temp file, 'none' to disable)")
     parser.add_argument("--results-dir", default=None, help="Save all outputs (results.json, report.html, log.txt) to a timestamped subdirectory here")
     args = parser.parse_args()
+
+    preflight_check(model=args.model)
 
     eval_set = json.loads(Path(args.eval_set).read_text())
     skill_path = Path(args.skill_path)


### PR DESCRIPTION
# Fix eval framework crashes from credential errors and silent failures

## Problem

Running the skill-creator eval framework locally is broken in three compounding ways:

1. **Silent data corruption** — `run_eval.py` pipes stderr to `/dev/null` and swallows non-zero exit codes from the Claude CLI. When credentials are missing or environment variables are wrong, every query silently returns `False` instead of raising an error. This makes it look like "no skill triggered" when in reality no evaluation ran at all, producing garbage results that poison any downstream analysis.

2. **Total state loss on improvement crash** — `run_loop.py` calls `improve_description()` without any error handling. If the Claude CLI fails during the improvement step (e.g., expired auth mid-run), the entire process crashes and all accumulated iteration history, partial scores, and diagnostic data are lost. The live HTML report and JSON output are never written.

3. **No early validation** — Both entrypoints launch expensive, highly-parallel evaluation suites before ever confirming that `claude -p` actually works. A user with bad credentials wastes minutes of wall-clock time (and potentially many API calls across worker processes) before getting a cryptic subprocess error buried in output.

It addresses this issue: https://github.com/anthropics/skills/issues/1149

## Solution

### 1. Surface CLI errors in `run_eval.py`

**`run_single_query()`:**
- Changed `stderr=subprocess.DEVNULL` to `stderr=subprocess.PIPE` in the `Popen` call so error output is captured instead of discarded.
- Added an exit-code check after the process completes. If `claude -p` exits non-zero, a `RuntimeError` is raised containing the exit code and the captured stderr text.

**`run_eval()`:**
- `RuntimeError` exceptions from worker futures are now re-raised with a clear message indicating this is a CLI/credential problem (not a trigger miss). Other exception types still fall through to the existing `append(False)` path to preserve tolerance for transient issues.

### 2. Preserve partial state on improvement crash in `run_loop.py`

The `improve_description()` call is now wrapped in a `try/except`. On failure:
- `exit_reason` is set to a descriptive message including the iteration number and error.
- The loop `break`s cleanly instead of crashing.
- Execution continues to the "find best iteration" logic, so all accumulated `history`, the live HTML report, and JSON results are still written to disk.

### 3. Fail-fast pre-flight credential check

A new `preflight_check()` function in `run_eval.py` runs a trivial `claude -p "Respond with exactly: ok"` call and validates:

| Check | Failure mode |
|---|---|
| CLI exists on `PATH` | `FileNotFoundError` — clear install/PATH message |
| CLI responds in time | `TimeoutExpired` — responsiveness warning |
| CLI exits cleanly | Non-zero exit code — prints stderr and tells the user to fix credentials |

This is called at the very top of `main()` in both `run_eval.py` and `run_loop.py`, before any eval set is loaded or any workers are spawned. `run_loop.py` imports it directly from `run_eval` to avoid duplication.

## Files changed

- **`skills/skill-creator/scripts/run_eval.py`** — Added `preflight_check()`, switched stderr from `DEVNULL` to `PIPE`, added exit-code checking in `run_single_query()`, and added `RuntimeError` propagation in `run_eval()`.
- **`skills/skill-creator/scripts/run_loop.py`** — Imported `preflight_check`, added it to `main()`, and wrapped `improve_description()` in a `try/except` that breaks the loop gracefully.

## Testing

- Both files pass `py_compile` with no syntax errors.
- All imports resolve correctly from the expected working directory (`skill-creator/`).
- The preflight check is designed to exercise the exact same subprocess path (env filtering, `--output-format`, model passthrough) used by the real evaluation, so a passing check gives high confidence the full suite will work.