### PR TITLE
Add schedule-after-usage-reset skill

### DIFF
--- a/skills/schedule-after-usage-reset/LICENSE.txt
+++ b/skills/schedule-after-usage-reset/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 patricksong1993
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/schedule-after-usage-reset/SKILL.md
+++ b/skills/schedule-after-usage-reset/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: schedule-after-usage-reset
+description: Schedule a task to run after the Claude usage limit resets. Use this skill whenever the user says things like "schedule this after my usage resets", "run this when my tokens refresh", "queue this task for after the limit lifts", "do this when usage resets", or any variation of wanting to defer a task until after a Claude usage/token limit reset. This skill finds the reset time and calls /schedule with that exact time.
+license: Complete terms in LICENSE.txt
+compatibility: Requires Claude Code on macOS with the built-in schedule skill. Reads OAuth credentials from Keychain (Claude Code-credentials).
+---
+
+# Schedule After Usage Reset
+
+Automatically find the usage reset time and call `/schedule` with it. No questions asked.
+
+## Steps
+
+### 1. Get the reset time
+
+Fetch from the Anthropic usage API:
+
+```bash
+token_json=$(/usr/bin/security find-generic-password -s 'Claude Code-credentials' -w 2>/dev/null)
+access_token=$(echo "$token_json" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('claudeAiOauth',{}).get('accessToken',''))")
+curl -s -H "Authorization: Bearer $access_token" \
+     -H "anthropic-beta: oauth-2025-04-20" \
+     -H "User-Agent: claude-code/2.1" \
+     "https://api.anthropic.com/api/oauth/usage"
+```
+
+Parse `five_hour.resets_at` (or `seven_day.resets_at`). Convert UTC → user's local timezone. Add 5 minutes as buffer.
+
+If rate limited, wait 15s and retry once. If still failing, ask the user for the reset time.
+
+### 2. Get the task
+
+If not provided as an argument, ask: "What should I run after the reset?"
+
+### 3. Call /schedule
+
+Invoke the `schedule` skill, passing the task and the reset time + 5min buffer:
+
+```
+/schedule "<task>" at <HH:MM> <timezone>
+```
+
+The `schedule` skill handles everything from there — just like calling it directly.
+
+## Example
+
+**User**: "Schedule this after my usage resets: summarize the new PRs in my inbox"
+
+**Behavior**: Fetch reset time from the usage API, add a 5-minute buffer, then invoke `/schedule` with the task and local time.


### PR DESCRIPTION
## Summary

Adds **schedule-after-usage-reset** — a Claude Code skill that defers a task until after your Claude usage limit resets, without manually checking the dashboard.

Upstream repo: https://github.com/lemondepat/schedule-after-usage-reset

## What it does

1. Fetches the actual reset time from the Anthropic usage API (`five_hour.resets_at` / `seven_day.resets_at`)
2. Converts UTC to local time and adds a 5-minute buffer
3. Invokes the built-in `/schedule` skill with the task and exact time

## When to use

Trigger phrases like *"schedule this after my usage resets"*, *"run this when my tokens refresh"*, or *"queue this for after the limit lifts"*.

## Structure

```
skills/schedule-after-usage-reset/
├── SKILL.md       # Core skill definition with YAML frontmatter
└── LICENSE.txt    # MIT License
```

## Requirements

- Claude Code on **macOS** (reads OAuth token from Keychain: `Claude Code-credentials`)
- Built-in **`schedule`** skill installed (used internally to create the deferred run)

## Example

**User**: "Schedule this after my usage resets: summarize the new PRs in my inbox"

**Behavior**: Query usage API → compute reset + 5min buffer → `/schedule "<task>" at <HH:MM> <timezone>`

## Testing

After copying or symlinking the skill into `~/.claude/skills/schedule-after-usage-reset/`:

1. Ensure Claude Code is logged in (Keychain credentials present)
2. Ask: *"Schedule this after my usage resets: echo hello"*
3. Confirm Claude fetches usage data and invokes `/schedule` with a concrete local time

## License

MIT — see `LICENSE.txt`

