### PR TITLE
Add A New Skill for Happy-Camp

### DIFF
--- a/skills/happy-cmap/LICENSE.txt
+++ b/skills/happy-cmap/LICENSE.txt
@@ -1,0 +1,30 @@
+© 2025 Anthropic, PBC. All rights reserved.
+
+LICENSE: Use of these materials (including all code, prompts, assets, files,
+and other components of this Skill) is governed by your agreement with
+Anthropic regarding use of Anthropic's services. If no separate agreement
+exists, use is governed by Anthropic's Consumer Terms of Service or
+Commercial Terms of Service, as applicable:
+https://www.anthropic.com/legal/consumer-terms
+https://www.anthropic.com/legal/commercial-terms
+Your applicable agreement is referred to as the "Agreement." "Services" are
+as defined in the Agreement.
+
+ADDITIONAL RESTRICTIONS: Notwithstanding anything in the Agreement to the
+contrary, users may not:
+
+- Extract these materials from the Services or retain copies of these
+  materials outside the Services
+- Reproduce or copy these materials, except for temporary copies created
+  automatically during authorized use of the Services
+- Create derivative works based on these materials
+- Distribute, sublicense, or transfer these materials to any third party
+- Make, offer to sell, sell, or import any inventions embodied in these
+  materials
+- Reverse engineer, decompile, or disassemble these materials
+
+The receipt, viewing, or possession of these materials does not convey or
+imply any license or right beyond those expressly granted above.
+
+Anthropic retains all right, title, and interest in these materials,
+including all copyrights, patents, and other intellectual property rights.

--- a/skills/happy-cmap/SKILL.md
+++ b/skills/happy-cmap/SKILL.md
@@ -1,0 +1,67 @@
+----
+name: simply-happy
+version: 0.1.0
+description: Launch a full-screen transparent fireworks effect on macOS. Triggered when the user expresses celebration, confetti, fireworks, milestones (PR merged / deployment / CI all green), festive occasions, or simply wants to "feel happy".
+---
+
+# simply-happy
+
+Make the screen "happy" — overlay a transparent, click-through fireworks animation on the macOS desktop that automatically fades out after a few seconds.
+
+## When to Use
+
+Use this skill to give the user a visual celebration when the conversation contains any of the following intents:
+
+- **Direct request**: "show me fireworks", "celebrate", "confetti", "let's party", "放个烟花", "撒花"
+- **Milestone achievement**: PR merged successfully, CI all green, deployment complete, demo finished, exam/contest passed
+- **Festive occasion**: Birthday, work anniversary, New Year's Eve, version milestone
+- **Emotional expression**: User wants to "feel happy", "what a great day", "I'm so excited"
+
+## How It Works
+
+This skill includes a `fireworks.swift` script (located in the `/scripts` directory alongside this SKILL.md). When executed, it will:
+
+1. Create a transparent, borderless, click-through window above all screens (layered above the menu bar and Dock)
+2. Continuously launch and explode colorful fireworks on screen, with trails and glow effects
+3. Fade out after the specified duration and automatically terminate the process, leaving no residue
+
+### Commands
+
+> `<SKILL_DIR>` refers to the absolute path of the directory containing this SKILL.md. The agent typically knows this path when loading the skill — replace it with the actual path before execution.
+
+**Default 8 seconds**:
+
+```bash
+swift "<SKILL_DIR>/scripts/fireworks.swift" &
+```
+
+**Custom duration (seconds)**:
+
+```bash
+swift "<SKILL_DIR>/scripts/fireworks.swift" 15 &
+```
+
+## Agent Behavior Guidelines
+
+- **Run in background**: Append `&` to the command to avoid blocking the current conversation flow
+- **Do not poll / sleep**: The script will automatically exit after the specified duration — no need for the agent to kill it
+- **Platform restriction**: Only invoke on macOS; on other systems (Linux / Windows), inform the user that "this fireworks effect is only supported on macOS"
+- **Trigger sparingly**: Only run one show at a time; do not trigger at the end of every message in a normal conversation to avoid visual disturbance
+- **Prefer default duration**: The default 8 seconds provides sufficient ceremony — do not add a duration parameter unless the user explicitly requests it
+
+## Requirements
+
+- macOS (any modern version, uses the built-in Cocoa / AppKit framework)
+- `swift` command available (bundled with Xcode or Command Line Tools; install with `xcode-select --install` if missing)
+- No network, disk write, or screen recording permissions required
+
+## Implementation Details
+
+- **Rocket**: A projectile that rises in a parabolic arc from the bottom of the screen with a fading trail, exploding upon reaching its target height
+- **Particle**: Colorful particles produced by the explosion, affected by gravity and air resistance; three-layer composition of trail + glow + core using the `plusLighter` blend mode for a luminous effect
+- **Window**: Pinned with `kCGMaximumWindowLevel`, click-through via `ignoresMouseEvents = true`, displayed across all Spaces with `canJoinAllSpaces + stationary`
+- **Animation**: Driven by a 60 FPS Timer, fade-in 0.35s / fade-out 1s, auto-terminates via `NSApp.terminate` when time is up
+
+## Acknowledgements
+
+Inspired by Happy Camp (快乐大本营) — "simply happy" is an attitude.

--- a/skills/happy-cmap/SKILL.md
+++ b/skills/happy-cmap/SKILL.md
@@ -1,10 +1,10 @@
 ----
-name: simply-happy
+name: happy-camp
 version: 0.1.0
 description: Launch a full-screen transparent fireworks effect on macOS. Triggered when the user expresses celebration, confetti, fireworks, milestones (PR merged / deployment / CI all green), festive occasions, or simply wants to "feel happy".
 ---
 
-# simply-happy
+# happy-camp
 
 Make the screen "happy" — overlay a transparent, click-through fireworks animation on the macOS desktop that automatically fades out after a few seconds.
 

--- a/skills/happy-cmap/scripts/fireworks.swift
+++ b/skills/happy-cmap/scripts/fireworks.swift
@@ -1,0 +1,208 @@
+#!/usr/bin/env swift
+import Cocoa
+
+// MARK: - Particle / Rocket
+
+final class Particle {
+    var x: CGFloat, y: CGFloat
+    var vx: CGFloat, vy: CGFloat
+    var life: CGFloat
+    let maxLife: CGFloat
+    let hue: CGFloat
+    let size: CGFloat
+    var trail: [(CGFloat, CGFloat, CGFloat)] = []
+
+    init(x: CGFloat, y: CGFloat, hue: CGFloat) {
+        self.x = x; self.y = y
+        let angle = CGFloat.random(in: 0 ..< (2 * .pi))
+        let speed = CGFloat.random(in: 70 ... 320)
+        self.vx = cos(angle) * speed
+        self.vy = sin(angle) * speed
+        let l = CGFloat.random(in: 1.1 ... 2.2)
+        self.life = l; self.maxLife = l
+        var h = hue + CGFloat.random(in: -0.04 ... 0.04)
+        if h < 0 { h += 1 }; if h >= 1 { h -= 1 }
+        self.hue = h
+        self.size = CGFloat.random(in: 2.2 ... 4.2)
+    }
+
+    func step(_ dt: CGFloat) -> Bool {
+        trail.append((x, y, alpha))
+        if trail.count > 6 { trail.removeFirst() }
+        x += vx * dt
+        y += vy * dt
+        vy -= 230 * dt          // gravity (NSView y-up)
+        let drag = pow(0.55, dt)
+        vx *= drag; vy *= drag
+        life -= dt
+        return life > 0
+    }
+
+    var alpha: CGFloat { max(0, life / maxLife) }
+}
+
+final class Rocket {
+    var x: CGFloat, y: CGFloat
+    var vx: CGFloat, vy: CGFloat
+    let hue: CGFloat
+    let explodeY: CGFloat
+    var trail: [(CGFloat, CGFloat)] = []
+
+    init(width: CGFloat, height: CGFloat) {
+        x = CGFloat.random(in: width * 0.15 ... width * 0.85)
+        y = 0
+        let target = CGFloat.random(in: height * 0.55 ... height * 0.85)
+        explodeY = target
+        let g: CGFloat = 380
+        vy = sqrt(2 * g * target) * 0.95
+        vx = CGFloat.random(in: -40 ... 40)
+        hue = CGFloat.random(in: 0 ... 1)
+    }
+
+    func step(_ dt: CGFloat) -> Bool {
+        trail.append((x, y))
+        if trail.count > 10 { trail.removeFirst() }
+        x += vx * dt
+        y += vy * dt
+        vy -= 380 * dt
+        return vy > 0 && y < explodeY
+    }
+}
+
+// MARK: - View
+
+final class FireworksView: NSView {
+    private var rockets: [Rocket] = []
+    private var particles: [Particle] = []
+    private var lastTick = CACurrentMediaTime()
+    private var spawnTimer: CGFloat = 0
+    private var timer: Timer?
+
+    override var isFlipped: Bool { false }
+
+    func start() {
+        lastTick = CACurrentMediaTime()
+        timer = Timer.scheduledTimer(withTimeInterval: 1.0 / 60.0, repeats: true) { [weak self] _ in
+            self?.tick()
+        }
+        if let t = timer { RunLoop.main.add(t, forMode: .common) }
+    }
+
+    func stop() { timer?.invalidate(); timer = nil }
+
+    private func tick() {
+        let now = CACurrentMediaTime()
+        var dt = CGFloat(now - lastTick); lastTick = now
+        if dt > 0.1 { dt = 0.1 }
+
+        let w = bounds.width, h = bounds.height
+        spawnTimer -= dt
+        if spawnTimer <= 0 {
+            rockets.append(Rocket(width: w, height: h))
+            spawnTimer = CGFloat.random(in: 0.20 ... 0.75)
+        }
+
+        var aliveR: [Rocket] = []
+        aliveR.reserveCapacity(rockets.count)
+        for r in rockets {
+            if r.step(dt) {
+                aliveR.append(r)
+            } else {
+                let count = Int.random(in: 90 ... 160)
+                for _ in 0 ..< count {
+                    particles.append(Particle(x: r.x, y: r.y, hue: r.hue))
+                }
+            }
+        }
+        rockets = aliveR
+        particles = particles.filter { $0.step(dt) }
+        needsDisplay = true
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        guard let ctx = NSGraphicsContext.current?.cgContext else { return }
+        ctx.clear(bounds)
+
+        // rocket trails & heads (normal blend)
+        for r in rockets {
+            for (i, p) in r.trail.enumerated() {
+                let a = CGFloat(i) / CGFloat(max(r.trail.count, 1)) * 0.55
+                ctx.setFillColor(NSColor(hue: r.hue, saturation: 0.4, brightness: 1.0, alpha: a).cgColor)
+                ctx.fillEllipse(in: CGRect(x: p.0 - 1.5, y: p.1 - 1.5, width: 3, height: 3))
+            }
+            ctx.setFillColor(NSColor(hue: r.hue, saturation: 0.5, brightness: 1.0, alpha: 1).cgColor)
+            ctx.fillEllipse(in: CGRect(x: r.x - 2.5, y: r.y - 2.5, width: 5, height: 5))
+        }
+
+        // particles with additive blend for glow
+        ctx.setBlendMode(.plusLighter)
+        for p in particles {
+            for (i, t) in p.trail.enumerated() {
+                let f = CGFloat(i) / CGFloat(max(p.trail.count, 1))
+                let a = t.2 * f * 0.35
+                let s = p.size * f
+                ctx.setFillColor(NSColor(hue: p.hue, saturation: 0.9, brightness: 1.0, alpha: a).cgColor)
+                ctx.fillEllipse(in: CGRect(x: t.0 - s/2, y: t.1 - s/2, width: s, height: s))
+            }
+            let glow = p.size * 4.5
+            ctx.setFillColor(NSColor(hue: p.hue, saturation: 0.75, brightness: 1.0, alpha: p.alpha * 0.20).cgColor)
+            ctx.fillEllipse(in: CGRect(x: p.x - glow/2, y: p.y - glow/2, width: glow, height: glow))
+            ctx.setFillColor(NSColor(hue: p.hue, saturation: 0.6, brightness: 1.0, alpha: p.alpha).cgColor)
+            ctx.fillEllipse(in: CGRect(x: p.x - p.size/2, y: p.y - p.size/2, width: p.size, height: p.size))
+        }
+        ctx.setBlendMode(.normal)
+    }
+}
+
+// MARK: - App bootstrap
+
+let app = NSApplication.shared
+app.setActivationPolicy(.accessory)
+
+let duration: TimeInterval = {
+    if CommandLine.arguments.count >= 2, let d = Double(CommandLine.arguments[1]) { return d }
+    return 8.0
+}()
+
+var windows: [NSWindow] = []
+var views: [FireworksView] = []
+for screen in NSScreen.screens {
+    let rect = screen.frame
+    let w = NSWindow(contentRect: rect, styleMask: [.borderless], backing: .buffered, defer: false)
+    w.isOpaque = false
+    w.backgroundColor = .clear
+    w.level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.maximumWindow)))
+    w.ignoresMouseEvents = true
+    w.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary, .ignoresCycle]
+    w.hasShadow = false
+    w.alphaValue = 0
+    let v = FireworksView(frame: NSRect(origin: .zero, size: rect.size))
+    v.wantsLayer = true
+    w.contentView = v
+    w.orderFrontRegardless()
+    v.start()
+    windows.append(w); views.append(v)
+}
+
+// fade in
+NSAnimationContext.runAnimationGroup { ctx in
+    ctx.duration = 0.35
+    for w in windows { w.animator().alphaValue = 1 }
+}
+
+// fade out + quit
+DispatchQueue.main.asyncAfter(deadline: .now() + duration - 1.0) {
+    NSAnimationContext.runAnimationGroup({ ctx in
+        ctx.duration = 1.0
+        for w in windows { w.animator().alphaValue = 0 }
+    }, completionHandler: {
+        for v in views { v.stop() }
+        NSApp.terminate(nil)
+    })
+}
+
+// Ctrl+C / SIGTERM clean exit
+signal(SIGINT) { _ in NSApp.terminate(nil) }
+signal(SIGTERM) { _ in NSApp.terminate(nil) }
+
+app.run()


### PR DESCRIPTION
Add a skill happy-camp:
Launch a full-screen transparent fireworks effect on macOS. Triggered when the user expresses celebration, confetti, fireworks, milestones (PR merged / deployment / CI all green), festive occasions, or simply wants to "feel happy".