### PR TITLE
feat: add mcp-server-builder skill — scaffold McpServerBase TypeScript MCP tools

### DIFF
--- a/skills/mcp-server-builder/LICENSE.txt
+++ b/skills/mcp-server-builder/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Anthropic, PBC.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/mcp-server-builder/SKILL.md
+++ b/skills/mcp-server-builder/SKILL.md
@@ -1,0 +1,292 @@
+---
+name: mcp-server-builder
+description: Scaffold a production-ready MCP server in TypeScript using the McpServerBase pattern. Invoke when the user asks to create, add, or build a new MCP tool or server. Generates package.json, tsconfig.json, src/index.ts with a typed McpServerBase subclass, and src/index.test.ts with Vitest tests — all wired to stdio transport.
+license: Complete terms in LICENSE.txt
+---
+
+# MCP Server Builder
+
+A scaffolding skill. When invoked, generate all boilerplate files for a working MCP server using the `McpServerBase` pattern — a minimal abstract class that handles transport, routing, and error formatting so you only write tool logic.
+
+> **Complements `mcp-builder`** — that skill teaches the 4-phase strategy for designing MCP servers. This skill generates the code once you know what to build.
+
+---
+
+## When to invoke
+
+Invoke this skill when the user says any of:
+- "create a new MCP tool / server"
+- "add an MCP server for X"
+- "scaffold an MCP server"
+- "build an MCP tool that does X"
+
+---
+
+## Step 1 — Gather requirements
+
+Ask the user (all four are required before writing any code):
+
+1. **Tool name** — the kebab-case name for the server package (e.g., `my-tool`). This becomes the npm package name and the MCP server name.
+2. **Tool description** — one sentence describing what the server does for an LLM agent.
+3. **Input schema** — what parameters each tool handler accepts (field names, types, required/optional).
+4. **Output shape** — what the tool returns on success (field names and types).
+
+If the user is exploratory ("build me an MCP tool for reading files"), propose sensible defaults and confirm before generating.
+
+---
+
+## Step 2 — File generation order
+
+Generate files in this sequence so each one can reference the previous:
+
+```
+<tool-name>/
+├── package.json          ← 1. dependencies + build scripts
+├── tsconfig.json         ← 2. TypeScript config (extends shared base)
+└── src/
+    ├── index.ts          ← 3. McpServerBase subclass with tool handlers
+    └── index.test.ts     ← 4. Vitest unit tests (no MCP transport needed)
+```
+
+---
+
+## Step 3 — Generate each file
+
+### 3.1 `package.json`
+
+```json
+{
+  "name": "@your-scope/<tool-name>",
+  "version": "1.0.0",
+  "description": "<one-line description>",
+  "type": "module",
+  "main": "build/index.js",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0"
+  }
+}
+```
+
+> If the project uses a shared `McpServerBase` package, add it to `dependencies` and import from it instead of re-implementing the class.
+
+---
+
+### 3.2 `tsconfig.json`
+
+```json
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./build",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}
+```
+
+If there is no shared `tsconfig.base.json`, use this standalone config:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "outDir": "./build",
+    "rootDir": "./src",
+    "declaration": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "build"]
+}
+```
+
+---
+
+### 3.3 `src/index.ts` — the McpServerBase subclass
+
+See [McpServerBase pattern reference](./reference/McpServerBase-pattern.md) for the full annotated implementation.
+
+**Key rules:**
+1. Extend `McpServerBase` — never instantiate `Server` directly.
+2. Call `super({ name: '<tool-name>', version: '1.0.0' })` in the constructor.
+3. Implement `protected registerTools(): void` — this is the only abstract method.
+4. Inside `registerTools`, call `this.addTool(name, description, inputSchema, handler)` once per tool.
+5. Handlers must return `this.success({ ...data })` or `this.error(err)` — never return a raw `{content:[...]}` object.
+6. End the file with `new MyToolServer().run().catch(console.error);`.
+7. All local imports must use `.js` extension (ESM): `import { helper } from './helper.js'`.
+
+**Template:**
+
+```typescript
+import { McpServerBase } from '@your-scope/shared';
+
+class MyToolServer extends McpServerBase {
+  constructor() {
+    super({ name: 'my-tool', version: '1.0.0' });
+  }
+
+  protected registerTools(): void {
+    this.addTool(
+      'do_thing',
+      'Does the thing and returns a result.',
+      {
+        type: 'object',
+        properties: {
+          path: { type: 'string', description: 'Absolute path to the target file' },
+          mode: { type: 'string', enum: ['fast', 'thorough'], description: 'Processing mode' },
+        },
+        required: ['path'],
+      },
+      async (args) => {
+        const { path, mode = 'fast' } = args as { path: string; mode?: string };
+        try {
+          const result = await processFile(path, mode);
+          return this.success({ path, mode, result });
+        } catch (err) {
+          return this.error(err);
+        }
+      }
+    );
+  }
+}
+
+new MyToolServer().run().catch(console.error);
+```
+
+---
+
+### 3.4 `src/index.test.ts` — Vitest tests
+
+**Key rule:** Test pure helper functions directly — do not test through the MCP transport. Extract logic to a separate module (e.g., `src/core.ts`) and test that module.
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { writeFileSync, mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { processFile } from './core.js';
+
+describe('processFile', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'my-tool-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('processes a file in fast mode', async () => {
+    const file = join(tmpDir, 'sample.ts');
+    writeFileSync(file, 'const x: any = 1;');
+    const result = await processFile(file, 'fast');
+    expect(result.violations).toHaveLength(1);
+  });
+
+  it('returns empty violations for clean file', async () => {
+    const file = join(tmpDir, 'clean.ts');
+    writeFileSync(file, 'const x: number = 1;');
+    const result = await processFile(file, 'fast');
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('uses thorough mode when specified', async () => {
+    const file = join(tmpDir, 'sample.ts');
+    writeFileSync(file, 'const x: any = 1;');
+    const resultFast = await processFile(file, 'fast');
+    const resultThorough = await processFile(file, 'thorough');
+    expect(resultThorough.violations.length).toBeGreaterThanOrEqual(resultFast.violations.length);
+  });
+});
+```
+
+Aim for 3–5 tests per exported function: happy path, empty/no-op case, and one edge case.
+
+---
+
+## Step 4 — Build and test
+
+After generating the files, instruct the user to run:
+
+```sh
+npm install
+npm run build      # must compile with zero errors
+npm test           # all tests must pass
+```
+
+**Smoke-test via JSON-RPC** (confirm stdio transport works):
+
+```sh
+echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \
+  | node build/index.js
+```
+
+Expected output: a JSON object with a `tools` array containing your registered tool names.
+
+---
+
+## Step 5 — Common pitfalls
+
+### Double-wrap bug
+**Wrong:** Handler returns `{content:[{type:'text',text:JSON.stringify(data)}]}` and is passed to `this.success()`.  
+**Right:** Handler returns `this.success({ ...plainData })`. The `success()` method wraps it — don't wrap it yourself.
+
+```typescript
+// WRONG — double-wrapped, breaks MCP clients
+async (args) => this.success({ content: [{ type: 'text', text: JSON.stringify(result) }] })
+
+// RIGHT — success() does the wrapping
+async (args) => this.success({ items: result.items, count: result.items.length })
+```
+
+### Missing super() call
+The `McpServerBase` constructor wires up handlers and registers tools. Without `super()`, none of that happens.
+
+```typescript
+// WRONG
+constructor() { /* nothing */ }
+
+// RIGHT
+constructor() {
+  super({ name: 'my-tool', version: '1.0.0' });
+}
+```
+
+### ESM import extensions
+With `"module": "NodeNext"`, TypeScript requires explicit `.js` extensions on local imports (the runtime resolves `.ts` → `.js` at build time).
+
+```typescript
+// WRONG — will fail at runtime
+import { helper } from './helper'
+
+// RIGHT
+import { helper } from './helper.js'
+```
+
+### Exposing shell execution via tool handlers
+Never call `execSync` / `spawnSync` in a tool handler with user-controlled arguments — this creates a command injection vector. If you need to run a subprocess, validate the exact executable path and arguments against an allowlist first.
+
+### Testing through MCP transport
+Unit tests that spin up the full MCP server are slow and fragile. Extract logic to pure functions in `src/core.ts` (or similar) and test those directly. The test file should never import `McpServerBase`.
+
+---
+
+## Reference
+
+- [McpServerBase pattern](./reference/McpServerBase-pattern.md) — full annotated implementation with inline comments
+- [MCP TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk) — upstream SDK reference
+- [MCP protocol spec](https://modelcontextprotocol.io/specification) — JSON-RPC message format

--- a/skills/mcp-server-builder/reference/McpServerBase-pattern.md
+++ b/skills/mcp-server-builder/reference/McpServerBase-pattern.md
@@ -1,0 +1,339 @@
+# McpServerBase Pattern Reference
+
+The `McpServerBase` abstract class wraps the MCP TypeScript SDK so you only write tool logic — transport, routing, error handling, and graceful shutdown are handled for you.
+
+---
+
+## Full implementation
+
+```typescript
+// src/McpServerBase.ts
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ErrorCode,
+  ListToolsRequestSchema,
+  McpError,
+} from '@modelcontextprotocol/sdk/types.js';
+
+// ─── Types ─────────────────────────────────────────────────────────────────
+
+export interface ServerConfig {
+  name: string;
+  version: string;
+}
+
+export interface ToolResult {
+  content: Array<{ type: 'text'; text: string }>;
+  isError?: boolean;
+}
+
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: {
+    type: 'object';
+    properties: Record<string, {
+      type: string;
+      description?: string;
+      enum?: string[];
+      items?: { type: string };
+    }>;
+    required?: string[];
+  };
+}
+
+type ToolHandler = (args: unknown) => Promise<ToolResult>;
+
+// ─── ToolRegistry ──────────────────────────────────────────────────────────
+
+class ToolRegistry {
+  private tools: Map<string, { definition: ToolDefinition; handler: ToolHandler }> = new Map();
+
+  register(name: string, description: string, inputSchema: ToolDefinition['inputSchema'], handler: ToolHandler): void {
+    if (this.tools.has(name)) throw new Error(`Tool already registered: ${name}`);
+    this.tools.set(name, { definition: { name, description, inputSchema }, handler });
+  }
+
+  getHandler(name: string): ToolHandler | undefined {
+    return this.tools.get(name)?.handler;
+  }
+
+  getAllDefinitions(): ToolDefinition[] {
+    return Array.from(this.tools.values()).map(t => t.definition);
+  }
+}
+
+// ─── McpServerBase ─────────────────────────────────────────────────────────
+
+export abstract class McpServerBase {
+  protected server: Server;
+  protected registry: ToolRegistry;
+  protected config: ServerConfig;
+
+  constructor(config: ServerConfig) {
+    this.config = config;
+    this.registry = new ToolRegistry();
+    this.server = new Server(
+      { name: config.name, version: config.version },
+      { capabilities: { tools: {} } }
+    );
+    this.setupHandlers();
+    this.setupErrorHandlers();
+    this.registerTools(); // calls the subclass override
+  }
+
+  // Override this in your subclass. Call this.addTool() for each tool.
+  protected abstract registerTools(): void;
+
+  protected addTool(
+    name: string,
+    description: string,
+    inputSchema: ToolDefinition['inputSchema'],
+    handler: ToolHandler
+  ): void {
+    this.registry.register(name, description, inputSchema, handler);
+  }
+
+  // Wrap a plain data object in a success ToolResult.
+  // Handlers MUST call this — never construct {content:[...]} manually.
+  protected success<T extends Record<string, unknown>>(data: T): ToolResult {
+    return {
+      content: [{ type: 'text', text: JSON.stringify({ success: true, ...data }, null, 2) }],
+    };
+  }
+
+  // Wrap an error in an error ToolResult.
+  protected error(error: unknown): ToolResult {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      content: [{ type: 'text', text: JSON.stringify({ success: false, error: message }, null, 2) }],
+      isError: true,
+    };
+  }
+
+  private setupHandlers(): void {
+    this.server.setRequestHandler(ListToolsRequestSchema, async () => ({
+      tools: this.registry.getAllDefinitions(),
+    }));
+
+    this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+      const { name, arguments: args } = request.params;
+      const handler = this.registry.getHandler(name);
+      if (!handler) {
+        throw new McpError(ErrorCode.MethodNotFound, `Unknown tool: ${name}`);
+      }
+      try {
+        return await handler(args);
+      } catch (err) {
+        if (err instanceof McpError) throw err;
+        const message = err instanceof Error ? err.message : String(err);
+        throw new McpError(ErrorCode.InternalError, `Tool execution failed: ${message}`);
+      }
+    });
+  }
+
+  private setupErrorHandlers(): void {
+    this.server.onerror = (error) => {
+      console.error(`[${this.config.name}] MCP Error:`, error);
+    };
+    process.on('SIGINT', async () => {
+      await this.shutdown();
+    });
+  }
+
+  async run(): Promise<void> {
+    const transport = new StdioServerTransport();
+    await this.server.connect(transport);
+    console.error(`${this.config.name} MCP server v${this.config.version} running on stdio`);
+  }
+
+  async shutdown(): Promise<void> {
+    await this.server.close();
+    process.exit(0);
+  }
+}
+```
+
+---
+
+## Minimal subclass — a file-reader tool
+
+```typescript
+#!/usr/bin/env node
+// src/index.ts
+import { McpServerBase } from './McpServerBase.js';
+import { readFileSync, existsSync } from 'fs';
+
+class FileReaderServer extends McpServerBase {
+  constructor() {
+    // Must call super() — sets up Server, registry, and calls registerTools().
+    super({ name: 'file-reader', version: '1.0.0' });
+  }
+
+  protected registerTools(): void {
+    this.addTool(
+      'read_file',
+      'Read the text content of a file at the given absolute path.',
+      {
+        type: 'object',
+        properties: {
+          path: { type: 'string', description: 'Absolute path to the file.' },
+          encoding: {
+            type: 'string',
+            enum: ['utf-8', 'base64'],
+            description: 'File encoding. Default: utf-8.',
+          },
+        },
+        required: ['path'],
+      },
+      async (args) => {
+        const { path, encoding = 'utf-8' } = args as { path: string; encoding?: 'utf-8' | 'base64' };
+        if (!existsSync(path)) return this.error(`File not found: ${path}`);
+        try {
+          const content = readFileSync(path, encoding);
+          // Pass a plain object to this.success() — never construct {content:[...]} yourself.
+          return this.success({ path, encoding, content, bytes: content.length });
+        } catch (err) {
+          return this.error(err);
+        }
+      }
+    );
+
+    this.addTool(
+      'file_exists',
+      'Check whether a file exists at the given absolute path.',
+      {
+        type: 'object',
+        properties: {
+          path: { type: 'string', description: 'Absolute path to check.' },
+        },
+        required: ['path'],
+      },
+      async (args) => {
+        const { path } = args as { path: string };
+        return this.success({ path, exists: existsSync(path) });
+      }
+    );
+  }
+}
+
+// Always end the file with this — starts the stdio transport.
+new FileReaderServer().run().catch(console.error);
+```
+
+---
+
+## Extracting testable logic
+
+Move pure business logic out of the handler into a `core.ts` module. Test that module directly — never test through the MCP transport.
+
+```typescript
+// src/core.ts
+import { readFileSync, existsSync } from 'fs';
+
+export interface ReadResult {
+  path: string;
+  content: string;
+  bytes: number;
+}
+
+export function readFileSafe(path: string, encoding: 'utf-8' | 'base64' = 'utf-8'): ReadResult {
+  if (!existsSync(path)) throw new Error(`File not found: ${path}`);
+  const content = readFileSync(path, encoding);
+  return { path, content, bytes: content.length };
+}
+```
+
+```typescript
+// src/core.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { writeFileSync, mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { readFileSafe } from './core.js';
+
+describe('readFileSafe', () => {
+  let tmpDir: string;
+
+  beforeEach(() => { tmpDir = mkdtempSync(join(tmpdir(), 'file-reader-test-')); });
+  afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('reads a utf-8 file', () => {
+    const file = join(tmpDir, 'hello.txt');
+    writeFileSync(file, 'hello world');
+    const result = readFileSafe(file);
+    expect(result.content).toBe('hello world');
+    expect(result.bytes).toBe(11);
+  });
+
+  it('throws when file does not exist', () => {
+    expect(() => readFileSafe('/nonexistent/path.txt')).toThrow('File not found');
+  });
+
+  it('reads in base64 encoding', () => {
+    const file = join(tmpDir, 'data.bin');
+    writeFileSync(file, 'abc');
+    const result = readFileSafe(file, 'base64');
+    expect(result.content).toBe(Buffer.from('abc').toString('base64'));
+  });
+});
+```
+
+---
+
+## Smoke-testing the MCP server
+
+```sh
+# Build
+npm run build
+
+# List registered tools
+echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \
+  | node build/index.js
+
+# Call a tool
+echo '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"read_file","arguments":{"path":"/etc/hostname"}}}' \
+  | node build/index.js
+```
+
+Expected `tools/list` output:
+```json
+{
+  "result": {
+    "tools": [
+      { "name": "read_file", "description": "...", "inputSchema": { ... } },
+      { "name": "file_exists", "description": "...", "inputSchema": { ... } }
+    ]
+  }
+}
+```
+
+Expected `tools/call` output:
+```json
+{
+  "result": {
+    "content": [{
+      "type": "text",
+      "text": "{\"success\":true,\"path\":\"/etc/hostname\",\"encoding\":\"utf-8\",\"content\":\"myhost\\n\",\"bytes\":7}"
+    }]
+  }
+}
+```
+
+---
+
+## Response shape
+
+`this.success()` always produces:
+```json
+{ "content": [{ "type": "text", "text": "{\"success\":true, ...yourData}" }] }
+```
+
+`this.error()` always produces:
+```json
+{ "content": [{ "type": "text", "text": "{\"success\":false, \"error\":\"message\"}" }], "isError": true }
+```
+
+LLM agents can branch on the `success` flag without parsing stack traces.


### PR DESCRIPTION
## Summary

Adds a new `mcp-server-builder` skill — a **scaffolding skill** that generates all boilerplate for a working MCP server in TypeScript when invoked by Claude.

### How it differs from `mcp-builder`

| | `mcp-builder` (existing) | `mcp-server-builder` (this PR) |
|---|---|---|
| **Purpose** | 4-phase strategic guide — design philosophy, API patterns, testing approach, evaluation creation | Generates actual files — package.json, tsconfig.json, src/index.ts, src/index.test.ts |
| **When to use** | Planning what to build and how to think about it | Scaffolding a new MCP server once you know what to build |
| **Output** | Strategic guidance and checklists | Working TypeScript code ready to `npm run build` |

These are complementary, not competing. The skill body even links to `mcp-builder` for users who need the strategy phase first.

## What gets generated

When invoked, Claude gathers 4 inputs (tool name, description, input schema, output shape) then generates:

```
<tool-name>/
├── package.json       MCP SDK dep + build/test scripts
├── tsconfig.json      strict TypeScript (NodeNext ESM)
└── src/
    ├── index.ts       McpServerBase subclass, typed handlers
    └── index.test.ts  Vitest tests on extracted pure functions
```

## Skill contents

- **`SKILL.md`** — 5-step guide: gather requirements → generate files → build → test → pitfalls
- **`reference/McpServerBase-pattern.md`** — full annotated McpServerBase implementation + minimal subclass example + smoke-test commands

## Common pitfalls covered

- **Double-wrap bug**: handlers returning `{content:[...]}` passed to `this.success()` — corrupts MCP responses silently
- **Missing `super()` call** — transport never starts
- **ESM import extensions** — `./helper` vs `./helper.js` at runtime
- **`execSync` in handlers** — command injection risk with user-controlled args

## Test plan

- [ ] Invoke the skill in Claude Code: "create an MCP server that reads files"
- [ ] Verify Claude asks for tool name, description, input schema, output shape
- [ ] Verify 4 files are generated with correct structure
- [ ] `npm run build` compiles clean, `npm test` passes
- [ ] JSON-RPC smoke test: `tools/list` returns registered tools

---

The McpServerBase pattern is used in [mcp-toolkit](https://github.com/Nishant-Chaudhary5338/mcp-toolkit) — 9 production MCP servers built with this exact pattern, 134 Vitest tests, CI on Node 20+22.
