### PR TITLE
Add coaching-and-mentoring skill

### DIFF
--- a/skills/coaching-and-mentoring/LICENSE.txt
+++ b/skills/coaching-and-mentoring/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Anthropic, PBC.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/coaching-and-mentoring/SKILL.md
+++ b/skills/coaching-and-mentoring/SKILL.md
@@ -18,77 +18,69 @@ description: >
 
 This skill enables Claude to design rigorous, evidence-based coaching and mentoring
 deliverables grounded in adult learning theory, ICF competencies, and organizational
-development frameworks. All outputs are context-adaptive, equity-aware, and
-ready for implementation.
+development best practices. Outputs are practical, role-specific, and outcome-oriented.
 
-## Output Types
+---
 
-| Output | When to Use |
+## Theoretical Foundations
+
+Always anchor designs in one or more of these frameworks — name them explicitly in outputs:
+
+| Framework | Application |
 |---|---|
-| Coaching Program Design | Building a structured coaching initiative |
-| Individual Development Plan (IDP) | Creating a personalized growth plan |
-| Mentoring Program Framework | Designing a formal or informal mentoring program |
-| 1:1 Coaching Agenda | Structuring coaching conversations |
-| Feedback Model Guide | Building or training feedback systems |
-| Coaching Impact Report | Measuring coaching effectiveness |
+| **Andragogy** (Knowles) | Self-directed, experience-based adult learning |
+| **Transformative Learning** (Mezirow) | Perspective shifts, reflective practice |
+| **Zone of Proximal Development** (Vygotsky) | Scaffolded growth via expert guidance |
+| **Self-Determination Theory** (Ryan & Deci) | Autonomy, competence, relatedness drives |
+| **Constructivism** (Kolb ELT) | Concrete experience → reflective observation → abstract conceptualization → active experimentation |
+| **ICF Core Competencies** | Ethical practice, co-active partnership, active listening, powerful questioning |
+| **Bloom's Taxonomy** | Cognitive scaffolding for learning goal design in IDPs |
 
-## Coaching Models
+---
 
-Always select and name the coaching model before producing output:
+## Deliverable Types & How to Build Each
 
-| Model | Structure | Best For |
+### 1. Coaching Frameworks
+
+Use when: designing structured coaching engagements, selecting a coaching model, or building a coaching process for an organization.
+
+**Step 1 — Clarify Context:**
+- Who is the coachee? (Level, role, development stage)
+- What is the coaching goal? (Performance, transition, leadership, career)
+- What is the time horizon? (Short-term sprint vs. long-term engagement)
+- Organizational or cultural constraints?
+
+**Step 2 — Select or Blend a Model:**
+
+| Model | Best For | Core Structure |
 |---|---|---|
-| GROW (Whitmore) | Goal → Reality → Options → Will | General performance and development coaching |
-| CLEAR (Hawkins) | Contract → Listen → Explore → Action → Review | Systemic and leadership coaching |
-| OSKAR (McKergow) | Outcome → Scaling → Know-how → Affirm → Review | Solution-focused coaching |
-| COACH (Zeus & Skiffington) | Curious → Open → Appreciate → Connect → Help | Relationship-centered coaching |
-| Cognitive Behavioral | Thoughts → Feelings → Behaviors → Outcomes | Mindset and resilience coaching |
-| Transformational | Identity → Values → Beliefs → Capabilities → Behaviors | Deep change and leadership coaching |
+| **GROW** (Whitmore) | Goal-oriented performance coaching | Goal → Reality → Options → Will |
+| **CLEAR** (Hawkins) | Systemic/leadership coaching | Contract → Listen → Explore → Action → Review |
+| **OSKAR** (McKergow & Clarke) | Solution-focused coaching | Outcome → Scaling → Know-how → Affirm → Review |
+| **FUEL** (Zenger & Stinnett) | Manager-as-coach conversations | Frame → Understand → Explore → Lay out |
+| **Co-Active** (Kimsey-House) | Whole-person development | Being ↔ Doing balance |
+| **RACSR** | Reflective supervision | Restorative → Accountable → Case → Skills → Review |
 
-Default to **GROW** unless the context indicates a different model is better suited.
-
-## Individual Development Plan (IDP) Template
-
-When producing an IDP, use this structure:
+**Step 3 — Build the Framework Document:**
+Include: purpose, model rationale, session cadence, conversation guide (opening/exploration/action/closing), between-session accountability structures, and success metrics.
 
 ---
-**Individual Development Plan**
-**Name:** [Coachee name or role]
-**Coach/Manager:** [Name or role]
-**Period:** [Date range]
-**Organizational Context:** [Department, role, level]
 
-**Development Focus Areas:**
+### 2. Mentoring Programs
 
-| Development Goal | Current State | Target State | Timeline | Success Indicators |
-|---|---|---|---|---|
-| [Goal 1] | [Where they are] | [Where they want to be] | [By when] | [How we'll know] |
-| [Goal 2] | | | | |
+Use when: designing formal or informal mentoring structures for organizations, schools, or cohorts.
 
-**Action Steps:**
+**Program Architecture Checklist:**
+- [ ] Program type: Formal / Informal / Peer / Group / Reverse / Developmental / Sponsorship
+- [ ] Eligibility and matching criteria (competency-based, affinity-based, developmental need)
+- [ ] Onboarding: goal-setting protocol, relationship contract, confidentiality norms
+- [ ] Session structure: cadence, agenda template, reflection tools
+- [ ] Training: mentor training (active listening, avoiding advice-giving traps, boundary-setting)
+- [ ] Milestone check-ins: 30/60/90-day touchpoints + program evaluator role
+- [ ] Evaluation: Kirkpatrick L1–L4 (Reaction → Learning → Behavior → Results)
+- [ ] Closure protocol: celebratory review, alumni network path
 
-| Action | Resources Needed | Support Required | Timeline | Completion Check |
-|---|---|---|---|---|
-| [Specific action] | [Tools, training, access] | [Manager, peer, mentor] | [Date] | [Done/In progress] |
-
-**Check-in Schedule:** [Frequency and format]
-**Review Date:** [Formal review date]
----
-
-## Mentoring Program Framework
-
-When designing a mentoring program, include:
-
-**Program Design Elements:**
-- Program purpose and theory of change
-- Eligibility criteria (mentor and mentee)
-- Matching methodology (see matching matrix below)
-- Program duration and structure (formal vs. informal)
-- Training and onboarding for mentors and mentees
-- Communication and check-in cadence
-- Evaluation and reporting plan
-
-**Mentor-Mentee Matching Matrix:**
+**Matching Matrix (example schema):**
 
 | Dimension | Mentee Need | Mentor Strength |
 |---|---|---|
@@ -98,7 +90,9 @@ When designing a mentoring program, include:
 | Cultural/identity alignment | | |
 | Availability/time zone | | |
 
-## Feedback Models
+---
+
+### 3. Feedback Models
 
 Use when: building structured feedback systems, designing feedback training, or writing feedback for a coachee.
 
@@ -106,52 +100,101 @@ Use when: building structured feedback systems, designing feedback training, or 
 
 | Model | Structure | Best For |
 |---|---|---|
-| SBI (CCL) | Situation > Behavior > Impact | Behavioral, observable feedback |
-| COIN | Context > Observation > Impact > Next steps | Developmental conversations |
-| STAR/AR | Situation/Task > Action > Result / Action Required | Performance reviews + coaching |
-| Feedforward (Goldsmith) | Future-focused suggestions only | Growth mindset cultures |
-| 360-Degree | Self + peer + manager + direct report | Leadership development |
-| Radical Candor (Scott) | Care personally + Challenge directly matrix | Manager coaching cultures |
+| **SBI** (CCL) | Situation → Behavior → Impact | Behavioral, observable feedback |
+| **COIN** | Context → Observation → Impact → Next steps | Developmental conversations |
+| **STAR/AR** | Situation/Task → Action → Result / Action Required | Performance reviews + coaching |
+| **Feedforward** (Goldsmith) | Future-focused suggestions only | Growth mindset cultures |
+| **360-Degree** | Self + peer + manager + direct report | Leadership development |
+| **Radical Candor** (Scott) | Care personally + Challenge directly matrix | Manager coaching cultures |
 
-## 1:1 Coaching Agenda Template
+**When writing feedback for a user:**
+1. Identify the model most appropriate to context
+2. Label the structural components clearly (can be shown or hidden from recipient)
+3. Ensure specificity: observable behaviors, not trait attributions
+4. Balance: affirm strengths + identify growth edge (avoid sandwich traps)
+5. Close with a clear forward-looking action or question
 
-Standard structure for coaching conversations:
+---
 
-| Time | Section | Purpose | Questions |
-|---|---|---|---|
-| 5 min | Check-in | Build rapport, set tone | "How are you doing? What's on your mind?" |
-| 5 min | Agenda Setting | Clarify focus | "What would you like to focus on today?" |
-| 30 min | Core Coaching | Explore, discover, plan | [Model-specific questions] |
-| 10 min | Action Planning | Commit to next steps | "What will you do? By when? What support do you need?" |
-| 5 min | Reflection + Close | Consolidate learning | "What was most valuable today? What will you carry forward?" |
-| 5 min | Admin | Schedule next session | [Logistics] |
+### 4. Individual Development Plans (IDPs)
 
-## Coaching Impact Measurement
+Use when: building a personalized growth plan for a coachee, employee, student, or program participant.
 
-Align to Kirkpatrick or ROI Framework:
+**IDP Architecture:**
 
-| Level | What to Measure | Methods |
+```
+Section 1: Professional Identity & Vision
+  - Long-term aspiration (3–5 years)
+  - Core values and motivators
+  - Signature strengths (StrengthsFinder, VIA, CliftonStrengths, or user-defined)
+
+Section 2: Current State Assessment
+  - Competency self-assessment (role-specific rubric or framework)
+  - Feedback synthesis (360 data, manager input, peer input)
+  - Energy audit: energizing vs. draining activities
+
+Section 3: Development Goals
+  - 2–4 SMART goals aligned to Bloom's levels (Analysis → Synthesis → Evaluation)
+  - Prioritization: urgency × impact matrix
+
+Section 4: Learning & Development Actions
+  - Formal: courses, certifications, conferences
+  - Social: mentoring, shadowing, communities of practice
+  - Experiential: stretch assignments, project leadership, cross-functional roles
+  - Reflective: journaling, peer coaching pairs, supervision
+
+Section 5: Milestones & Accountability
+  - 30/60/90-day checkpoints
+  - Success indicators (behavioral + outcome)
+  - Accountability partner or sponsor
+
+Section 6: Review & Iteration
+  - Cadence for IDP revisits
+  - Reflection prompts: What worked? What shifted? What's next?
+```
+
+---
+
+### 5. Coaching Ethics & Boundaries
+
+Embed when relevant:
+- **ICF Code of Ethics**: Confidentiality, dual relationships, scope of practice
+- **Coaching vs. Therapy boundary**: Coaching is present/future-focused; past trauma → refer to licensed mental health professional
+- **Power dynamics**: Especially in organizational coaching — clarify who the "client" is (individual vs. sponsor)
+- **Cultural humility**: Avoid imposing Western coaching assumptions; adapt framework to cultural context
+- **Informed consent**: Coachee must understand goals, methods, and limits of the engagement
+
+---
+
+### 6. Measuring Coaching Impact
+
+Use **Kirkpatrick Four Levels** as the default evaluation architecture:
+
+| Level | Question | Example Measure |
 |---|---|---|
-| L1 Reaction | Coachee satisfaction with coaching | Session surveys, NPS |
-| L2 Learning | Knowledge and insight gained | Pre/post reflection, competency self-assessment |
-| L3 Behavior | Practice change in role | Manager observation, 360 follow-up |
-| L4 Results | Organizational outcomes | Performance data, retention, promotion rate |
-| ROI | Financial return on coaching investment | Cost vs. outcomes analysis |
+| **L1 Reaction** | Did they find it valuable? | Session satisfaction survey |
+| **L2 Learning** | What knowledge/insight was gained? | Pre/post self-assessment |
+| **L3 Behavior** | Did behavior change on the job? | Manager observation, 360 delta |
+| **L4 Results** | Did it affect organizational outcomes? | Retention, promotion, performance KPIs |
 
-## Equity and Inclusion in Coaching
+For executive/leadership coaching, add **Phillips ROI Level 5**: monetary value of behavior change vs. program cost.
 
-Always embed equity considerations:
+---
 
-- **Power dynamics**: Name and address power differentials between coach and coachee
-- **Cultural humility**: Adapt frameworks to cultural context; avoid universalizing Western models
-- **Identity-aware coaching**: Acknowledge how identity (race, gender, disability, etc.) shapes development experiences
-- **Access**: Ensure coaching resources, tools, and time are equitably distributed
+## Output Formatting Standards
 
-## Coaching Ethics
+- **Frameworks**: Header + purpose statement + model rationale + structured process + evaluation plan
+- **IDPs**: Sectioned document with tables, goal statements, and action timelines
+- **Feedback**: Labeled model components + behavioral specificity + forward action
+- **Programs**: Architecture overview + matching logic + session templates + evaluation schema
+- **All outputs**: Name the theoretical grounding; use tables for comparison/selection; include measurable outcomes
 
-Reference ICF Code of Ethics:
-- Maintain confidentiality
-- Avoid dual relationships
-- Clarify coaching vs. therapy boundaries
-- Operate within competence
-- Prioritize coachee's wellbeing and autonomy
+---
+
+## Reference Files
+
+Load when needed:
+- `references/frameworks-deep-dive.md` — Extended model documentation (GROW, CLEAR, Co-Active, OSKAR)
+- `references/idp-templates.md` — Role-specific IDP templates (educator, leader, technologist, researcher)
+- `references/feedback-scripts.md` — Model conversation scripts and SBI/COIN examples
+- `references/evaluation-toolkit.md` — Kirkpatrick survey templates, 360 rubrics, ROI calculation guide

--- a/skills/coaching-and-mentoring/SKILL.md
+++ b/skills/coaching-and-mentoring/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: coaching-and-mentoring
+description: >
+  Design coaching frameworks, mentoring programs, feedback models, and individual
+  development plans (IDPs) using evidence-based adult learning and coaching practices.
+  Use this skill whenever a user asks to build a coaching program, mentoring structure,
+  develop feedback systems, create IDPs or growth plans, design leadership coaching
+  frameworks, set up peer mentoring, structure 1:1s, or apply models like GROW, CLEAR,
+  OSKAR, SBI, or 360-degree feedback. Also trigger for requests involving competency
+  mapping, coachee/mentee onboarding, coaching ethics, or measuring coaching impact
+  via Kirkpatrick or ROI frameworks. If the user mentions "coaching," "mentoring,"
+  "feedback model," "development plan," or "career growth framework," use this skill.
+---
+
+# Coaching & Mentoring Skill
+
+## Purpose
+
+This skill enables Claude to design rigorous, evidence-based coaching and mentoring
+deliverables grounded in adult learning theory, ICF competencies, and organizational
+development frameworks. All outputs are context-adaptive, equity-aware, and
+ready for implementation.
+
+## Output Types
+
+| Output | When to Use |
+|---|---|
+| Coaching Program Design | Building a structured coaching initiative |
+| Individual Development Plan (IDP) | Creating a personalized growth plan |
+| Mentoring Program Framework | Designing a formal or informal mentoring program |
+| 1:1 Coaching Agenda | Structuring coaching conversations |
+| Feedback Model Guide | Building or training feedback systems |
+| Coaching Impact Report | Measuring coaching effectiveness |
+
+## Coaching Models
+
+Always select and name the coaching model before producing output:
+
+| Model | Structure | Best For |
+|---|---|---|
+| GROW (Whitmore) | Goal → Reality → Options → Will | General performance and development coaching |
+| CLEAR (Hawkins) | Contract → Listen → Explore → Action → Review | Systemic and leadership coaching |
+| OSKAR (McKergow) | Outcome → Scaling → Know-how → Affirm → Review | Solution-focused coaching |
+| COACH (Zeus & Skiffington) | Curious → Open → Appreciate → Connect → Help | Relationship-centered coaching |
+| Cognitive Behavioral | Thoughts → Feelings → Behaviors → Outcomes | Mindset and resilience coaching |
+| Transformational | Identity → Values → Beliefs → Capabilities → Behaviors | Deep change and leadership coaching |
+
+Default to **GROW** unless the context indicates a different model is better suited.
+
+## Individual Development Plan (IDP) Template
+
+When producing an IDP, use this structure:
+
+---
+**Individual Development Plan**
+**Name:** [Coachee name or role]
+**Coach/Manager:** [Name or role]
+**Period:** [Date range]
+**Organizational Context:** [Department, role, level]
+
+**Development Focus Areas:**
+
+| Development Goal | Current State | Target State | Timeline | Success Indicators |
+|---|---|---|---|---|
+| [Goal 1] | [Where they are] | [Where they want to be] | [By when] | [How we'll know] |
+| [Goal 2] | | | | |
+
+**Action Steps:**
+
+| Action | Resources Needed | Support Required | Timeline | Completion Check |
+|---|---|---|---|---|
+| [Specific action] | [Tools, training, access] | [Manager, peer, mentor] | [Date] | [Done/In progress] |
+
+**Check-in Schedule:** [Frequency and format]
+**Review Date:** [Formal review date]
+---
+
+## Mentoring Program Framework
+
+When designing a mentoring program, include:
+
+**Program Design Elements:**
+- Program purpose and theory of change
+- Eligibility criteria (mentor and mentee)
+- Matching methodology (see matching matrix below)
+- Program duration and structure (formal vs. informal)
+- Training and onboarding for mentors and mentees
+- Communication and check-in cadence
+- Evaluation and reporting plan
+
+**Mentor-Mentee Matching Matrix:**
+
+| Dimension | Mentee Need | Mentor Strength |
+|---|---|---|
+| Technical domain | | |
+| Leadership stage | | |
+| Industry context | | |
+| Cultural/identity alignment | | |
+| Availability/time zone | | |
+
+## Feedback Models
+
+Use when: building structured feedback systems, designing feedback training, or writing feedback for a coachee.
+
+**Core Models:**
+
+| Model | Structure | Best For |
+|---|---|---|
+| SBI (CCL) | Situation > Behavior > Impact | Behavioral, observable feedback |
+| COIN | Context > Observation > Impact > Next steps | Developmental conversations |
+| STAR/AR | Situation/Task > Action > Result / Action Required | Performance reviews + coaching |
+| Feedforward (Goldsmith) | Future-focused suggestions only | Growth mindset cultures |
+| 360-Degree | Self + peer + manager + direct report | Leadership development |
+| Radical Candor (Scott) | Care personally + Challenge directly matrix | Manager coaching cultures |
+
+## 1:1 Coaching Agenda Template
+
+Standard structure for coaching conversations:
+
+| Time | Section | Purpose | Questions |
+|---|---|---|---|
+| 5 min | Check-in | Build rapport, set tone | "How are you doing? What's on your mind?" |
+| 5 min | Agenda Setting | Clarify focus | "What would you like to focus on today?" |
+| 30 min | Core Coaching | Explore, discover, plan | [Model-specific questions] |
+| 10 min | Action Planning | Commit to next steps | "What will you do? By when? What support do you need?" |
+| 5 min | Reflection + Close | Consolidate learning | "What was most valuable today? What will you carry forward?" |
+| 5 min | Admin | Schedule next session | [Logistics] |
+
+## Coaching Impact Measurement
+
+Align to Kirkpatrick or ROI Framework:
+
+| Level | What to Measure | Methods |
+|---|---|---|
+| L1 Reaction | Coachee satisfaction with coaching | Session surveys, NPS |
+| L2 Learning | Knowledge and insight gained | Pre/post reflection, competency self-assessment |
+| L3 Behavior | Practice change in role | Manager observation, 360 follow-up |
+| L4 Results | Organizational outcomes | Performance data, retention, promotion rate |
+| ROI | Financial return on coaching investment | Cost vs. outcomes analysis |
+
+## Equity and Inclusion in Coaching
+
+Always embed equity considerations:
+
+- **Power dynamics**: Name and address power differentials between coach and coachee
+- **Cultural humility**: Adapt frameworks to cultural context; avoid universalizing Western models
+- **Identity-aware coaching**: Acknowledge how identity (race, gender, disability, etc.) shapes development experiences
+- **Access**: Ensure coaching resources, tools, and time are equitably distributed
+
+## Coaching Ethics
+
+Reference ICF Code of Ethics:
+- Maintain confidentiality
+- Avoid dual relationships
+- Clarify coaching vs. therapy boundaries
+- Operate within competence
+- Prioritize coachee's wellbeing and autonomy


### PR DESCRIPTION
## Coaching & Mentoring Skill

This skill designs coaching frameworks, mentoring programs, feedback models, and individual development plans (IDPs) using evidence-based adult learning and coaching practices.

### What it does

- Supports multiple coaching models: GROW, CLEAR, OSKAR, COACH, Cognitive Behavioral, and Transformational
- - Produces IDPs, mentoring program frameworks, 1:1 coaching agendas, feedback model guides, and coaching impact reports
- - Applies ICF competencies and organizational development frameworks
- - Embeds equity, cultural humility, and coaching ethics into every output
- - Aligns coaching impact measurement to Kirkpatrick and ROI frameworks
### No external API required

This skill works standalone without any external API or integration.