### PR TITLE
Add closeout skill

### DIFF
--- a/skills/closeout/LICENSE.txt
+++ b/skills/closeout/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Anthropic, PBC.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/closeout/SKILL.md
+++ b/skills/closeout/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: closeout
+description: Wrap up a coding session by writing a structured closeout doc, updating per-repo context.md / progress.md, and actively scanning for unfinished work (uncommitted changes, unpushed commits, untested deploys, broken refs). Use at the end of an interactive coding session, when the user says "wrap up", "closeout", or "summarize the session", or when asked what's left to do. Takes an optional session slug as an argument.
+---
+
+# Session Closeout
+
+A session is not done when the last edit lands. It is done when (a) the work is documented in places future sessions will actually read, and (b) every loose end has been either fixed or explicitly listed. This skill enforces both.
+
+## Pre-Flight (read before acting)
+
+Before writing anything, gather context. Skipping this is the #1 reason closeouts produce empty or wrong content.
+
+1. **Identify touched repos.** Anything edited, committed, or where commands ran. If unsure, `git status` in candidate dirs.
+2. **Collect commits.** For each touched repo: `git log --oneline @{u}..HEAD 2>/dev/null` for unpushed; `git log --since="6 hours ago" --oneline` for recent. (Git accepts relative dates natively, so this is portable across Linux/macOS without needing `date -d`.)
+3. **Diff state.** `git status` and `git diff --stat` in each touched repo. Note uncommitted/unstaged.
+4. **Confirm with the user** if the session boundary is ambiguous (e.g., "this session started when you asked X, right?"). Do not guess if the scope is wide.
+
+If `[slug]` is missing, derive one from the dominant theme of the work (`fix-auth-redirect`, `add-csv-export`). Keep it kebab-case and short.
+
+## Procedure
+
+### Step 1: Write the closeout doc
+
+Default location: `.claude/closeouts/YYYY-MM-DD-[slug].md` inside the primary repo for the session. If the work spanned multiple repos with no clear primary, pick the repo with the most commits or ask. If `.claude/closeouts/` does not exist, create it.
+
+Use this structure (omit sections that don't apply, but don't omit because the section is hard to fill — fill it):
+
+```markdown
+# <Session Title>
+**Date:** YYYY-MM-DD
+**Duration:** approximate
+**Repos touched:** list
+
+## Context & Motivation
+Why this work was initiated. The user's original request and any refinements during the session.
+
+## Decisions Made
+For each significant decision:
+- **Decision:** What was decided
+- **Alternatives considered:** What else was on the table
+- **Rationale:** Why this option was chosen
+- **Trade-offs:** What was given up
+
+## What Was Built / Changed
+Chronological narrative. File paths, commit hashes, PR links.
+
+## Architecture & Design
+For new systems or non-trivial changes: how it works, data flow, key constraints.
+
+## Open Items & Follow-ups
+(Filled in by Step 3 — leave empty placeholder for now.)
+
+## Key Files
+Links to important files created or modified.
+```
+
+### Step 2: Update per-repo context files (most commonly skipped)
+
+This is the highest-leverage step. New Claude Code sessions load each repo's `CLAUDE.md` and any nearby `context.md` / `progress.md`. They do *not* read closeout docs. If you only write the closeout doc, future sessions will not see your work.
+
+For **every** touched repo:
+
+1. **`context.md`** (at repo root or `docs/context.md`, follow existing convention if present):
+   - Current state: working / broken / in-progress
+   - What changed in this session (one-paragraph summary)
+   - Key decisions and rationale (link to closeout doc for detail)
+   - Open items for this repo specifically
+
+2. **`progress.md`** (optional but recommended for repos with active iteration):
+   - Append a dated entry with commit hashes and one-line summaries
+
+If the repo has neither file, create `context.md`. Don't create `progress.md` if there's no convention for it in the repo — that's clutter.
+
+### Step 3: Open-items scan (do not skip)
+
+Before declaring the closeout done, actively scan for unfinished work. Many sessions are declared done with dirty state — this step catches that.
+
+Run through each check explicitly. Do not write "none" without performing the check.
+
+1. **Uncommitted changes.** `git status` in every touched repo. Anything staged or unstaged is an open item.
+2. **Unpushed commits.** `git log --oneline @{u}..HEAD 2>/dev/null` in every touched repo.
+3. **Untested deploys.** Was anything deployed, restarted, or rolled out this session? If yes: was it verified working (curl, browser check, log inspection)? "It deployed without errors" is not verification.
+4. **Broken references.** Did the session produce docs, comments, or PR descriptions referencing files, URLs, or symbols? Verify they exist.
+5. **Promised but undelivered.** Read back the user's original request. Was every part addressed? Gaps are open items.
+6. **Follow-up work surfaced.** Did the session reveal future work (migration step 2, cleanup pass, deferred refactor)? Note it.
+7. **Documentation gaps.** Did the work reveal missing docs in the repo's CLAUDE.md or similar? Flag it.
+
+For each item found:
+- **Fixable in under 2 minutes:** fix it now. Do not list it.
+- **Requires a user decision:** list it with context and options.
+- **Future work:** note it as a follow-up.
+
+Fill the **Open Items & Follow-ups** section of the closeout doc with the remaining (post-fix) items. If the list is empty after scanning, that's fine — but only after scanning.
+
+### Step 4: Stage the changes — then ask before committing
+
+Stage the closeout doc and any updated `context.md` / `progress.md` files in each touched repo (`git add` only). Then **stop and ask the user** before committing or pushing.
+
+Show the user:
+- One line per repo: `repo-name: N files staged (closeout + M context updates)`
+- A proposed commit message per repo, e.g. `closeout: <session title>`
+- The pushed remotes that would receive the change
+
+Then ask explicitly: "Commit and push to N repos? (y/N)". Do not commit or push without an explicit yes from the user.
+
+This skill does not silently mutate git history. If the user declines, leave the staged changes in place so they can commit themselves.
+
+## Quality Gates (mandatory before declaring done)
+
+- [ ] Closeout doc written and staged in the primary repo
+- [ ] `context.md` updated (or created) and staged in **every** touched repo
+- [ ] User has been shown the staged changes and asked to confirm commit + push
+- [ ] If user confirmed: all commits created and pushed; `git status` clean
+- [ ] If user declined: staged changes left in place (do not unstage)
+- [ ] Open-items scan performed item by item (not skipped, not "none" without checking)
+- [ ] If anything was deployed this session, deployment verified working
+
+If any gate fails, do not declare the closeout complete. Either fix the gap or call it out explicitly to the user.
+
+## Open Items Scan (for this skill itself)
+
+This skill makes changes. Apply its own rules to its own execution:
+- All files written? (closeout doc + context updates)
+- All intended files staged? (`git diff --cached` shows what you meant to commit)
+- If the user confirmed commit + push in Step 4: all commits actually created and pushed?
+- If the user declined: staged changes still in place, not silently unstaged?
+- Anything promised in the closeout doc but not actually done? (e.g., "fixed X" written into the doc but no corresponding edit on disk)
+
+## Notes
+
+- **Active scan, not passive list.** "Open items" sections in closeout docs are usually wrong because the writer didn't actually look. Step 3 exists to force a real scan. Treat it as a checklist, not a prompt.
+- **Closeout docs are reference, not memory.** Don't write the closeout doc and skip context.md updates — future sessions won't find the closeout doc on their own.
+- **Don't fabricate.** If you don't know how long the session was, write "approximate" or leave it. Don't make up commit hashes, PR numbers, or decisions that weren't actually made.
+- **One closeout per session, not per task.** If the user asks for closeout mid-session and continues, that's fine — write a partial closeout, then update at the real end. Don't pile up half-closeouts.


### PR DESCRIPTION
## Summary

Adds a `closeout` skill: a session-end procedure that writes a structured closeout doc, updates per-repo `context.md` / `progress.md` so future sessions actually find the work, and runs an active scan for unfinished items (uncommitted changes, unpushed commits, untested deploys, broken refs, undelivered promises).

The skill stages changes and explicitly asks for user confirmation before any commit or push — it does not silently mutate git history.

## Why

Two real failure modes this addresses:

1. **Sessions declared done with dirty state.** Uncommitted edits, unpushed commits, untested deploys, half-mentioned follow-ups routinely slip through ad-hoc "wrap this up" prompts. The skill enforces an item-by-item scan instead of allowing "no open items" without actually checking.

2. **Closeout docs landing in dead-letter locations.** A summary written somewhere future sessions don't load doesn't propagate. The skill specifically writes to per-repo `context.md` / `progress.md` because that's what new sessions actually read on startup.

There aren't currently any session-closeout / wrap-up skills in this repo's existing 17 — this fills a gap that complements the more domain-focused skills (pdf, docx, brand-guidelines, mcp-builder, etc.) rather than overlapping with them.

## What's in the skill

- Pre-flight context gathering (which repos touched, what commits, what diff state)
- Step-by-step procedure: write closeout doc → update per-repo context files → run open-items scan → stage and ask before commit/push
- Explicit quality gates (mandatory checklist before declaring done)
- Self-application clause (the skill applies its own rules to its own execution)

## Design choices worth flagging for reviewers

- **No auto-commit.** Public-marketplace skills that silently push to multiple repos felt like the wrong default. The skill stages, summarizes, and asks. If the user declines, staged changes are left in place — not unstaged.
- **Per-repo `context.md` instead of central memory.** New sessions load `CLAUDE.md` + nearby `context.md` / `progress.md`; they don't read closeout docs in arbitrary locations. The skill writes where future sessions actually look.
- **Active scan, not passive list.** Each open-items check is explicit (`git status` in every touched repo, `@{u}..HEAD` for unpushed commits, etc.). Skills that say "review for open items" without enumerating produce "none" without scanning.

## Compatibility

Pure markdown instructions + shell commands the agent already has. No bundled scripts, no external dependencies. Should work cleanly in Claude Code, the API, claude.ai skills, and other agentskills.io-compatible clients.

License: Apache 2.0 (matching repo convention).
