### PR TITLE
Add grant-writing skill

### DIFF
--- a/skills/grant-writing/LICENSE.txt
+++ b/skills/grant-writing/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Anthropic, PBC.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/grant-writing/SKILL.md
+++ b/skills/grant-writing/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: grant-writing
+description: >
+  Produces professional grant proposals, logic models, needs statements, budgets with indirect cost (F&A) calculations, and evaluation plans for nonprofit and educational organizations. Use this skill whenever a user mentions grants, RFPs, funding proposals, logic models, needs statements, budget justifications, or evaluation plans — even if they just say "help me apply for funding," "write a proposal," "build a logic model," or "I need an eval plan for a grant." Supports all funder types (Federal, private foundation, state/local, corporate) and org types (K-12, higher ed, nonprofit, government). Always use this skill for any grant-related task.
+  ---
+
+  # Grant Writing Skill
+
+  Produces rigorous, funder-aligned grant documents across all major output types. Supports both RFP-extraction and manual funder-priority modes.
+
+  ---
+
+  ## Step 1 — Intake & Mode Selection
+
+  Before writing anything, collect the following. Ask only for what's missing — never repeat questions already answered.
+
+  ### Required inputs
+  | Field | Purpose |
+  |---|---|
+  | Organization name, type, and mission | Grounds all narrative voice |
+  | Project title and 1–2 sentence description | Anchors scope |
+  | Target population | Needed for needs statement & logic model |
+  | Geographic scope | Needed for data sourcing in needs statement |
+  | Requested amount (or range) | Drives budget structure |
+  | Project period | Affects budget lines and eval timeline |
+  | Funder name and type | Drives alignment strategy |
+
+  ### Funder alignment mode — choose one:
+  - **RFP Mode**: User pastes RFP/NOFO text → run the **RFP Parser** (see `references/funder-alignment.md`)
+  - **Manual Mode**: User describes funder priorities → use the **Priority Mapping Template** (see `references/funder-alignment.md`)
+
+  ---
+
+  ## Step 2 — Output Menu
+
+  After intake, confirm which outputs the user needs. Produce them in this recommended sequence when doing a full proposal:
+
+  ```
+  1. Needs Statement
+  2. Logic Model
+  3. Full Grant Narrative
+  4. Evaluation Plan
+  5. Budget + Justification
+  ```
+
+  Each section can also be produced standalone. Jump directly to the relevant section below.
+
+  ---
+
+  ## Step 3 — Needs Statement
+
+  **Purpose:** Establish urgency using data. Must demonstrate a gap between current and desired state.
+
+  ### Structure
+  1. **Population & context** — Who is affected, where, and how many
+  2. **Problem data** — 2–4 local/regional statistics (cite source + year)
+  3. **Root cause framing** — Why the problem persists (systemic, resource, capacity)
+  4. **Gap statement** — What is missing that this project will address
+  5. **Consequence of inaction** — What happens without intervention
+  6. **Transition** — Bridge to the proposed solution
+
+  ### Quality checks
+  - [ ] At least one local or regional data point (not national only)
+  - [ ] Statistics are < 5 years old
+  - [ ] Gap is specific, not generic ("students lack access to X" not "education is a challenge")
+  - [ ] Avoids deficit framing — centers community assets alongside needs
+
+  ### Funder-type calibration
+  | Funder | Emphasis |
+  |---|---|
+  | Federal (Dept of Ed, NSF) | Align gap to program priorities in NOFO; cite NAEP, NCES, Census |
+  | Private foundation | Connect to funder's theory of change; use community voice language |
+  | State/local | Use state data dashboards, ESSA data, state report cards |
+  | Corporate | Frame ROI: workforce, economic mobility, community impact |
+
+  ---
+
+  ## Step 4 — Logic Model (W.K. Kellogg Framework)
+
+  **Framework:** W.K. Kellogg Foundation Logic Model format with Theory of Change narrative.
+
+  ### Template
+
+  | Component | Definition | Produce for this project |
+  |---|---|---|
+  | **Situation** | Problem/need driving the work | Pull from Needs Statement |
+  | **Inputs** | Staff, funds, partners, data, facilities | List all committed resources |
+  | **Activities** | What the program does | 4–8 specific, verb-led actions |
+  | **Outputs** | Direct products of activities | Countable: # trained, # sessions, # materials |
+  | **Short-term outcomes** | Changes in knowledge/skill (0–1 yr) | 2–3 SMART outcomes |
+  | **Medium-term outcomes** | Changes in behavior/practice (1–3 yr) | 2–3 SMART outcomes |
+  | **Long-term outcomes** | Systems/condition change (3–5 yr) | 1–2 aspirational outcomes |
+  | **Assumptions** | Conditions required for logic to hold | List 3–5 |
+  | **External factors** | Contextual risks outside program control | List 3–5 |
+
+  ### Theory of Change narrative
+  After the table, write a 2–3 sentence "if-then" causal chain:
+  > "If [inputs] are deployed through [activities], then [outputs] will generate [short-term outcomes], which will lead to [long-term impact] because [assumption]."
+
+  ---
+
+  ## Step 5 — Full Grant Narrative
+
+  Produce sections in funder's required order if specified. Default structure:
+
+  ### 5.1 Executive Summary / Abstract (1 page max)
+  - Organization, project title, amount, period, population, core strategy, primary outcome
+
+  ### 5.2 Organizational Capacity
+  - Mission alignment, track record, relevant prior grants, key personnel credentials
+  - Include 1–2 measurable past results ("In 2023, X served Y participants achieving Z")
+
+  ### 5.3 Project Design / Program Plan
+  - Derive directly from logic model activities
+  - Use timeline table: Month | Activity | Lead | Milestone
+  - Address: evidence base for approach, equity strategy, sustainability plan
+
+  ### 5.4 Partnerships & Community Engagement
+  - Named partners with roles and MOUs if available
+  - Community voice: how target population shaped the design
+
+  ### 5.5 Evaluation Plan
+  → Defer to Step 6 (Evaluation Plan section)
+
+  ### 5.6 Dissemination / Sustainability
+  - How results will be shared and how the program continues post-grant
+
+  ### Narrative voice rules
+  - Write in active voice; subject = the organization or the participants
+  - Use specific, concrete language — never vague ("comprehensive," "innovative," "holistic" without evidence)
+  - Mirror funder's language from RFP verbatim where strategic (signal alignment)
+  - Page limits: respect them; flag to user if content exceeds limit
+
+  ---
+
+  ## Step 6 — Evaluation Plan
+
+  Read `references/evaluation-frameworks.md` to select the appropriate framework. Decision guide:
+
+  | Use case | Recommended framework |
+  |---|---|
+  | Training / professional development | **Kirkpatrick** (4 levels) |
+  | Public health or behavior change program | **RE-AIM** (5 dimensions) |
+  | Community development / capacity building | **W.K. Kellogg Logic Model** (already in Step 4) |
+  | Emerging, complex, or adaptive programs | **Developmental Evaluation** (Patton) |
+  | Federal education grants (Dept of Ed) | Kirkpatrick or RE-AIM depending on program type |
+
+  ### Minimum evaluation plan components
+  1. **Evaluation questions** — 3–5, mapped to outcomes in logic model
+  2. **Data sources** — for each question (survey, assessment, admin data, focus group)
+  3. **Data collection timeline** — baseline, midpoint, endline
+  4. **Evaluator role** — internal vs. external; justify
+  5. **Framework-specific section** — (see `references/evaluation-frameworks.md`)
+  6. **Reporting plan** — to funder and to participants
+
+  ---
+
+  ## Step 7 — Budget & Budget Justification
+
+  Read `references/budget-templates.md` for line-item templates and indirect cost guidance.
+
+  ### Budget structure
+
+  **Personnel** (largest category — typically 50–70% of budget)
+  - List each position: Title | % FTE | Annual Salary | Grant-Funded % | Grant Amount
+  - Include fringe benefits as separate line (use actual rate or 25–30% if unknown)
+
+  **Non-Personnel categories**
+  | Category | Examples |
+  |---|---|
+  | Consultants / Subcontracts | Evaluator, trainer, subject matter expert |
+  | Travel | Mileage, airfare, per diem (use GSA rates for federal) |
+  | Equipment | > $5,000 per unit (federal threshold) |
+  | Supplies | Curriculum materials, technology < $5,000 |
+  | Indirect / F&A | See below |
+  | Other Direct Costs | Participant incentives, printing, subscriptions |
+
+  ### Indirect Cost (F&A) calculation
+
+  ```
+  Indirect Cost = Direct Cost Base × Negotiated Rate
+
+  Federal rate options:
+  - Use organization's negotiated rate (NICRA) if available
+  - De minimis rate: 10% of Modified Total Direct Costs (MTDC) — available to any org without a negotiated rate (2 CFR §200.414)
+  - MTDC excludes: equipment, capital, patient care, subcontract amounts > $25K, tuition
+
+  Private foundations: Many cap indirect at 10–15%; always check funder policy.
+  State grants: Vary — check state regulations.
+  ```
+
+  ### Budget justification format
+  For each line item write 2–3 sentences:
+  1. What it is and who/what it supports
+  2. How the cost was calculated
+  3. Why it is necessary for project success
+
+  ### Budget narrative quality checks
+  - [ ] All costs are allowable, allocable, and reasonable (2 CFR §200 for federal)
+  - [ ] Indirect rate source is cited
+  - [ ] No double-counting across cost categories
+  - [ ] Cost-share / match requirements noted if applicable
+
+  ---
+
+  ## Step 8 — Final Quality Review
+
+  Before delivering any output, run this checklist:
+
+  - [ ] Funder priorities mirrored in narrative (from RFP parser or manual map)
+  - [ ] Logic model outputs connect to evaluation questions
+  - [ ] Budget totals match narrative cost references
+  - [ ] All statistics cited with source and year
+  - [ ] Outcomes are SMART (Specific, Measurable, Achievable, Relevant, Time-bound)
+  - [ ] Equity lens present in needs statement, design, and evaluation
+  - [ ] Page/word limits respected
+  - [ ] No unsupported superlatives ("first," "unique," "only") without evidence
+
+  ---
+
+  ## Reference Files
+
+  Load these only when working on the relevant section:
+
+  | File | When to read |
+  |---|---|
+  | `references/funder-alignment.md` | Step 1 — RFP parsing or manual priority mapping |
+  | `references/evaluation-frameworks.md` | Step 6 — Selecting and building evaluation plan |
+  | `references/budget-templates.md` | Step 7 — Budget line items and F&A calculation |
+  | `references/funder-alignment.md` | Step 1 — RFP parsing or manual priority mapping |
+  | `references/evaluation-frameworks.md` | Step 6 — Selecting and building evaluation plan |
+  | `references/budget-templates.md` | Step 7 — Budget line items and F&A calculation |

--- a/skills/grant-writing/references/budget-templates.md
+++ b/skills/grant-writing/references/budget-templates.md
@@ -1,0 +1,166 @@
+# Budget Templates & Indirect Cost Reference
+
+## Line-Item Budget Template
+
+Use this structure for all budgets. Adjust categories to match funder's required format.
+
+### Section A — Personnel
+
+| Position | Staff Name (or TBD) | Annual Salary | % FTE on Grant | Months | Grant-Funded Salary | Fringe Rate | Fringe Amount | Total |
+|---|---|---|---|---|---|---|---|---|
+| Project Director | | $_________ | ___% | ___ | $_______ | ___% | $_______ | $_______ |
+| Lead Trainer | | $_________ | ___% | ___ | $_______ | ___% | $_______ | $_______ |
+| Data Coordinator | | $_________ | ___% | ___ | $_______ | ___% | $_______ | $_______ |
+| **Personnel Subtotal** | | | | | | | | **$_______** |
+
+**Fringe benefit rate notes:**
+- Use actual negotiated rate if available
+- Approximate rates if actual unknown: Full-time = 28–35%; Part-time = 10–15%; Contractors = 0%
+- Federal grants: must use organization's documented fringe rate
+
+---
+
+### Section B — Consultants / Subcontracts
+
+| Consultant Role | # Days | Daily Rate | Total |
+|---|---|---|---|
+| External Evaluator | ___ | $_______ | $_______ |
+| Curriculum Developer | ___ | $_______ | $_______ |
+| **Consultants Subtotal** | | | **$_______** |
+
+**Notes:**
+- Federal: subcontracts > $25K excluded from MTDC base for indirect calculation
+- Justify rates: "Consistent with [organization's / market] rate for comparable expertise"
+
+---
+
+### Section C — Travel
+
+| Purpose | # Travelers | # Trips | Airfare | Per Diem | Ground/Other | Total |
+|---|---|---|---|---|---|---|
+| Conference attendance | | | $_______ | $_______ | $_______ | $_______ |
+| Site visits | | | $_______ | $_______ | $_______ | $_______ |
+| **Travel Subtotal** | | | | | | **$_______** |
+
+**Federal rate compliance:**
+- Use GSA per diem rates: https://www.gsa.gov/travel/plan-book/per-diem-rates
+- Mileage: use current IRS standard mileage rate (check annually)
+- Always fly coach / economy class unless exception documented
+
+---
+
+### Section D — Equipment
+
+| Item | Unit Cost | Quantity | Total |
+|---|---|---|---|
+| (List only items ≥ $5,000 per unit) | $_______ | ___ | $_______ |
+| **Equipment Subtotal** | | | **$_______** |
+
+**Note:** Equipment is excluded from MTDC base for indirect cost calculation.
+
+---
+
+### Section E — Supplies
+
+| Item | Unit Cost | Quantity | Total |
+|---|---|---|---|
+| Curriculum materials | $_______ | ___ | $_______ |
+| Participant workbooks | $_______ | ___ | $_______ |
+| Technology (< $5,000/unit) | $_______ | ___ | $_______ |
+| **Supplies Subtotal** | | | **$_______** |
+
+---
+
+### Section F — Other Direct Costs
+
+| Item | Calculation | Total |
+|---|---|---|
+| Participant stipends / incentives | ___ participants × $_______ | $_______ |
+| Printing and reproduction | | $_______ |
+| Software subscriptions | | $_______ |
+| Evaluation instruments / licensing | | $_______ |
+| **Other Direct Costs Subtotal** | | **$_______** |
+
+**Note:** Participant incentives must comply with funder policy. Federal: document IRB if applicable.
+
+---
+
+### Section G — Indirect Costs (F&A)
+
+```
+TOTAL DIRECT COSTS (A + B + C + D + E + F)    $__________
+
+LESS MTDC EXCLUSIONS (for federal grants):
+  - Equipment (Section D)                       ($__________)
+  - Subcontracts > $25,000                      ($__________)
+  - Other excluded costs                        ($__________)
+
+MODIFIED TOTAL DIRECT COSTS (MTDC)             $__________
+
+INDIRECT RATE:  _____%
+  (Negotiated NICRA rate OR 10% de minimis per 2 CFR §200.414)
+
+INDIRECT COST AMOUNT (MTDC × Rate)             $__________
+```
+
+---
+
+### Budget Summary
+
+| Category | Amount |
+|---|---|
+| A. Personnel (salaries + fringe) | $_______ |
+| B. Consultants / Subcontracts | $_______ |
+| C. Travel | $_______ |
+| D. Equipment | $_______ |
+| E. Supplies | $_______ |
+| F. Other Direct Costs | $_______ |
+| **Total Direct Costs** | **$_______** |
+| G. Indirect Costs | $_______ |
+| **TOTAL PROJECT BUDGET** | **$_______** |
+
+---
+
+## Budget Justification Paragraph Templates
+
+### Personnel — Project Director (example)
+> "The Project Director (1.0 FTE, 12 months) will provide overall leadership and coordination for all grant activities, including partner management, reporting, and program oversight. Salary of $[X] reflects [Organization]'s current pay scale for this position. Fringe benefits are calculated at [X]%, consistent with [Organization]'s documented rate, totaling $[X]."
+
+### External Evaluator (example)
+> "An independent external evaluator will be contracted at $[X]/day for [X] days ($[X] total) to design and implement the project evaluation plan, including instrument development, data collection oversight, and preparation of the annual evaluation report. An external evaluator is required to ensure objectivity and credibility of findings reported to [funder]."
+
+### Indirect Costs (de minimis — example)
+> "Indirect costs are calculated at the federally approved de minimis rate of 10% of Modified Total Direct Costs (MTDC) per 2 CFR §200.414(f), as [Organization] does not currently hold a negotiated indirect cost rate agreement. MTDC excludes equipment ($[X]) and the portion of the subcontract exceeding $25,000 ($[X]). Total indirect costs: $[X]."
+
+### Indirect Costs (negotiated rate — example)
+> "Indirect costs are calculated at [Organization]'s federally negotiated rate of [X]% applied to Modified Total Direct Costs of $[X], per the Negotiated Indirect Cost Rate Agreement (NICRA) with [cognizant federal agency], effective [date]. Total indirect costs: $[X]."
+
+---
+
+## Cost-Share / Match Requirements
+
+If the funder requires match:
+
+| Match type | Definition |
+|---|---|
+| Cash match | Direct expenditures from non-federal sources |
+| In-kind match | Non-cash contributions (volunteer time, donated space, equipment) |
+| Third-party match | Contributions from partners, not the applicant |
+
+**Documenting volunteer time (in-kind):**
+> Use Bureau of Labor Statistics independent sector rate or specific professional rate.
+> Formula: Hours × Hourly Rate = In-Kind Value
+
+**Match tracking note:** Include in budget justification how match will be tracked and documented.
+
+---
+
+## Common Budget Errors to Avoid
+
+- [ ] Salary exceeds 100% FTE across all funding sources for any one person
+- [ ] Fringe rate applied to consultant fees (consultants do not receive fringe)
+- [ ] Equipment costs included in indirect cost base (must be excluded for MTDC)
+- [ ] Per diem rates exceed GSA schedule without justification
+- [ ] No justification narrative for any line item ≥ $1,000
+- [ ] Indirect rate applied to the full budget including equipment and large subcontracts
+- [ ] Cost-share not sourced from allowable, verifiable non-federal funds

--- a/skills/grant-writing/references/evaluation-frameworks.md
+++ b/skills/grant-writing/references/evaluation-frameworks.md
@@ -1,0 +1,115 @@
+# Evaluation Frameworks Reference
+
+## Framework 1 — Kirkpatrick Model (4 Levels)
+
+**Best for:** Training programs, professional development, capacity-building grants.
+**Common funders:** Dept of Ed, state PD grants, corporate training grants.
+
+### Template
+
+| Level | What it measures | Data source(s) | Timing |
+|---|---|---|---|
+| **1 — Reaction** | Participant satisfaction and perceived relevance | Post-session survey (Likert scale) | Immediately after each session |
+| **2 — Learning** | Knowledge, skills, or attitudes gained | Pre/post assessment; portfolio; observation rubric | Pre (baseline) + Post (each module) |
+| **3 — Behavior** | Transfer of learning to practice | Classroom observation, supervisor rating, self-report survey | 60–90 days post-training |
+| **4 — Results** | Organizational/student outcomes attributable to the program | Student achievement data, attendance, graduation rate | End of year / program end |
+
+### Evaluation questions (sample — adapt to project)
+1. To what extent did participants find training relevant to their practice? (Level 1)
+2. Did participants demonstrate mastery of [skill] at program completion? (Level 2)
+3. How frequently are participants applying [practice] in their professional context? (Level 3)
+4. What changes in [student outcome] are observed among participants' students? (Level 4)
+
+### Kirkpatrick reporting table
+Include in grant narrative:
+> "Evaluation will employ a four-level Kirkpatrick framework. Level 1 data (reaction) will be collected via post-session surveys administered immediately following each of the [X] training sessions. Level 2 (learning) will be assessed through pre/post competency assessments. Level 3 (behavior transfer) will be measured at 90-day follow-up using [instrument]. Level 4 (results) will draw on [data source] to assess changes in [outcome] by [date]."
+
+---
+
+## Framework 2 — RE-AIM (Glasgow et al.)
+
+**Best for:** Public health interventions, behavior change programs, community health or wellness grants.
+**Common funders:** NIH, HRSA, CDC, health foundations.
+
+### Dimensions template
+
+| Dimension | Evaluation question | Indicator(s) | Data source |
+|---|---|---|---|
+| **Reach** | Who participates, and are they representative of the target population? | % of eligible population enrolled; demographic match to community | Enrollment records, census data |
+| **Effectiveness** | What outcomes does the program produce? | Primary outcome change score; effect size | Pre/post assessment, administrative data |
+| **Adoption** | Which sites/providers deliver the program, and are they representative? | % of eligible sites/staff participating | Site survey, HR records |
+| **Implementation** | Is the program delivered as intended? | Fidelity score; dosage delivered vs. planned | Observation logs, attendance records |
+| **Maintenance** | Are effects and delivery sustained over time? | 6-month and 12-month follow-up data; continued site delivery | Follow-up survey, program records |
+
+### RE-AIM reporting paragraph (template)
+> "Evaluation will be guided by the RE-AIM framework. Reach will be assessed by comparing participant demographics to [target population] census data. Effectiveness will be measured through [primary outcome] using a pre/post design with [instrument]. Adoption will be tracked by documenting [staff/site] participation rates. Implementation fidelity will be assessed through [observation/log] with a target fidelity threshold of ≥80%. Maintenance will be evaluated at 6- and 12-months post-program through follow-up surveys and continued data tracking."
+
+---
+
+## Framework 3 — W.K. Kellogg Logic Model Evaluation Extension
+
+**Best for:** Community development, capacity-building, multi-year grants where evaluation is embedded in the logic model.
+**Common funders:** Kellogg, community foundations, state community development grants.
+
+This framework uses the logic model outputs (Step 4 of the skill) as the evaluation spine.
+
+### Evaluation-to-logic-model mapping
+
+For each logic model outcome, define:
+
+| Outcome (from logic model) | Type | Indicator | Instrument | Baseline source | Data collection frequency |
+|---|---|---|---|---|---|
+| [Short-term outcome 1] | Knowledge/attitude | [Measurable indicator] | [Survey/assessment] | [Source] | [Pre/post] |
+| [Medium-term outcome 1] | Behavior/practice | [Measurable indicator] | [Observation/report] | [Source] | [Annual] |
+| [Long-term outcome 1] | Condition change | [Measurable indicator] | [Admin data] | [Source] | [End of grant + 1 yr] |
+
+### Data management note
+Specify: Who collects, who stores, who analyzes, and who reports. Include data sharing agreements if applicable.
+
+---
+
+## Framework 4 — Developmental Evaluation (Patton)
+
+**Best for:** Emerging, complex, adaptive programs; innovation grants; systems-change initiatives where outcomes are not yet fully known.
+**Common funders:** MacArthur, Hewlett, federal i3/EIR Development grants, USAID.
+
+**Core principle:** The evaluator is embedded in the team and contributes to real-time learning and adaptation — not just end-point measurement.
+
+### Developmental evaluation plan components
+
+1. **Evaluative thinking integration**
+   - Describe how evaluation questions will be revisited quarterly as program evolves
+   - Identify the embedded evaluator role (internal learning officer or external partner)
+
+2. **Complexity-sensitive indicators**
+   - Use a small set of core indicators (3–5) + adaptive indicators that may change
+   - Document indicator evolution in a "learning log"
+
+3. **Learning cycles**
+   - Define regular reflection points: monthly team reviews, quarterly stakeholder convenings
+   - Output: "What did we learn? What will we change?"
+
+4. **Emergent outcomes**
+   - Acknowledge that not all outcomes are predictable; document unexpected results
+   - Use a "contribution analysis" approach rather than attribution claims
+
+5. **Reporting format**
+   - Quarterly learning memos (internal) + annual summary (to funder)
+   - Include "most significant change" stories
+
+### Developmental evaluation narrative paragraph (template)
+> "Given the emergent nature of [program], this project will employ Developmental Evaluation (Patton, 2011) to support real-time learning and adaptation. An embedded evaluator will participate in monthly team reflection sessions and quarterly stakeholder reviews. Core indicators — including [1–2 examples] — will be tracked throughout, while additional adaptive indicators will emerge through iterative learning cycles. Learning memos will be produced quarterly to document progress, unexpected findings, and program adaptations. An annual evaluation summary will be submitted to [funder]."
+
+---
+
+## Evaluation Plan Quality Standards
+
+Regardless of framework, all evaluation plans must include:
+
+- [ ] 3–5 specific evaluation questions
+- [ ] At least one baseline data point (or plan to collect one)
+- [ ] Named instruments or data sources for each question
+- [ ] Data collection timeline tied to project period
+- [ ] Statement on evaluator independence (internal vs. external)
+- [ ] Plan for communicating results to participants and community
+- [ ] Budget line for evaluation (recommended: 5–15% of total project budget)

--- a/skills/grant-writing/references/funder-alignment.md
+++ b/skills/grant-writing/references/funder-alignment.md
@@ -1,0 +1,84 @@
+# Funder Alignment Reference
+
+## RFP Mode — Parser Protocol
+
+When user pastes RFP/NOFO text, extract the following in a structured table before writing anything:
+
+### Extraction Template
+
+| Field | Extracted Content |
+|---|---|
+| **Program purpose** | (1–2 sentences from the funder's stated goal) |
+| **Priority populations** | (Who must be served) |
+| **Absolute priorities** | (Required; disqualifying if not addressed) |
+| **Competitive priorities** | (Optional but scored; note point value if listed) |
+| **Invitational priorities** | (Encouraged but unscored) |
+| **Required activities** | (Mandated program components) |
+| **Prohibited activities** | (Explicitly excluded uses of funds) |
+| **Evaluation requirements** | (What the funder requires for data/reporting) |
+| **Eligibility requirements** | (Org type, geography, prior grant history) |
+| **Page/word limits** | (By section if specified) |
+| **Key review criteria** | (Scoring rubric items if provided) |
+| **Deadline and submission portal** | |
+
+After extraction, present this table to the user for confirmation before proceeding.
+
+### Keyword mirroring strategy
+- Identify the 8–12 highest-frequency content words in the RFP (excluding stop words)
+- Use these exact terms in the narrative — do not paraphrase funder language
+- Flag any priority not yet addressed in the draft
+
+---
+
+## Manual Mode — Priority Mapping Template
+
+When user describes funder priorities without an RFP, complete this map:
+
+### Priority Mapping Worksheet
+
+**Funder name:** _______________
+**Funder type:** [ ] Federal [ ] Private Foundation [ ] State/Local [ ] Corporate
+
+| Funder priority | How this project addresses it | Evidence / proof point |
+|---|---|---|
+| 1. | | |
+| 2. | | |
+| 3. | | |
+| 4. | | |
+| 5. | | |
+
+After completing the map, confirm with user: "Are there any funder priorities I've missed or mischaracterized?"
+
+---
+
+## Funder-Type Style Guides
+
+### Federal (NSF, Dept of Ed, NIH, USDA)
+- **Tone:** Technical, evidence-based, regulatory-compliant
+- **Citations:** Peer-reviewed literature preferred; government data sources (NCES, CDC, Census)
+- **Compliance language:** Reference relevant authorizing statute (e.g., ESSA Title IV, Perkins V, IDEA)
+- **Evaluation:** Requires rigorous, preferably experimental or quasi-experimental design for Dept of Ed i3/EIR grants; logic models required for most
+- **Budget:** Must comply with 2 CFR §200 (Uniform Guidance); use de minimis 10% MTDC if no NICRA
+- **Key phrases funders respond to:** "evidence-based," "data-driven," "continuous improvement," "equity," "scale," "replication"
+
+### Private Foundations (Gates, Walton, Kellogg, MacArthur, etc.)
+- **Tone:** Mission-aligned, narrative-driven, community-centered
+- **Citations:** Mix of data and community voice/stories
+- **Evaluation:** Typically more flexible; Developmental Evaluation well-received for complex programs
+- **Budget:** Often cap indirect at 10–15%; check each foundation's specific policy
+- **Key phrases funders respond to:** "systems change," "theory of change," "community-led," "equity-centered," "lived experience," "scalable model"
+- **Note:** Many foundations use LOI (Letter of Inquiry) before full proposal; offer to draft LOI if needed
+
+### State / Local Government
+- **Tone:** Compliance-focused, outcome-driven, locally contextualized
+- **Citations:** State report card data, state demographic data, district CNA (Comprehensive Needs Assessment)
+- **Evaluation:** Often tied to state accountability metrics; align outcomes to state strategic plan goals
+- **Budget:** Reference state procurement/grant regulations; indirect rates vary by state
+- **Key phrases:** "aligned with state plan," "evidence-based intervention," "measurable outcomes," "district capacity"
+
+### Corporate / CSR
+- **Tone:** ROI-forward, partnership-oriented, brand-aligned
+- **Citations:** Workforce data, economic mobility stats, local community impact
+- **Evaluation:** Simpler; focus on outputs and short-term outcomes; tell a compelling story
+- **Budget:** Often smaller grants ($5K–$50K); indirect costs may not be recognized — plan accordingly
+- **Key phrases:** "community investment," "talent pipeline," "workforce readiness," "shared value," "measurable community impact"


### PR DESCRIPTION
## Add grant-writing skill

This skill helps Claude produce professional grant proposals, logic models, needs statements, budgets with indirect cost (F&A) calculations, and evaluation plans for nonprofit and educational organizations.

### What this skill does
- Supports all funder types: Federal, private foundation, state/local, corporate
- - Supports all org types: K-12, higher ed, nonprofit, government
- - Produces: Needs Statements, Logic Models (W.K. Kellogg Framework), Full Grant Narratives, Evaluation Plans, and Budgets with F&A calculations
- - Includes RFP extraction mode and manual funder-priority mode
- - Provides a Final Quality Review checklist
### No external API required
This skill runs entirely on Claude's built-in knowledge and reasoning — no third-party API needed.