### PR TITLE
Add metaprompt skill

### DIFF
--- a/skills/metaprompt/LICENSE.txt
+++ b/skills/metaprompt/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 couldbeme
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/metaprompt/SKILL.md
+++ b/skills/metaprompt/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: metaprompt
+description: Transform a vague task into a precise, structured, reusable prompt using prompt-engineering best practices. Use when the user wants to write, improve, optimize, or debug a prompt.
+license: Complete terms in LICENSE.txt
+---
+
+# Metaprompt Generator
+
+When this skill is active, turn a fuzzy, underspecified request into a high-quality, reusable prompt. The deliverable is **the prompt itself** — self-contained, ready to paste into any capable model, and written so a stranger could run it against the intended inputs and get the intended result without asking what the author meant.
+
+This is meta-work: you are not answering the user's underlying task, you are engineering the prompt that will. Resist the urge to just do the task — produce the instrument.
+
+## When to use
+
+Engage this skill when the user:
+- Has a goal but isn't sure how to phrase the prompt ("help me write a prompt that…")
+- Wants to improve or tighten a prompt that gives inconsistent or shallow results
+- Is about to hand a complex, multi-step task to an AI and wants it to land the first time
+- Asks you to "optimize," "rewrite," or "debug" an existing prompt
+
+Do **not** silently restructure a prompt the user only asked you to *run*. This skill is for when the prompt is the product.
+
+## The process
+
+Work through these five steps, then deliver.
+
+### 1. Analyze the task
+Clarify before generating. Pin down:
+- **Outcome** — what does "done" look like? What's the concrete deliverable and its shape?
+- **Audience & context** — who consumes the output, in what setting?
+- **Inputs available** — what material will the prompt have to work with at run time?
+- **Constraints** — length, tone, format, domain rules, hard "never do X" boundaries.
+- **Failure modes** — what could the model plausibly misread, over-generalize, or hallucinate?
+
+If a load-bearing detail is missing and you can't safely default it, ask **one** focused clarifying question. Otherwise proceed on stated, reasonable assumptions and name them.
+
+### 2. Apply prompt-engineering principles
+Build the prompt around these. Each maps to a deeper entry in `references/prompt-patterns.md` — consult it when a task needs more than the defaults.
+- **Role** — give the model a specific, capable persona ("You are a…").
+- **Explicit goal & success criteria** — state what a good answer must contain.
+- **Structure** — decompose non-trivial work into ordered phases or numbered steps.
+- **Reasoning scaffold** — for analysis/decision tasks, ask for the work, not just the verdict (see patterns file).
+- **Constraints** — spell out format, length, tone, scope, and prohibitions.
+- **Edge handling** — say what to do on missing/ambiguous/out-of-scope input (ask vs. assume).
+- **Output format** — specify the exact shape: headings, bullets, table, JSON schema, word budget.
+- **Economy** — precise over verbose; every line earns its place.
+
+### 3. Generate the prompt
+Produce the complete prompt in a **single fenced code block** so it copies cleanly. It must be self-contained — runnable without this conversation as context.
+
+### 4. Self-review
+Before presenting, silently check the draft against:
+- **Ambiguity** — could any instruction be read two ways?
+- **Completeness** — are role, goal, structure, constraints, and output all covered?
+- **Edge cases** — does it say what to do when something is missing or unclear?
+- **Economy** — is anything redundant or padding?
+
+Fix what you find. Don't narrate the review unless asked.
+
+### 5. Present
+Deliver exactly:
+1. The finished prompt (in a code block).
+2. A 1–2 sentence note on the key design choices you made and why.
+3. An offer to iterate — tighten it, adapt it for a specific model, or turn it into a reusable template/skill.
+
+## Worked example
+
+**User request:** "I need a prompt to summarize customer support tickets."
+
+**Weak prompt (what to avoid):** "Summarize this support ticket."
+
+**Strong prompt (what this skill produces):**
+```
+You are a senior customer-support analyst. Summarize the support ticket below for a team lead who has 15 seconds to triage it.
+
+Produce exactly:
+- **One-line summary** (≤20 words): the core problem.
+- **Severity**: P1 (outage/data loss) | P2 (broken feature) | P3 (question/minor).
+- **Customer ask**: what they want to happen, in their words.
+- **Next action**: the single most useful next step for the team.
+
+Rules:
+- Use only information in the ticket. If severity is unclear, choose the lower one and add "(assumed)".
+- No greetings, no restating the rules, no apology language.
+
+Ticket:
+"""
+{ticket_text}
+"""
+```
+
+The strong version fixes role, audience, exact output schema, a severity rubric, an ambiguity rule, and a delimited input slot — turning an unreliable one-liner into a deterministic instrument.
+
+## Quality bar
+
+A finished prompt passes when: a person who has never seen this conversation could take it, supply the intended inputs, and get the intended result — without needing to ask the author what they meant. If it would still need a verbal explanation to work, it isn't done.
+
+## RESOURCES
+
+- **references/prompt-patterns.md** — a deeper pattern library to draw on when the five defaults aren't enough: role/persona patterns, decomposition strategies, reasoning-elicitation (chain-of-thought, plan-then-execute), few-shot construction, output-schema/JSON patterns, guardrails and edge-handling phrasings, common failure modes with their fixes, and model-specific notes. Read it when a task is high-stakes, ambiguous, or structurally unusual.

--- a/skills/metaprompt/references/prompt-patterns.md
+++ b/skills/metaprompt/references/prompt-patterns.md
@@ -1,0 +1,77 @@
+# Prompt Patterns — reference library
+
+Draw on these when the five defaults in `SKILL.md` aren't enough. Each pattern lists *when* to reach for it and a *template fragment* to adapt — not boilerplate to paste verbatim.
+
+## 1. Role / persona patterns
+
+| When | Fragment |
+|---|---|
+| Domain expertise matters | `You are a senior <role> with deep experience in <domain>.` |
+| Audience-shaping matters more than expertise | `You are explaining to <audience> who knows <X> but not <Y>.` |
+| A specific stance is needed | `You are a skeptical reviewer whose job is to find what's wrong, not to praise.` |
+
+Keep the persona concrete and *functional* — a role exists to bias behavior, not for flavor. Avoid stacking adjectives ("world-class genius expert"); they add tokens, not capability.
+
+## 2. Decomposition strategies
+
+- **Phased**: number the steps when order matters and later steps depend on earlier ones.
+- **Checklist**: a flat list of must-cover items when order is irrelevant but completeness matters.
+- **Map-then-reduce**: "First list all candidates. Then evaluate each. Then pick." — prevents premature convergence.
+- **Separate analysis from output**: "Think through X. Then produce only the final table." — keeps reasoning out of the deliverable.
+
+## 3. Reasoning elicitation
+
+- **Chain-of-thought**: `Work through this step by step before giving your answer.` Use for math, logic, multi-constraint problems.
+- **Plan-then-execute**: `First write a brief plan. Then carry it out.` Use for multi-file or multi-stage tasks.
+- **Self-critique pass**: `Draft an answer, then critique it for <failure modes>, then produce the improved version.` Use for high-stakes single-shot output.
+- **Force the work, hide the work**: ask for reasoning, then `Output only the final result.` when the user wants a clean deliverable but better quality.
+
+> Note: on strong reasoning models, heavy CoT scaffolding can be redundant or even counterproductive — state the goal and constraints clearly and let the model reason. Add explicit scaffolds when output is inconsistent without them.
+
+## 4. Few-shot construction
+
+- Use 1–3 examples when the **format** or **judgment boundary** is hard to describe in words.
+- Make examples *diverse* and include at least one **edge/negative** case ("here's a borderline input and the correct handling").
+- Label the parts: `Input: … / Correct output: …`.
+- Don't few-shot what a single clear instruction already pins down — examples cost tokens and can over-anchor.
+
+## 5. Output-schema / structured output
+
+- **Exact shape**: enumerate the fields and their order. Ambiguity in the schema becomes variance in the output.
+- **JSON**: `Respond with ONLY valid JSON matching: {"field": "<type/desc>", ...}. No prose, no code fence.`
+- **Tables**: name the columns and the sort order.
+- **Budgets**: give length limits per section ("≤20 words"), not just overall — they're more enforceable.
+- For machine consumption, add: `If a value is unknown, use null — never invent one.`
+
+## 6. Guardrails & edge-handling phrasings
+
+- Ambiguity: `If the input is ambiguous, choose the most conservative reading and flag the assumption.`
+- Missing data: `If required information is absent, say what's missing instead of guessing.`
+- Scope: `If the request falls outside <scope>, say so and stop — do not attempt it.`
+- Anti-sycophancy: `If the premise is flawed, say so directly before answering.`
+- Grounding: `Use only the provided source. Do not add facts from general knowledge.`
+
+## 7. Common failure modes → fixes
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Inconsistent format run-to-run | Output shape underspecified | Add an exact schema + a worked example |
+| Model "explains" instead of doing | No output-only instruction | `Output only <deliverable>. No preamble.` |
+| Hallucinated facts | No grounding rule | Restrict to provided sources + "say if unknown" |
+| Ignores a constraint | Constraint buried mid-paragraph | Move constraints to a labeled list near the end |
+| Too verbose | No length budget | Per-section word limits |
+| Refuses or over-hedges a benign task | Persona/role too cautious | Adjust the role; state the legitimate purpose |
+| Drifts off-task on long inputs | Instruction far from the input | Restate the one key instruction right before the input block |
+
+## 8. Mechanical hygiene
+
+- **Delimit inputs** with clear fences (`"""`, `<input>…</input>`) so instructions can't be confused with data.
+- **Put the most important instruction last** *or* repeat it next to the input — recency helps on long prompts.
+- **Name placeholders** explicitly (`{ticket_text}`) so the user knows what to fill.
+- **One prompt, one job** — if it's doing three unrelated things, it's three prompts (or a phased pipeline).
+
+## 9. Model-specific notes
+
+- **Reasoning-heavy models** (e.g. high-effort Claude/o-series): lighter CoT scaffolding; lead with goal + constraints; trust the reasoning.
+- **Smaller/faster models**: more explicit structure, more examples, tighter output schemas; decompose aggressively.
+- **Tool-using agents**: state which tools exist and when to use each; specify the stop condition ("you're done when…").


### PR DESCRIPTION
## What

Adds **`metaprompt`** — a prompt-engineering skill that transforms a vague, underspecified request into a precise, structured, reusable prompt the user can paste into any capable model.

## Why

Writing a good prompt is a repeatable discipline (role, explicit success criteria, decomposition, edge-handling, output schema, economy). This skill makes that discipline a one-step, on-demand capability, and ships a reference library so Claude can reach for deeper patterns on high-stakes or unusual tasks.

## Structure

Follows the `algorithmic-art` bundle convention:

```
skills/metaprompt/
├── SKILL.md                      # frontmatter + direct operating instructions + worked example + quality bar
├── LICENSE.txt                   # MIT
└── references/
    └── prompt-patterns.md        # pattern library: roles, decomposition, reasoning elicitation,
                                   # few-shot, output schemas, guardrails, failure-mode→fix table, model notes
```

- Body is written as **direct operating instructions** to Claude (not slash-command meta).
- `description` carries explicit *"Use when…"* triggers for reliable auto-invocation, kept ≤200 chars for cross-surface compatibility.
- A `## RESOURCES` section points Claude at the bundled reference file.

## Testing

- Frontmatter validated: `name` 10/64, `description` 179/200, `license` present.
- Self-contained; no external dependencies.