### PR TITLE
fix(xlsx): report recalc timeouts as failures

### DIFF
--- a/skills/xlsx/scripts/recalc.py
+++ b/skills/xlsx/scripts/recalc.py
@@ -91,7 +91,14 @@ def recalc(filename, timeout=30):
 
     result = subprocess.run(cmd, capture_output=True, text=True, env=get_soffice_env())
 
-    if result.returncode != 0 and result.returncode != 124:  
+    if result.returncode == 124:
+        return {
+            "status": "recalc_timeout",
+            "error": f"LibreOffice recalculation timed out after {timeout} seconds",
+            "timeout_seconds": timeout,
+        }
+
+    if result.returncode != 0:
         error_msg = result.stderr or "Unknown error during recalculation"
         if "Module1" in error_msg or "RecalculateAndSave" not in error_msg:
             return {"error": "LibreOffice macro not configured properly"}
@@ -166,7 +173,7 @@ def main():
         print("Usage: python recalc.py <excel_file> [timeout_seconds]")
         print("\nRecalculates all formulas in an Excel file using LibreOffice")
         print("\nReturns JSON with error details:")
-        print("  - status: 'success' or 'errors_found'")
+        print("  - status: 'success', 'errors_found', or 'recalc_timeout'")
         print("  - total_errors: Total number of Excel errors found")
         print("  - total_formulas: Number of formulas in the file")
         print("  - error_summary: Breakdown by error type with locations")

--- a/skills/xlsx/scripts/test_recalc.py
+++ b/skills/xlsx/scripts/test_recalc.py
@@ -1,0 +1,38 @@
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import recalc
+
+
+class RecalcTests(unittest.TestCase):
+    def test_timeout_does_not_scan_stale_formula_cache(self) -> None:
+        with tempfile.NamedTemporaryFile(suffix=".xlsx") as tmp:
+            workbook_path = Path(tmp.name)
+            completed = subprocess.CompletedProcess(
+                args=["timeout", "1", "soffice"],
+                returncode=124,
+                stdout="",
+                stderr="",
+            )
+
+            with mock.patch.object(
+                recalc, "setup_libreoffice_macro", return_value=True
+            ), mock.patch.object(
+                recalc, "get_soffice_env", return_value={}
+            ), mock.patch.object(
+                recalc.subprocess, "run", return_value=completed
+            ), mock.patch.object(
+                recalc, "load_workbook"
+            ) as load_workbook:
+                result = recalc.recalc(workbook_path, timeout=1)
+
+        self.assertEqual(result["status"], "recalc_timeout")
+        self.assertEqual(result["timeout_seconds"], 1)
+        load_workbook.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Treat LibreOffice timeout exit code `124` as a recalculation failure in `skills/xlsx/scripts/recalc.py`.

Previously, the timeout wrapper allowed return code `124` to continue into the cached-value scan. If LibreOffice timed out before recalculating and saving formula caches, `openpyxl(data_only=True)` could inspect stale cached values and incorrectly report `success`.

This change returns a structured `recalc_timeout` status immediately and avoids scanning potentially stale formula caches after a timeout.

## Test plan

- `python3 -m unittest test_recalc.py`
- `python3 -m py_compile recalc.py test_recalc.py`

## Manual reproduction

I also verified the behavior with a workbook containing 1000 formulas and a timeout wrapper that exits with code `124`.

Before this change, the script continued after the timeout and reported success:

```json
{
  "status": "success",
  "total_errors": 0,
  "error_summary": {},
  "total_formulas": 1000
}
```

After this change, it stops at the timeout and reports:

```json
{
  "status": "recalc_timeout",
  "error": "LibreOffice recalculation timed out after 1 seconds",
  "timeout_seconds": 1
}
```
