### PR TITLE
fix(eval-viewer): resolve eval_metadata.json path mismatch

### DIFF
--- a/skills/skill-creator/eval-viewer/generate_review.py
+++ b/skills/skill-creator/eval-viewer/generate_review.py
@@ -87,8 +87,12 @@ def build_run(root: Path, run_dir: Path) -> dict | None:
     prompt = ""
     eval_id = None
 
-    # Try eval_metadata.json
-    for candidate in [run_dir / "eval_metadata.json", run_dir.parent / "eval_metadata.json"]:
+    # Try eval_metadata.json — walk up to eval-N/ level
+    for candidate in [
+        run_dir / "eval_metadata.json",
+        run_dir.parent / "eval_metadata.json",
+        run_dir.parent.parent / "eval_metadata.json",
+    ]:
         if candidate.exists():
             try:
                 metadata = json.loads(candidate.read_text())

--- a/skills/xlsx/scripts/office/soffice.py
+++ b/skills/xlsx/scripts/office/soffice.py
@@ -42,6 +42,8 @@ _SHIM_SO = Path(tempfile.gettempdir()) / "lo_socket_shim.so"
 
 
 def _needs_shim() -> bool:
+    if not hasattr(socket, "AF_UNIX"):
+        return True
     try:
         s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         s.close()


### PR DESCRIPTION
## Description

`generate_review.py`'s `build_run` function only searched for `eval_metadata.json` at `run_dir` and `run_dir.parent`, but the file actually resides one more level up (at the `eval-N/` directory level). This caused the eval-review viewer to fail to find the metadata.

`aggregate_benchmark.py`'s `load_run_results` already handles this correctly by looking for `eval_metadata.json` at `eval_dir / "eval_metadata.json"`. This fix adds `run_dir.parent.parent` as a third search location to match that behavior.

Fixes #1095