### PR TITLE
Add wordpress-plugin-development skill

### DIFF
--- a/skills/wordpress-plugin-development/LICENSE.txt
+++ b/skills/wordpress-plugin-development/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 AtlasAiDev.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/wordpress-plugin-development/SKILL.md
+++ b/skills/wordpress-plugin-development/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: wordpress-plugin-development
+description: Build WordPress plugins correctly and pass wp.org Plugin Directory review. Covers the full Plugin Developer Handbook (security, hooks, REST, shortcodes, blocks, CPTs/taxonomies, settings/meta, privacy/GDPR, users/roles, HTTP API, WP-Cron, JS/Ajax, i18n, readme/assets/SVN) and the 19 wp.org guidelines that cause closures (trialware, telemetry without opt-in, remote-loaded assets, missing source for minified files, wrong text-domain literal, missing REST permission_callback, vendored library collisions). Use when building a WordPress plugin or fixing a Plugins Team closure, preparing a submission, auditing compliance, responding to Plugin Check warnings, adding REST routes/shortcodes/blocks, registering CPTs/taxonomies/settings/meta, enqueuing scripts, wiring cron or activation hooks, translations, sanitizing/escaping, capability/nonce checks, or bundling PHP libs. Apply proactively on code under `wp-content/plugins/` or when you see `register_rest_route`, `add_shortcode`, `register_post_type`, `register_setting`, `current_user_can`, `esc_html__`, `WP_PLUGIN_DIR`, or Freemius. Skip non-plugin PHP, themes, or pure JS UI.
+---
+
+# WordPress Plugin Development & wp.org Guidelines
+
+A field guide for building WordPress plugins correctly and shipping plugins that pass — and stay
+on — the wp.org directory. It combines two bodies of knowledge:
+
+1. **wp.org Directory survival** — the Plugins Team review cycle is slow and surprising; catch
+   problems before submission, not after closure.
+2. **The official Plugin Developer Handbook** — the canonical "how to build it right" reference
+   (basics, security, hooks, data APIs, privacy, cron, i18n, etc.), distilled RULE-first.
+
+## When to use this skill
+
+Any time you are reading or writing code under `wp-content/plugins/`. The triggers in the
+description are not exhaustive — anything touching WordPress plugin APIs from inside a plugin
+folder is fair game.
+
+Skip it for: WordPress theme code (different review track), standalone PHP outside a plugin, pure
+JS/front-end work that doesn't touch a plugin's PHP.
+
+## How to use this skill
+
+The body below is a fast-loading triage layer. For the actual rules and code patterns, jump to the
+appropriate reference file.
+
+**wp.org directory & compliance (closure-survival):**
+
+| You are working on… | Open this reference |
+|---|---|
+| The closure email itself, or the master list of guidelines | `references/guidelines.md` |
+| Anything translatable, or any echoed/returned HTML | `references/i18n-and-escaping.md` |
+| Hooks, paths, settings, uploads, REST routes (compliance angle) | `references/hooks-paths-uploads-rest.md` |
+| Running Plugin Check, or prefixing Freemius / vendored libs | `references/plugin-check-and-prefixing.md` |
+
+**Plugin Developer Handbook (how to build it right):**
+
+| You are working on… | Open this reference |
+|---|---|
+| Plugin header, activation/deactivation/uninstall, paths, structure | `references/handbook-plugin-basics.md` |
+| Capabilities, validation, sanitizing, escaping, nonces | `references/handbook-security.md` |
+| Actions/filters, admin menus, shortcodes | `references/handbook-hooks-menus-shortcodes.md` |
+| Options API, Settings API, post meta, CPTs, taxonomies | `references/handbook-settings-data.md` |
+| Privacy/GDPR, users & roles, HTTP API, WP-Cron | `references/handbook-privacy-users-http-cron.md` |
+| Enqueuing JS/CSS, jQuery, Ajax, i18n, dev tools, readme/assets/SVN | `references/handbook-js-i18n-tools-directory.md` |
+
+Each reference is self-contained markdown — read the one you need, ignore the rest. The handbook
+references are sourced from developer.wordpress.org/plugins/ (verify file:line/API details against
+current core, as APIs evolve).
+
+## The 80/20 — what causes most rejections
+
+If you only remember a handful of rules, remember these. They show up in roughly every other closure notice the Plugins Team sends.
+
+1. **No trialware (Guideline 5).** Every feature shipped in the wp.org ZIP must work, fully, with no license check. "Pro features" belong in a separate plugin hosted off wp.org. Locked code in the free ZIP — even unreachable code — is a hard block.
+2. **No phoning home without opt-in (Guideline 7).** Any HTTP request that sends user/site/usage data needs an explicit, off-by-default checkbox. Pulling Chart.js from jsDelivr on every admin page counts as phoning home.
+3. **Bundle remote assets locally (Guideline 8).** CDN-hosted JS/CSS, remote font files, third-party API clients pulling code from your server — all forbidden unless the resource is genuinely a service. Ship the file inside the ZIP.
+4. **Source for every compiled file (Guideline 4).** Every webpack/vite/babel/sass output needs either bundled source or a public GitHub link in the readme. No mangled identifiers.
+5. **Text domain == plugin slug, as a literal.** Every `__()`, `_e()`, `esc_html__()` etc. needs `'your-plugin-slug'` (no underscores, no variables, no constants).
+6. **Escape on output.** Every shortcode return, block `render_callback`, `the_content` filter, admin notice — escape every dynamic part at the last moment with `esc_html` / `esc_attr` / `esc_url` / `wp_kses_post`.
+7. **`permission_callback` on every REST route.** Never omit it, never set `null`. Use `__return_true` for intentionally public, `current_user_can( … )` for everything else.
+8. **Don't `define()` core constants.** `ABSPATH`, `WPINC`, `WP_CONTENT_DIR` are core's. A plugin that redefines them gets flagged under "changing global behaviour".
+9. **Use `plugin_dir_path( __FILE__ )` and friends, not `WP_PLUGIN_DIR . '/your-slug'`.** Users rename folders.
+10. **Write to `wp_upload_dir()`, never to `plugin_dir_path()`.** Plugin folder is wiped on upgrade and public-readable.
+11. **Don't force-deactivate other plugins.** Use WP 6.5+ Plugin Dependencies (`Requires Plugins:` header) instead of `deactivate_plugins( 'other-plugin/foo.php' )`.
+12. **Prefix vendored PHP libraries.** Freemius, Guzzle, Monolog — anything in `vendor/` — must be prefixed (Strauss is the current recommendation) so it doesn't collide with another plugin's copy.
+
+## The triage workflow
+
+When you encounter plugin code, audit it in this order:
+
+1. **Read the relevant reference file first** for the specific area you are touching. Don't try to remember rules — look them up.
+2. **Run Plugin Check** (the official wp.org tool) before believing the code is clean: `wp plugin check <slug>` or via WP admin → Tools → Plugin Check. See `references/plugin-check-and-prefixing.md` for setup.
+3. **Grep for known anti-patterns** before each commit. The reference files end with checklists — use them as grep targets:
+   - `grep -rn "define.*ABSPATH" .` — should find zero non-comment hits
+   - `grep -rn "WP_PLUGIN_URL.*'/" .` — should find zero
+   - `grep -rn "__(\$" .` — variables in gettext calls
+   - `grep -rn "deactivate_plugins" .` — should be empty (or only Freemius-vendored)
+   - `grep -rn "include ABSPATH" .` — should be `require_once`, inside a callback
+4. **For library conflicts** specifically (Freemius being the usual culprit), use Strauss — see `references/plugin-check-and-prefixing.md`.
+
+## On reviewer mistakes
+
+The closure emails from `plugins@wordpress.org` are partly machine-generated (marked `✨`). They will sometimes flag false positives. The reviewer's own guidance:
+
+> "Note that there may be false positives — we are humans and make mistakes, we apologize if there is anything we have gotten wrong. If you have doubts you can ask us for clarification, when asking us please be clear, concise, direct and include an example."
+
+That said, in practice it is almost always faster to **fix** a borderline flag than to argue it. Every back-and-forth round is days of waiting. Push back only when a fix would meaningfully regress the product, and when you do, reply with a concise paragraph + a code example.
+
+## On replying to a closure thread
+
+If the user is responding to an actual closure email:
+
+1. Reply on the same thread (don't open a new submission).
+2. Be concise. The Plugins Team review the full plugin again — you do not need to enumerate every change.
+3. Include "the entire plugin is now in SVN trunk/ and tagged as <version>" as the operative statement.
+4. Acknowledge their feedback briefly. Ask clarifying questions only if you genuinely cannot infer what they meant.
+5. Do not paste blocks of code. They will read the SVN repo.
+
+## On the SVN release
+
+Even when the plugin is closed, you can still upload to SVN. The flow:
+
+1. Bump `Version:` in the main plugin file's header.
+2. Bump `Stable tag:` in `readme.txt`.
+3. `svn co https://plugins.svn.wordpress.org/<slug>/`
+4. Copy your built plugin into `trunk/`. Make sure your `.distignore` / build process excludes dev files (`src/`, `.github/`, `node_modules/`, `package.json` only-if-not-used-at-runtime, `.git/`, `tests/`, etc.).
+5. `svn add` new files, `svn delete` removed ones.
+6. `svn cp trunk tags/<version>` to create the tag.
+7. `svn ci -m "Release <version>"` — the message can be terse; SVN log is not the user-facing changelog (readme is).
+8. Reply on the HelpScout / email thread that the new version is up.
+
+## Reference index
+
+**wp.org directory & compliance:**
+- [`references/guidelines.md`](references/guidelines.md) — All 19 numbered guidelines + the Guideline 4 deep dive for compiled/minified code
+- [`references/i18n-and-escaping.md`](references/i18n-and-escaping.md) — Text domains, gettext rules, escape functions, shortcode/block/filter escaping, XSS vectors
+- [`references/hooks-paths-uploads-rest.md`](references/hooks-paths-uploads-rest.md) — Actions/filters, plugin paths, Settings API, uploads dir, REST permission_callback
+- [`references/plugin-check-and-prefixing.md`](references/plugin-check-and-prefixing.md) — Plugin Check setup + usage, library-prefixing with Strauss / Mozart / PHP-Scoper, Freemius prefixing recipe
+
+**Plugin Developer Handbook (developer.wordpress.org/plugins/):**
+- [`references/handbook-plugin-basics.md`](references/handbook-plugin-basics.md) — Plugin header fields, single-file vs folder, activation/deactivation/uninstall, path & URL functions, best practices
+- [`references/handbook-security.md`](references/handbook-security.md) — Capabilities, validation, sanitizing input, escaping output, nonces; context→function tables; common vulns
+- [`references/handbook-hooks-menus-shortcodes.md`](references/handbook-hooks-menus-shortcodes.md) — Actions vs filters, priorities, custom hooks, admin menus, shortcodes
+- [`references/handbook-settings-data.md`](references/handbook-settings-data.md) — Options API, Settings API, post meta + meta boxes, custom post types, taxonomies
+- [`references/handbook-privacy-users-http-cron.md`](references/handbook-privacy-users-http-cron.md) — Privacy/GDPR exporters & erasers, users/roles/caps, HTTP API, WP-Cron
+- [`references/handbook-js-i18n-tools-directory.md`](references/handbook-js-i18n-tools-directory.md) — Enqueuing, jQuery, Ajax, internationalization, dev tools, readme.txt/assets/SVN

--- a/skills/wordpress-plugin-development/references/guidelines.md
+++ b/skills/wordpress-plugin-development/references/guidelines.md
@@ -1,0 +1,224 @@
+# WordPress.org Plugin Directory Guidelines — Reference
+
+Source: https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/
+
+Every numbered guideline the WordPress.org Plugin Directory imposes on plugin authors. Use this as a quick rules reference — always check the live page for the canonical, latest version, since the directory team reserves the right to amend guidelines at any time (see Guideline 18).
+
+---
+
+## Guideline 1 — GPL Compatibility
+
+Every file shipped to the directory must be released under the GPL or a GPL-compatible license. That covers PHP, JS, CSS, images, fonts, data files, and any bundled third-party libraries. "GPLv2 or later" is the recommended choice because it matches WordPress core.
+
+**Violation example:** Bundling a proprietary JS chart library whose license forbids redistribution, or an image released under a CC "non-commercial" license.
+
+---
+
+## Guideline 2 — Developer Responsibility
+
+The author of a plugin is solely accountable for everything inside the ZIP, including third-party libraries, images, API usage, and adherence to external services' terms. Licensing of every dependency must be verifiable before submission; if you cannot confirm a license, you cannot ship the file. Deliberately working around guidelines, or re-adding code the review team asked you to drop, is itself a violation.
+
+**Violation example:** Restoring an obfuscated tracker module that reviewers previously required to be removed, in a later release tag.
+
+---
+
+## Guideline 3 — Stable Version on the Directory
+
+The build users actually receive is the one on WordPress.org. Authors who develop elsewhere (GitHub, a SaaS dashboard, etc.) must keep the directory copy current; treating the SVN repo as a stale mirror while distributing newer code through other channels can cause removal.
+
+**Violation example:** Shipping v4.0 to paying users via a private update server while the WordPress.org directory still serves v2.1.
+
+---
+
+## Guideline 4 — Code Must Be (Mostly) Human Readable
+
+Source must remain readable to future maintainers and reviewers. Tools and techniques whose effect is to obscure logic — packer-style obfuscation, uglify's name mangling, deliberately cryptic identifiers like `$z12sdf813d` — are disallowed. Obfuscation is treated as a common cover for malicious payloads, which is why the rule is strict. (See the dedicated deep-dive at the end of this file for the practical workflow this imposes on compiled plugins.)
+
+**Violation example:** Shipping a JS file consisting of a single line of mangled, name-shortened code with no readable counterpart available.
+
+---
+
+## Guideline 5 — No Trialware
+
+Plugins may not bundle features that are locked behind payment, a trial timer, or a usage quota, nor may they ship as sandbox-only API clients. All functionality contained in the plugin must be fully usable. Paid tiers belong in a separate add-on plugin distributed off WordPress.org, or in the remote service itself (see Guideline 6). Up-selling other paid products is fine within the limits of Guideline 11.
+
+**Violation example:** A plugin whose export-to-CSV button shows "Upgrade to Pro to unlock" after 30 days of use. Or a plugin whose `get_player_id()` always returns player 1 unless a Pro license is detected.
+
+---
+
+## Guideline 6 — Software as a Service Is Permitted
+
+A plugin may serve as a client for an external paid service (video hosting, transcription, AI, etc.). The remote service must offer genuine functionality, and its purpose and terms should be documented in the readme — a link to the Terms of Use is encouraged. What is not allowed: services whose only job is license-key validation, services manufactured by carving local code out of the plugin to fake a remote dependency, or plugins that are essentially storefronts for products bought elsewhere.
+
+**Violation example:** A plugin that contains a working PDF generator locally but calls a remote endpoint solely to check whether the user paid this month.
+
+---
+
+## Guideline 7 — No User Tracking Without Consent
+
+External calls that transmit any user, site, or usage data require explicit opt-in — typically a checkbox or a deliberate registration step. The readme should document what data is collected and why, ideally with a privacy policy link. Prohibited patterns include silent telemetry, deceptive consent flows, hotlinking unrelated remote assets, undocumented use of remote blocklists, and tracking ad networks. Genuine SaaS plugins are an exception: configuring an Akismet or Twitter-style integration is itself the consent.
+
+**Violation example:** A plugin that pings `https://stats.example.com/collect` with site URL and admin email on every activation, with no setting to disable it.
+
+---
+
+## Guideline 8 — No Executable Code Through Third-Party Channels
+
+Communication with documented remote services is fine, but the plugin itself must not run arbitrary code that comes from outside the directory. Specifically forbidden:
+
+- Self-updating from a non-WordPress.org server
+- Installing a "Pro" sibling plugin from elsewhere
+- Loading non-font JS/CSS from third-party CDNs (host it locally)
+- Pulling remotely curated lists where the service's terms don't allow it
+- Wiring admin pages through iframes instead of real APIs
+
+Remote management dashboards that push code from their own domain (not inside wp-admin) are permitted.
+
+**Violation example:** A plugin that downloads `premium-features.php` from the vendor's S3 bucket and `include`s it at runtime. Or `wp_enqueue_script('chart', 'https://cdn.jsdelivr.net/npm/chart.js')`.
+
+---
+
+## Guideline 9 — No Illegal, Dishonest, or Offensive Conduct
+
+A catch-all behavioural rule covering both the plugin's code and the author's conduct. Includes black-hat SEO and keyword stuffing, paid-traffic schemes, review manipulation (including sockpuppet accounts), pay-to-unlock messaging, plagiarising other authors, false claims of legal compliance (GDPR/ADA "guarantees"), abusing user server resources (crypto-mining, botnets), harassment of community members, identity falsification to evade prior sanctions, and deliberate loophole-hunting. Violations of the WordPress.org Community Code of Conduct, WordCamp Code of Conduct, and Forum Guidelines fall under this clause too.
+
+**Violation example:** A plugin that uses idle browser cycles on the site's frontend to mine cryptocurrency for the developer.
+
+---
+
+## Guideline 10 — No Forced Front-End Credits or Links
+
+"Powered by" badges, attribution links, and similar credits on the public site must be off by default and toggled on only by an informed, explicit user choice — not buried in a EULA. The plugin's core functionality cannot be gated on credits being visible. Remote services may brand their own output, but the branding has to live in the service's response, not in the plugin's PHP.
+
+**Violation example:** A contact form plugin that prints "Form by Acme — get yours at acme.io" beneath every form unless the user finds a hidden constant to disable it.
+
+---
+
+## Guideline 11 — Don't Hijack the Admin Dashboard
+
+Plugin UI should feel native to WordPress. Upgrade nags, promotional banners, and alerts should be scoped to the plugin's own settings screen or used very sparingly site-wide. Site-wide notices and dashboard widgets must be dismissible (or auto-dismiss when their condition clears). Error messages must explain the fix and remove themselves once fixed. Backend advertising is discouraged and is often a violation of the upstream ad network's own rules; tracking referral clicks via those ads is also blocked by Guideline 7. Linking to your own site or social channels is welcome.
+
+**Violation example:** A persistent red banner on every admin page promoting the Pro version, with no dismiss control. Or a top-level admin menu placed at position 20 (next to Pages) "for visibility" instead of an unobtrusive slot.
+
+---
+
+## Guideline 12 — Readmes and Public Pages Must Not Spam
+
+The readme, translation files, and other directory-facing text are written for human users, not for search engines. Spammy practices include affiliate links without disclosure, tagging competitors, using more than five tags, keyword stuffing, repeating the same tag, and any black-hat SEO. Affiliate links are allowed if disclosed and pointed directly at the partner (no cloaking or redirect URLs). A tag is acceptable only when the plugin genuinely extends that product — a WooCommerce extension may tag "woocommerce", but an Akismet alternative may not tag "akismet".
+
+**Violation example:** A readme with `Tags: seo, yoast, rankmath, aioseo, seopress, allinoneseo` on a plugin that competes with Yoast.
+
+---
+
+## Guideline 13 — Use WordPress's Bundled Libraries
+
+WordPress already ships jQuery, PHPMailer, SimplePie, PHPass, Atom Lib, and more. Plugins must use those bundled copies rather than including their own forks or different versions, which avoids version conflicts and keeps security patches centralised in core.
+
+**Violation example:** Enqueuing your own `jquery-3.6.0.min.js` from the plugin's `assets/` directory instead of declaring `jquery` as a dependency in `wp_enqueue_script()`.
+
+---
+
+## Guideline 14 — Don't Commit Constantly
+
+SVN on WordPress.org is a release channel, not a development branch. Every commit — even readme tweaks — regenerates the distributed ZIP. Push only when you're shipping (stable, beta, or RC). Tiny rapid-fire commits are treated as gaming the "Recently Updated" list. Write meaningful messages; avoid "update", "wip", "fix". The one acknowledged exception is a readme commit purely to bump "Tested up to" for a new WordPress release.
+
+**Violation example:** Twelve commits in an hour, each labelled "typo", each touching one character of the readme.
+
+---
+
+## Guideline 15 — Increment the Version on Every Release
+
+Update notices fire only when the version number changes. Trunk's `readme.txt` must always show the current version. Use SVN tags for releases and keep stable-tag pointers in sync. Releasing changes without a version bump means users will never receive the update.
+
+**Violation example:** Pushing a security patch but leaving `Stable tag: 2.4.1` and `Version: 2.4.1` unchanged.
+
+---
+
+## Guideline 16 — Submit a Complete Plugin
+
+Submissions are reviewed by humans inspecting an actual ZIP, so the plugin must be functional and finished at submission time. The directory does not reserve slugs for future builds or trademark holders; if you take a slug and never publish, it can be reassigned.
+
+**Violation example:** Submitting an empty plugin scaffold to reserve the slug `super-cool-ai`.
+
+---
+
+## Guideline 17 — Respect Trademarks, Copyrights, and Project Names
+
+A plugin slug cannot lead with a trademark or project name you don't represent. "WordPress" is a Foundation trademark and is blocked outright in slugs and domain names. If you don't own the brand, position it after a descriptor: `dancing-sloths-for-superbox`, not `super-sandbox-dancing-sloths`. The same applies to upstream projects you're integrating with — only the `mellowyellowsandbox.js` team can lead a slug with `mellowyellowsandbox`. Original branding is encouraged.
+
+**Violation example:** A third-party developer publishing a plugin with the slug `woocommerce-shipping-extras`.
+
+---
+
+## Guideline 18 — Directory Maintenance Rights Reserved
+
+The Plugins team reserves the right to:
+
+- Update the guidelines whenever needed
+- Remove or disable any plugin, even for reasons not listed here
+- Grant exceptions and grace periods on a case-by-case basis
+- Reassign a plugin to a new maintainer if the original goes inactive
+- Patch a plugin without the author's consent when user safety requires it
+
+The promise in return is that these powers are used sparingly and respectfully.
+
+**Not really a violation a developer commits** — this is the meta-rule that explains why a removal can happen outside the strict letter of guidelines 1–17.
+
+---
+
+## Guideline 4 in Depth — Compiled, Minified, and Build-Tool Code
+
+Guideline 4 is the rule that catches most modern JS/CSS workflows by surprise, so it deserves its own section. The directory page is briefer than the practice that the review team enforces, so the points below combine the literal rule with the operational expectations.
+
+### What the rule literally says
+
+- Obfuscation tools that hide intent — `packer`, uglify's mangle, and lookalikes — are not allowed.
+- Cryptic identifiers (`$z12sdf813d`, single-letter variables across hundreds of lines) count as obscuring code.
+- Developers must give the public maintained access to source code and build tools through one of two routes:
+  1. Ship the source inside the deployed plugin, or
+  2. Link from the readme to the development repo (GitHub, GitLab, Bitbucket, etc.) where the unminified source lives.
+- The page strongly recommends documenting how the build tools are run.
+
+### Minified JS and CSS
+
+The page text does not literally use the word "minified" — its examples are obfuscation tools. In review practice, however, minified-only assets without an accompanying source are treated under the same rule: minification by itself is fine for performance, but the human-readable source must be reachable somewhere (either bundled in the ZIP or linked from the readme).
+
+Safe pattern:
+- `assets/js/foo.min.js` (shipped, minified)
+- `assets/js/foo.js` (shipped, original) **or** `https://github.com/you/foo` linked from `readme.txt`
+
+Unsafe pattern:
+- Only `assets/js/foo.min.js` shipped, no source-mapped or unminified counterpart anywhere public.
+
+### What counts as "compiled" code
+
+The guideline page itself does not enumerate build tools by name. In practice the review team applies the rule to any pipeline that produces output that differs meaningfully from what a developer wrote, including:
+
+- Webpack / Vite / Rollup / Parcel / esbuild bundles
+- Babel / TypeScript / SWC transpilation output
+- Sass / Less / PostCSS compiled stylesheets
+- React/JSX builds (e.g. via `@wordpress/scripts`)
+- Gulp or Grunt pipelines that minify, concatenate, or transform
+- Composer-installed or npm-installed dependencies that ship as built artefacts
+
+For each of those, the unprocessed source — `.jsx`, `.ts`, `.scss`, the webpack entry files, the `package.json` and `composer.json` — must be available either inside the deployed plugin or via the readme's development link.
+
+### Readme expectations
+
+- State where the source lives if it isn't bundled.
+- Document the build command(s): which Node version, which `npm` script (`npm run build`, `gulp build`, etc.), what the output directory is.
+- Document any environment requirements (Composer version, PHP version for build tooling, etc.).
+
+A readme that just says "minified for performance" with no source link will typically be flagged.
+
+### Exception language
+
+Guideline 4 itself does not carry an explicit "unless…" clause. The room for judgement comes from Guideline 18's general right to grant exceptions case by case. In practice the reviewers focus on intent: a clearly named minified bundle with public source alongside it is fine, while mangled identifiers and missing source are not, regardless of the tool that produced them.
+
+### Practical checklist for compiled plugins
+
+1. Keep readable source for every shipped JS/CSS file — bundled in the ZIP or in a public repo linked from `readme.txt`.
+2. Don't enable name-mangling/obfuscation in production builds; standard minification only.
+3. Commit a `package.json` and/or `composer.json` so the build is reproducible.
+4. Include a short "Building from source" or "Development" section in the readme: prerequisites, install command, build command, output paths.
+5. When upstream dependencies ship only minified, document the upstream source URL in the readme so reviewers can verify it.

--- a/skills/wordpress-plugin-development/references/handbook-hooks-menus-shortcodes.md
+++ b/skills/wordpress-plugin-development/references/handbook-hooks-menus-shortcodes.md
@@ -1,0 +1,109 @@
+# Hooks, Administration Menus & Shortcodes
+
+Compiled from the WordPress Plugin Developer Handbook.
+
+## 1. Hooks
+
+Source: https://developer.wordpress.org/plugins/hooks/ (+ actions, filters, custom-hooks, advanced-topics)
+
+**RULE — actions vs filters.** Actions *do* something and return nothing. Filters *modify* a value
+and **MUST return** it. Need to change data flowing onward → filter; need to perform a task → action.
+
+### Actions
+`add_action( $hook, $cb, $priority = 10, $accepted_args = 1 )`. To receive >1 arg from
+`do_action()`, raise `accepted_args`.
+```php
+function wporg_custom( $post_id, $post ) { /* ... */ }
+add_action( 'save_post', 'wporg_custom', 10, 2 );
+```
+Fire: `do_action( $hook, $arg1, ... )`; `do_action_ref_array( $hook, $args )` for by-reference.
+
+### Filters
+`add_filter( $hook, $cb, $priority = 10, $accepted_args = 1 )` — callback MUST return.
+```php
+function wporg_title( $title ) { return 'The ' . $title; }
+add_filter( 'the_title', 'wporg_title' );
+```
+Fire: `apply_filters( $hook, $value, ...$extra )` returns the value; extra args are read-only context.
+
+### Priority & custom hooks
+Lower priority runs earlier; same priority runs in registration order. Expose your own hooks for
+extensibility (`do_action()` for events, `apply_filters()` for output values) and **always prefix**
+hook names.
+```php
+do_action( 'wporg_after_settings_page_html' );
+$args = apply_filters( 'wporg_post_type_args', $args );
+```
+
+### Removing hooks & advanced
+`remove_action`/`remove_filter` must match the **exact same callable AND priority**, after the add.
+`current_filter()` returns the executing hook; `did_action( $hook )` counts fires.
+
+Gotchas: a filter that returns nothing wipes the value. `accepted_args` mismatch → extra args
+arrive `null`. `remove_*` priority mismatch silently fails. Closures/object methods are hard to
+remove. Unprefixed custom hooks collide.
+
+## 2. Administration menus
+
+Source: https://developer.wordpress.org/plugins/administration-menus/ (+ top-level-menus, sub-menus)
+
+**RULE — register on `admin_menu`.** A single option page should be a **sub-menu** under an
+existing parent, not a new top-level item.
+```php
+add_action( 'admin_menu', function () {
+    add_menu_page( 'WPOrg', 'WPOrg', 'manage_options',
+        'wporg', 'wporg_page_html', 'dashicons-admin-generic', 25 );
+} );
+```
+`add_menu_page( $page_title, $menu_title, $capability, $menu_slug, $cb, $icon, $position )`.
+`add_submenu_page( $parent_slug, $page_title, $menu_title, $capability, $menu_slug, $cb, $position )`.
+
+**RULE — the page callback MUST (1) check capability and (2) escape output.**
+```php
+function wporg_page_html() {
+    if ( ! current_user_can( 'manage_options' ) ) return;
+    echo '<div class="wrap"><h1>' . esc_html( get_admin_page_title() ) . '</h1></div>';
+}
+```
+Built-in parent slugs / wrappers: `index.php` (`add_dashboard_page`), `edit.php`
+(`add_posts_page`), `upload.php` (`add_media_page`), `edit-comments.php` (`add_comments_page`),
+`themes.php` (`add_theme_page`), `plugins.php` (`add_plugins_page`), `users.php`
+(`add_users_page`), `tools.php` (`add_management_page`), `options-general.php`
+(`add_options_page`).
+
+Gotchas: hidden menu ≠ security boundary — the callback must still check caps. Unescaped page HTML
+is XSS. Registering outside `admin_menu` doesn't work. Duplicate `$menu_slug` clobbers. Reuse the
+parent slug for the landing submenu to avoid a duplicate first item.
+
+## 3. Shortcodes
+
+Source: https://developer.wordpress.org/plugins/shortcodes/ (+ basic, enclosing, parameters, tinymce)
+
+**RULE — register with `add_shortcode( $tag, $cb )`; the callback MUST RETURN a string, never `echo`.**
+```php
+add_shortcode( 'wporg', 'wporg_shortcode' );
+function wporg_shortcode( $atts = [], $content = null, $tag = '' ) {
+    return $content;
+}
+```
+Signature `( $atts, $content = null, $tag = '' )`. Related: `do_shortcode()`, `remove_shortcode()`,
+`shortcode_exists()`.
+
+### Attributes — merge defaults + sanitize/escape
+```php
+$atts = array_change_key_case( (array) $atts, CASE_LOWER );
+$a    = shortcode_atts( [ 'title' => 'WordPress.org' ], $atts, $tag );
+return '<h2>' . esc_html( $a['title'] ) . '</h2>';
+```
+
+### Enclosing & nested
+`[wporg]` → `$content` null; `[wporg]...[/wporg]` → `$content` set. Run nested shortcodes:
+```php
+return '<div>' . do_shortcode( $content ) . '</div>';
+```
+TinyMCE-enhanced shortcodes render live in the visual editor (core: audio, caption, gallery,
+playlist, video).
+
+Gotchas: echoing instead of returning dumps output at the top of the post (#1 bug). Sanitize
+`$atts`, escape output. Lowercase keys. Don't forget `do_shortcode($content)` for nested. Keep the
+callback light (runs per occurrence). Prefix tags to avoid collisions.

--- a/skills/wordpress-plugin-development/references/handbook-js-i18n-tools-directory.md
+++ b/skills/wordpress-plugin-development/references/handbook-js-i18n-tools-directory.md
@@ -1,0 +1,156 @@
+# JavaScript/Ajax, i18n, Developer Tools & the wp.org Directory
+
+Compiled from the WordPress Plugin Developer Handbook.
+
+## 1. Enqueuing scripts & styles
+
+Source: https://developer.wordpress.org/plugins/javascript/enqueuing/
+
+**RULE: never hardcode `<script>`/`<link>` tags** — always enqueue. Hook the enqueue:
+`wp_enqueue_scripts` (front-end), `admin_enqueue_scripts` (admin; callback gets `$hook` — bail if
+not your page), `login_enqueue_scripts`.
+
+```php
+wp_enqueue_script( $handle, $src, $deps, $ver, $args );
+// $src: plugins_url('/js/x.js', __FILE__) — never a hardcoded URL
+// $args (WP 6.3+): array( 'in_footer' => true, 'strategy' => 'defer'|'async' )  (legacy: bool $in_footer)
+wp_enqueue_style( $handle, $src, $deps, $ver, $media );
+```
+```php
+add_action( 'admin_enqueue_scripts', function ( $hook ) {
+    if ( 'toplevel_page_myplugin' !== $hook ) return;
+    wp_enqueue_script( 'myplugin', plugins_url( '/js/app.js', __FILE__ ),
+        array( 'jquery' ), '1.0.0', array( 'in_footer' => true ) );
+} );
+```
+`wp_register_script/style()` define without printing; `wp_enqueue_*` prints. Pass data:
+`wp_localize_script($handle,$obj,$data)`, `wp_add_inline_script($handle,$js,'before'|'after')`,
+`wp_set_script_translations($handle,'text-domain',$path)`.
+
+Gotchas: localize/translations calls must run after the script is registered. Top-level admin hook
+is `toplevel_page_{slug}`; submenu `{parent}_page_{slug}`. Bump `$ver` to bust caches.
+
+## 2. jQuery
+
+Source: https://developer.wordpress.org/plugins/javascript/jquery/
+
+**RULE: WordPress jQuery runs in `noConflict` — global `$` is unavailable.** Use `jQuery` or alias:
+```javascript
+( function( $ ) { $( '.pref' ).on( 'change', fn ); } )( jQuery );
+```
+Declare `array('jquery')` as a dependency; don't bundle your own jQuery.
+
+## 3. Ajax (admin-ajax.php)
+
+Source: https://developer.wordpress.org/plugins/javascript/ajax/
+
+**RULE: classic Ajax POSTs to `wp-admin/admin-ajax.php`; the URL must come from PHP**, every request
+carries an `action` and a nonce.
+```php
+wp_localize_script( 'my-js', 'my_ajax_obj', array(
+    'ajax_url' => admin_url( 'admin-ajax.php' ),
+    'nonce'    => wp_create_nonce( 'my_nonce_action' ),
+) );
+add_action( 'wp_ajax_my_tag_count',        'my_tag_count' ); // logged-in
+add_action( 'wp_ajax_nopriv_my_tag_count', 'my_tag_count' ); // logged-out (only if needed)
+function my_tag_count() {
+    check_ajax_referer( 'my_nonce_action' );
+    if ( ! current_user_can( 'edit_posts' ) ) wp_send_json_error( 'forbidden', 403 );
+    $title = sanitize_text_field( wp_unslash( $_POST['title'] ) );
+    wp_send_json_success( array( 'count' => 5 ) ); // ends with wp_die()
+}
+```
+`wp_ajax_{action}` = logged-in; `wp_ajax_nopriv_{action}` = logged-out (register only if anonymous
+access is required). **The REST API (`register_rest_route` with `permission_callback`) is the
+modern alternative.**
+
+Gotchas: forgetting `wp_die()` returns trailing `0`. Nonce action string must match.
+
+## 4. Internationalization (i18n)
+
+Source: https://developer.wordpress.org/plugins/internationalization/ (+ how-to, localization)
+
+**RULE: text domain == plugin slug, as a LITERAL string — never a variable/constant.**
+```php
+__( 'Save', 'my-plugin' );   // ✅
+__( 'Save', $domain );           // ❌
+```
+Functions: `__()`/`_e()`; escaping variants `esc_html__()`, `esc_html_e()`, `esc_attr__()`,
+`esc_attr_e()`; context `_x()`/`_ex()`; plurals `_n()`/`_nx()`/`_n_noop()`; `number_format_i18n()`,
+`date_i18n()`.
+
+**Never interpolate variables — use `printf` with placeholders (numbered for multiple args):**
+```php
+printf( /* translators: %s: city */ esc_html__( 'Your city is %s.', 'my-plugin' ), esc_html( $city ) );
+printf( /* translators: 1: city 2: zip */ esc_html__( 'City %1$s, zip %2$s.', 'my-plugin' ), $city, $zip );
+```
+**Since WP 4.6, wp.org-hosted plugins load translations automatically** from
+translate.wordpress.org — `load_plugin_textdomain()` is largely unnecessary. JS: 
+`wp_set_script_translations()`. Pipeline: `.pot` → `.po` → `.mo`; generate with
+`wp i18n make-pot . languages/my-plugin.pot`.
+
+Gotchas: add `/* translators: ... */` immediately before the call. Don't translate empty strings;
+avoid markup in translatable strings; translations don't load before `init`.
+
+## 5. Developer tools
+
+Source: https://developer.wordpress.org/plugins/developer-tools/
+
+Debug constants (wp-config.php): `WP_DEBUG`, `WP_DEBUG_LOG`, `WP_DEBUG_DISPLAY`, `SCRIPT_DEBUG`
+(unminified core assets), `SAVEQUERIES`. Tools: **Debug Bar** (+ add-ons), **Query Monitor**,
+**Plugin Check (PCP)** — run before submitting/updating.
+
+Gotchas: never leave `WP_DEBUG`/`SCRIPT_DEBUG` on in production; `WP_DEBUG_LOG` requires `WP_DEBUG`.
+
+## 6. WordPress.org Plugin Directory
+
+Source: https://developer.wordpress.org/plugins/wordpress-org/ (+ readme, assets, guidelines, faq)
+
+### readme.txt
+Lives in `/trunk/readme.txt`, Markdown subset; validate with the official readme validator. Header:
+```
+=== My Plugin ===
+Contributors: wporg_userid
+Tags: audio, accessibility            (max 5)
+Requires at least: 4.7
+Tested up to: 6.5                     (major WP version, numbers only)
+Requires PHP: 7.0
+Stable Tag: 4.3
+License: GPLv2 or later
+```
+**Stable Tag is the release switch:** wp.org reads it from `/trunk/readme.txt`, then serves
+`/tags/{StableTag}/` (whose readme must also carry the right tag). Displayed **version comes from
+the main PHP file's `Version:` header**. `Stable Tag: trunk` is prohibited for new plugins.
+Sections: Description, Installation, FAQ, Screenshots, Changelog, Upgrade Notice. Since WP 5.8,
+`Requires PHP`/`Requires at least` are parsed from the main PHP file.
+
+### Assets (top-level `assets/` SVN dir, NOT trunk/tags)
+Icons `icon-128x128.*` / `icon-256x256.*` / `icon.svg`. Banners `banner-772x250.*` /
+`banner-1544x500.*`. Screenshots `screenshot-1.*`, `screenshot-2.*` (lowercase; descriptions map to
+the readme Screenshots section).
+
+### SVN release flow
+Dirs: `/trunk/` (current code), `/tags/` (releases), `/assets/`, `/branches/`. SVN is a **release**
+repo — push finished work only. Tag by copying trunk:
+```bash
+svn cp trunk tags/1.2.3
+svn ci -m "tagging 1.2.3"
+```
+
+### Detailed guidelines (terse)
+GPLv2+-compatible · responsible for bundled code · stable working version on wp.org · human-
+readable code, no obfuscation · **no trialware/locked features in the free plugin** · SaaS allowed
+if substantive + documented · **no tracking without explicit opt-in** · no executing externally-
+fetched code · no dishonest/black-hat behavior · "Powered by" credits opt-in · no dashboard
+hijacking (notices dismissible) · no readme spam (≤5 tags) · use WordPress-bundled libraries · SVN
+commits limited to releases · increment version each release · plugin complete at submission ·
+respect trademarks.
+
+### Developer FAQ highlights
+Slug is permanent after approval (display name changes via the PHP header + readme). Committers get
+SVN write access via Advanced; Contributors are listed authors. Closing a plugin is permanent;
+SVN stays open for forking. Tag releases with version numbers only.
+
+Gotchas: forgetting to update Stable Tag (or the tag-folder readme) breaks auto-updates. PHP-header
+vs readme version mismatch shows the wrong version. `assets/` must NOT live inside trunk. Don't set
+`Tested up to` past the current WP release.

--- a/skills/wordpress-plugin-development/references/handbook-plugin-basics.md
+++ b/skills/wordpress-plugin-development/references/handbook-plugin-basics.md
@@ -1,0 +1,146 @@
+# Plugin Basics, Header & Lifecycle
+
+Compiled from the WordPress Plugin Developer Handbook.
+
+## 1. What a plugin is & how WordPress loads it
+
+Source: https://developer.wordpress.org/plugins/intro/ · https://developer.wordpress.org/plugins/plugin-basics/
+
+**RULE:** A plugin extends WordPress without touching core (core updates overwrite changes).
+The minimum viable plugin is **one PHP file in `wp-content/plugins/` with a header comment
+containing a Plugin Name**. WordPress scans the `plugins` folder **and one level of sub-folders**
+for PHP files with a plugin header.
+
+```php
+<?php
+/**
+ * Plugin Name: My Awesome Plugin
+ */
+```
+
+Single-file plugins can sit directly in `plugins/`; conventionally a plugin lives in its own
+folder with the main file matching the folder name. Distributed plugins must use a
+GPLv2-compatible license.
+
+Gotchas: only the top level + one sub-folder level is scanned — don't bury the header file
+deeper. Folder/file names must be unique to avoid ecosystem collisions.
+
+## 2. The plugin header
+
+Source: https://developer.wordpress.org/plugins/plugin-basics/header-requirements/
+
+**RULE:** Header is a comment block in the **main PHP file**. The *only* required field is
+`Plugin Name`.
+
+```php
+<?php
+/**
+ * Plugin Name:       My Plugin
+ * Plugin URI:        https://example.com/my-plugin
+ * Description:       Short description (< 140 chars).
+ * Version:           1.0.0
+ * Requires at least: 5.6
+ * Requires PHP:      7.4
+ * Author:            Your Name
+ * License:           GPLv2 or later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain:       my-plugin
+ * Domain Path:       /languages
+ * Requires Plugins:  woocommerce, another-plugin
+ * Network:           true
+ * Update URI:        https://example.com/my-plugin
+ */
+```
+
+| Field | Required? | Notes |
+|---|---|---|
+| `Plugin Name` | **Required** | Only mandatory field |
+| `Plugin URI` | Optional | Must be unique; not a wp.org URL |
+| `Description` | Optional | < 140 chars |
+| `Version` | Optional | `version_compare()`-friendly |
+| `Requires at least` / `Requires PHP` | Optional | Min WP / PHP; since WP 5.8 parsed from main file (not readme) |
+| `Author` / `Author URI` / `License` / `License URI` | Optional | |
+| `Text Domain` / `Domain Path` | Optional | i18n; defaults to slug since WP 4.6 |
+| `Network` | Optional | `true` = network-wide multisite |
+| `Update URI` | Optional | Controls update source (prevents wp.org slug hijack) |
+| `Requires Plugins` | Optional | Comma-separated wp.org **slugs** of dependencies (WP 6.5+) |
+
+Gotchas: `Requires Plugins` takes slugs only, no commas inside a slug. `Plugin URI` must not point
+to wordpress.org. `1.02` is NOT greater than `1.1` under `version_compare()`.
+
+## 3. Activation & deactivation hooks
+
+Source: https://developer.wordpress.org/plugins/plugin-basics/activation-deactivation-hooks/
+
+**RULE:** `register_activation_hook( __FILE__, $cb )` / `register_deactivation_hook( __FILE__, $cb )`.
+First arg = the **main plugin file**. Activation = setup (tables, default options, rewrite rules).
+Deactivation = light cleanup (NOT permanent deletion).
+
+```php
+function pluginprefix_activate() {
+    pluginprefix_setup_post_type(); // register CPT first
+    flush_rewrite_rules();          // then flush
+}
+register_activation_hook( __FILE__, 'pluginprefix_activate' );
+```
+
+Gotchas: `flush_rewrite_rules()` must run AFTER the CPT is registered. Deactivation is not
+uninstall — never delete user data here.
+
+## 4. Uninstall: `uninstall.php` vs `register_uninstall_hook`
+
+Source: https://developer.wordpress.org/plugins/plugin-basics/uninstall-methods/
+
+**RULE:** Permanently delete all plugin data on uninstall. Two mutually exclusive options:
+
+1. `uninstall.php` in the plugin root (preferred) — auto-run on delete; MUST guard:
+```php
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) { die; }
+delete_option( 'wporg_option' );
+```
+2. `register_uninstall_hook( __FILE__, 'cb' )` — keeps logic in main file (`WP_UNINSTALL_PLUGIN`
+   is NOT defined in this path).
+
+Gotchas: if `uninstall.php` exists, the registered hook is ignored — pick one. On multisite,
+looping every blog is expensive. Always guard `uninstall.php` against direct access.
+
+## 5. Path & URL functions
+
+Source: https://developer.wordpress.org/plugins/plugin-basics/determining-plugin-and-content-directories/
+
+**RULE:** Never hardcode paths. URLs for assets (enqueue); filesystem paths for `include`/`require`/file I/O.
+
+| Function | Returns |
+|---|---|
+| `plugin_dir_path( __FILE__ )` | Filesystem path, trailing slash |
+| `plugin_dir_url( __FILE__ )` | URL, trailing slash |
+| `plugins_url( $path, __FILE__ )` | Full URL to a file |
+| `plugin_basename( __FILE__ )` | `folder/file.php` identifier |
+
+Constants `WP_PLUGIN_DIR`, `WP_PLUGIN_URL`, `WP_CONTENT_DIR/URL` have **no** trailing slash. Site
+helpers: `site_url()`, `home_url()`, `admin_url()`, `content_url()`, `wp_upload_dir()`; multisite
+variants `network_site_url()`, `network_admin_url()`.
+
+Gotchas: mixing path (filesystem) and URL functions is the #1 mistake. `require plugins_url(...)`
+fails.
+
+## 6. Including PHP files & best practices
+
+Source: https://developer.wordpress.org/plugins/plugin-basics/best-practices/
+
+**RULE:** Build include paths from `plugin_dir_path( __FILE__ )` / `__DIR__`. Load admin-only code
+conditionally. Prefix every global symbol with a unique 4–5+ char prefix; wrap in classes/
+namespaces; guard against redeclaration; block direct access.
+
+```php
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-core.php';
+if ( is_admin() ) { require_once __DIR__ . '/admin/admin.php'; }
+
+if ( ! defined( 'ABSPATH' ) ) { exit; } // block direct access
+```
+
+Recommended structure: `plugin-name.php`, `uninstall.php`, `/languages`, `/includes`, `/admin`,
+`/public`.
+
+Gotchas: NEVER use reserved prefixes `wp_`, `__`, `_`, `WordPress`. Unprefixed names are the
+leading cause of fatal conflicts. Missing `ABSPATH` guard exposes files to direct browser access.

--- a/skills/wordpress-plugin-development/references/handbook-privacy-users-http-cron.md
+++ b/skills/wordpress-plugin-development/references/handbook-privacy-users-http-cron.md
@@ -1,0 +1,124 @@
+# Privacy, Users/Roles, HTTP API & WP-Cron
+
+Compiled from the WordPress Plugin Developer Handbook.
+
+## 1. Privacy & GDPR
+
+Source: https://developer.wordpress.org/plugins/privacy/ (+ exporter, eraser, suggesting policy text)
+
+**Why:** GDPR/CCPA require sites to disclose, export, and erase personal data. Any plugin storing
+personal data (emails, IPs, names, analytics, telemetry, cookies/localStorage) must hook into
+WordPress's privacy tools.
+
+**RULES**
+- If you store personal data, register **both** an exporter and an eraser.
+- Disclose third-party sharing/SDKs/telemetry and browser storage in suggested policy text.
+- Restrict access to personal data by capability; clean up on uninstall.
+- Use `wp_privacy_anonymize_data()` to minimize (e.g. anonymize IPs).
+
+Suggest policy text on `admin_init`:
+```php
+add_action( 'admin_init', function () {
+    if ( ! function_exists( 'wp_add_privacy_policy_content' ) ) return;
+    $content = '<p class="privacy-policy-tutorial">Tutorial prose (excluded when copied).</p>'
+        . '<strong>' . __( 'Suggested text:' ) . '</strong> '
+        . __( 'We store page-view analytics including IP-derived city.', 'my-plugin' );
+    wp_add_privacy_policy_content( 'My Plugin', wp_kses_post( wpautop( $content, false ) ) );
+} );
+```
+
+Exporter via `wp_privacy_personal_data_exporters`, callback `( $email, $page = 1 )` returns
+`['data' => [...groups], 'done' => bool]`; paginate while `done` is false.
+Eraser via `wp_privacy_personal_data_erasers`, returns
+`['items_removed'=>bool,'items_retained'=>bool,'messages'=>[],'done'=>bool]`.
+
+Gotchas: having an exporter but no eraser (or vice-versa) is a common gap. Guard
+`wp_add_privacy_policy_content` with `function_exists`, only on `admin_init`. Paginate large
+datasets via `$page` or they time out.
+
+## 2. Users, roles & capabilities
+
+Source: https://developer.wordpress.org/plugins/users/ (+ roles-and-capabilities, working-with-users, user-metadata)
+
+A *role* is a named bucket of *capabilities*. Default roles: Super Admin, Administrator, Editor,
+Author, Contributor, Subscriber. Principle of least privilege.
+
+**RULE — check capabilities, not roles.**
+```php
+if ( current_user_can( 'edit_posts' ) ) { /* ... */ }
+```
+Manage roles/caps (run on activation, not every load — `add_role` only writes the first time):
+```php
+add_role( 'myplugin_manager', 'My Plugin Manager', array( 'read' => true, 'manage_myplugin' => true ) );
+get_role( 'editor' )->add_cap( 'manage_myplugin' );
+```
+Read users: `wp_get_current_user()`, `get_current_user_id()`, `get_userdata( $id )`.
+Create/update/delete: `wp_create_user()`, `wp_insert_user()` (returns ID or `WP_Error`),
+`wp_update_user()`, `wp_delete_user( $id, $reassign )` (**if `$reassign` is invalid, the user's
+content is deleted**). Check `username_exists()`/`email_exists()` first; handle `is_wp_error()`.
+User meta: `add/update/get/delete_user_meta()` (same single/array semantics as post meta).
+
+Gotchas: `$user->roles[0] === 'administrator'` is wrong — check the cap. `get_user_meta(..., false)`
+returns an array. Re-running `add_role()` won't add new caps on upgrade — use `get_role()->add_cap()`.
+
+## 3. HTTP API
+
+Source: https://developer.wordpress.org/plugins/http-api/
+
+**RULE — use the HTTP API, never raw cURL / `file_get_contents()`** (honors proxy settings,
+required for wp.org). **Prefer `wp_safe_remote_*`** for any user-influenced URL (SSRF protection).
+
+Functions: `wp_remote_get/post/head/request()` and safe twins `wp_safe_remote_*`. Read with
+`wp_remote_retrieve_body()`, `wp_remote_retrieve_response_code()`, `wp_remote_retrieve_header()`.
+Always `is_wp_error()` first.
+
+```php
+$res = wp_safe_remote_post( 'https://api.example.com/v1/items', array(
+    'timeout' => 15,
+    'headers' => array( 'Content-Type' => 'application/json', 'Authorization' => 'Bearer ' . $token ),
+    'body'    => wp_json_encode( array( 'name' => $name ) ),
+) );
+if ( is_wp_error( $res ) ) return $res;
+$code = wp_remote_retrieve_response_code( $res );
+$body = wp_remote_retrieve_body( $res );
+```
+
+Gotchas: default `timeout` is 5s. `is_wp_error()` only catches transport failures — a 4xx/5xx still
+returns a normal array, so check the response code. Never `sslverify => false`. **Phoning home:**
+wp.org forbids sending site data externally without explicit informed opt-in; default-on telemetry
+is a violation. `body` as array sends form-encoded; for JSON use `wp_json_encode()` + set
+`Content-Type`.
+
+## 4. WP-Cron
+
+Source: https://developer.wordpress.org/plugins/cron/ (+ understanding, scheduling, system-task-scheduler)
+
+**Key fact:** WP-Cron is **request-triggered, not a real daemon** — events fire on page loads.
+Guarantees eventual, never precise, timing. Default intervals: `hourly`, `twicedaily`, `daily`,
+`weekly` (WP 5.4+). Intervals are in **seconds**.
+
+Custom interval:
+```php
+add_filter( 'cron_schedules', function ( $s ) {
+    $s['fifteen_minutes'] = array( 'interval' => 15 * MINUTE_IN_SECONDS,
+        'display' => esc_html__( 'Every 15 Minutes', 'my-plugin' ) );
+    return $s;
+} );
+```
+
+**RULE: register the `cron_schedules` filter AND `add_action(event → callback)` at load time** (the
+callback must exist whenever cron fires), and guard scheduling with `wp_next_scheduled()`:
+```php
+add_action( 'my_cron_hook', 'my_cron_task' );          // every request
+if ( ! wp_next_scheduled( 'my_cron_hook' ) ) {
+    wp_schedule_event( time(), 'fifteen_minutes', 'my_cron_hook' );
+}
+```
+Also: `wp_schedule_single_event()`, `wp_unschedule_event()`, `wp_clear_scheduled_hook()`.
+Unschedule on deactivation. Replace with real cron on busy sites:
+`define('DISABLE_WP_CRON', true);` + OS scheduler hitting `wp-cron.php?doing_wp_cron`.
+
+Gotchas: scheduling only in the activation hook without registering the callback at load → cron
+fires with no handler. Re-scheduling without `wp_next_scheduled()` stacks duplicates. Registering
+`cron_schedules` only on activation breaks rescheduling. WP-Cron is unsuitable for time-critical
+jobs.

--- a/skills/wordpress-plugin-development/references/handbook-security.md
+++ b/skills/wordpress-plugin-development/references/handbook-security.md
@@ -1,0 +1,133 @@
+# Security — capabilities, validation, sanitizing, escaping, nonces
+
+Compiled from the WordPress Plugin Developer Handbook "Security" chapter (now consolidated into
+the Common APIs Security Handbook).
+
+> **Core principle:** Never trust input. *Validate* on the way in, *sanitize* before storing,
+> *escape* on the way out. Treat `$_GET`, `$_POST`, `$_REQUEST`, `$_COOKIE`, `$_SERVER`, `$_FILES`
+> as untrusted.
+
+## 1. Checking user capabilities
+
+Source: https://developer.wordpress.org/plugins/security/checking-user-capabilities/
+
+**RULE: any data-changing action (admin OR public) checks `current_user_can()` first.**
+```php
+if ( current_user_can( 'edit_others_posts' ) ) { /* ... */ }
+```
+**RULE: check by capability, never by role.** Roles are mutable bundles of caps.
+```php
+// WRONG: if ( 'administrator' === $user->roles[0] )
+// RIGHT: if ( current_user_can( 'manage_options' ) )
+```
+Pick the narrowest cap: `edit_posts` (author), `edit_others_posts` (editor), `manage_options`
+(admin). Multisite network actions need `manage_network`, `manage_network_options` etc.; prefer a
+specific cap over `is_super_admin()`.
+
+## 2. Data validation
+
+Source: https://developer.wordpress.org/apis/security/data-validation/
+
+**RULE: validation tests data against a pattern (valid/invalid) and does NOT alter it** — distinct
+from sanitizing (cleans/changes) and escaping (safe for output). Validate as early as possible.
+Prefer an **allowlist** over a blocklist. Use strict comparison.
+
+```php
+$allowed = array( 'author', 'post_author', 'date', 'post_date' );
+$orderby = sanitize_key( $_POST['orderby'] );
+if ( in_array( $orderby, $allowed, true ) ) { /* valid */ }
+$id = absint( $_GET['id'] ); // non-negative integer
+```
+Format checks: `preg_match()`, `ctype_*`, `is_email()`, `term_exists()`, `username_exists()`,
+`validate_file()`.
+
+## 3. Securing / sanitizing input
+
+Source: https://developer.wordpress.org/apis/security/sanitizing/
+
+**RULE: sanitize untrusted input before use/storage.** `sanitize_text_field()` checks UTF-8,
+strips tags, removes line breaks/tabs/extra whitespace.
+**RULE: superglobals are slashed — call `wp_unslash()` BEFORE sanitizing.**
+```php
+$title = sanitize_text_field( wp_unslash( $_POST['title'] ) );
+$email = sanitize_email( wp_unslash( $_POST['email'] ) );
+```
+Function set: `sanitize_email`, `sanitize_file_name`, `sanitize_hex_color`, `sanitize_html_class`,
+`sanitize_key`, `sanitize_meta`, `sanitize_mime_type`, `sanitize_option`, `sanitize_sql_orderby`,
+`sanitize_term`, `sanitize_text_field`, `sanitize_textarea_field`, `sanitize_title`,
+`sanitize_user`, `sanitize_url`, plus `absint()` and `wp_kses()`/`wp_kses_post()`.
+
+## 4. Securing / escaping output
+
+Source: https://developer.wordpress.org/apis/security/escaping/
+
+**RULE: escape as late as possible — ideally at the `echo`.** Match the function to the context.
+```php
+echo '<a href="' . esc_url( $url ) . '">' . esc_html( $text ) . '</a>';
+```
+- `esc_html()` — text between tags
+- `esc_attr()` — attribute values
+- `esc_url()` — href/src; `esc_url_raw()` for storage/redirects
+- `esc_js()` — inline JS (+ `wp_json_encode()`)
+- `esc_textarea()` — `<textarea>` content
+- `wp_kses()` / `wp_kses_post()` — output that must keep some HTML
+
+Translated echoes use the escaping i18n variants: `esc_html__()`, `esc_html_e()`, `esc_attr__()`,
+`esc_attr_e()`, `esc_html_x()`. Exception: when late escaping is impractical (e.g. generated
+scripts), escape at build time and name the variable `_escaped`/`_safe`.
+
+## 5. Nonces (CSRF protection)
+
+Source: https://developer.wordpress.org/apis/security/nonces/
+
+**RULE: protect every state-changing request with a nonce tied to a specific action (+ object ID).**
+```php
+wp_nonce_field( 'delete-comment_' . $comment_id );             // form
+$url = wp_nonce_url( $bare_url, 'trash-post_' . $post->ID );    // URL
+$n   = wp_create_nonce( 'my-action_' . $post->ID );             // raw token
+```
+Verify per context:
+- `check_admin_referer( $action )` — admin form/URL; checks nonce + referrer; 403 on fail.
+- `check_ajax_referer( $action )` — AJAX; checks nonce; dies on fail.
+- `wp_verify_nonce( $nonce, $action )` — manual; returns false/1/2.
+
+Lifetime ~12–24h (filter `nonce_life`). **Nonces are NOT authn/authz** — always also call
+`current_user_can()`.
+
+## Quick reference
+
+### Input → sanitize
+| Context | Function |
+|---|---|
+| Single-line text | `sanitize_text_field()` |
+| Multi-line text | `sanitize_textarea_field()` |
+| Email | `sanitize_email()` |
+| Key / meta key | `sanitize_key()` |
+| Integer ≥ 0 | `absint()` |
+| URL (storage) | `sanitize_url()` / `esc_url_raw()` |
+| Slug | `sanitize_title()` |
+| File name | `sanitize_file_name()` |
+| CSS class | `sanitize_html_class()` |
+| HTML (post) | `wp_kses_post()` |
+| HTML (custom) | `wp_kses()` |
+| Always first on superglobals | `wp_unslash()` |
+
+### Output → escape
+| Context | Function |
+|---|---|
+| Text in HTML | `esc_html()` |
+| Attribute | `esc_attr()` |
+| URL | `esc_url()` |
+| Inline JS / JSON-in-attr | `esc_js()` + `wp_json_encode()` |
+| `<textarea>` | `esc_textarea()` |
+| Keep safe HTML | `wp_kses_post()` / `wp_kses()` |
+| Translated echo | `esc_html_e()` / `esc_attr_e()` |
+
+## Common vulnerabilities & WP defenses
+
+- **XSS** — escape late with context-correct `esc_*`; constrain rich HTML with `wp_kses*`.
+- **CSRF** — nonces verified by `check_admin_referer`/`check_ajax_referer`.
+- **SQLi** — `$wpdb->prepare()` with `%s`/`%d`/`%f`; never concatenate; `sanitize_sql_orderby()` +
+  allowlist for ORDER BY/column names.
+- **SSRF** — validate/allowlist hosts; use `wp_safe_remote_get()`.
+- **Auth bypass** — `current_user_can()` on every privileged action, in addition to nonces.

--- a/skills/wordpress-plugin-development/references/handbook-settings-data.md
+++ b/skills/wordpress-plugin-development/references/handbook-settings-data.md
@@ -1,0 +1,152 @@
+# Settings, Options, Metadata, Custom Post Types & Taxonomies
+
+Compiled from the WordPress Plugin Developer Handbook.
+
+## 1. Options API
+
+Source: https://developer.wordpress.org/plugins/settings/options-api/
+
+Options are key/value rows in `{$prefix}options`. Single-site: `*_option()`; multisite network-wide:
+`*_site_option()`.
+
+**RULES**
+- Prefix every option name with your slug. The namespace is global.
+- `add_option($name,$value,'',$autoload)` creates; fails silently if it exists.
+- `get_option($name,$default)` returns value or `$default` (default `false`).
+- `update_option($name,$value,$autoload)` upserts; only writes if changed.
+- `delete_option($name)` removes.
+- **Autoload**: autoloaded options load on every request via one query. Set `autoload=false` for
+  **large** or **rarely-read** options. `update_option()` does not change autoload of an existing
+  option unless passed explicitly.
+- Store related settings as ONE array, not many rows.
+
+```php
+add_option( 'myplugin_settings_data', array( 'enabled' => true ), '', false );
+$s = get_option( 'myplugin_settings_data', array() );
+$s['enabled'] = false;
+update_option( 'myplugin_settings_data', $s );
+```
+
+Gotchas: don't autoload big blobs. Unprefixed names collide. `add_option` won't overwrite.
+
+## 2. Settings API
+
+Source: https://developer.wordpress.org/plugins/settings/settings-api/ (+ using-settings-api)
+
+The form POSTs to `wp-admin/options.php`, which does **capability + nonce checks for you** — so a
+standard settings form needs no hand-rolled nonce/`current_user_can()`. Register on `admin_init`.
+
+**RULES**
+- `register_setting( $group, $option, $args )` whitelists the option. Use the modern `$args`:
+  `type`, **`sanitize_callback` (always provide)**, `show_in_rest` (true for JS/Gutenberg access),
+  `default`, `description`.
+- `add_settings_section( $id, $title, $cb, $page )`.
+- `add_settings_field( $id, $label, $cb, $page, $section, $args )`.
+- In the form: `settings_fields( $group )` (nonce/action) + `do_settings_sections( $page )`.
+
+```php
+add_action( 'admin_init', function () {
+    register_setting( 'myplugin_group', 'myplugin_settings_data', array(
+        'type' => 'array', 'sanitize_callback' => 'myplugin_sanitize_settings',
+        'show_in_rest' => false, 'default' => array(),
+    ) );
+    add_settings_section( 'myplugin_main', 'Main', '__return_false', 'myplugin_page' );
+    add_settings_field( 'myplugin_enabled', 'Enabled', 'myplugin_field_html', 'myplugin_page', 'myplugin_main' );
+} );
+```
+
+Gotchas: `$group` must match in `register_setting` + `settings_fields`. Missing `settings_fields()`
+breaks the nonce. A missing/loose `sanitize_callback` is the main injection risk. `show_in_rest`
+needed for a React/Gutenberg UI to read the option.
+
+## 3. Post metadata
+
+Source: https://developer.wordpress.org/plugins/metadata/ (+ managing, custom-meta-boxes)
+
+**RULES**
+- `add_post_meta($id,$key,$value,$unique)`; `update_post_meta($id,$key,$value,$prev)` (upsert);
+  `get_post_meta($id,$key,$single)`; `delete_post_meta($id,$key,$value)`.
+- **Underscore prefix (`_myplugin_x`)** = hidden/protected meta (excluded from the custom-fields UI).
+  Also prefix with your slug.
+- `register_post_meta($type,$key,$args)` with `type`, `single`, `default`, **`sanitize_callback`**,
+  **`auth_callback`**, **`show_in_rest`** — preferred for Gutenberg.
+
+```php
+register_post_meta( 'post', '_myplugin_attachment_url', array(
+    'type' => 'string', 'single' => true, 'show_in_rest' => true,
+    'sanitize_callback' => 'esc_url_raw',
+    'auth_callback' => fn( $a, $k, $pid ) => current_user_can( 'edit_post', $pid ),
+) );
+```
+
+**Custom meta boxes** — `add_meta_box()` on `add_meta_boxes`; no submit button (saves with the
+post). The `save_post` handler MUST guard autosave + nonce + capability + sanitization:
+```php
+add_action( 'save_post', function ( $post_id ) {
+    if ( defined('DOING_AUTOSAVE') && DOING_AUTOSAVE ) return;
+    if ( ! isset($_POST['myplugin_nonce']) || ! wp_verify_nonce($_POST['myplugin_nonce'],'myplugin_save') ) return;
+    if ( ! current_user_can( 'edit_post', $post_id ) ) return;
+    if ( isset($_POST['myplugin_field']) )
+        update_post_meta( $post_id, '_myplugin_field', sanitize_text_field( wp_unslash( $_POST['myplugin_field'] ) ) );
+} );
+```
+
+Gotchas: handbook meta-box examples omit nonce/cap/autosave/sanitize — you must add them.
+`save_post` fires repeatedly. `get_post_meta(..., false)` returns an array. Block-editor fields need
+`show_in_rest`.
+
+## 4. Custom post types
+
+Source: https://developer.wordpress.org/plugins/post-types/ (+ registering-custom-post-types)
+
+**RULES**
+- `register_post_type( $key, $args )` on `init`.
+- **Key ≤ 20 chars**, lowercase, **prefixed**; never `wp_`. Generic keys collide.
+- Key args: `public`, **`show_in_rest` (true → block editor + REST)**, `supports`, `has_archive`,
+  `rewrite`, `capability_type`, `labels`, `menu_icon`.
+- **Flush rewrite rules only on activation**, after registering — never on `init`.
+
+```php
+add_action( 'init', function () {
+    register_post_type( 'myplugin_item', array(
+        'public' => true, 'show_in_rest' => true, 'has_archive' => true,
+        'supports' => array( 'title', 'editor' ),
+        'rewrite' => array( 'slug' => 'myplugin-item' ),
+        'labels' => array( 'name' => 'Items', 'singular_name' => 'Item' ),
+    ) );
+} );
+```
+
+Gotchas: `flush_rewrite_rules()` on `init` runs every request — activation only. Without
+`show_in_rest` the type uses the classic editor and is invisible to REST/Gutenberg.
+
+## 5. Custom taxonomies
+
+Source: https://developer.wordpress.org/plugins/taxonomies/ (+ working-with / registering)
+
+**RULES**
+- `register_taxonomy( $taxonomy, $object_types, $args )` on `init`; register before/with the post
+  types it attaches to.
+- Key ≤ 32 chars, lowercase, prefixed. Args: `hierarchical`, `labels`, **`show_in_rest`**,
+  `rewrite`, `public`, `show_ui`, `show_admin_column`, `query_var`.
+- Associate later with `register_taxonomy_for_object_type( $taxonomy, $post_type )`.
+
+```php
+add_action( 'init', function () {
+    register_taxonomy( 'myplugin_topic', array( 'post', 'myplugin_item' ), array(
+        'hierarchical' => true, 'show_in_rest' => true, 'show_admin_column' => true,
+        'rewrite' => array( 'slug' => 'myplugin-topic' ),
+        'labels' => array( 'name' => 'Topics', 'singular_name' => 'Topic' ),
+    ) );
+} );
+```
+
+Gotchas: URL-affecting taxonomies need a rewrite flush on activation (not `init`). `show_in_rest`
+required for the block-editor sidebar.
+
+## Cross-cutting principles
+
+1. Prefix everything — options, meta keys, CPT/taxonomy keys.
+2. `show_in_rest` is the Gutenberg gate (settings, meta, CPT, taxonomy).
+3. Never `flush_rewrite_rules()` on `init` — activation only.
+4. Settings API gives nonce + capability handling free; raw meta boxes do not.

--- a/skills/wordpress-plugin-development/references/hooks-paths-uploads-rest.md
+++ b/skills/wordpress-plugin-development/references/hooks-paths-uploads-rest.md
@@ -1,0 +1,578 @@
+# WordPress.org Plugin Review: Common Rejection Patterns Reference
+
+A consolidated guide for plugin authors covering hooks, path resolution, the Settings API, the uploads directory, file upload helpers, and REST API permission callbacks. Aimed at avoiding the most frequent reasons plugins are kicked back during wp.org review.
+
+---
+
+## 1. Hooks (Actions + Filters)
+
+WordPress exposes two hook types. Both are registered with a callable, but they have very different contracts.
+
+### Actions vs. filters at a glance
+
+| Aspect | Action | Filter |
+|---|---|---|
+| Purpose | Run side-effect code at a chosen moment | Transform a value and return it |
+| Return value | Ignored | Required — must return modified data |
+| Registered with | `add_action()` | `add_filter()` |
+| Fired by | `do_action()` (in core or your code) | `apply_filters()` |
+
+### Registering an action
+
+```php
+add_action( 'init', 'myplugin_bootstrap' );
+
+function myplugin_bootstrap() {
+    // Runs once WordPress has finished loading plugins and is ready.
+}
+```
+
+The signature is:
+
+```php
+add_action( string $hook_name, callable $callback, int $priority = 10, int $accepted_args = 1 );
+```
+
+A lower `$priority` runs earlier. If a hook passes multiple arguments, bump `$accepted_args` so your callback receives them:
+
+```php
+add_action( 'save_post', 'myplugin_on_save', 10, 2 );
+
+function myplugin_on_save( $post_id, $post ) {
+    // ...
+}
+```
+
+### Registering a filter
+
+```php
+add_filter( 'the_title', 'myplugin_decorate_title' );
+
+function myplugin_decorate_title( $title ) {
+    return '[Featured] ' . $title; // Always return — never echo.
+}
+```
+
+A filter must be free of side effects. Don't write to options, don't echo, don't redirect — just return the (possibly modified) value.
+
+### Why core files must NOT be loaded with plain `include`
+
+A frequent review rejection is plugins that top-level `include` core files like `wp-load.php`, `wp-admin/includes/file.php`, or `wp-blog-header.php` from the plugin's main file. This breaks because:
+
+1. The main plugin file is loaded by WordPress itself — by the time it runs, core *is* already loading. Re-including bootstraps it twice.
+2. Plugins are sometimes loaded out of band (CLI, must-use plugins, network activation). A hard `include` of an admin file fatals on the front-end.
+3. Direct includes bypass the hook system, so other plugins/themes can't intercept anything.
+
+The same anti-pattern applies inside REST route handlers, shortcode callbacks, and `the_content` filter callbacks — these should **register** themselves via hooks, then load any required core files lazily inside the callback (only when needed):
+
+```php
+// WRONG — runs on every page load, even front-end requests.
+require_once ABSPATH . 'wp-admin/includes/file.php';
+require_once ABSPATH . 'wp-admin/includes/media.php';
+
+add_action( 'rest_api_init', function () {
+    register_rest_route( 'myplugin/v1', '/upload', [
+        'methods'             => 'POST',
+        'callback'            => 'myplugin_rest_upload',
+        'permission_callback' => function () { return current_user_can( 'upload_files' ); },
+    ] );
+} );
+
+// RIGHT — load only inside the handler.
+function myplugin_rest_upload( WP_REST_Request $request ) {
+    require_once ABSPATH . 'wp-admin/includes/file.php';
+    require_once ABSPATH . 'wp-admin/includes/media.php';
+    // ... handle upload ...
+}
+```
+
+### Never `define()` core constants
+
+`ABSPATH`, `WP_CONTENT_DIR`, `WPINC`, `WP_PLUGIN_DIR`, and similar constants are owned by core. A plugin that defines them:
+
+- Will fatal if the constant is already defined (which it almost always is).
+- If guarded with `defined()`, will silently change core behavior on rare bootstrap paths.
+- Will fail review on sight.
+
+```php
+// NEVER do this in a plugin.
+if ( ! defined( 'ABSPATH' ) ) {
+    define( 'ABSPATH', dirname( __FILE__ ) . '/' );
+}
+```
+
+The single legitimate use of `ABSPATH` in plugin code is the front-matter direct-access guard at the top of every PHP file:
+
+```php
+<?php
+defined( 'ABSPATH' ) || exit;
+```
+
+### "I need code to run only when WP is loaded"
+
+Use a hook. Pick the earliest one whose contract matches your needs:
+
+| Hook | When it fires | Use for |
+|---|---|---|
+| `plugins_loaded` | All active plugins loaded | Loading your own files, instantiating your bootstrap class |
+| `init` | WP core fully initialized; user not yet resolved on front-end | Registering post types, taxonomies, shortcodes, REST routes (via `rest_api_init`), blocks |
+| `wp_loaded` | Everything (plugins + theme + init) done | Final wiring that depends on theme being loaded |
+| `admin_init` | Admin-only equivalent of `init` | Settings API registration, admin-only checks |
+
+```php
+// Main plugin file
+add_action( 'plugins_loaded', 'myplugin_load' );
+
+function myplugin_load() {
+    require_once __DIR__ . '/includes/class-myplugin.php';
+    MyPlugin::instance();
+}
+```
+
+---
+
+## 2. Determining Plugin and Content Paths
+
+Hardcoded paths are the second-most-common rejection cause. Users can move `wp-content`, rename it, symlink it, run multisite with subdirectories, or rename your plugin's own folder.
+
+### The four canonical functions
+
+```php
+// 1. Filesystem path to YOUR plugin's directory, with trailing slash.
+$dir = plugin_dir_path( __FILE__ );
+// → /var/www/html/wp-content/plugins/my-plugin/
+
+// 2. URL to YOUR plugin's directory, with trailing slash.
+$url = plugin_dir_url( __FILE__ );
+// → https://example.com/wp-content/plugins/my-plugin/
+
+// 3. URL to an asset inside YOUR plugin.
+$asset = plugins_url( 'assets/logo.png', __FILE__ );
+// → https://example.com/wp-content/plugins/my-plugin/assets/logo.png
+
+// 4. __FILE__ — the magic constant resolved by PHP, used as the anchor.
+```
+
+Always pass `__FILE__` (from the main plugin file or a file that *knows* its location) as the second argument. That's how these helpers resolve symlinks and renamed `wp-content` directories correctly.
+
+### Enqueueing assets the right way
+
+```php
+add_action( 'wp_enqueue_scripts', 'myplugin_assets' );
+
+function myplugin_assets() {
+    wp_enqueue_style(
+        'myplugin',
+        plugins_url( 'css/myplugin.css', MYPLUGIN_FILE ),
+        [],
+        MYPLUGIN_VERSION
+    );
+    wp_enqueue_script(
+        'myplugin',
+        plugins_url( 'js/myplugin.js', MYPLUGIN_FILE ),
+        [ 'jquery' ],
+        MYPLUGIN_VERSION,
+        true
+    );
+}
+```
+
+### Why `WP_PLUGIN_URL . '/my-plugin'` is fragile
+
+It looks like it should work, but it breaks under any of these conditions:
+
+- The user renamed the plugin folder (allowed — wp.org slug isn't enforced post-install).
+- `wp-content` was renamed via `WP_CONTENT_DIR` / `WP_CONTENT_URL`.
+- `wp-content/plugins` is symlinked from outside the web root.
+- The site runs in a multisite where `WP_PLUGIN_URL` resolves differently than expected.
+- The user has `WP_PLUGIN_DIR` defined to a non-standard location.
+
+`plugins_url( 'asset', __FILE__ )` handles all of these correctly because it resolves from your file's actual location.
+
+### Recommended: define constants in the main plugin file
+
+```php
+<?php
+/**
+ * Plugin Name: My Plugin
+ */
+defined( 'ABSPATH' ) || exit;
+
+define( 'MYPLUGIN_VERSION', '1.0.0' );
+define( 'MYPLUGIN_FILE',    __FILE__ );
+define( 'MYPLUGIN_DIR',     plugin_dir_path( __FILE__ ) ); // trailing slash
+define( 'MYPLUGIN_URL',     plugin_dir_url( __FILE__ ) );  // trailing slash
+define( 'MYPLUGIN_BASENAME', plugin_basename( __FILE__ ) ); // 'my-plugin/my-plugin.php'
+
+require_once MYPLUGIN_DIR . 'includes/bootstrap.php';
+```
+
+Other files in the plugin can now use these constants and don't need their own `__FILE__` anchoring.
+
+### `get_theme_root()` vs. `WP_CONTENT_DIR . '/themes'`
+
+These are *not* equivalent.
+
+- `WP_CONTENT_DIR . '/themes'` assumes the canonical layout. It will be wrong if the site uses `register_theme_directory()` to register extra theme folders, or if a multisite child has its own theme root.
+- `get_theme_root()` (and `get_theme_root_uri()`) return the active theme root for the current request, honoring filters like `theme_root` and `theme_root_uri`.
+
+```php
+// WRONG — assumes one fixed theme directory.
+$themes_dir = WP_CONTENT_DIR . '/themes';
+
+// RIGHT
+$themes_dir = get_theme_root();
+$themes_url = get_theme_root_uri();
+```
+
+---
+
+## 3. Settings API
+
+Plugin settings must be stored in `wp_options` (or `wp_sitemeta` for network options), not in files inside the plugin folder. The plugin directory is wiped on upgrade, world-readable over HTTP, and not writable on many hosts.
+
+### The workflow
+
+```php
+add_action( 'admin_init', 'myplugin_register_settings' );
+
+function myplugin_register_settings() {
+
+    // 1. Register the option (lives in wp_options as 'myplugin_options').
+    register_setting(
+        'myplugin_group',          // option group — used by settings_fields()
+        'myplugin_options',        // option name in wp_options
+        [
+            'type'              => 'array',
+            'sanitize_callback' => 'myplugin_sanitize_options',
+            'default'           => [ 'enabled' => false, 'api_key' => '' ],
+        ]
+    );
+
+    // 2. A visual section on the settings page.
+    add_settings_section(
+        'myplugin_section_main',
+        __( 'Main settings', 'myplugin' ),
+        'myplugin_section_main_intro',
+        'myplugin'                 // page slug
+    );
+
+    // 3. Individual fields inside the section.
+    add_settings_field(
+        'myplugin_field_enabled',
+        __( 'Enable feature', 'myplugin' ),
+        'myplugin_render_enabled',
+        'myplugin',                // same page slug
+        'myplugin_section_main'
+    );
+}
+
+function myplugin_section_main_intro() {
+    echo '<p>' . esc_html__( 'Configure plugin behavior.', 'myplugin' ) . '</p>';
+}
+
+function myplugin_render_enabled() {
+    $options = get_option( 'myplugin_options', [] );
+    $checked = ! empty( $options['enabled'] );
+    printf(
+        '<input type="checkbox" name="myplugin_options[enabled]" value="1" %s>',
+        checked( $checked, true, false )
+    );
+}
+```
+
+### Sanitize / validate callback
+
+The sanitize callback runs every time the option is saved. It receives the raw `$_POST` value and must return the cleaned value.
+
+```php
+function myplugin_sanitize_options( $input ) {
+    $output = [];
+    $output['enabled'] = ! empty( $input['enabled'] );
+    $output['api_key'] = isset( $input['api_key'] )
+        ? sanitize_text_field( $input['api_key'] )
+        : '';
+    if ( $output['api_key'] !== '' && ! preg_match( '/^[A-Za-z0-9_-]{20,64}$/', $output['api_key'] ) ) {
+        add_settings_error(
+            'myplugin_options',
+            'invalid_key',
+            __( 'API key format is invalid.', 'myplugin' )
+        );
+        $output['api_key'] = ''; // reject the bad value
+    }
+    return $output;
+}
+```
+
+### Rendering the form page
+
+```php
+function myplugin_render_settings_page() {
+    if ( ! current_user_can( 'manage_options' ) ) {
+        return;
+    }
+    ?>
+    <div class="wrap">
+        <h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
+        <form action="options.php" method="post">
+            <?php
+            settings_fields( 'myplugin_group' );   // nonce + option_page hidden inputs
+            do_settings_sections( 'myplugin' );    // renders sections + fields
+            submit_button();
+            ?>
+        </form>
+    </div>
+    <?php
+}
+```
+
+### Why store config in `wp_options` and not in plugin files
+
+- The plugin directory is overwritten on update — config written there is lost.
+- Plugin files are served over HTTP; anything written there leaks (API keys, secrets).
+- Many hosts mark `wp-content/plugins` read-only.
+- Backups and migration tools expect site config in the database.
+
+For per-site options on multisite use `get_option()`/`update_option()`. For network-wide settings use `get_site_option()`/`update_site_option()`.
+
+---
+
+## 4. Where to Write Files
+
+Plugin code that needs to write to disk should *always* go through `wp_upload_dir()` — never write to your own plugin folder.
+
+### `wp_upload_dir()` return value
+
+`wp_upload_dir( $time = null, $create_dir = true, $refresh_cache = false )` returns an associative array:
+
+| Key | Meaning | Example |
+|---|---|---|
+| `path` | Absolute filesystem path to the *current month's* uploads dir | `/var/www/wp-content/uploads/2026/05` |
+| `url` | URL matching `path` | `https://example.com/wp-content/uploads/2026/05` |
+| `subdir` | The relative slice (year/month or empty) | `/2026/05` |
+| `basedir` | Absolute path to the uploads root (no year/month) | `/var/www/wp-content/uploads` |
+| `baseurl` | URL matching `basedir` | `https://example.com/wp-content/uploads` |
+| `error` | `false` on success, error string on failure | `false` |
+
+Pass `$time` as `'YYYY/MM'` to get paths for a specific month. Year/month bucketing only happens if the site has "Organize my uploads into month- and year-based folders" enabled in Settings → Media; otherwise `path` equals `basedir` and `subdir` is empty.
+
+### Multisite behavior
+
+On multisite, each subsite gets its own uploads directory by default — typically `wp-content/uploads/sites/{blog_id}/`. `wp_upload_dir()` returns the *current* site's uploads, so subsite plugin code automatically writes to the right place. To target the main site explicitly, wrap the call in `switch_to_blog( get_main_site_id() )` / `restore_current_blog()`.
+
+### Recommended pattern: a plugin-specific subdir inside uploads
+
+```php
+function myplugin_storage_dir() {
+    $upload = wp_upload_dir();
+    if ( ! empty( $upload['error'] ) ) {
+        return new WP_Error( 'upload_dir', $upload['error'] );
+    }
+    $dir = trailingslashit( $upload['basedir'] ) . 'myplugin';
+    if ( ! file_exists( $dir ) ) {
+        wp_mkdir_p( $dir );
+        // Block directory listing.
+        @file_put_contents( $dir . '/index.php', "<?php\n// Silence is golden.\n" );
+    }
+    if ( ! is_writable( $dir ) ) {
+        return new WP_Error( 'not_writable', 'Plugin storage dir is not writable.' );
+    }
+    return $dir;
+}
+
+function myplugin_storage_url() {
+    $upload = wp_upload_dir();
+    return trailingslashit( $upload['baseurl'] ) . 'myplugin';
+}
+```
+
+### Why writing to the plugin folder is forbidden
+
+- Auto-update wipes the entire plugin directory and re-extracts the ZIP. Anything you wrote there is gone.
+- Files inside `wp-content/plugins/your-plugin/` are served by the web server. Writing user data there exposes it (cache files with auth tokens, generated MP3s with private content, etc.).
+- Many production hosts make the plugins directory read-only; your write silently fails.
+- wp.org review will flag this immediately.
+
+### `wp_handle_upload()` vs. `media_handle_upload()`
+
+Use these instead of moving `$_FILES` yourself. They run all the security checks (MIME, extension blocklist, size, nonce optionally) and place the file under `wp_upload_dir()`.
+
+**`wp_handle_upload()`** — moves the file into uploads, returns metadata, but does *not* create a database row.
+
+```php
+if ( ! function_exists( 'wp_handle_upload' ) ) {
+    require_once ABSPATH . 'wp-admin/includes/file.php';
+}
+
+$result = wp_handle_upload(
+    $_FILES['my_file'],
+    [ 'test_form' => false ] // we're not inside an admin form, so skip the form action check
+);
+
+if ( isset( $result['error'] ) ) {
+    wp_die( esc_html( $result['error'] ) );
+}
+// $result = [ 'file' => '/abs/path', 'url' => '...', 'type' => 'image/png' ]
+```
+
+**`media_handle_upload()`** — calls `wp_handle_upload()` *and* creates an attachment post (so the file shows up in Media Library, gets sub-sizes generated, extracts EXIF/ID3, etc.).
+
+```php
+require_once ABSPATH . 'wp-admin/includes/image.php';
+require_once ABSPATH . 'wp-admin/includes/file.php';
+require_once ABSPATH . 'wp-admin/includes/media.php';
+
+$attachment_id = media_handle_upload( 'my_file', $post_id );
+
+if ( is_wp_error( $attachment_id ) ) {
+    wp_die( esc_html( $attachment_id->get_error_message() ) );
+}
+// $attachment_id is now a real attachment post ID.
+```
+
+Rule of thumb: if the uploaded file should appear in the Media Library, use `media_handle_upload()`. If it's an internal artifact (a cache file, a generated thumbnail or export file that you're storing per-post), use `wp_handle_upload()` or write directly via `wp_upload_dir()` + `wp_mkdir_p()`.
+
+### Permission and writability checks
+
+```php
+$upload = wp_upload_dir();
+
+if ( ! empty( $upload['error'] ) ) {
+    return new WP_Error( 'upload_dir', $upload['error'] );
+}
+if ( ! wp_is_writable( $upload['basedir'] ) ) {
+    return new WP_Error( 'not_writable', 'Uploads directory is not writable.' );
+}
+```
+
+Prefer `wp_is_writable()` over the raw PHP `is_writable()` — it handles a Windows-specific edge case where `is_writable()` reports incorrectly on read-only files.
+
+---
+
+## 5. REST API `permission_callback`
+
+The single most common REST-related rejection: omitting `permission_callback`, or setting it to `null`. Since WordPress 5.5 this triggers a `_doing_it_wrong` notice and may be hard-blocked in the future.
+
+### Signature
+
+```php
+register_rest_route(
+    string $namespace,   // e.g. 'myplugin/v1' — never just 'v1', never empty
+    string $route,       // e.g. '/items/(?P<id>\d+)'
+    array  $args         // methods, callback, permission_callback, args, ...
+);
+```
+
+Always register inside the `rest_api_init` action:
+
+```php
+add_action( 'rest_api_init', 'myplugin_register_routes' );
+
+function myplugin_register_routes() {
+    register_rest_route( 'myplugin/v1', '/items', [
+        'methods'             => WP_REST_Server::READABLE,    // GET
+        'callback'            => 'myplugin_get_items',
+        'permission_callback' => '__return_true',             // intentionally public
+    ] );
+
+    register_rest_route( 'myplugin/v1', '/items', [
+        'methods'             => WP_REST_Server::CREATABLE,   // POST
+        'callback'            => 'myplugin_create_item',
+        'permission_callback' => function () {
+            return current_user_can( 'edit_posts' );
+        },
+    ] );
+}
+```
+
+### Why `permission_callback` must always be set
+
+- It runs *before* your callback, so it's your one chance to reject unauthenticated/unauthorized requests cleanly.
+- Omitting it is treated as a programming error by core and surfaces in debug logs.
+- A `null` callback is treated the same as missing — it does **not** mean "public." Use `__return_true` for that.
+- Review reviewers grep for `register_rest_route` and check every result for a non-null permission callback.
+
+### `__return_true` for intentionally public endpoints
+
+Only use this when the data really is public-by-design (e.g. a published-post lookup that mirrors what the front-end already shows):
+
+```php
+'permission_callback' => '__return_true',
+```
+
+Add a code comment explaining *why* it's public — this helps reviewers and future you.
+
+### `current_user_can()` for protected endpoints
+
+Check capabilities, not roles. Capabilities are stable across role customizations and multisite super-admin overrides; role names aren't.
+
+```php
+// Admin-only endpoint.
+'permission_callback' => function () {
+    return current_user_can( 'manage_options' );
+},
+
+// Per-resource check (note the second arg).
+'permission_callback' => function ( WP_REST_Request $request ) {
+    $post_id = (int) $request['id'];
+    return current_user_can( 'edit_post', $post_id );
+},
+```
+
+Avoid checks like `wp_get_current_user()->roles[0] === 'administrator'` — they fail for super admins, custom roles, and multisite.
+
+### Nonces are separate from `permission_callback`
+
+The REST API authenticates logged-in cookie requests via the `X-WP-Nonce` header (or `_wpnonce` query param) with action `wp_rest`. The `permission_callback` checks *authorization* (can this user do the thing); the nonce checks *authenticity* (is the request really from a logged-in session). Both run — you don't manually call `wp_verify_nonce()` inside a REST callback for the standard cookie auth case.
+
+For non-cookie auth (Application Passwords, OAuth), the nonce isn't required; the auth header authenticates the user, and your `permission_callback` still runs.
+
+```js
+// Browser-side (admin or front-end with wp-api enqueued):
+wp.apiFetch( {
+    path: '/myplugin/v1/items',
+    method: 'POST',
+    data: { title: 'hello' }
+} );
+// apiFetch automatically attaches the X-WP-Nonce header.
+```
+
+### Return a `WP_Error` for custom denial messages
+
+```php
+'permission_callback' => function () {
+    if ( ! is_user_logged_in() ) {
+        return new WP_Error(
+            'rest_not_logged_in',
+            __( 'You must be logged in.', 'myplugin' ),
+            [ 'status' => 401 ]
+        );
+    }
+    if ( ! current_user_can( 'edit_posts' ) ) {
+        return new WP_Error(
+            'rest_forbidden',
+            __( 'You cannot edit items.', 'myplugin' ),
+            [ 'status' => 403 ]
+        );
+    }
+    return true;
+},
+```
+
+---
+
+## Quick rejection checklist
+
+Before you submit to wp.org, grep your plugin for these:
+
+- [ ] No `include`/`require` of `wp-load.php`, `wp-config.php`, or `wp-blog-header.php`.
+- [ ] No `define( 'ABSPATH', ... )` or other core constant definitions.
+- [ ] No hardcoded `wp-content/plugins/my-plugin/...` strings.
+- [ ] No `WP_PLUGIN_URL . '/my-plugin'` or `WP_PLUGIN_DIR . '/my-plugin'`.
+- [ ] No writes inside `plugin_dir_path( __FILE__ )` — use `wp_upload_dir()`.
+- [ ] Every `register_rest_route()` call has a non-null `permission_callback`.
+- [ ] Settings live in `wp_options` via `register_setting()`, not in plugin files.
+- [ ] Every option has a `sanitize_callback`.
+- [ ] All output is escaped (`esc_html`, `esc_attr`, `esc_url`, `wp_kses_post`).
+- [ ] All input is sanitized at entry (`sanitize_text_field`, `absint`, etc.).
+- [ ] File operations go through `wp_handle_upload()`, `media_handle_upload()`, or `WP_Filesystem`.

--- a/skills/wordpress-plugin-development/references/i18n-and-escaping.md
+++ b/skills/wordpress-plugin-development/references/i18n-and-escaping.md
@@ -1,0 +1,297 @@
+# WordPress.org Plugin Review: i18n and Output Escaping
+
+Rules-of-the-road extracted from the official WordPress developer docs. wp.org reviewers reject plugins that violate these — treat each rule as load-bearing.
+
+## Part 1 — Internationalization
+
+### 1.1 Why the rules are strict
+
+Gettext is a static-extraction system. Tools like `makepot`/WP-CLI's `i18n make-pot` scan source files with a parser, not a runtime. If a translatable string or its text domain is anything other than a string literal at the call site, the extractor cannot see it and the translation is lost. wp.org reviewers run the same tooling.
+
+### 1.2 The text domain rule
+
+The text domain **MUST be a single-quoted string literal** that exactly matches the plugin slug (folder name on wp.org). Lowercase, dashes only — no underscores, no spaces, no variables, no constants, no concatenation.
+
+```php
+// WRONG — variable as domain
+__( 'Save changes', $this->domain );
+
+// WRONG — constant as domain
+__( 'Save changes', TEXT_TO_AUDIO_TEXT_DOMAIN );
+
+// WRONG — underscores / wrong slug
+__( 'Save changes', 'text_to_audio' );
+
+// RIGHT
+__( 'Save changes', 'my-plugin' );
+```
+
+The plugin header should declare it (optional since 4.6 but recommended):
+
+```
+/* Text Domain: my-plugin */
+/* Domain Path: /languages */
+```
+
+### 1.3 The message-string rule
+
+The first argument **MUST be a string literal**. No variables, no concatenation, no ternaries, no `sprintf` inside the gettext call.
+
+```php
+// WRONG — interpolated variable
+__( "Hello $name", 'my-plugin' );
+
+// WRONG — concatenation
+__( 'Hello ' . $name, 'my-plugin' );
+
+// WRONG — variable as message
+__( $message, 'my-plugin' );
+
+// RIGHT — placeholder, formatted outside
+printf(
+    /* translators: %s: user display name */
+    esc_html__( 'Hello %s', 'my-plugin' ),
+    esc_html( $name )
+);
+```
+
+### 1.4 Full gettext function list
+
+Retrieval (return value):
+- `__( $text, $domain )` — translate, return
+- `_x( $text, $context, $domain )` — translate with disambiguation context
+- `_n( $single, $plural, $number, $domain )` — pluralized
+- `_nx( $single, $plural, $number, $context, $domain )` — plural + context
+- `_n_noop( $single, $plural, $domain )` — deferred plural for storage in arrays
+- `_nx_noop( $single, $plural, $context, $domain )` — deferred plural + context
+- `translate_nooped_plural( $nooped, $count, $domain )` — resolve a noop
+
+Echo variants: `_e()`, `_ex()`.
+
+Escape-and-translate (always prefer these in output contexts):
+- `esc_html__()`, `esc_html_e()`, `esc_html_x()`
+- `esc_attr__()`, `esc_attr_e()`, `esc_attr_x()`
+
+Locale-aware formatters: `number_format_i18n()`, `date_i18n()`.
+
+### 1.5 The `/* translators: */` comment
+
+Whenever a string contains `%s`, `%d`, `%1$s`, etc., place a translator comment immediately above the gettext call. wp.org and core both flag missing comments.
+
+```php
+/* translators: %s: number of files generated */
+$msg = sprintf( esc_html__( '%s files generated.', 'my-plugin' ), $count );
+
+/* translators: 1: post title, 2: author name */
+$msg = sprintf(
+    esc_html__( '%1$s by %2$s', 'my-plugin' ),
+    esc_html( $title ),
+    esc_html( $author )
+);
+```
+
+Use numbered placeholders (`%1$s`, `%2$s`) whenever there are two or more — translators must be able to reorder them.
+
+### 1.6 `load_plugin_textdomain()` and the 6.7+ notice
+
+Loader signature:
+
+```php
+add_action( 'init', 'myplugin_load_textdomain' );
+function myplugin_load_textdomain() {
+    load_plugin_textdomain(
+        'my-plugin',
+        false,
+        dirname( plugin_basename( __FILE__ ) ) . '/languages'
+    );
+}
+```
+
+Rules:
+- Hook on `init`, **never** earlier (`plugins_loaded` is now too early).
+- Do not call any gettext function before `init` fires. WordPress 6.7 introduced a `_doing_it_wrong` notice titled **"Translation loading triggered too early"** / `_load_textdomain_just_in_time` whenever a `__()`-family call runs before `init`. Common culprits: translatable strings in class constructors, in plugin-header bootstrap, in `register_activation_hook` callbacks, or inside files loaded by autoload.
+- For wp.org-hosted plugins with translations on translate.wordpress.org, the loader is technically optional from 4.6+, but keeping it is harmless and supports sideloaded `.mo`/`.l10n.php` files.
+
+### 1.7 Common mistakes reviewers reject
+
+| Mistake | Fix |
+| --- | --- |
+| Variable as text — `__( $msg, ... )` | Hard-code the literal, parameterize with `%s` |
+| Variable as domain — `__( 'x', $domain )` | Hard-code `'my-plugin'` |
+| Mismatched domain across files | Grep the whole plugin; one literal everywhere |
+| Missing escape wrapper in output — `_e( ... )` inside HTML | Use `esc_html_e()` / `esc_attr_e()` |
+| Concatenating two `__()` calls | Use one string with placeholders |
+| Empty string `__( '', ... )` | Never translate the empty string (returns metadata) |
+| `\r\n` line endings in messages | Use `\n` only |
+| Calling gettext before `init` | Defer; or wrap in an `init`-hooked callback |
+
+---
+
+## Part 2 — Output Escaping
+
+### 2.1 Late-escape rule
+
+Escape at the point of output. Not at assignment, not at function entry, not in a helper four calls up. Reviewers and static scanners verify the **last expression before `echo`/`return`**.
+
+```php
+// WRONG — escaped early, mutated later
+$url = esc_url( $raw_url );
+$url .= '?token=' . $token;          // now unsafe again
+echo '<a href="' . $url . '">';
+
+// RIGHT
+echo '<a href="' . esc_url( $raw_url . '?token=' . $token ) . '">';
+```
+
+### 2.2 The four primary families
+
+| Function | Use for | Example |
+| --- | --- | --- |
+| `esc_html()` | Text between tags | `<p><?php echo esc_html( $title ); ?></p>` |
+| `esc_attr()` | Quoted attribute values | `<div class="<?php echo esc_attr( $cls ); ?>">` |
+| `esc_url()` | `href`, `src`, `action`, any URL | `<a href="<?php echo esc_url( $u ); ?>">` |
+| `esc_js()` | Inline JS string literals / `data-json` | `<button onclick="doX('<?php echo esc_js( $v ); ?>')">` |
+
+Also: `esc_textarea()` for textareas, `esc_xml()` / `ent2ncr()` for XML feeds.
+
+```php
+// WRONG — esc_attr on a URL strips/encodes incorrectly and misses URL-specific filtering
+<a href="<?php echo esc_attr( $url ); ?>">
+
+// RIGHT
+<a href="<?php echo esc_url( $url ); ?>">
+```
+
+### 2.3 Translate + escape combos
+
+Inside HTML output always prefer the escape-aware variant. `_e()` and `__()` alone in markup is a review flag.
+
+```php
+// WRONG
+<button><?php _e( 'Submit', 'my-plugin' ); ?></button>
+<input value="<?php _e( 'Save', 'my-plugin' ); ?>">
+
+// RIGHT
+<button><?php esc_html_e( 'Submit', 'my-plugin' ); ?></button>
+<input value="<?php esc_attr_e( 'Save', 'my-plugin' ); ?>">
+
+// With context disambiguation
+<th><?php echo esc_html_x( 'Post', 'column header', 'my-plugin' ); ?></th>
+```
+
+### 2.4 When `wp_kses_post()` / `wp_kses()` is correct
+
+Use these only when you need to **emit HTML you do not control** but want to preserve a known-safe subset. Stripping with `esc_html()` would mangle markup, so you allow-list instead.
+
+Good fits:
+- Freemius notice/dialog HTML returned by the SDK
+- Admin notice bodies that legitimately include `<a>`, `<strong>`, `<code>`
+- Button HTML assembled from settings that may include an `<svg>` icon
+
+```php
+// Freemius / notice content — allow post-grade HTML
+echo wp_kses_post( $freemius_message );
+
+// Tight allow-list for a specific surface
+echo wp_kses(
+    $snippet,
+    array(
+        'a'      => array( 'href' => array(), 'title' => array(), 'rel' => array() ),
+        'strong' => array(),
+        'em'     => array(),
+        'br'     => array(),
+    )
+);
+```
+
+Never use `wp_kses_post()` as a lazy "escape everything" — it permits `<a>`, `<img>`, inline styles, etc.
+
+### 2.5 Shortcode callbacks
+
+Shortcodes **return** their output (do not echo). The returned string is inserted into post content verbatim by `do_shortcode()` — your callback is responsible for escaping every dynamic piece.
+
+```php
+// WRONG — raw attribute interpolated into HTML
+function myplugin_button( $atts ) {
+    return '<button class="' . $atts['class'] . '">Click me</button>';
+}
+
+// RIGHT
+function myplugin_button( $atts ) {
+    $atts = shortcode_atts( array( 'class' => '' ), $atts, 'myplugin_button' );
+    return sprintf(
+        '<button class="%s">%s</button>',
+        esc_attr( $atts['class'] ),
+        esc_html__( 'Click me', 'my-plugin' )
+    );
+}
+```
+
+### 2.6 `the_content` filter callbacks
+
+Anything appended to `the_content` is echoed inside post HTML. Escape the dynamic parts; allow-list any HTML you assemble.
+
+```php
+add_filter( 'the_content', 'myplugin_prepend_button' );
+function myplugin_prepend_button( $content ) {
+    $button = sprintf(
+        '<button data-id="%d">%s</button>',
+        (int) get_the_ID(),
+        esc_html__( 'Read more', 'my-plugin' )
+    );
+    return $button . $content;   // $content is already filtered/escaped by core
+}
+```
+
+### 2.7 Block `render_callback`
+
+Server-rendered blocks return a string of HTML. Same rule as shortcodes — escape every attribute, allow-list any rich HTML.
+
+```php
+function myplugin_render_block( $attributes ) {
+    $label = isset( $attributes['label'] ) ? $attributes['label'] : '';
+    $color = isset( $attributes['color'] ) ? $attributes['color'] : '#000';
+
+    return sprintf(
+        '<div class="myplugin-block" style="color:%1$s">%2$s</div>',
+        esc_attr( $color ),
+        esc_html( $label )
+    );
+}
+```
+
+### 2.8 XSS vectors a reviewer will probe
+
+- `$_GET` / `$_POST` / `$_REQUEST` / `$_SERVER['REQUEST_URI']` echoed without escaping
+- Settings values printed in admin forms without `esc_attr()`
+- User-supplied URLs (`href`, `src`, redirect targets) not run through `esc_url()`
+- AJAX/REST responses that echo HTML built from request input
+- Translation calls inside HTML without the `esc_*_e` wrapper (translators can become an injection vector)
+- JSON blobs in `data-*` attributes without `esc_attr()` (and `wp_json_encode()` — never raw `json_encode`)
+- Inline `<script>var x = <?php echo $v; ?>` — use `wp_json_encode()` plus `esc_js()` if interpolated
+- Admin notices built from option values — wrap with `wp_kses_post()` or escape per-field
+
+### 2.9 Quick decision tree
+
+```
+Output is text inside tags?            esc_html / esc_html_e
+Output is an attribute value?          esc_attr / esc_attr_e
+Output is a URL?                       esc_url
+Output is inline JS or JSON-in-attr?   esc_js (and wp_json_encode for objects)
+Output is trusted-shape HTML?          wp_kses_post  (or wp_kses with allow-list)
+Output is from the_content?            already escaped — do not double-escape
+```
+
+---
+
+## Part 3 — Combined checklist before submitting to wp.org
+
+- [ ] Every `__`/`_e`/`_n`/`_x` call uses a single string literal as message and `'<slug>'` as domain
+- [ ] No gettext call fires before `init` (no 6.7 just-in-time notice in `debug.log`)
+- [ ] Every `%s`/`%d` string has a `/* translators: */` comment
+- [ ] Every HTML output context uses an `esc_*` function on dynamic data
+- [ ] No `_e()` or bare `__()` left inside template HTML
+- [ ] `esc_url()` (not `esc_attr()`) on every URL attribute
+- [ ] `wp_kses_post()` only where rich HTML is intentional (Freemius, button HTML)
+- [ ] Shortcode and block render callbacks return fully escaped strings
+- [ ] No `$_GET`/`$_POST` echoed without escape + nonce + capability check

--- a/skills/wordpress-plugin-development/references/plugin-check-and-prefixing.md
+++ b/skills/wordpress-plugin-development/references/plugin-check-and-prefixing.md
@@ -1,0 +1,369 @@
+# Plugin Check + Library Prefixing — Reference
+
+A field guide for shipping a plugin that survives the wp.org review queue. Covers the Plugin Check tool, how the review team operates, and how to prefix vendored PHP libraries so your plugin does not break sites that ship other plugins using the same dependency.
+
+---
+
+## Plugin Check (PCP)
+
+### What it is
+
+Plugin Check is the WordPress.org-published tool that runs the same automated checks the review team runs against submissions. It does not replace the human reviewer, but every modern rejection email leans on its output, and the team confirmed in October 2025 that PCP now runs automatic security scans on every plugin **update** as well as new submissions. If your build fails PCP locally, expect the review team's internal scanner to fail it the same way.
+
+The plugin is published by WordPress.org, requires WordPress 6.3+ and PHP 7.4+, and is developed in the open at https://github.com/WordPress/plugin-check/.
+
+### Installing
+
+```bash
+# WP admin
+# Plugins > Add New > search "Plugin Check" > Install > Activate
+
+# wp-cli on a working site
+wp plugin install plugin-check --activate
+
+# From GitHub (latest trunk, useful if you want the bleeding-edge checks)
+git clone https://github.com/WordPress/plugin-check.git wp-content/plugins/plugin-check
+wp plugin activate plugin-check
+```
+
+### Running before submission
+
+From the admin UI: `Tools > Plugin Check`. You need `manage_plugins` capability. The screen lets you pick which check categories to run, run them, and export results as CSV / JSON / Markdown or Excel.
+
+From the CLI:
+
+```bash
+# Check an installed plugin by main file or slug
+wp plugin check hello.php
+wp plugin check my-plugin
+
+# Check a plugin from disk that is not installed
+wp plugin check /path/to/my-plugin
+
+# Check from a URL
+wp plugin check https://example.com/my-plugin.zip
+
+# Only static checks run by default under wp-cli.
+# To also run runtime checks, preload the plugin's cli.php:
+wp plugin check hello.php \
+  --require=./wp-content/plugins/plugin-check/cli.php
+
+# Filter by category, ignore specific sniff codes, get a stricter exit:
+wp plugin check my-plugin --categories=plugin_repo,security
+wp plugin check my-plugin --ignore-codes=WordPress.WP.I18n.MissingTranslatorsComment
+wp plugin check my-plugin --format=json --severity=7
+```
+
+### What it catches
+
+Checks are grouped into categories. The `plugin_repo` category is the one that maps to wp.org submission requirements; the rest are best-practice. Categories include:
+
+- **Plugin repo / general** — readme.txt presence, Stable Tag, plugin headers (Name, Plugin URI, Description, Author URI, Requires at least, Requires PHP, Requires Plugins), license validation (GPLv2+, Apache, MIT, ISC, MPL-2.0, WTFPL, Unlicense), trademark conflicts in slug/name, forbidden plugin headers, restricted contributors, "Tested up to" mismatch between header and readme.
+- **Security** — `WordPress.Security.ValidatedSanitizedInput` (missing sanitization), nonce verification including insecure `wp_verify_nonce()` usage, direct database queries that bypass `$wpdb` helpers, direct file access guards (`ABSPATH` constant), forbidden functions (`exec`, `passthru`, `proc_open`, `shell_exec`, `move_uploaded_file`, `eval`-flavored constructs), `ALLOW_UNFILTERED_UPLOADS` use, `parse_str()` without a second argument, `wp_safe_redirect` over `wp_redirect`.
+- **Internationalization** — text-domain mismatches, missing translator comments, `load_plugin_textdomain()` call (now warning — wp.org loads translations automatically).
+- **Performance** — non-blocking script enqueues (missing `defer`/`async`), enqueued styles size, enqueued resources from CDN.
+- **Accessibility** — image alt and labeling sniffs.
+- **Code quality / "prefixing"** — function and class name prefixing, restricted classes / functions, code obfuscation, heredoc/nowdoc usage, minified file detection, AI instructions / dev-only directories left in the ZIP, External Admin Menu Links, Plugin Update Checker (PUC) detection, mismatched "Tested up to" between plugin header and readme.
+
+### Reading pass / warn / error
+
+Output has three tiers:
+
+- **Error** — blocks approval if it is in the `plugin_repo` category. Fix before submitting.
+- **Warning** — best-practice issue. Some warnings are now upgraded to errors during human review (especially missing sanitization, missing escaping, trademark conflicts).
+- **Low severity error / warning** — surfaced with the CLI flag below.
+
+```bash
+# Show low-severity entries too
+wp plugin check my-plugin --include-low-severity
+```
+
+### Common warnings developers ignore that turn into rejections
+
+- **`WordPress.Security.ValidatedSanitizedInput`** on `$_GET` / `$_POST`. Flagged as a warning by PHPCS, treated as a hard block by reviewers.
+- **`WordPress.Security.EscapeOutput`** — every echoed value must pass through `esc_html`, `esc_attr`, `esc_url`, `wp_kses_post`, etc.
+- **Trademark in slug** — `woo-…`, `wp-…`, `wordpress-…`, `elementor-…`, `gutenberg-…`, brand names. Previously borderline names now fail.
+- **`load_plugin_textdomain()` still being called** — converted to a warning; reviewers still ask you to remove it.
+- **Forbidden / discouraged PHP functions** — `eval`, `create_function`, `assert`, `extract`, base64-encoded payloads (read as obfuscation).
+- **Minified JS / CSS without sources** — you must ship the readable source or it reads as obfuscation.
+- **External admin menu links** — top-level admin menu items that point off-site fail the check.
+- **PUC (Plugin Update Checker) calls** — wp.org does not allow self-updating plugins from the directory.
+- **"Tested up to" too low or too high** — must be the current major release, not a future one and not three versions behind.
+
+---
+
+## Plugins Team communications
+
+### Review process in brief
+
+1. You upload a ZIP at https://wordpress.org/plugins/developers/add/.
+2. The Internal Scanner (which embeds PCP) runs immediately. As of August 2025 the team reported that ~85% of first reviews are now automated.
+3. A human reviewer reads the scanner output and your code.
+4. You receive a reply from `plugins@wordpress.org`. Replies come from that address.
+5. You reply to the same email thread with a fixed ZIP attached, or push a new SVN tag and reply confirming the version number. Do not open a second submission; reply on the existing thread.
+
+### Where re-review requests go
+
+- Reply directly to the `plugins@wordpress.org` thread.
+- For policy clarifications (not your specific submission) use the comments on the relevant post at https://make.wordpress.org/plugins/ or the `#pluginreview` channel on the Making WordPress Slack.
+- The 500+ submissions/week throughput means turnaround is days to weeks, not hours. Do not nudge before five business days.
+
+### What has shifted recently
+
+- **July 2025** — readme.txt must be written in English as the base language. Localized readmes go through translate.wordpress.org, not the ZIP.
+- **August 2025** — Plugin Rollout (phased releases) launched, allowing 24-hour staggered auto-updates.
+- **October 2025** — PCP now runs automatic security reports on every plugin **update**, not just new submissions. Updates can now be flagged the same way submissions are.
+- **2025 retrospective** — 12,713 plugins reviewed (+40.6% YoY), 69.5% approval rate, 10+ new code-quality checks added (including prefixing) and 5+ new security checks (nonces, direct DB queries, forbidden functions, minified-file detection, `wp_safe_redirect`).
+
+---
+
+## Why prefix vendored PHP libraries
+
+### The shared-execution-space problem
+
+Every active plugin loads into the same PHP process. If plugin A bundles Guzzle 5 under the `GuzzleHttp\` namespace and plugin B bundles Guzzle 7 under the **same** namespace, whichever loads first wins. The loser either gets the wrong class definitions and crashes with `Fatal error: Cannot declare class GuzzleHttp\Client, because the name is already in use`, or worse, silently calls methods with mismatched signatures.
+
+This is the single most common cause of "site went white after activating your plugin" support tickets, and the wp.org code-quality "prefixing" check exists specifically to flag it.
+
+### When prefixing is required vs not
+
+- **Required**: any third-party library you ship under `vendor/` — Freemius SDK, Guzzle, Monolog, Symfony components, league/* packages, action-scheduler when bundled, anything you `composer require`d that is not WordPress core.
+- **Not required**: your own code that already lives under a unique vendor namespace (e.g. `MyCompany\MyPlugin\…`). PSR-4 namespaces you control are fine.
+- **Not required**: dependencies that WordPress core already ships (don't bundle them at all — there's an explicit check for re-bundling core libraries).
+
+### The class_exists / function_exists fallback pattern
+
+For a single small helper you don't want to prefix, you can guard it:
+
+```php
+if ( ! class_exists( '\\Acme\\Helper' ) ) {
+    require_once __DIR__ . '/lib/helper.php';
+}
+
+if ( ! function_exists( 'acme_format_money' ) ) {
+    require_once __DIR__ . '/lib/format-money.php';
+}
+```
+
+This is a poor substitute for prefixing because:
+
+- The version that wins is whichever plugin loads first — usually arbitrary.
+- If two plugins ship different API surfaces under the same class name, one of them will crash at call sites.
+- It does not work for namespaced classes with autoloaders — by the time `class_exists` fires, the autoloader may already have committed.
+
+Use it only for tiny, version-stable helpers. For real dependencies, prefix.
+
+---
+
+## Strauss (recommended for new projects)
+
+Strauss is the maintained successor to Mozart. It prefixes namespaces, classnames, and constants in your `vendor/` tree into a separate output directory so each plugin ships its own isolated copy.
+
+### Install
+
+```bash
+composer require --dev brianhenryie/strauss
+```
+
+### composer.json config
+
+```json
+{
+  "require": {
+    "freemius/wordpress-sdk": "^2.7"
+  },
+  "require-dev": {
+    "brianhenryie/strauss": "^0.20"
+  },
+  "extra": {
+    "strauss": {
+      "target_directory": "vendor-prefixed",
+      "namespace_prefix": "Acme\\MyPlugin\\Dependencies\\",
+      "classmap_prefix": "Acme_MyPlugin_",
+      "constant_prefix": "ACME_MYPLUGIN_",
+      "packages": [],
+      "update_call_sites": false,
+      "include_root_autoload": false,
+      "optimize_autoloader": true,
+      "exclude_from_copy": {
+        "packages": [],
+        "namespaces": [],
+        "file_patterns": []
+      },
+      "exclude_from_prefix": {
+        "packages": [],
+        "namespaces": [],
+        "file_patterns": []
+      },
+      "delete_vendor_packages": true,
+      "delete_vendor_files": false
+    }
+  },
+  "scripts": {
+    "prefix-namespaces": [
+      "strauss",
+      "@php composer dump-autoload"
+    ],
+    "post-install-cmd": ["@prefix-namespaces"],
+    "post-update-cmd": ["@prefix-namespaces"]
+  }
+}
+```
+
+Key keys:
+
+- `namespace_prefix` — the namespace every PSR-4 class in vendor gets nested under.
+- `target_directory` — where prefixed copies are written. Ship this directory; `.distignore` the original `vendor/`.
+- `classmap_prefix` — prefix for non-namespaced (legacy) classes.
+- `constant_prefix` — prefix for `define()`d global constants.
+- `delete_vendor_files` / `delete_vendor_packages` — clean the original `vendor/` after copying so you can't accidentally autoload both.
+
+### Running
+
+```bash
+# After composer install, this runs automatically via the post-install-cmd hook.
+# Manual invocation:
+vendor/bin/strauss
+composer prefix-namespaces
+
+# Dry run to see what would change:
+vendor/bin/strauss --dry-run
+```
+
+### What it handles
+
+Classes, traits, interfaces, function-style files (Composer `files` autoloaders), and global constants. License files are preserved.
+
+---
+
+## Mozart (legacy)
+
+Mozart was the original tool. It still works, but most new WordPress plugins are migrating to Strauss for the unified output dir and `files` autoloader support.
+
+```json
+{
+  "require-dev": {
+    "coenjacobs/mozart": "^1.2"
+  },
+  "extra": {
+    "mozart": {
+      "dep_namespace": "Acme\\MyPlugin\\Dependencies\\",
+      "dep_directory": "/vendor-prefixed/",
+      "classmap_directory": "/vendor-prefixed/classes/",
+      "classmap_prefix": "Acme_MyPlugin_",
+      "packages": [
+        "freemius/wordpress-sdk"
+      ],
+      "excluded_packages": [],
+      "delete_vendor_directories": true
+    }
+  }
+}
+```
+
+Run with `vendor/bin/mozart compose`. Strauss configuration concepts map almost 1:1 — you can migrate by renaming `dep_namespace` → `namespace_prefix`, `dep_directory` → `target_directory`, etc.
+
+---
+
+## PHP-Scoper
+
+PHP-Scoper takes a different angle: rather than copy-and-prefix selected packages, it scopes an **entire build artifact** (typically a PHAR, but also a plain `build/` directory) so every namespace inside the artifact gets a generated prefix.
+
+```bash
+composer require --dev humbug/php-scoper
+
+# Or via PHAR
+wget https://github.com/humbug/php-scoper/releases/latest/download/php-scoper.phar
+```
+
+`scoper.inc.php`:
+
+```php
+<?php
+use Isolated\Symfony\Component\Finder\Finder;
+
+return [
+    'prefix' => 'AcmeMyPluginScoped',
+    'finders' => [
+        Finder::create()
+            ->files()
+            ->in('vendor')
+            ->name('*.php'),
+    ],
+    'exclude-namespaces' => [
+        'WP_',
+        'WordPress\\',
+    ],
+    'exclude-classes' => ['/^WP_/'],
+    'exclude-functions' => ['/^wp_/'],
+    'exclude-constants' => ['/^WP_/', '/^ABSPATH$/'],
+];
+```
+
+Run:
+
+```bash
+php-scoper add-prefix --output-dir=build/scoped
+php-scoper inspect path/to/some-file.php
+```
+
+Best for plugins that ship many libraries or a real PHAR. More setup overhead than Strauss: you write the finder, manage the build output, and re-run autoloader generation against the scoped directory. The PHP-Scoper docs explicitly recommend end-to-end testing of the scoped artifact before release because scoping touches more surface area than Strauss does.
+
+---
+
+## When to use which
+
+- **Strauss** — default recommendation for WordPress plugins with a small `vendor/` (1–10 packages). Composer-native, prefixes only what you tell it to, leaves your own source untouched.
+- **PHP-Scoper** — large plugins shipping dozens of libraries, plugins that build a PHAR, plugins where you want everything in vendor scoped including transitive deps you didn't list explicitly.
+- **Manual prefixing + `class_exists` guards** — tiny plugins with one or two hand-vendored helper files where the overhead of a composer pipeline isn't worth it.
+- **Mozart** — only if you have an existing Mozart pipeline that works. New projects: skip it.
+
+---
+
+## Concrete Freemius example
+
+Freemius SDK is the single most common source of "PHP library conflicts" warnings on wp.org reviews. Every paid plugin using Freemius ships its own copy of the same SDK; without prefixing, the first plugin to load wins and the rest silently hit the wrong SDK code, breaking license activation in ways that look like Freemius bugs but are not.
+
+### Prefixing Freemius with Strauss
+
+```json
+{
+  "require": {
+    "freemius/wordpress-sdk": "^2.7"
+  },
+  "require-dev": {
+    "brianhenryie/strauss": "^0.20"
+  },
+  "extra": {
+    "strauss": {
+      "target_directory": "freemius",
+      "namespace_prefix": "Acme\\MyPlugin\\Freemius\\",
+      "classmap_prefix": "Acme_MyPlugin_FS_",
+      "constant_prefix": "ACME_MYPLUGIN_FS_",
+      "packages": [
+        "freemius/wordpress-sdk"
+      ],
+      "delete_vendor_packages": true
+    }
+  }
+}
+```
+
+Then in your plugin bootstrap, load the prefixed copy:
+
+```php
+// Before:
+// require_once __DIR__ . '/vendor/freemius/wordpress-sdk/start.php';
+
+// After Strauss has run:
+require_once __DIR__ . '/freemius/freemius/wordpress-sdk/start.php';
+```
+
+### Caveats — test the license flow end-to-end
+
+- Freemius internally references its own classes by string in several places (option keys, transient names, hook names). Prefixing **class names** is safe; prefixing **option keys or hook names** is not — Strauss does not touch string literals by default, which is the behavior you want.
+- The Freemius dashboard / opt-in modal uses globally registered admin pages. After prefixing, verify: install flow, activation, deactivation feedback modal, license key entry, license sync, plan upgrade webhook, and uninstall.
+- If you previously shipped an **unprefixed** SDK and users already activated licenses, the option keys may not match after you switch to a prefixed build. Plan a one-time migration that copies the old `fs_*` options to the new prefixed names on upgrade.
+- Freemius themselves publish a `freemius/wordpress-sdk-prefix` helper script for plugins that aren't on Composer. If you are on Composer, Strauss is the cleaner integration.
+
+Test on a staging site with a real (sandboxed) Freemius product before pushing the prefixed build to wp.org — a broken license flow is a worse outcome than a "library conflict" warning.


### PR DESCRIPTION
## What

A new skill, `skills/wordpress-plugin-development/`, distilling two bodies of knowledge developers need when building WordPress plugins:

1. **The Plugin Developer Handbook** (developer.wordpress.org/plugins/) — compressed RULE-first reference notes covering plugin basics, security, hooks/menus/shortcodes, settings & data, privacy/users/HTTP/cron, and JS/i18n/dev-tools/readme/SVN.
2. **wp.org Plugin Directory survival** — the 19 numbered guidelines plus the patterns that actually cause closures (trialware, phoning home without opt-in, remote-loaded assets, missing source for compiled files, missing `permission_callback`, wrong text-domain literal, vendored-library collisions).

`SKILL.md` is a small triage layer (an 80/20 quick list + a table pointing at 10 reference files); references load only when the model opens them, keeping the skill cheap to trigger.

## Why

The wp.org Plugins Team review cycle is slow and surprising — closures cost days per round-trip, and most of them are the same dozen mistakes. Every plugin author re-learns these the hard way. Putting them in a skill catches them before submission instead of after a closure email.

The handbook side is similarly worth distilling — the official docs are authoritative but spread across ~40 pages, and the "do this / not that" patterns are buried in prose.

## Scope / triggering

Triggers on: code under `wp-content/plugins/`, or any of `register_rest_route`, `add_shortcode`, `register_post_type`, `register_setting`, `current_user_can`, `esc_html__`, `WP_PLUGIN_DIR`, Freemius, or active Plugin Check / closure work.

Explicitly skips: WordPress themes (different review track), standalone PHP outside a plugin, pure frontend JS that doesn't touch plugin PHP.

## Structure

- `SKILL.md` — 80/20 quick-reference, triage workflow, reference index
- `references/guidelines.md` — all 19 wp.org guidelines + Guideline 4 deep dive
- `references/i18n-and-escaping.md` — text domains, gettext rules, escape functions, XSS vectors
- `references/hooks-paths-uploads-rest.md` — actions/filters, paths, uploads, REST `permission_callback`
- `references/plugin-check-and-prefixing.md` — Plugin Check + Strauss/Mozart/PHP-Scoper recipes
- `references/handbook-plugin-basics.md` — header, lifecycle, paths, best practices
- `references/handbook-security.md` — capabilities, validation, sanitizing, escaping, nonces
- `references/handbook-hooks-menus-shortcodes.md` — actions vs filters, admin menus, shortcodes
- `references/handbook-settings-data.md` — Options API, Settings API, meta, CPTs, taxonomies
- `references/handbook-privacy-users-http-cron.md` — privacy/GDPR, roles, HTTP API, WP-Cron
- `references/handbook-js-i18n-tools-directory.md` — enqueuing, jQuery, Ajax, i18n, readme/SVN
- `LICENSE.txt` — Apache-2.0, matching other skills in this repo

## Sources & testing

Derived from public WordPress.org / developer.wordpress.org documentation. Code examples are written from scratch to illustrate rules — no copied prose from the handbook.

Used in-house against an actively-developed plugin (Plugin Check + closure-response cycles) over several review rounds. Happy to iterate on structure/format if it doesn't match repo conventions.

Maintained by [AtlasAiDev](https://github.com/atlasaidev) — WordPress plugin & AI tooling team.