### PR TITLE
Add professional-learning skill

### DIFF
--- a/skills/professional-learning/LICENSE.txt
+++ b/skills/professional-learning/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Anthropic, PBC.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/professional-learning/SKILL.md
+++ b/skills/professional-learning/SKILL.md
@@ -15,117 +15,80 @@ description: >
 # Professional Learning Skill
 
 ## Purpose
-
 Generate rigorous, equity-centered, outcomes-driven professional learning artifacts grounded in
 adult learning science. All outputs are **Structured Markdown** by default (headers, tables,
 timelines). Offer DOCX conversion via the `docx` skill when the user requests a downloadable file.
 
+---
+
 ## Output Types
 
-| Output Type | When to Use | Key Components |
+| Output Type | Trigger Phrases |
+|---|---|
+| **Workshop Agenda & Facilitation Guide** | "agenda," "workshop," "PD session," "facilitation plan" |
+| **PLC Meeting Protocol & Norms** | "PLC," "team meeting," "collaborative inquiry," "professional learning community" |
+| **Coaching Cycle Framework** | "coaching cycle," "observation," "debrief," "coaching plan," "instructional coaching" |
+| **Full PD Session Design** | "full session," "PD design," "training plan," "objectives + materials" |
+| **Adult Learning Experience Plan** | "onboarding," "staff training," "org development," "capacity building," "L&D" |
+
+---
+
+## Mandatory Embedded Frameworks
+
+Always apply **all five** frameworks. They are not optional add-ons.
+
+### 1. Andragogy (Knowles)
+Every design must honor the six assumptions of adult learners:
+- Self-concept: treat participants as autonomous learners
+- Experience: surface and build on prior knowledge
+- Readiness: connect content to immediate professional needs
+- Orientation: problem-centered, not subject-centered
+- Motivation: intrinsic over extrinsic
+- Need to know: state the "why" before the "what"
+
+### 2. Backward Design (ADDIE-aligned)
+Build in this sequence — never skip steps:
+1. **Outcomes first** → What should participants *know, do, believe* after?
+2. **Evidence** → How will you measure transfer? (feeds Kirkpatrick)
+3. **Learning experiences** → Activities, protocols, materials
+4. **Facilitation plan** → Timing, transitions, facilitation moves
+5. **Evaluation** → Always embed (see Kirkpatrick section)
+
+### 3. Kirkpatrick Levels 1–4 (always embed L1–L2 minimum)
+
+| Level | Focus | Artifact to Include |
 |---|---|---|
-| Workshop Agenda | User wants a single session plan | Objectives, timed agenda, materials, facilitation notes |
-| PLC Protocol | Team learning meeting with structured dialogue | Norms, protocol type, roles, timing |
-| Coaching Cycle | Ongoing instructional coaching relationship | Pre-conference, observation, post-conference |
-| PD Series Plan | Multi-session program | Learning arc, session summaries, evaluation plan |
-| Onboarding Plan | New staff or role transition | Week-by-week plan, goals, check-ins |
-| Training Deck Outline | Slide-by-slide plan | Objectives, slide structure, facilitation cues |
+| L1 Reaction | Did participants find it valuable? | Exit ticket, pulse check, satisfaction survey |
+| L2 Learning | Did they acquire knowledge/skill? | Pre/post prompt, performance task, reflection rubric |
+| L3 Behavior | Did they apply it on the job? | 30-day follow-up protocol, classroom walkthrough tool |
+| L4 Results | Did it impact outcomes? | Data collection plan, metric linkage |
 
-## Core Adult Learning Principles (Always Apply)
+> **Default rule**: Always embed L1 + L2 artifacts in every output. Include L3 when session length ≥ half-day or multi-session. Include L4 only when explicitly requested or when the user mentions program evaluation/impact.
 
-These principles ground every output. Reference explicitly when relevant:
+### 4. Cognitive Coaching / GROWTH Model
+Use this structure for all coaching cycle outputs:
 
-**Knowles' Andragogy:**
-- Adults need to know *why* they're learning
-- Adults learn best when connecting to prior experience
-- Adults are self-directed; offer choice and agency
-- Adults are problem-centered, not subject-centered
+| Phase | GROWTH Anchor | Key Questions |
+|---|---|---|
+| Pre-observation | **G**oal + **R**eality | What are you hoping participants/students will do? What's currently happening? |
+| Observation | **O**ptions | What evidence are you collecting? |
+| Debrief | **W**ay forward | What patterns did you notice? What would you keep/change? |
+| Follow-up | **T**imeline + **H**abits | What's the next step? By when? What support do you need? |
 
-**Kirkpatrick's Four Levels (for evaluation planning):**
-- L1 Reaction: Did participants find it valuable?
-- L2 Learning: Did knowledge/skills change?
-- L3 Behavior: Is practice changing in the classroom/workplace?
-- L4 Results: What's the organizational/student impact?
-
-**GROWTH Coaching Model (for coaching cycles):**
-Goal → Reality → Options → Will → Tactics → Habits
-
-## Workshop Agenda Template
-
-When producing a workshop agenda, use this structure:
-
----
-**[Workshop Title]**
-**Duration:** [X hours / X minutes]
-**Audience:** [Who is attending]
-**Facilitator:** [Name or role]
-**Learning Objectives:**
-By the end of this session, participants will be able to:
-1. [Objective 1 — measurable verb]
-2. [Objective 2]
-3. [Objective 3]
-
-**Materials:** [List]
-**Technology:** [List or "None required"]
-
-| Time | Activity | Format | Purpose | Facilitator Notes |
-|---|---|---|---|---|
-| 0:00–0:10 | Welcome & Norms | Whole group | Set tone, activate prior knowledge | [Specific notes] |
-| 0:10–0:25 | Opening Activity | [Pairs/Small group/Individual] | [Purpose] | [Notes] |
-| ... | ... | ... | ... | ... |
-| [Last slot] | Closure & Next Steps | Whole group | Consolidate learning, set application goal | [Notes] |
-
-**Evaluation:** [L1 exit ticket / L2 pre-post / L3 follow-up plan]
----
-
-## PLC Protocol Templates
-
-When producing a PLC protocol, identify the protocol type:
-
-| Protocol | Best For | Time | Structure |
-|---|---|---|---|
-| Tuning Protocol | Refining student work or teacher practice | 45–60 min | Warm/cool feedback + reflection |
-| Consultancy Protocol | Solving a specific dilemma | 45–60 min | Presenter share → clarifying Qs → discussion → debrief |
-| Data Protocol | Analyzing student performance data | 30–60 min | Data share → observations → inferences → implications |
-| Text-Based Discussion | Building shared understanding from reading | 30–45 min | Individual → pairs → whole group |
-| Success Analysis | Celebrating and scaling what works | 30–45 min | Share → identify factors → transfer |
-
-Produce a full facilitation guide including: roles (facilitator, presenter, timekeeper, recorder), norms, timed steps, and debrief questions.
-
-## Coaching Cycle Template
-
-Structure a coaching cycle in three phases:
-
-**Pre-Conference:**
-- Coaching focus (teacher-identified)
-- Look-fors agreed upon
-- Data collection method
-
-**Observation:**
-- Scripting/data collection tool
-- Non-evaluative lens
-
-**Post-Conference:**
-- Data share (non-evaluative)
-- Reflection questions (GROWTH model)
-- Action step(s) with timeline
-- Next cycle focus
-
-## Equity and UDL Integration
-
-Always embed equity and Universal Design for Learning (UDL) into designs:
-
-**Equity Lens:**
-Representation: How is content accessible (visual, text, audio)?
-Action/Expression: How can participants engage/respond flexibly?
-Engagement: What sustains motivation across diverse participants?
+### 5. UDL & Equity-Centered Facilitation
+Every output must include at least **one explicit UDL annotation** per activity:
+- Representation: How is content accessible (visual, text, audio)?
+- Action/Expression: How can participants engage/respond flexibly?
+- Engagement: What sustains motivation across diverse participants?
 
 Additionally flag:
-Power dynamics in facilitation (who speaks, who decides)
-Language access (multilingual participants, jargon reduction)
-Psychological safety protocols (norms, anonymous response options)
+- Power dynamics in facilitation (who speaks, who decides)
+- Language access (multilingual participants, jargon reduction)
+- Psychological safety protocols (norms, anonymous response options)
 
-## Duration Inference
+---
+
+## Session Length Inference Rules
 
 When duration is not specified, infer from context:
 
@@ -139,9 +102,151 @@ When duration is not specified, infer from context:
 
 Always state the inferred duration at the top of the output with a note: *"Duration inferred as [X] — adjust if needed."*
 
-## References
+---
 
-Read reference files for extended frameworks and evaluation instruments:
+## Output Structure Templates
 
-`references/framework-citations.md` — Extended framework citations (Knowles, Kirkpatrick, UDL guidelines, GROWTH model source literature)
-`references/evaluation-instruments.md` — Ready-to-use L1–L3 instruments, rubrics, and survey stems
+### Template A: Workshop Agenda & Facilitation Guide
+
+```
+## [Title]
+**Audience**: [role/level]  **Duration**: [X min/hrs]  **Facilitator**: [name/role]
+**Learning Objectives** (Bloom's action verbs):
+  - Participants will [verb] [content] in order to [purpose].
+
+---
+### Agenda
+
+| Time | Segment | Activity | Materials | Facilitation Notes | UDL Note |
+|------|---------|----------|-----------|-------------------|----------|
+
+---
+### Evaluation Artifacts
+- **L1 Exit Ticket**: [prompt]
+- **L2 Performance Indicator**: [task or reflection rubric]
+```
+
+### Template B: PLC Meeting Protocol
+
+```
+## PLC Meeting — [Date/Cycle]
+**Team**: [grade/dept/school]  **Duration**: [X min]  **Facilitator**: [name]
+**Inquiry Question**: [student-centered question driving this cycle]
+**Norms**: [list or link]
+
+---
+### Protocol Sequence
+
+| Time | Phase | Purpose | Facilitation Move |
+|------|-------|---------|------------------|
+
+---
+### Data Examined: [source + artifact]
+### Decisions Made: [action items + owner + deadline]
+### L1 Check: [team pulse — 1-word whip-around or thumb vote]
+```
+
+### Template C: Coaching Cycle Framework
+
+```
+## Coaching Cycle — [Coachee Name/Role]
+**Coach**: [name]  **Cycle Goal**: [SMART goal]  **Timeline**: [start → end]
+
+---
+### GROWTH Cycle Log
+
+| Date | Phase | Key Questions Used | Evidence Collected | Next Step |
+|------|-------|-------------------|-------------------|-----------|
+
+---
+### L2 Indicator: [observable behavior shift to track]
+### L3 Follow-up: [30-day check-in protocol]
+```
+
+### Template D: Full PD Session Design
+
+```
+## PD Session Design Document
+**Title** | **Audience** | **Duration** | **Designer** | **Date**
+
+### Part 1: Outcomes & Alignment
+| Objective | Bloom's Level | Kirkpatrick Level | Standard/Competency Aligned |
+
+### Part 2: Learning Arc
+[Opening hook → Activate prior knowledge → New learning → Application → Transfer → Closure]
+
+### Part 3: Materials & Resources
+[List with access/equity notes]
+
+### Part 4: Facilitation Guide
+[Full timed agenda — see Template A format]
+
+### Part 5: Evaluation Suite
+- L1 Reaction instrument
+- L2 Learning artifact
+- L3 Transfer protocol (if ≥ half-day)
+```
+
+### Template E: Adult Learning Experience Plan (Onboarding / Org Training)
+
+```
+## Adult Learning Experience Plan
+**Program**: [name]  **Audience**: [role]  **Duration**: [hours/days/weeks]
+**Organizational Goal Linkage**: [strategic priority or KPI]
+
+### Learning Pathway
+
+| Module | Duration | Mode | Outcome | Kirkpatrick Level Targeted |
+|--------|---------|------|---------|---------------------------|
+
+### Andragogy Alignment Check
+[One row per Knowles assumption — confirm each is addressed]
+
+### Evaluation Plan
+| Kirkpatrick Level | Instrument | Timing | Owner |
+```
+
+---
+
+## Facilitation Language Bank
+Reference when writing facilitation notes:
+
+- **Activating prior knowledge**: "Turn and talk: What do you already know about…?"
+- **Cognitive conflict**: "Look at this data. What surprises you?"
+- **Sense-making**: "What patterns are you noticing across these examples?"
+- **Transfer**: "How would you apply this in your context next week?"
+- **Psychological safety**: "Take 60 seconds to write before we share aloud."
+- **Equity check**: "Who hasn't spoken yet? Let's hear from a different voice."
+
+---
+
+## Out of Scope
+This skill does **not** produce:
+- Student-facing lesson plans or K-12 curriculum units (→ use `instructional-design` skill)
+- HR performance reviews or disciplinary documentation
+- Grant proposals or logic models (→ use `grant-writing` skill)
+- Program evaluation reports (→ use `program-evaluation` skill)
+
+If a request overlaps with these, note the boundary and offer to hand off to the appropriate skill.
+
+---
+
+## Quick-Start Decision Tree
+
+```
+User request received
+        │
+        ├─ Mentions "coaching," "observation," "debrief" ──→ Template C
+        ├─ Mentions "PLC," "team protocol," "inquiry" ────→ Template B
+        ├─ Mentions "agenda," "workshop," "facilitate" ───→ Template A
+        ├─ Mentions "onboarding," "training program" ─────→ Template E
+        └─ Mentions "design," "full session," "materials" → Template D
+```
+
+When in doubt between A and D: **A** if the user wants a single session run document; **D** if they want a complete design package with materials and evaluation suite.
+
+---
+
+## Reference Files
+- `references/frameworks.md` — Extended framework citations (Knowles, Kirkpatrick, UDL guidelines, GROWTH model source literature)
+- `references/evaluation-instruments.md` — Ready-to-use L1–L3 instruments, rubrics, and survey stems

--- a/skills/professional-learning/SKILL.md
+++ b/skills/professional-learning/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: professional-learning
+description: >
+  Design professional development sessions, workshop agendas, PLC (professional learning community)
+  protocols, coaching cycles, and adult learning experiences for educators and organizational staff.
+  Use this skill whenever a user asks to plan, build, design, or facilitate any form of professional
+  learning — including PD days, staff training, team meetings with a learning goal, instructional
+  coaching cycles, onboarding programs, or capacity-building workshops. Trigger even when the user
+  says things like "help me plan a PD session," "build a PLC agenda," "design a coaching cycle,"
+  "create a staff training," "facilitate a team learning experience," or "help me run a workshop."
+  Serves K-12 teachers and coaches, school/district administrators, higher education faculty,
+  nonprofit/NGO staff, and corporate L&D teams.
+---
+
+# Professional Learning Skill
+
+## Purpose
+
+Generate rigorous, equity-centered, outcomes-driven professional learning artifacts grounded in
+adult learning science. All outputs are **Structured Markdown** by default (headers, tables,
+timelines). Offer DOCX conversion via the `docx` skill when the user requests a downloadable file.
+
+## Output Types
+
+| Output Type | When to Use | Key Components |
+|---|---|---|
+| Workshop Agenda | User wants a single session plan | Objectives, timed agenda, materials, facilitation notes |
+| PLC Protocol | Team learning meeting with structured dialogue | Norms, protocol type, roles, timing |
+| Coaching Cycle | Ongoing instructional coaching relationship | Pre-conference, observation, post-conference |
+| PD Series Plan | Multi-session program | Learning arc, session summaries, evaluation plan |
+| Onboarding Plan | New staff or role transition | Week-by-week plan, goals, check-ins |
+| Training Deck Outline | Slide-by-slide plan | Objectives, slide structure, facilitation cues |
+
+## Core Adult Learning Principles (Always Apply)
+
+These principles ground every output. Reference explicitly when relevant:
+
+**Knowles' Andragogy:**
+- Adults need to know *why* they're learning
+- Adults learn best when connecting to prior experience
+- Adults are self-directed; offer choice and agency
+- Adults are problem-centered, not subject-centered
+
+**Kirkpatrick's Four Levels (for evaluation planning):**
+- L1 Reaction: Did participants find it valuable?
+- L2 Learning: Did knowledge/skills change?
+- L3 Behavior: Is practice changing in the classroom/workplace?
+- L4 Results: What's the organizational/student impact?
+
+**GROWTH Coaching Model (for coaching cycles):**
+Goal → Reality → Options → Will → Tactics → Habits
+
+## Workshop Agenda Template
+
+When producing a workshop agenda, use this structure:
+
+---
+**[Workshop Title]**
+**Duration:** [X hours / X minutes]
+**Audience:** [Who is attending]
+**Facilitator:** [Name or role]
+**Learning Objectives:**
+By the end of this session, participants will be able to:
+1. [Objective 1 — measurable verb]
+2. [Objective 2]
+3. [Objective 3]
+
+**Materials:** [List]
+**Technology:** [List or "None required"]
+
+| Time | Activity | Format | Purpose | Facilitator Notes |
+|---|---|---|---|---|
+| 0:00–0:10 | Welcome & Norms | Whole group | Set tone, activate prior knowledge | [Specific notes] |
+| 0:10–0:25 | Opening Activity | [Pairs/Small group/Individual] | [Purpose] | [Notes] |
+| ... | ... | ... | ... | ... |
+| [Last slot] | Closure & Next Steps | Whole group | Consolidate learning, set application goal | [Notes] |
+
+**Evaluation:** [L1 exit ticket / L2 pre-post / L3 follow-up plan]
+---
+
+## PLC Protocol Templates
+
+When producing a PLC protocol, identify the protocol type:
+
+| Protocol | Best For | Time | Structure |
+|---|---|---|---|
+| Tuning Protocol | Refining student work or teacher practice | 45–60 min | Warm/cool feedback + reflection |
+| Consultancy Protocol | Solving a specific dilemma | 45–60 min | Presenter share → clarifying Qs → discussion → debrief |
+| Data Protocol | Analyzing student performance data | 30–60 min | Data share → observations → inferences → implications |
+| Text-Based Discussion | Building shared understanding from reading | 30–45 min | Individual → pairs → whole group |
+| Success Analysis | Celebrating and scaling what works | 30–45 min | Share → identify factors → transfer |
+
+Produce a full facilitation guide including: roles (facilitator, presenter, timekeeper, recorder), norms, timed steps, and debrief questions.
+
+## Coaching Cycle Template
+
+Structure a coaching cycle in three phases:
+
+**Pre-Conference:**
+- Coaching focus (teacher-identified)
+- Look-fors agreed upon
+- Data collection method
+
+**Observation:**
+- Scripting/data collection tool
+- Non-evaluative lens
+
+**Post-Conference:**
+- Data share (non-evaluative)
+- Reflection questions (GROWTH model)
+- Action step(s) with timeline
+- Next cycle focus
+
+## Equity and UDL Integration
+
+Always embed equity and Universal Design for Learning (UDL) into designs:
+
+**Equity Lens:**
+Representation: How is content accessible (visual, text, audio)?
+Action/Expression: How can participants engage/respond flexibly?
+Engagement: What sustains motivation across diverse participants?
+
+Additionally flag:
+Power dynamics in facilitation (who speaks, who decides)
+Language access (multilingual participants, jargon reduction)
+Psychological safety protocols (norms, anonymous response options)
+
+## Duration Inference
+
+When duration is not specified, infer from context:
+
+| Context Clue | Inferred Duration |
+|---|---|
+| "Quick meeting," "check-in," "team huddle" | 30–45 min |
+| "PLC meeting," "team PD," single topic | 60–90 min |
+| "Workshop," "PD session," "training" | 2–3 hours |
+| "PD day," "full-day," "retreat" | 6–7 hours |
+| "Series," "cycle," "program" | Multi-session (note sessions + total hours) |
+
+Always state the inferred duration at the top of the output with a note: *"Duration inferred as [X] — adjust if needed."*
+
+## References
+
+Read reference files for extended frameworks and evaluation instruments:
+
+`references/framework-citations.md` — Extended framework citations (Knowles, Kirkpatrick, UDL guidelines, GROWTH model source literature)
+`references/evaluation-instruments.md` — Ready-to-use L1–L3 instruments, rubrics, and survey stems

--- a/skills/professional-learning/references/evaluation-instruments.md
+++ b/skills/professional-learning/references/evaluation-instruments.md
@@ -1,0 +1,109 @@
+# Evaluation Instruments
+
+## Level 1 — Reaction Instruments
+
+### Exit Ticket (Universal — 3 questions, 3 min)
+1. On a scale of 1–5, rate the relevance of today's session to your current work.
+2. One thing you will think about or try as a result of today.
+3. One question you still have or one thing that could be improved.
+
+---
+
+### 4Cs Reflection Protocol (15 min — suitable for longer sessions)
+| Prompt | Purpose |
+|--------|---------|
+| **Connection**: What connected to what you already know or do? | Surface relevance |
+| **Challenge**: What challenged or surprised your thinking? | Cognitive engagement |
+| **Concept**: What is the most important idea/concept? | Comprehension check |
+| **Change**: What do you want to do differently as a result? | Transfer readiness |
+
+---
+
+### Pulse Check (Anonymous — mid-session, 2 min)
+> Use when facilitating 2+ hour sessions.
+
+Rate each item 1 (low) – 5 (high):
+- The pace of this session
+- The clarity of the content
+- My engagement level
+- The usefulness for my practice
+- Open field: "What would make this more valuable?"
+
+---
+
+## Level 2 — Learning Instruments
+
+### Pre/Post Knowledge Probe (Adapt to topic)
+Ask the same 3–5 questions before and after the session.
+Format: open-ended OR forced-choice (agree/disagree/unsure).
+Compare cohort responses to measure knowledge shift.
+
+---
+
+### Performance Task Rubric (Generic — adapt dimensions to topic)
+
+| Dimension | 4 — Exceeds | 3 — Meets | 2 — Approaching | 1 — Beginning |
+|-----------|------------|----------|----------------|--------------|
+| **Accuracy** | Applies concept correctly with nuance | Applies concept correctly | Partially applies; minor errors | Misapplies concept |
+| **Depth** | Rich evidence, specific examples | Adequate evidence | Superficial evidence | Little or no evidence |
+| **Transfer** | Connects to own context independently | Connects with prompting | Limited connection | No connection made |
+| **UDL/Equity Lens** | Proactively considers access and inclusion | Considers when prompted | Partial consideration | Not addressed |
+
+---
+
+### Single-Point Rubric Template
+Use for coaching and self-assessment contexts.
+
+| Areas for Growth | Evidence of Proficiency | Areas of Strength |
+|-----------------|------------------------|------------------|
+| (Coachee/participant fills in) | [Core standard/competency described here] | (Coachee/participant fills in) |
+
+---
+
+## Level 3 — Behavior / Transfer Instruments
+
+### 30-Day Transfer Check-In (Facilitator sends via email or form)
+1. What did you try in your practice as a result of our session?
+2. What worked? What didn't?
+3. What support do you need to continue?
+4. Rate your implementation: Not yet started / Tried once / Trying regularly / Embedded in practice
+
+---
+
+### Classroom/Workplace Walkthrough Observation Tool
+> Align indicators to session learning objectives.
+
+| Indicator | Look-Fors | Evidence Observed | Not Yet Evident |
+|-----------|----------|------------------|----------------|
+| [Objective 1 behavior] | [Observable action] | ☐ | ☐ |
+| [Objective 2 behavior] | [Observable action] | ☐ | ☐ |
+| [Equity/UDL indicator] | [Observable action] | ☐ | ☐ |
+
+---
+
+### Coaching Debrief Protocol (Post-Observation, 20–30 min)
+**Pausing** — Facilitator waits 5–7 seconds after each response before speaking.
+
+1. "Tell me about the goal you had for this [lesson/meeting/session]."
+2. "What did you notice about [specific indicator]?"
+3. "If you were to do this again, what would you keep? What would you change?"
+4. "What's one next step you want to commit to?"
+5. "How can I best support you?"
+
+---
+
+## Level 4 — Results Data Collection Plan Template
+
+| Organizational Goal | Linked PD Outcome | Data Source | Baseline | Target | Timeline | Owner |
+|--------------------|------------------|-------------|---------|--------|---------|-------|
+| [Strategic priority] | [L3 behavior change] | [Assessment, survey, observation system] | [Current metric] | [Goal metric] | [Quarter/Year] | [Role] |
+
+---
+
+## Equity Lens Audit Checklist (Apply to any evaluation instrument)
+- [ ] Language is plain and accessible (≤ 8th grade reading level where possible)
+- [ ] Available in languages spoken by participant group
+- [ ] Anonymous response option is available
+- [ ] No items assume access to technology, materials, or resources participants may not have
+- [ ] Likert scales include a neutral/not applicable option
+- [ ] Power dynamics: results not used punitively

--- a/skills/professional-learning/references/frameworks.md
+++ b/skills/professional-learning/references/frameworks.md
@@ -1,0 +1,91 @@
+# Frameworks Reference
+
+## Andragogy — Knowles (1984)
+Six assumptions of adult learners:
+1. **Self-concept**: Adults are self-directed; involve them in planning.
+2. **Experience**: Richest resource for learning; use case studies, reflection.
+3. **Readiness**: Tied to developmental tasks and social roles.
+4. **Orientation**: Problem-centered, not subject-centered.
+5. **Motivation**: Primarily internal (career growth, self-esteem, quality of life).
+6. **Need to know**: Adults want to know WHY before investing effort.
+
+> Source: Knowles, M. S., Holton, E. F., & Swanson, R. A. (2015). *The Adult Learner* (8th ed.). Routledge.
+
+---
+
+## Kirkpatrick Model (1959, updated 2016)
+| Level | Name | Question | Methods |
+|-------|------|----------|---------|
+| 1 | Reaction | Did they find it engaging/relevant? | Surveys, exit tickets, pulse checks |
+| 2 | Learning | Did they gain knowledge/skill/attitude? | Pre/post assessments, demonstrations, rubrics |
+| 3 | Behavior | Did they apply it on the job? | Observations, walkthroughs, supervisor check-ins (30/60/90 days) |
+| 4 | Results | Did it produce organizational outcomes? | Data trends, KPIs, student achievement metrics |
+
+> Source: Kirkpatrick, J. D., & Kirkpatrick, W. K. (2016). *Kirkpatrick's Four Levels of Training Evaluation*. ATD Press.
+
+---
+
+## ADDIE Model
+| Phase | Key Actions |
+|-------|-------------|
+| Analysis | Needs assessment, learner analysis, context analysis |
+| Design | Learning objectives (Bloom's), sequencing, assessment strategy |
+| Development | Materials, facilitator guide, evaluation instruments |
+| Implementation | Delivery, facilitation, participant engagement |
+| Evaluation | Formative (L1–L2) and summative (L3–L4) data collection |
+
+---
+
+## Backward Design — Wiggins & McTighe (2005)
+Stage 1: Identify desired results (enduring understandings, essential questions)
+Stage 2: Determine acceptable evidence (performance tasks, other evidence)
+Stage 3: Plan learning experiences and instruction
+
+---
+
+## Cognitive Coaching — Costa & Garmston (2015)
+Three goals: autonomy, sense of community, interdependence.
+Four support functions: coaching, consulting, collaborating, evaluating.
+Five states of mind: consciousness, craftsmanship, efficacy, flexibility, interdependence.
+
+> Source: Costa, A. L., & Garmston, R. J. (2015). *Cognitive Coaching: Developing Self-Directed Leaders and Learners* (3rd ed.). Rowman & Littlefield.
+
+---
+
+## GROWTH Coaching Model
+| Letter | Phase | Focus |
+|--------|-------|-------|
+| G | Goal | What do you want to achieve? |
+| R | Reality | What is currently happening? |
+| O | Options | What could you do? What are the possibilities? |
+| W | Way Forward | What will you do? What's the first step? |
+| T | Timeline | By when? What milestones? |
+| H | Habits/Accountability | How will you sustain this? Who will support you? |
+
+> Source: Greene, J., & Grant, A. M. (2003). *Solution-Focused Coaching*. Pearson Education.
+
+---
+
+## UDL Guidelines — CAST (2018)
+**Principle 1 — Representation** (the "what" of learning)
+- Provide options for perception, language/symbols, comprehension
+
+**Principle 2 — Action & Expression** (the "how" of learning)
+- Provide options for physical action, expression/communication, executive function
+
+**Principle 3 — Engagement** (the "why" of learning)
+- Provide options for recruiting interest, sustaining effort/persistence, self-regulation
+
+> Source: CAST (2018). *Universal Design for Learning Guidelines version 2.2*. https://udlguidelines.cast.org
+
+---
+
+## Bloom's Taxonomy — Revised (Anderson & Krathwohl, 2001)
+| Level | Action Verbs for Objectives |
+|-------|----------------------------|
+| Remember | define, list, recall, identify, name |
+| Understand | explain, summarize, classify, describe, interpret |
+| Apply | use, demonstrate, implement, execute, solve |
+| Analyze | differentiate, compare, examine, deconstruct, attribute |
+| Evaluate | judge, critique, justify, assess, prioritize |
+| Create | design, construct, develop, generate, produce |


### PR DESCRIPTION
## Professional Learning Skill

This skill designs professional development sessions, workshop agendas, PLC protocols, coaching cycles, and adult learning experiences for educators and organizational staff.

### What it does

- Generates workshop agendas, PLC protocols, coaching cycles, PD series plans, onboarding plans, and training deck outlines
- - Grounds all outputs in adult learning science (Knowles' Andragogy, Kirkpatrick's Four Levels, GROWTH coaching model)
- - Embeds equity and Universal Design for Learning (UDL) into every design
- - Infers duration from context when not specified
- - Outputs as structured Markdown or DOCX
### No external API required

This skill works standalone without any external API or integration.