### PR TITLE
fix(xlsx): guard AF_UNIX access for Windows compatibility

### DIFF
--- a/skills/xlsx/scripts/office/soffice.py
+++ b/skills/xlsx/scripts/office/soffice.py
@@ -42,6 +42,8 @@ _SHIM_SO = Path(tempfile.gettempdir()) / "lo_socket_shim.so"
 
 
 def _needs_shim() -> bool:
+    if not hasattr(socket, "AF_UNIX"):
+        return True
     try:
         s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         s.close()


### PR DESCRIPTION
On Windows, `socket.AF_UNIX` does not exist, so accessing it raises `AttributeError`. This causes the xlsx skill to crash when importing `soffice.py`.

Add a `hasattr(socket, \AF_UNIX\)` guard in `_needs_shim()` to return `True` early when AF_UNIX is unavailable, preventing the crash.