### PR TITLE
docs: add web artifacts builder compatibility link

### DIFF
--- a/web-artifacts-builder/SKILL.md
+++ b/web-artifacts-builder/SKILL.md
@@ -1,0 +1,8 @@
+# Web Artifacts Builder Skill
+
+This compatibility page keeps older links to the web artifacts builder skill working.
+It is not the canonical skill definition.
+
+The canonical skill lives at:
+
+[skills/web-artifacts-builder/SKILL.md](../skills/web-artifacts-builder/SKILL.md)


### PR DESCRIPTION
## Summary

- Add a lightweight compatibility page at `web-artifacts-builder/SKILL.md`.
- Point readers to the canonical skill at `skills/web-artifacts-builder/SKILL.md`.

## Why

The Claude blog post linked in #141 points to the older root-level path, which currently returns 404. Since the actual skill lives under `skills/web-artifacts-builder/`, this keeps the older link usable without duplicating the skill implementation or changing marketplace configuration.

Fixes #141.

## Verification

- Confirmed `skills/web-artifacts-builder/SKILL.md` exists.
- Confirmed the compatibility page links to the canonical path.
- Ran `git diff --cached --check` before commit.

## Risk

Low. Documentation-only compatibility page; canonical skill location remains unchanged.
