### PR TITLE
Add pii-scrub skill

### DIFF
--- a/skills/pii-scrub/LICENSE.txt
+++ b/skills/pii-scrub/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Anthropic, PBC.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/pii-scrub/SKILL.md
+++ b/skills/pii-scrub/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: pii-scrub
+description: Sanitize files for external sharing - bug reports, GitHub issues, security disclosures, support tickets, log dumps, session captures, screenshots-with-paths, any public artifact. Substitutes a baseline library of PII patterns (UUIDs, IPv4/IPv6, emails, credentials, phone, SSN, credit card) plus user-supplied context tokens (username, hostname, employer, infrastructure terms, internal tool names). Audits and re-audits. Use whenever the user is about to share a file/archive/log externally and asks for redaction, scrub, sanitization, anonymization, or "is this safe to send/upload/post?"
+---
+
+# PII Scrub
+
+A repeatable procedure for redacting files before external sharing. Pattern-based substitution with mandatory audit and re-audit passes.
+
+## When to invoke
+
+The user is about to share something externally and wants it cleaned. Triggers include:
+
+- "scrub this for PII"
+- "sanitize the zip before I upload"
+- "is this safe to send to <triager / support / GitHub>?"
+- "redact <user / hostname / employer> from these files"
+- preparing a bug report, support ticket, or public attachment
+- preparing public artifacts (issue reproductions, blog posts, demo log captures)
+
+## The procedure (always all six steps)
+
+### 1. Confirm scope with the user
+
+Before scrubbing anything, ask:
+
+- **Which files or directories?** Explicit list. Walk subdirectories if asked.
+- **Which context tokens?** This is per-session — usernames, hostnames, employer names, internal tool names, infrastructure terms, project codenames. The baseline patterns DO NOT cover these; the user must supply them.
+- **In-place edits, or output to a new location?** In-place is faster for ad-hoc scrubs; output-to-new is safer when source artifacts are precious. Common pattern: stage copies in a "ready to ship" directory, then run the scrub in place.
+
+Echo the plan back before running anything destructive.
+
+### 2. Apply substitutions
+
+Run `scripts/scrub.ps1` (Windows, PowerShell 7+) or `scripts/scrub.py` (Linux/macOS/Windows, Python 3.8+). Both implement the same substitution and audit logic. The script:
+
+- Applies user-provided context tokens first (case-insensitive literal match by default).
+- Applies baseline regex patterns from `scripts/patterns.json` second.
+- Writes back UTF-8 without BOM. No trailing newline added.
+
+**Default substitution placeholders:**
+
+| Pattern | Replacement |
+|---|---|
+| Full UUID (8-4-4-4-12 hex) | `<session-id>` |
+| IPv4 | `<ip>` |
+| IPv6 (strict, 4+ segments) | `<ipv6>` |
+| IPv6 (compressed `::` form, with leading segment) | `<ipv6>` |
+| Email | `<email>` |
+| JWT-shaped (`eyJ...`) | `<credential>` |
+| Anthropic API key (`sk-ant-*`) | `<credential>` |
+| OpenAI API key (`sk-*`) | `<credential>` |
+| GitHub token (`ghp_*` and variants) | `<credential>` |
+| AWS access key (`AKIA*`) | `<credential>` |
+| Generic `(api_key\|access_token\|secret\|bearer\|password) [=:] value` (unquoted or JSON-quoted key) | `<key>: <credential>` (key name and separator preserved) |
+| US-shaped phone number | `<phone>` |
+| US SSN | `<ssn>` |
+| Credit-card-shaped number | `<credit-card>` |
+
+**Why credential-shaped patterns all redact to `<credential>` instead of type-specific placeholders** (`<api-key>`, `<github-token>`, etc.): the credential type itself is metadata an attacker can use to narrow attack surface. Telling a reader "this was an AWS access key" or "this was a GitHub PAT" reveals what kind of infrastructure or service was being used. Identifier-shaped patterns (`<email>`, `<ip>`, `<phone>`) stay type-specific because the category aids comprehension and isn't sensitive in the same way.
+
+User context tokens use whatever replacement the user specifies (e.g., `acme-corp` → `<employer>`, `mycli` → `<internal-tool>`).
+
+`patterns.json` also defines `audit_only` entries — patterns that are flagged for human review but NOT auto-substituted. Currently: PEM-style private key markers (`-----BEGIN ... PRIVATE KEY-----`) and suspiciously long base64 blobs.
+
+### 3. Audit pass
+
+After substitution, scan all output files with the same patterns the script just applied. Goal: zero hits. The script does this automatically and exits non-zero if any pattern matches.
+
+### 4. Re-audit after any fix
+
+If the audit catches something, fix it AND re-run the audit. **Never declare clean after one pass.**
+
+Real-world example: a first pass caught a username, but a follow-up pass caught an internal tool name that the user had forgotten to include in their context token list. Three iterations to reach zero hits is common.
+
+### 5. Prompt the human to skim
+
+The audit catches **structured patterns**. It does NOT catch:
+
+- Free-form text mentioning identifying details ("my coworker Sarah said...")
+- Project codenames the user forgot to add to the context token list
+- Comments in code referring to internal systems
+- Anything that doesn't match a pattern but a human eye would recognize
+
+Tell the user:
+
+> Audit caught all pattern matches. It cannot catch identifying free-form text. Open the two largest output files and skim them before sharing. This is the only step that gets you from ~99% to truly clean.
+
+### 6. If bundling into an archive
+
+After scrubbing contents:
+
+- **Sanitize the archive filename.** Example failure mode: a zip named `acmecorp-2024-evidence.zip` defeats the entire content scrub. Apply the same context-token substitutions to the filename.
+- **Sanitize internal filenames.** If any included file has an identifying name (e.g., `session-alice-laptop.log`), rename before zipping.
+- **Re-audit the archive contents** after build. Zipping sometimes touches paths or metadata.
+
+## Lessons / gotchas
+
+These came from real failures during real scrubs. Internalize them.
+
+- **Re-audit is mandatory.** First pass often misses something. Patterns that depend on context tokens require the user to remember to include them; humans forget. The second pass catches what was missed.
+- **Strict IPv6 regex.** A loose IPv6 pattern like `(?:[0-9a-fA-F]{1,4}:){2,}[0-9a-fA-F]{1,4}` matches `HH:MM:SS` timestamps and produces false positives. The bundled `patterns.json` uses a strict form (4+ segments) plus a compressed-form pattern that requires at least one hex segment before `::`.
+- **Word-boundary for short employer/tool names.** A 6-letter token like `corpio` (hypothetical) would match the substring inside `corporation`. For tokens shorter than 8 characters or with common substrings, pass them via `-SubstitutionsRegex` (PowerShell) or `--sub-regex` (Python) with explicit `\b` word boundaries, OR visually inspect the output after substitution.
+- **Filename of the archive.** Easy to forget. Apply the same scrub to filenames as to contents.
+- **Filenames inside archives.** If any file in the bundle has an identifying name, rename before zipping.
+- **Welcome banners and tool output.** Many CLI tools print "Welcome back <name>" or similar. If a debug log captures startup, that string is in there. Add the user's display name (not just their username) to the context token list.
+- **Manual review is non-negotiable.** Pattern matching is necessary but not sufficient.
+- **SSN pattern over-redacts any NNN-NN-NNNN sequence.** The pattern `\b\d{3}-\d{2}-\d{4}\b` matches any three-digit dash two-digit dash four-digit sequence — not just actual SSNs. Build numbers, RFC section references, and structured identifiers in the form `000-00-0000` will be replaced. If your file contains those, skim the output or exclude them with a pre-processing pass before running the skill.
+- **Credit-card pattern over-redacts in 4-digit groups.** The pattern matches any 13-to-20-digit run with 4-digit grouping and no Luhn check. RFC IDs, version strings like `Build 2024-1234-5678-9012-3456`, and tracking numbers like `1234 5678 9012 3456 7890` will get redacted to `<credit-card>`. This is an intentional over-redaction trade — false-positive on a tracking number is cheaper than false-negative on a real card. If you have docs full of structured numerics, add a `-SubstitutionsRegex` rule that pre-replaces those specific patterns before the baseline runs, or skim the output for surprise redactions.
+- **UTF-16 LE (and other non-UTF-8) files are skipped, not scrubbed.** Windows PowerShell 5.1 (the version built into Windows, `powershell.exe`) emits UTF-16 LE by default for `Out-File`, `>`, and most `Export-*` cmdlets. PowerShell 7+ (`pwsh.exe`) defaults to UTF-8, but files already on disk from PS 5.1 sessions, or generated by other Windows tools (Event Viewer exports, WEVTUTIL, etc.), remain in UTF-16 LE. The `is_textual` heuristic treats >1% null bytes as binary, which UTF-16 ASCII content triggers. The audit pass refuses to certify CLEAN when any file is skipped: verdict reads `AUDITED N of M files; X skipped (could not safely scan as text). Cannot certify CLEAN.` with non-zero exit. Re-encode as UTF-8 before running the skill on those files, or scrub them by hand. Quick re-encode: `Get-Content $file -Encoding Unicode | Set-Content $file -Encoding UTF8`.
+- **`--sub` replacement values may contain `=`; `--sub-regex` replacements should not.** On the Python CLI, `--sub KEY=VALUE` splits at the FIRST `=`: the key is everything to the left and the value is everything to the right. So `--sub 'myhost=server=01'` correctly substitutes `myhost` → `server=01`. By contrast, `--sub-regex PATTERN=VALUE` splits at the LAST `=` so regex patterns containing `=` (lookaheads, literals) are not corrupted. Keep this asymmetry in mind: if your `--sub-regex` replacement needs a literal `=`, the parse will break. On the PowerShell side, `-Substitutions` and `-SubstitutionsRegex` both accept hashtables, so there is no parsing ambiguity — the key-value split is handled by the caller.
+- **`$N` interpretation in replacement strings differs by sub type.** In REGEX subs (`-SubstitutionsRegex` / `--sub-regex`), `$N` is a backreference to capture group N in both engines (PowerShell natively; `scrub.py` via an internal translator that converts `$N` → `\N` before passing to `re.sub`). In LITERAL subs (`-Substitutions` / `--sub`), the pattern is `re.escape(key)` with no capture groups, and both engines preserve `$N` as literal `$N` in the output (PowerShell's documented behavior when group N doesn't exist; `scrub.py` matches via a separate literal-sub translator). The whole-match reference `$0` IS interpreted in both engines, in both literal and regex subs. The escape `$$` produces a literal `$` in both engines.
+  Examples: `-Substitutions @{ 'acme' = 'team $1 ops' }` produces `team $1 ops` (literal `$1` preserved). `-Substitutions @{ 'acme' = 'wrapped($0)' }` produces `wrapped(acme)` (`$0` is whole match). `-Substitutions @{ 'acme' = 'price $$5' }` produces `price $5` (`$$` escapes).
+- **Scrubbing a JSON file produces structurally invalid JSON.** The `generic-bearer-secret` pattern replaces the credential value with the unquoted placeholder `<credential>`, so `"api_key": "s3cr3t"` becomes `"api_key": <credential>` — which a JSON parser will reject. This is intentional (the placeholder is unambiguous to a human reader) and is covered by the "No file-format awareness" scope. If you need to re-import the scrubbed file as JSON, replace the placeholder manually or exclude the credential field before scrubbing.
+
+## Invocation examples
+
+**Basic invocation** (PowerShell):
+
+```powershell
+& "$env:USERPROFILE\.claude\skills\pii-scrub\scripts\scrub.ps1" `
+    -Files @('C:\path\to\file1.log','C:\path\to\file2.txt') `
+    -Substitutions @{
+        'alice'    = '<user>'
+        'lab-host' = '<hostname>'
+        'acmecorp' = '<employer>'
+    }
+```
+
+**Linux/macOS/Windows** (Python):
+
+```bash
+python3 ~/.claude/skills/pii-scrub/scripts/scrub.py \
+    --files /path/to/file1.log /path/to/file2.txt \
+    --sub 'alice=<user>' --sub 'lab-host=<hostname>' --sub 'acmecorp=<employer>'
+```
+
+**Scrub a directory of staged artifacts** (PowerShell):
+
+```powershell
+$files = Get-ChildItem 'C:\artifacts-ready-to-ship' -File -Recurse | Select-Object -ExpandProperty FullName
+& "$env:USERPROFILE\.claude\skills\pii-scrub\scripts\scrub.ps1" -Files $files -Substitutions @{
+    'alice' = '<user>'; 'lab-host' = '<hostname>'
+}
+```
+
+**Audit only** (no substitutions, just check what's there):
+
+```powershell
+& "$env:USERPROFILE\.claude\skills\pii-scrub\scripts\scrub.ps1" -Files $files -AuditOnly
+```
+
+**Word-bounded substitution** (avoids a short token matching inside a longer word):
+
+```powershell
+& "$env:USERPROFILE\.claude\skills\pii-scrub\scripts\scrub.ps1" `
+    -Files $files `
+    -SubstitutionsRegex @{ '\bshorttoken\b' = '<redacted>' }
+```
+
+## Companion files
+
+- `scripts/scrub.ps1` — Windows substitution and audit engine. PowerShell 7+.
+- `scripts/scrub.py` — Cross-platform substitution and audit engine. Python 3.8+, no third-party dependencies.
+- `scripts/patterns.json` — baseline regex pattern library. Shared by both scripts. Edit to extend.
+
+## What this skill does NOT do
+
+By design, this is **regex + operator-supplied tokens**. Scoping out what it doesn't cover heads off scope creep and tells the user when to reach for a different tool:
+
+- **No named-entity recognition (NER).** The skill won't infer that "Sarah from the legal team" is a person's name and redact it. Free-form references to people, projects, or systems must be added to the context token list explicitly, or skimmed manually.
+- **No ML / contextual classification.** If you have a token that looks like a common word (e.g., a project codenamed "Apple"), the skill cannot disambiguate. Use `-SubstitutionsRegex` / `--sub-regex` with explicit word boundaries, or visually inspect output.
+- **No reverse translation.** Substitution is one-way. Keep an unscrubbed copy if you need the original.
+- **No file-format awareness.** The skill treats files as text. It will redact patterns appearing inside JSON keys, code comments, log timestamps, base64 blobs, etc. — anything that matches a pattern. Audit and skim the output.
+- **No transport or encryption.** This skill produces sanitized files. Sharing them safely (channel, recipient, retention) is up to you.
+- **No detection of identifying-but-not-pattern-matching text.** Pattern matching catches structured PII. Free-form text mentioning an internal system by name or a coworker by first name will pass through silently unless that exact string is in the context token list. Step 5 (human skim) is the backstop for this.
+
+If you need any of the above, build on top of this skill or use a different tool.
+
+## When NOT to use
+
+- Code about to be committed to a private repo where the team already knows the names. The skill is for **external** sharing.
+- Files containing legitimate IPv4/IPv6 addresses that are the actual subject of the discussion (e.g., a networking bug report where the IP is the bug). Use `-AuditOnly` to see what's there without rewriting.
+- Anything the user wants to share AS-IS for forensic-fidelity reasons (e.g., an authoritative incident report where substituting IDs would damage evidentiary value).
+
+In those cases, the skill is still useful as an audit-only check — surface what's there, let the user decide what to substitute manually.

--- a/skills/pii-scrub/scripts/patterns.json
+++ b/skills/pii-scrub/scripts/patterns.json
@@ -1,0 +1,95 @@
+{
+  "$comment": "Baseline PII patterns applied by scrub.ps1 and scrub.py. Add or extend by editing this file. Each entry: name (identifier), pattern (regex, must work in both .NET and Python's re module), replacement (string). PATTERN ORDER: patterns run in the order listed below; substitutions are applied sequentially. Where one pattern's matches could be a subset of another's, use lookahead/lookbehind to make the patterns mutually exclusive (see openai-api-key for an example) rather than relying on order.",
+  "baseline": [
+    {
+      "name": "full-uuid",
+      "pattern": "\\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\\b",
+      "replacement": "<session-id>"
+    },
+    {
+      "name": "ipv4",
+      "pattern": "\\b(?:\\d{1,3}\\.){3}\\d{1,3}\\b",
+      "replacement": "<ip>"
+    },
+    {
+      "name": "ipv6-strict",
+      "$comment": "Requires 4+ segments. Loose IPv6 regex (2+ segments) matches HH:MM:SS timestamps.",
+      "pattern": "\\b(?:[0-9a-fA-F]{1,4}:){4,}[0-9a-fA-F]{1,4}\\b",
+      "replacement": "<ipv6>"
+    },
+    {
+      "name": "ipv6-compressed",
+      "$comment": "Compressed IPv6 (:: form). Requires at least one hex segment before :: to avoid false-positives on timestamps (HH:MM:SS). Misses bare ::1 (loopback) by design; that's not PII.",
+      "pattern": "\\b[0-9a-fA-F]{1,4}(?::[0-9a-fA-F]{1,4})*::(?:[0-9a-fA-F]{1,4}(?::[0-9a-fA-F]{1,4})*)?\\b",
+      "replacement": "<ipv6>"
+    },
+    {
+      "name": "email",
+      "pattern": "\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}\\b",
+      "replacement": "<email>"
+    },
+    {
+      "$comment": "All credential-shaped patterns redact to <credential> (not <api-key>, <jwt-token>, etc.) to avoid leaking which TYPE of credential was in the source. The credential type itself is metadata an attacker can use to narrow attack surface. JWT minimum-length is 10 chars after eyJ to catch minimal valid JWTs (header eyJhbGciOiJIUzI1NiJ9 is 16 chars after eyJ); raise this if you see false-positives on non-JWT base64 strings.",
+      "name": "jwt-token",
+      "pattern": "eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+",
+      "replacement": "<credential>"
+    },
+    {
+      "name": "anthropic-api-key",
+      "pattern": "sk-ant-[A-Za-z0-9_-]{20,}",
+      "replacement": "<credential>"
+    },
+    {
+      "name": "openai-api-key",
+      "$comment": "Negative lookahead (?!ant-) excludes Anthropic keys; otherwise this pattern would also match sk-ant-* and force a fragile dependency on running anthropic-api-key first.",
+      "pattern": "sk-(?!ant-)[A-Za-z0-9]{20,}",
+      "replacement": "<credential>"
+    },
+    {
+      "name": "github-token",
+      "$comment": "GitHub personal access tokens (classic and fine-grained) and OAuth tokens.",
+      "pattern": "\\b(?:ghp|gho|ghu|ghs|ghr|github_pat)_[A-Za-z0-9_]{20,}\\b",
+      "replacement": "<credential>"
+    },
+    {
+      "name": "aws-access-key",
+      "pattern": "\\bAKIA[0-9A-Z]{16}\\b",
+      "replacement": "<credential>"
+    },
+    {
+      "name": "generic-bearer-secret",
+      "$comment": "Catches obvious credential assignments, including JSON-quoted key names. Case-insensitive on the key name. Group $2 optionally captures a closing quote on the key name (JSON style: `\"api_key\":`) and re-emits it so JSON structure is preserved. Separator (= or : with surrounding whitespace) is captured into $3 and preserved so YAML/JSON files keep their structure: `api_key: value` -> `api_key: <credential>`, NOT `api_key=<credential>`. Quotes around the value are matched but dropped from output (intentional; the quotes around <credential> would be misleading).",
+      "pattern": "(?i)(api[_-]?key|access[_-]?token|secret|bearer|password)([\"']?)(\\s*[=:]\\s*)[\"']?[A-Za-z0-9_-]{16,}[\"']?",
+      "replacement": "$1$2$3<credential>"
+    },
+    {
+      "name": "phone-us",
+      "$comment": "US-shaped phone numbers in common forms: 555-867-5309, 555.867.5309, 555 867 5309, (555) 867-5309, +1 555-867-5309, +1-555-867-5309. Does not match international formats outside +1. May catch unrelated NNN-NNN-NNNN sequences (e.g., some serial numbers, dates with the right shape) — review audit output.",
+      "pattern": "(?:\\+?1[-.\\s]?)?(?:\\(\\d{3}\\)\\s?|\\d{3}[-.\\s])\\d{3}[-.\\s]\\d{4}",
+      "replacement": "<phone>"
+    },
+    {
+      "name": "ssn-us",
+      "pattern": "\\b\\d{3}-\\d{2}-\\d{4}\\b",
+      "replacement": "<ssn>"
+    },
+    {
+      "name": "credit-card",
+      "$comment": "Catches 13-16 digit sequences with common separators. Not Luhn-verified.",
+      "pattern": "\\b(?:\\d{4}[\\s-]?){3,4}\\d{1,4}\\b",
+      "replacement": "<credit-card>"
+    }
+  ],
+  "audit_only": [
+    {
+      "name": "private-key-block",
+      "$comment": "PEM-style private key markers. If this matches, STOP — the file should not be shared.",
+      "pattern": "-----BEGIN (?:RSA |EC |OPENSSH |PGP |DSA |ENCRYPTED )?PRIVATE KEY-----"
+    },
+    {
+      "name": "long-base64-blob",
+      "$comment": "Suspiciously long base64 blobs. Often legit (icons, data URIs); flagged for human review.",
+      "pattern": "[A-Za-z0-9+/]{100,}={0,2}"
+    }
+  ]
+}

--- a/skills/pii-scrub/scripts/scrub.ps1
+++ b/skills/pii-scrub/scripts/scrub.ps1
@@ -1,0 +1,275 @@
+#requires -Version 7
+<#
+.SYNOPSIS
+PII scrub and audit for files about to be shared externally.
+
+.DESCRIPTION
+Applies user-provided context-token substitutions plus a baseline library of
+PII regex patterns from patterns.json. Audits the result; exits non-zero if any
+pattern still matches after substitution.
+
+The skill that owns this script lives at ~/.claude/skills/pii-scrub/.
+See SKILL.md in the same directory for the full procedure and gotchas.
+
+.PARAMETER Files
+Absolute paths to the files to scrub. Pass an array.
+
+.PARAMETER Substitutions
+Hashtable of literal-string -> replacement-string. Matched case-insensitively
+as literals (regex-escaped). Applied BEFORE baseline patterns.
+
+For tokens that risk substring matches in legitimate words (e.g., a 6-letter
+employer name that appears inside common English words), prefer adding them
+to -SubstitutionsRegex instead with explicit \b word boundaries.
+
+.PARAMETER SubstitutionsRegex
+Hashtable of regex-pattern -> replacement-string. Use when you need word
+boundaries, case sensitivity, or other regex features.
+
+.PARAMETER PatternsPath
+Path to patterns.json. Defaults to the file next to this script.
+
+.PARAMETER AuditOnly
+Skip substitution. Only run the audit pass and report what matches. Useful
+for surveying a file before deciding what to redact.
+
+.PARAMETER ExtraAuditPatterns
+Additional regex patterns to audit for (won't be substituted, just reported).
+Pass an array of hashtables: @(@{name='foo';pattern='bar'}, ...).
+
+.EXAMPLE
+& "$env:USERPROFILE\.claude\skills\pii-scrub\scrub.ps1" `
+    -Files @('C:\out\report.txt','C:\out\log.json') `
+    -Substitutions @{ 'alice'='<user>'; 'lab-host'='<hostname>' }
+
+.EXAMPLE
+$files = (Get-ChildItem 'C:\artifacts' -File -Recurse).FullName
+& "$env:USERPROFILE\.claude\skills\pii-scrub\scrub.ps1" -Files $files -AuditOnly
+
+.EXAMPLE
+# Word-bounded substitution (avoids a short token matching inside a longer word)
+& "$env:USERPROFILE\.claude\skills\pii-scrub\scrub.ps1" `
+    -Files $files `
+    -SubstitutionsRegex @{ '\bshorttoken\b' = '<redacted>' }
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string[]]$Files,
+
+    [hashtable]$Substitutions = @{},
+
+    [hashtable]$SubstitutionsRegex = @{},
+
+    [string]$PatternsPath,
+
+    [switch]$AuditOnly,
+
+    [hashtable[]]$ExtraAuditPatterns = @()
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $PatternsPath) {
+    $PatternsPath = Join-Path $PSScriptRoot 'patterns.json'
+}
+if (-not (Test-Path -LiteralPath $PatternsPath)) {
+    throw "patterns.json not found at: $PatternsPath"
+}
+
+$patternsConfig = Get-Content -LiteralPath $PatternsPath -Raw | ConvertFrom-Json
+$baselinePatterns = $patternsConfig.baseline
+$auditOnlyPatterns = if ($patternsConfig.PSObject.Properties.Name -contains 'audit_only') {
+    $patternsConfig.audit_only
+} else { @() }
+
+function Test-FileTextual {
+    param([string]$Path)
+    # Heuristic: if first 8KB has > 1% null bytes, treat as binary.
+    if (-not (Test-Path -LiteralPath $Path)) { return $false }
+    $size = (Get-Item -LiteralPath $Path).Length
+    if ($size -eq 0) { return $false }
+    $sample = [System.IO.File]::ReadAllBytes($Path) | Select-Object -First ([Math]::Min($size, 8192))
+    if ($sample.Count -eq 0) { return $false }
+    $nullCount = ($sample | Where-Object { $_ -eq 0 }).Count
+    return ($nullCount / $sample.Count) -lt 0.01
+}
+
+function Invoke-Substitution {
+    param([string]$Content, [hashtable]$Subs, [hashtable]$RegexSubs)
+    foreach ($key in $Subs.Keys) {
+        if ([string]::IsNullOrEmpty($key)) {
+            Write-Warning "skipping empty key in -Substitutions"
+            continue
+        }
+        $regex = '(?i)' + [regex]::Escape($key)
+        $Content = $Content -replace $regex, $Subs[$key]
+    }
+    foreach ($key in $RegexSubs.Keys) {
+        if ([string]::IsNullOrEmpty($key)) {
+            Write-Warning "skipping empty key in -SubstitutionsRegex"
+            continue
+        }
+        $Content = $Content -replace $key, $RegexSubs[$key]
+    }
+    return $Content
+}
+
+function Invoke-Audit {
+    param(
+        [string]$Path,
+        [object[]]$Patterns,
+        [hashtable]$ContextSubs,
+        [hashtable]$ContextRegexSubs,
+        [hashtable[]]$Extra
+    )
+    $hits = @()
+    if (-not (Test-FileTextual -Path $Path)) { return $hits }
+    $c = Get-Content -LiteralPath $Path -Raw -ErrorAction SilentlyContinue
+    if (-not $c) { return $hits }
+
+    foreach ($p in $Patterns) {
+        $m = [regex]::Matches($c, $p.pattern)
+        if ($m.Count -gt 0) {
+            $hits += [PSCustomObject]@{
+                File = $Path
+                Pattern = $p.name
+                Count = $m.Count
+                Sample = $m[0].Value
+            }
+        }
+    }
+    foreach ($key in $ContextSubs.Keys) {
+        if ([string]::IsNullOrEmpty($key)) { continue }
+        $m = [regex]::Matches($c, '(?i)' + [regex]::Escape($key))
+        if ($m.Count -gt 0) {
+            $hits += [PSCustomObject]@{
+                File = $Path
+                Pattern = "context-literal: $key"
+                Count = $m.Count
+                Sample = $m[0].Value
+            }
+        }
+    }
+    foreach ($key in $ContextRegexSubs.Keys) {
+        if ([string]::IsNullOrEmpty($key)) { continue }
+        $m = [regex]::Matches($c, $key)
+        if ($m.Count -gt 0) {
+            $hits += [PSCustomObject]@{
+                File = $Path
+                Pattern = "context-regex: $key"
+                Count = $m.Count
+                Sample = $m[0].Value
+            }
+        }
+    }
+    foreach ($p in $Extra) {
+        $m = [regex]::Matches($c, $p.pattern)
+        if ($m.Count -gt 0) {
+            $hits += [PSCustomObject]@{
+                File = $Path
+                Pattern = "extra: $($p.name)"
+                Count = $m.Count
+                Sample = $m[0].Value
+            }
+        }
+    }
+    return $hits
+}
+
+# === Substitution pass ===
+if (-not $AuditOnly) {
+    foreach ($f in $Files) {
+        if (-not (Test-Path -LiteralPath $f)) {
+            Write-Warning "skipping (not found): $f"
+            continue
+        }
+        if ((Get-Item -LiteralPath $f).Length -eq 0) {
+            Write-Warning "skipping (empty): $f"
+            continue
+        }
+        if (-not (Test-FileTextual -Path $f)) {
+            Write-Warning "skipping (binary): $f"
+            continue
+        }
+        $orig = Get-Content -LiteralPath $f -Raw
+        if (-not $orig) { continue }
+
+        $new = Invoke-Substitution -Content $orig -Subs $Substitutions -RegexSubs $SubstitutionsRegex
+        foreach ($p in $baselinePatterns) {
+            $new = $new -replace $p.pattern, $p.replacement
+        }
+
+        if ($new -ne $orig) {
+            Set-Content -LiteralPath $f -Value $new -Encoding utf8 -NoNewline
+            Write-Host "scrubbed: $f"
+        } else {
+            Write-Host "unchanged: $f"
+        }
+    }
+}
+
+# === Audit pass ===
+Write-Host ""
+Write-Host "=== Audit pass ==="
+$allHits = @()
+$skipped = @()  # files we couldn't audit (binary / missing / etc.)
+$auditPatterns = @($baselinePatterns) + @($auditOnlyPatterns)
+foreach ($f in $Files) {
+    if (-not (Test-Path -LiteralPath $f)) {
+        $skipped += [PSCustomObject]@{ File = $f; Reason = 'not found' }
+        continue
+    }
+    if ((Get-Item -LiteralPath $f).Length -eq 0) {
+        $skipped += [PSCustomObject]@{ File = $f; Reason = 'empty file' }
+        continue
+    }
+    if (-not (Test-FileTextual -Path $f)) {
+        # Common case on Windows: PowerShell's default Out-File / > / Export-*
+        # cmdlets emit UTF-16 LE, which Test-FileTextual classifies as binary.
+        # Captured PS session logs land here.
+        $skipped += [PSCustomObject]@{ File = $f; Reason = 'binary or non-UTF-8 (UTF-16 / encoded)' }
+        continue
+    }
+    $hits = Invoke-Audit -Path $f -Patterns $auditPatterns -ContextSubs $Substitutions -ContextRegexSubs $SubstitutionsRegex -Extra $ExtraAuditPatterns
+    $allHits += $hits
+}
+
+$auditedCount = $Files.Count - $skipped.Count
+if ($allHits.Count -eq 0 -and $skipped.Count -eq 0) {
+    $patternCount = $baselinePatterns.Count + $auditOnlyPatterns.Count + $Substitutions.Count + $SubstitutionsRegex.Count + $ExtraAuditPatterns.Count
+    Write-Host "VERDICT: CLEAN. Zero hits across $patternCount patterns in $($Files.Count) file(s)."
+} elseif ($allHits.Count -eq 0 -and $skipped.Count -gt 0) {
+    Write-Host "VERDICT: AUDITED $auditedCount of $($Files.Count) files; $($skipped.Count) skipped (could not safely scan as text). Cannot certify CLEAN."
+    foreach ($s in $skipped) { Write-Host "  skipped: $($s.File) ($($s.Reason))" }
+    Write-Host ""
+    Write-Host "If any skipped file may contain PII, either re-encode it as UTF-8 first or scrub it by hand. The audit cannot inspect files it cannot decode as text."
+    exit 1
+} else {
+    Write-Host "VERDICT: $($allHits.Count) hit(s) remaining. Review:"
+    $allHits | Format-Table File, Pattern, Count, Sample -AutoSize -Wrap
+    if ($skipped.Count -gt 0) {
+        Write-Host ""
+        Write-Host "ALSO: $($skipped.Count) file(s) skipped (could not safely scan as text):"
+        foreach ($s in $skipped) { Write-Host "  skipped: $($s.File) ($($s.Reason))" }
+    }
+    Write-Host ""
+    Write-Host "NOTE: audit_only patterns (e.g., private-key-block, long-base64-blob) are flagged for review, not auto-substituted."
+    exit 1
+}
+
+# === Manual review prompt ===
+$textualFiles = $Files | Where-Object { Test-FileTextual -Path $_ }
+if ($textualFiles.Count -gt 0) {
+    Write-Host ""
+    Write-Host "MANUAL REVIEW recommended for the two largest files:"
+    Get-Item $textualFiles | Sort-Object Length -Descending | Select-Object -First 2 | ForEach-Object {
+        Write-Host "  - $($_.FullName) ($($_.Length) bytes)"
+    }
+    Write-Host ""
+    Write-Host "Pattern matching catches structured PII. It does NOT catch identifying free-form text."
+    Write-Host "Skim these two files before sharing externally."
+}
+
+exit 0

--- a/skills/pii-scrub/scripts/scrub.py
+++ b/skills/pii-scrub/scripts/scrub.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""PII scrub and audit for files about to be shared externally.
+
+Applies user-provided context-token substitutions plus a baseline library of
+PII regex patterns from patterns.json. Audits the result; exits non-zero if
+any pattern still matches after substitution.
+
+The skill that owns this script lives at ~/.claude/skills/pii-scrub/.
+See SKILL.md for the full procedure and gotchas.
+
+Usage:
+    scrub.py --files file1.txt file2.log \\
+             --sub alice=\\<user\\> --sub lab-host=\\<hostname\\>
+
+    scrub.py --files file.log --audit-only
+
+    scrub.py --files file.log --sub-regex '\\bshorttoken\\b=<redacted>'
+
+Tested on Python 3.8+. No third-party dependencies.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+
+def is_textual(path: Path, sample_size: int = 8192) -> bool:
+    """Heuristic: if first 8KB has >1% null bytes, treat as binary."""
+    if not path.exists() or path.stat().st_size == 0:
+        return False
+    try:
+        with path.open("rb") as fh:
+            sample = fh.read(sample_size)
+    except OSError:
+        return False
+    if not sample:
+        return False
+    null_count = sample.count(b"\x00")
+    return (null_count / len(sample)) < 0.01
+
+
+def parse_kv(items, label, split_on_last=False):
+    """Parse KEY=VALUE strings into a dict.
+
+    split_on_last=False (default, used for --sub literal subs): split at the
+    FIRST '='. The key is a literal token (username, hostname, etc.) and almost
+    never contains '='; the replacement value may (e.g. --sub 'myhost=server=01').
+
+    split_on_last=True (used for --sub-regex): split at the LAST '='. The regex
+    pattern may contain '=' (lookaheads, literals) so splitting first would corrupt
+    the pattern; the replacement is typically a short placeholder that won't contain '='.
+    """
+    out = {}
+    if not items:
+        return out
+    for item in items:
+        if "=" not in item:
+            sys.stderr.write(f"warning: --{label} entry missing '=': {item!r}\n")
+            continue
+        if split_on_last:
+            key, value = item.rsplit("=", 1)
+        else:
+            key, value = item.split("=", 1)
+        out[key] = value
+    return out
+
+
+_DOLLAR_BACKREF = re.compile(r"\$(?:\$|(\d))")
+
+
+def _translate_replacement(replacement: str) -> str:
+    """Translate PowerShell-style $N backreferences to Python's \\N,
+    and PowerShell-style $$ escape to literal $.
+
+    Used for REGEX substitutions (--sub-regex and patterns.json), where the
+    pattern can legitimately have capture groups that $N should reference.
+
+    patterns.json uses PowerShell's $1, $2, ... convention because it's the
+    primary engine. Python's re.sub uses \\1, \\2, ... so we translate here
+    so the same patterns.json works for both engines. PowerShell's $$ escape
+    for a literal $ is honored too so the cross-engine workaround in SKILL.md
+    actually works on the Python side.
+    """
+    def _sub(m):
+        if m.group(1) is None:  # $$ matched -> emit literal $
+            return '$'
+        return '\\' + m.group(1)
+    return _DOLLAR_BACKREF.sub(_sub, replacement)
+
+
+def _translate_replacement_for_literal(replacement: str) -> str:
+    """Translate replacement strings for LITERAL-key substitutions.
+
+    Literal-key substitutions use re.escape(key) as the regex, which has no
+    capture groups by construction. PowerShell's -replace behavior for such
+    replacements (verified empirically against pwsh 7.5.5):
+        $$  -> literal $
+        $0  -> whole match (always defined)
+        $N  -> preserved as literal $N (because group N doesn't exist)
+    Translate to keep Python's re.sub aligned:
+        $$  -> literal $       (PS escape -> our escape)
+        $0  -> \\g<0>          (Python's whole-match syntax in replacement)
+        $N  -> leave alone     (Python re.sub treats $ as non-metachar so $N
+                                passes through as literal, matching PS)
+    Without this translation, Python's re.sub would raise re.error on $N
+    references because re.sub interprets neither $$ nor $0 the way PS does.
+    """
+    def _sub(m):
+        if m.group(1) is None:        # $$ matched
+            return '$'
+        if m.group(1) == '0':         # $0 -> whole match
+            return '\\g<0>'
+        return m.group(0)             # $N (N>=1) -> literal $N
+    return _DOLLAR_BACKREF.sub(_sub, replacement)
+
+
+def apply_substitutions(content, literal_subs, regex_subs):
+    for key, replacement in literal_subs.items():
+        if not key:
+            sys.stderr.write("warning: skipping empty literal substitution key\n")
+            continue
+        pattern = re.compile(re.escape(key), re.IGNORECASE)
+        # Literal-key patterns have no capture groups by construction. Use the
+        # literal-sub translator so $N references resolve to empty (matching
+        # PowerShell's silent-empty behavior) instead of crashing on
+        # 'invalid group reference N'. See SKILL.md gotcha section.
+        content = pattern.sub(_translate_replacement_for_literal(replacement), content)
+    for key, replacement in regex_subs.items():
+        try:
+            content = re.sub(key, _translate_replacement(replacement), content)
+        except re.error as exc:
+            sys.stderr.write(f"warning: bad --sub-regex pattern {key!r}: {exc}\n")
+    return content
+
+
+def audit_file(path: Path, patterns, literal_subs, regex_subs, extra_audit):
+    hits = []
+    if not is_textual(path):
+        return hits
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return hits
+    for entry in patterns:
+        matches = list(re.finditer(entry["pattern"], text))
+        if matches:
+            hits.append(
+                {
+                    "file": str(path),
+                    "pattern": entry["name"],
+                    "count": len(matches),
+                    "sample": matches[0].group(0),
+                }
+            )
+    for key in literal_subs:
+        if not key:
+            continue
+        matches = list(re.finditer(re.escape(key), text, re.IGNORECASE))
+        if matches:
+            hits.append(
+                {
+                    "file": str(path),
+                    "pattern": f"context-literal: {key}",
+                    "count": len(matches),
+                    "sample": matches[0].group(0),
+                }
+            )
+    for key in regex_subs:
+        try:
+            matches = list(re.finditer(key, text))
+        except re.error:
+            continue
+        if matches:
+            hits.append(
+                {
+                    "file": str(path),
+                    "pattern": f"context-regex: {key}",
+                    "count": len(matches),
+                    "sample": matches[0].group(0),
+                }
+            )
+    for entry in extra_audit:
+        matches = list(re.finditer(entry["pattern"], text))
+        if matches:
+            hits.append(
+                {
+                    "file": str(path),
+                    "pattern": f"extra: {entry['name']}",
+                    "count": len(matches),
+                    "sample": matches[0].group(0),
+                }
+            )
+    return hits
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Scrub PII from files for external sharing.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--files",
+        nargs="+",
+        required=True,
+        help="Paths of files to scrub.",
+    )
+    parser.add_argument(
+        "--sub",
+        action="append",
+        metavar="KEY=VALUE",
+        help="Literal context substitution (case-insensitive). Repeatable.",
+    )
+    parser.add_argument(
+        "--sub-regex",
+        action="append",
+        metavar="PATTERN=VALUE",
+        help="Regex context substitution. Repeatable. Use for word boundaries.",
+    )
+    parser.add_argument(
+        "--patterns",
+        default=None,
+        help="Path to patterns.json. Defaults to the file next to this script.",
+    )
+    parser.add_argument(
+        "--audit-only",
+        action="store_true",
+        help="Skip substitution. Audit pass only.",
+    )
+    args = parser.parse_args()
+
+    patterns_path = (
+        Path(args.patterns)
+        if args.patterns
+        else Path(__file__).resolve().parent / "patterns.json"
+    )
+    if not patterns_path.exists():
+        sys.stderr.write(f"error: patterns.json not found at {patterns_path}\n")
+        return 2
+
+    with patterns_path.open("r", encoding="utf-8") as fh:
+        config = json.load(fh)
+    baseline_patterns = config.get("baseline", [])
+    audit_only_patterns = config.get("audit_only", [])
+
+    literal_subs = parse_kv(args.sub, "sub", split_on_last=False)
+    regex_subs = parse_kv(args.sub_regex, "sub-regex", split_on_last=True)
+    files = [Path(p) for p in args.files]
+
+    # === Substitution pass ===
+    if not args.audit_only:
+        for path in files:
+            if not path.exists():
+                sys.stderr.write(f"warning: skipping (not found): {path}\n")
+                continue
+            if path.stat().st_size == 0:
+                sys.stderr.write(f"warning: skipping (empty): {path}\n")
+                continue
+            if not is_textual(path):
+                sys.stderr.write(f"warning: skipping (binary): {path}\n")
+                continue
+            try:
+                original = path.read_text(encoding="utf-8")
+            except UnicodeDecodeError:
+                sys.stderr.write(f"warning: skipping (non-utf8): {path}\n")
+                continue
+            if not original:
+                continue
+            new = apply_substitutions(original, literal_subs, regex_subs)
+            for entry in baseline_patterns:
+                new = re.sub(entry["pattern"], _translate_replacement(entry["replacement"]), new)
+            if new != original:
+                path.write_text(new, encoding="utf-8", newline="")
+                print(f"scrubbed: {path}")
+            else:
+                print(f"unchanged: {path}")
+
+    # === Audit pass ===
+    print("\n=== Audit pass ===")
+    all_hits = []
+    skipped = []  # files we couldn't audit (binary / missing / etc.)
+    audit_patterns = baseline_patterns + audit_only_patterns
+    for path in files:
+        if not path.exists():
+            skipped.append((path, "not found"))
+            continue
+        if path.stat().st_size == 0:
+            skipped.append((path, "empty file"))
+            continue
+        if not is_textual(path):
+            # Common case on Windows: PowerShell's default Out-File / > / Export-*
+            # cmdlets emit UTF-16 LE, which is_textual classifies as binary.
+            # Captured PS session logs land here.
+            skipped.append((path, "binary or non-UTF-8 (UTF-16 / encoded)"))
+            continue
+        all_hits.extend(
+            audit_file(path, audit_patterns, literal_subs, regex_subs, [])
+        )
+
+    audited_count = len(files) - len(skipped)
+    if not all_hits and not skipped:
+        pattern_count = (
+            len(baseline_patterns)
+            + len(audit_only_patterns)
+            + len(literal_subs)
+            + len(regex_subs)
+        )
+        print(
+            f"VERDICT: CLEAN. Zero hits across {pattern_count} patterns "
+            f"in {len(files)} file(s)."
+        )
+    elif not all_hits and skipped:
+        print(
+            f"VERDICT: AUDITED {audited_count} of {len(files)} files; "
+            f"{len(skipped)} skipped (could not safely scan as text). "
+            f"Cannot certify CLEAN."
+        )
+        for path, reason in skipped:
+            print(f"  skipped: {path} ({reason})")
+        print(
+            "\nIf any skipped file may contain PII, either re-encode it as UTF-8 "
+            "first or scrub it by hand. The audit cannot inspect files it cannot "
+            "decode as text."
+        )
+        return 1
+    else:
+        print(f"VERDICT: {len(all_hits)} hit(s) remaining. Review:")
+        for hit in all_hits:
+            sample = hit["sample"][:80].replace("\n", " ")
+            print(
+                f"  {hit['file']} | {hit['pattern']} | "
+                f"count={hit['count']} | sample={sample!r}"
+            )
+        if skipped:
+            print(f"\nALSO: {len(skipped)} file(s) skipped (could not safely scan as text):")
+            for path, reason in skipped:
+                print(f"  skipped: {path} ({reason})")
+        print(
+            "\nNOTE: audit_only patterns (e.g., private-key-block, "
+            "long-base64-blob) are flagged for review, not auto-substituted."
+        )
+        return 1
+
+    # === Manual review prompt ===
+    textual = [p for p in files if is_textual(p)]
+    if textual:
+        biggest = sorted(textual, key=lambda p: p.stat().st_size, reverse=True)[:2]
+        print("\nMANUAL REVIEW recommended for the largest output files:")
+        for path in biggest:
+            print(f"  - {path} ({path.stat().st_size} bytes)")
+        print(
+            "\nPattern matching catches structured PII. It does NOT catch "
+            "identifying free-form text."
+        )
+        print("Skim these before sharing externally.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What this adds

A cross-platform skill for sanitizing files before external sharing — bug reports, GitHub issues, support tickets, log dumps, session captures, any public artifact.

## Gap this fills

The repo has passing mentions of PII in other skills but no dedicated file-level scrub skill. This fills that gap with a repeatable, auditable procedure.

## What the skill does

Six-step procedure:
1. Confirm scope (files, context tokens, in-place vs output location)
2. Apply substitutions — baseline patterns + user-supplied context tokens
3. Audit pass — zero hits required
4. Re-audit after any fix (never declare clean from one pass)
5. Prompt human to skim — pattern matching is necessary but not sufficient
6. Sanitize archive filenames and internal filenames if bundling

**Baseline patterns (14):** full UUID, IPv4, IPv6 (strict + compressed), email, JWT, Anthropic / OpenAI / GitHub / AWS credentials, generic `key=value` and `key: value` credential assignments (including JSON-quoted key names), US phone, SSN, credit card.

**Audit-only patterns (2):** PEM private key markers (including `-----BEGIN ENCRYPTED PRIVATE KEY-----`), suspiciously long base64 blobs.

All credential-shaped patterns redact to `<credential>` rather than type-specific placeholders (`<api-key>`, `<github-token>`, etc.) — the credential type is itself metadata that narrows attack surface.

User-supplied context tokens (username, hostname, employer, internal tool names) are applied first, before baseline patterns, via literal case-insensitive match or explicit regex with word boundaries.

## Engines

- `scripts/scrub.ps1` — PowerShell 7+, Windows
- `scripts/scrub.py` — Python 3.8+, cross-platform, no third-party dependencies
- `scripts/patterns.json` — shared pattern library, used by both engines

Both engines produce identical output on the same input. Verified by a 37-case cross-engine test suite (not included in this subtree — lives in the standalone development repo at [6a6f686e6e79/pii-scrub-skill](https://github.com/6a6f686e6e79/pii-scrub-skill)).

## Scope-out (by design)

- No named-entity recognition — "Sarah from legal" won't be caught unless added to context tokens
- No ML / contextual classification
- No reverse translation (substitution is one-way)
- No file-format awareness (treats all files as text)
- No transport or encryption

## Invocation

```powershell
# PowerShell
& "$env:USERPROFILE\.claude\skills\pii-scrub\scripts\scrub.ps1" `
    -Files @('C:\path\to\file1.log') `
    -Substitutions @{ 'alice' = '<user>'; 'lab-host' = '<hostname>' }
```

```bash
# Python
python3 ~/.claude/skills/pii-scrub/scripts/scrub.py \
    --files /path/to/file1.log \
    --sub 'alice=<user>' --sub 'lab-host=<hostname>'
```