### PR TITLE
Add Walter Skills to Partner Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,4 @@ The markdown content below contains the instructions, examples, and guidelines t
 Skills are a great way to teach Claude how to get better at using specific pieces of software. As we see awesome example skills from partners, we may highlight some of them here:
 
 - **Notion** - [Notion Skills for Claude](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0)
+- **Walter** - [Walter Skills for Claude](https://github.com/walterwritesai/walter-skills) - 12 drop-in markdown skills for SEO content writing, AI humanization, AI detection, and keyword preservation.


### PR DESCRIPTION
Adds a Walter Skills entry under Partner Skills, linking to [https://github.com/walterwritesai/walter-skills](https://github.com/walterwritesai/walter-skills).

Walter Skills is a public collection of 12 drop-in markdown skills for Claude projects, covering SEO content writing, AI humanization, AI detection, keyword preservation, agency QC, local SEO, programmatic SEO, and content repurposing. Each skill follows the Agent Skills spec with YAML frontmatter and is MIT licensed. The skills invoke Walter Writes AI tools via MCP for the humanization and detection steps.

The entry mirrors the existing Notion line in style and length. Happy to adjust wording or scope if helpful.