### PR TITLE
Add voice-prompt skill: hands-free voice dictation

### DIFF
--- a/skills/voice-prompt/LICENSE
+++ b/skills/voice-prompt/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 jayu1023
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/voice-prompt/SKILL.md
+++ b/skills/voice-prompt/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: voice-prompt
+description: Hands-free voice dictation for Claude Code. Records the user's microphone, transcribes locally with faster-whisper, types the result into whichever window is focused, and presses Enter when the user says a trigger phrase ("go", "send it", "submit", "hit enter"). Includes a runtime-toggleable self-learner that biases Whisper's transcription with the user's accepted prompts and a user-editable vocabulary file. Use when the user asks for voice input, dictation, speech-to-text, mic input, hands-free coding, "talk to Claude", or says things like "I want to speak my prompts" or "type as I talk".
+license: Complete terms in LICENSE
+---
+
+# voice-prompt
+
+Hands-free voice input for Claude Code. Transcription is 100% local (faster-whisper); the listener types into the focused window and submits on a configurable trigger phrase.
+
+## When this skill is invoked
+
+### If the user wants to set up / install voice input
+
+1. Check whether the runtime deps are installed:
+   ```bash
+   python3 -c "import sounddevice, faster_whisper, numpy" 2>/dev/null && echo OK || echo MISSING
+   ```
+2. If `MISSING`, run the setup script (it picks the right packages per platform):
+   ```bash
+   bash skills/voice-prompt/setup.sh
+   ```
+3. Remind the user of the platform-specific permissions:
+   - **macOS** — System Settings → Privacy & Security → grant **both** Microphone and Accessibility to their terminal. Without Accessibility, the keystroke step silently no-ops (this is the #1 support question).
+   - **Linux** — X11 session required for `xdotool` (Wayland users need `ydotool`).
+   - **Windows** — no special permissions; `pyautogui` handles input.
+
+### If the user wants to start dictating now
+
+Launch the listener as a background process so the user can keep focus on their Claude Code window:
+
+```bash
+python3 skills/voice-prompt/voice_prompt.py
+```
+
+Or on macOS open it in a separate Terminal window:
+```bash
+bash skills/voice-prompt/launch.sh
+```
+
+Explain the voice commands once on first run:
+
+| Say | Effect |
+|---|---|
+| `<your prompt>` + `go` / `send it` / `submit` / `hit enter` / `do it` | types the prompt, strips the trigger word, presses Enter |
+| `pause listening` / `mute` / `go to sleep` | stops typing but keeps mic on |
+| `resume listening` / `unmute` / `wake up` | resumes typing |
+| `stop learning` / `pause learning` | turns the self-learner off; nothing new is appended |
+| `start learning` / `resume learning` | re-enables the self-learner |
+| `stop listening` / `quit listening` / `exit voice` | exits the listener |
+
+### The self-learner
+
+Every accepted prompt (the text said before a submit trigger) is appended to `~/.claude/skills/voice-prompt/state/history.txt`. The next audio chunk transcribed by Whisper receives that history (plus the user-editable `state/vocab.txt`) as its `initial_prompt`, biasing transcription toward terms the user actually uses (function names, libraries, accent quirks).
+
+- The learner state is persisted in `state/learn.enabled` so the on/off choice survives restarts.
+- Starting with `python3 voice_prompt.py --no-learn` begins a session with the learner off.
+- Deleting `state/history.txt` wipes everything learned.
+
+### Customization
+
+Encourage the user to edit `~/.claude/skills/voice-prompt/state/vocab.txt` with project-specific terms (function names, libraries, abbreviations) for an immediate accuracy boost. They can also edit `TRIGGER_WORDS`, `STOP_WORDS`, `MODEL_SIZE`, and `COMPUTE_TYPE` at the top of `voice_prompt.py`.
+
+## Files in this skill
+
+- `SKILL.md` — this file
+- `voice_prompt.py` — cross-platform listener (macOS osascript / Linux xdotool / Windows pyautogui)
+- `setup.sh` — installs PortAudio / xdotool / pyautogui + Python deps as needed for the host platform
+- `launch.sh` — opens the listener in a new Terminal window on macOS
+- `LICENSE` — MIT
+- `README.md` — user-facing documentation (features, install, troubleshooting)
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Text doesn't appear when typing | Missing Accessibility permission (macOS) | System Settings → Privacy & Security → Accessibility → enable terminal |
+| Listener exits with "no audio device" | Missing Microphone permission | System Settings → Privacy & Security → Microphone → enable terminal |
+| Trigger word fires mid-sentence | Common word matched accidentally | Change `TRIGGER_WORDS` in `voice_prompt.py` to rarer phrases (e.g. `"computer go"`) |
+| Transcription slow / garbled | CPU-bound on large model | Switch `MODEL_SIZE` to `tiny.en` or `base.en` |
+| Linux: nothing types | Wayland (xdotool is X11-only) | Install [`ydotool`](https://github.com/ReimuNotMoe/ydotool) and adapt the two `xdotool` calls in `voice_prompt.py` |

--- a/skills/voice-prompt/launch.sh
+++ b/skills/voice-prompt/launch.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Opens a new Terminal window running the voice-prompt listener so the user
+# can keep focus on their Claude Code window.
+set -euo pipefail
+
+SCRIPT="$HOME/.claude/skills/voice-prompt/voice_prompt.py"
+
+if [ ! -f "$SCRIPT" ]; then
+  echo "ERROR: $SCRIPT not found." >&2
+  exit 1
+fi
+
+# Open in a new Terminal.app window. If iTerm is preferred, the user can
+# replace "Terminal" with "iTerm" below.
+osascript <<EOF
+tell application "Terminal"
+  activate
+  do script "echo '── voice-prompt listener (Cmd+W to stop) ──'; python3 $SCRIPT"
+end tell
+EOF
+
+echo "[voice-prompt] Listener launched in a new Terminal window."
+echo "[voice-prompt] Click back into your Claude Code window and start speaking."

--- a/skills/voice-prompt/setup.sh
+++ b/skills/voice-prompt/setup.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# voice-prompt setup: cross-platform installer.
+set -euo pipefail
+
+PY=${PYTHON:-python3}
+OS="$(uname -s)"
+
+echo "[voice-prompt] Detected: $OS"
+
+if ! command -v "$PY" >/dev/null 2>&1; then
+  echo "ERROR: python3 not found on PATH." >&2
+  exit 1
+fi
+
+case "$OS" in
+  Darwin)
+    # PortAudio for sounddevice; AppleScript ships with macOS.
+    if command -v brew >/dev/null 2>&1; then
+      brew list --versions portaudio >/dev/null 2>&1 || brew install portaudio
+    else
+      echo "WARN: Homebrew not found — sounddevice may fail. Install PortAudio manually." >&2
+    fi
+    EXTRA=()
+    ;;
+  Linux)
+    # xdotool to send keystrokes; portaudio19-dev for sounddevice build.
+    if ! command -v xdotool >/dev/null 2>&1; then
+      echo "[voice-prompt] xdotool missing. On Debian/Ubuntu:  sudo apt install xdotool portaudio19-dev"
+      echo "[voice-prompt] On Fedora:                          sudo dnf install xdotool portaudio-devel"
+      echo "[voice-prompt] On Arch:                            sudo pacman -S xdotool portaudio"
+    fi
+    EXTRA=()
+    ;;
+  MINGW*|MSYS*|CYGWIN*|Windows_NT)
+    # Windows uses pyautogui as the typing backend.
+    EXTRA=(pyautogui)
+    ;;
+  *)
+    echo "WARN: unknown OS '$OS' — proceeding with Python deps only." >&2
+    EXTRA=()
+    ;;
+esac
+
+"$PY" -m pip install --user --upgrade pip
+"$PY" -m pip install --user \
+  sounddevice \
+  numpy \
+  faster-whisper \
+  "${EXTRA[@]}"
+
+echo
+echo "[voice-prompt] Done."
+echo
+echo "Permissions reminder:"
+case "$OS" in
+  Darwin)
+    echo "  System Settings → Privacy & Security → Microphone   → enable your terminal"
+    echo "  System Settings → Privacy & Security → Accessibility → enable your terminal"
+    ;;
+  Linux)
+    echo "  Make sure your user is in the 'audio' group (sudo usermod -aG audio \$USER)"
+    echo "  X11 is required for xdotool (Wayland users: try 'ydotool' as a drop-in replacement)"
+    ;;
+esac
+echo
+echo "Start the listener:"
+echo "  python3 ~/.claude/skills/voice-prompt/voice_prompt.py"

--- a/skills/voice-prompt/voice_prompt.py
+++ b/skills/voice-prompt/voice_prompt.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""voice-prompt listener.
+
+Records mic audio in chunks, transcribes locally with faster-whisper, types
+the result into the focused window, and presses Enter on a trigger phrase.
+
+Features
+--------
+- Cross-platform typing (macOS osascript / Linux xdotool / Windows pyautogui).
+- Pause/resume via voice: "pause listening" / "resume listening".
+- Self-learning vocabulary: every accepted prompt (text before a submit
+  trigger) is appended to ~/.claude/skills/voice-prompt/state/history.txt and
+  used as Whisper's `initial_prompt` so it learns the words *you* actually use
+  (function names, library names, jargon, your accent's habits).
+- Learner can be toggled at runtime: "stop learning" / "start learning".
+- A user-editable vocabulary file at state/vocab.txt is always prepended.
+"""
+
+from __future__ import annotations
+
+import argparse
+import platform
+import queue
+import shutil
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import numpy as np
+import sounddevice as sd
+from faster_whisper import WhisperModel
+
+# ---------- config ------------------------------------------------------------
+
+SAMPLE_RATE = 16000
+CHUNK_SECONDS = 2.5
+MODEL_SIZE = "base.en"
+COMPUTE_TYPE = "int8"
+SILENCE_RMS = 0.005
+
+TRIGGER_WORDS = {
+    "go", "send", "send it", "enter", "hit enter",
+    "submit", "submit it", "do it",
+}
+STOP_WORDS = {"stop listening", "quit listening", "exit voice", "stop voice"}
+PAUSE_WORDS = {"pause listening", "pause voice", "mute", "mute voice", "go to sleep"}
+RESUME_WORDS = {"resume listening", "resume voice", "unmute", "unmute voice", "wake up"}
+LEARN_OFF_WORDS = {"stop learning", "pause learning", "no more learning", "stop training"}
+LEARN_ON_WORDS = {"start learning", "begin learning", "resume learning", "start training"}
+
+STATE_DIR = Path.home() / ".claude" / "skills" / "voice-prompt" / "state"
+VOCAB_FILE = STATE_DIR / "vocab.txt"      # user-editable, one term/phrase per line
+HISTORY_FILE = STATE_DIR / "history.txt"  # auto-appended accepted prompts
+FLAG_FILE = STATE_DIR / "learn.enabled"   # persists learner on/off between runs
+HISTORY_MAX_LINES = 500
+INITIAL_PROMPT_MAX_CHARS = 900            # Whisper caps around ~224 tokens
+
+SYSTEM = platform.system()
+
+
+# ---------- typing backends ---------------------------------------------------
+
+def _mac_run(script: str) -> None:
+    subprocess.run(["osascript", "-e", script], check=False,
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def _type_mac(text: str) -> None:
+    safe = text.replace("\\", "\\\\").replace('"', '\\"')
+    _mac_run(f'tell application "System Events" to keystroke "{safe}"')
+
+
+def _enter_mac() -> None:
+    _mac_run('tell application "System Events" to key code 36')
+
+
+def _type_linux(text: str) -> None:
+    subprocess.run(["xdotool", "type", "--delay", "1", "--", text], check=False)
+
+
+def _enter_linux() -> None:
+    subprocess.run(["xdotool", "key", "Return"], check=False)
+
+
+def _type_win(text: str) -> None:
+    import pyautogui
+    pyautogui.write(text, interval=0.005)
+
+
+def _enter_win() -> None:
+    import pyautogui
+    pyautogui.press("enter")
+
+
+def pick_backend():
+    if SYSTEM == "Darwin":
+        return _type_mac, _enter_mac, "AppleScript (osascript)"
+    if SYSTEM == "Linux":
+        if not shutil.which("xdotool"):
+            sys.exit("ERROR: xdotool not found. Install with: sudo apt install xdotool")
+        return _type_linux, _enter_linux, "xdotool"
+    if SYSTEM == "Windows":
+        try:
+            import pyautogui  # noqa: F401
+        except ImportError:
+            sys.exit("ERROR: pyautogui missing. Run: pip install pyautogui")
+        return _type_win, _enter_win, "pyautogui"
+    sys.exit(f"ERROR: unsupported platform: {SYSTEM}")
+
+
+type_text, press_enter, BACKEND_NAME = pick_backend()
+
+
+# ---------- vocab / learner ---------------------------------------------------
+
+def ensure_state() -> None:
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    if not VOCAB_FILE.exists():
+        VOCAB_FILE.write_text(
+            "# voice-prompt vocab — one term or short phrase per line.\n"
+            "# Add words / names / jargon you use a lot so Whisper learns them.\n"
+            "# Lines starting with # are ignored.\n"
+        )
+    if not HISTORY_FILE.exists():
+        HISTORY_FILE.write_text("")
+
+
+def learner_enabled() -> bool:
+    # File present (any content) ⇒ on. Default: on.
+    return not (FLAG_FILE.exists() and FLAG_FILE.read_text().strip() == "off")
+
+
+def set_learner(on: bool) -> None:
+    FLAG_FILE.write_text("on" if on else "off")
+
+
+def load_vocab_lines() -> list[str]:
+    if not VOCAB_FILE.exists():
+        return []
+    out = []
+    for line in VOCAB_FILE.read_text().splitlines():
+        line = line.strip()
+        if line and not line.startswith("#"):
+            out.append(line)
+    return out
+
+
+def load_history_lines() -> list[str]:
+    if not HISTORY_FILE.exists():
+        return []
+    return [l for l in HISTORY_FILE.read_text().splitlines() if l.strip()]
+
+
+def build_initial_prompt() -> str | None:
+    """Combine user vocab + recent accepted prompts to bias Whisper."""
+    parts: list[str] = []
+    parts.extend(load_vocab_lines())
+    if learner_enabled():
+        parts.extend(load_history_lines()[-80:])
+    if not parts:
+        return None
+    prompt = " ".join(parts)
+    if len(prompt) > INITIAL_PROMPT_MAX_CHARS:
+        prompt = prompt[-INITIAL_PROMPT_MAX_CHARS:]
+    return prompt
+
+
+def append_history(text: str) -> None:
+    if not learner_enabled():
+        return
+    text = text.strip()
+    if not text:
+        return
+    with HISTORY_FILE.open("a") as f:
+        f.write(text + "\n")
+    lines = HISTORY_FILE.read_text().splitlines()
+    if len(lines) > HISTORY_MAX_LINES:
+        HISTORY_FILE.write_text("\n".join(lines[-HISTORY_MAX_LINES:]) + "\n")
+
+
+# ---------- matching helpers --------------------------------------------------
+
+def normalize(s: str) -> str:
+    return s.lower().strip().rstrip(".!?, ")
+
+
+def matches_any(text: str, phrases: set[str]) -> str | None:
+    norm = normalize(text)
+    for p in sorted(phrases, key=len, reverse=True):
+        if p in norm:
+            return p
+    return None
+
+
+def ends_with_trigger(text: str) -> tuple[bool, str, str]:
+    norm = normalize(text)
+    for trig in sorted(TRIGGER_WORDS, key=len, reverse=True):
+        if norm == trig:
+            return True, trig, ""
+        if norm.endswith(" " + trig):
+            return True, trig, text[: -len(trig)].rstrip(".!?, ")
+    return False, "", text
+
+
+# ---------- audio loop --------------------------------------------------------
+
+def recorder(audio_q: "queue.Queue[np.ndarray]", stop: threading.Event) -> None:
+    block = int(SAMPLE_RATE * CHUNK_SECONDS)
+    with sd.InputStream(samplerate=SAMPLE_RATE, channels=1, dtype="float32") as stream:
+        while not stop.is_set():
+            buf, _ = stream.read(block)
+            audio_q.put(buf[:, 0].copy())
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="voice-prompt listener")
+    parser.add_argument("--no-learn", action="store_true",
+                        help="start with the learner OFF for this session")
+    parser.add_argument("--model", default=MODEL_SIZE,
+                        help=f"whisper model size (default: {MODEL_SIZE})")
+    args = parser.parse_args()
+
+    ensure_state()
+    if args.no_learn:
+        set_learner(False)
+
+    print(f"voice-prompt: platform={SYSTEM}  backend={BACKEND_NAME}")
+    print(f"voice-prompt: loading faster-whisper model={args.model} compute={COMPUTE_TYPE}")
+    print("  (first run downloads ~150MB, then it's cached)")
+    sys.stdout.flush()
+    model = WhisperModel(args.model, device="cpu", compute_type=COMPUTE_TYPE)
+
+    print(f"  learner    : {'ON' if learner_enabled() else 'OFF'} "
+          f"(vocab={len(load_vocab_lines())} terms, "
+          f"history={len(load_history_lines())} prompts)")
+    print(f"  vocab file : {VOCAB_FILE}")
+    print(f"  triggers   : {sorted(TRIGGER_WORDS)}")
+    print(f"  pause/res  : {sorted(PAUSE_WORDS)} ↔ {sorted(RESUME_WORDS)}")
+    print(f"  learn off  : {sorted(LEARN_OFF_WORDS)}")
+    print(f"  learn on   : {sorted(LEARN_ON_WORDS)}")
+    print(f"  exit       : {sorted(STOP_WORDS)}")
+    print("Switch focus to your Claude Code window now. Listening starts in 3s…")
+    sys.stdout.flush()
+    time.sleep(3)
+    print("[listening]")
+    sys.stdout.flush()
+
+    audio_q: "queue.Queue[np.ndarray]" = queue.Queue()
+    stop = threading.Event()
+    threading.Thread(target=recorder, args=(audio_q, stop), daemon=True).start()
+
+    muted = False
+    initial_prompt = build_initial_prompt()
+
+    try:
+        while True:
+            audio = audio_q.get()
+            if float(np.abs(audio).mean()) < SILENCE_RMS:
+                continue
+            segments, _ = model.transcribe(
+                audio,
+                language="en",
+                vad_filter=True,
+                vad_parameters=dict(min_silence_duration_ms=300),
+                initial_prompt=initial_prompt,
+            )
+            text = " ".join(s.text.strip() for s in segments).strip()
+            if not text:
+                continue
+            print(f"  heard{' (muted)' if muted else ''}: {text}")
+            sys.stdout.flush()
+
+            # --- control commands run even when muted ----------------------
+            if matches_any(text, STOP_WORDS):
+                print("[stop word — exiting]")
+                break
+            if matches_any(text, PAUSE_WORDS):
+                muted = True
+                print("[paused — say 'resume listening' to continue]")
+                sys.stdout.flush()
+                continue
+            if matches_any(text, RESUME_WORDS):
+                muted = False
+                print("[resumed]")
+                sys.stdout.flush()
+                continue
+            if matches_any(text, LEARN_OFF_WORDS):
+                set_learner(False)
+                print("[learner OFF — accepted prompts will not be saved]")
+                sys.stdout.flush()
+                continue
+            if matches_any(text, LEARN_ON_WORDS):
+                set_learner(True)
+                initial_prompt = build_initial_prompt()
+                print("[learner ON — accepted prompts will be saved]")
+                sys.stdout.flush()
+                continue
+
+            if muted:
+                continue
+
+            # --- normal dictation flow -------------------------------------
+            matched, trig, remainder = ends_with_trigger(text)
+            if matched:
+                if remainder:
+                    type_text(remainder + " ")
+                    time.sleep(0.15)
+                    append_history(remainder)
+                    initial_prompt = build_initial_prompt()
+                press_enter()
+                print(f"  → submitted (trigger: '{trig}')"
+                      f"{'  [learned]' if learner_enabled() and remainder else ''}")
+                sys.stdout.flush()
+            else:
+                type_text(text + " ")
+    except KeyboardInterrupt:
+        print("\n[interrupted]")
+    finally:
+        stop.set()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a new skill, `voice-prompt`, that lets users dictate prompts to Claude Code instead of typing. Audio is recorded from the default mic, transcribed locally with faster-whisper (no API calls, no PyTorch), typed into the focused window, and submitted when the user says a configurable trigger phrase like \"go\" / \"send it\" / \"submit\".

## Why

Typing is a bottleneck for accessibility users, long-form prompts, and mobile-style fluid thinking. Existing voice solutions either require cloud APIs (privacy concerns), don't integrate with terminal-based tools like Claude Code, or lack vocabulary adaptation. This skill is fully local, cross-platform, and learns the user's jargon over time.

## What's included

\`\`\`
skills/voice-prompt/
├── SKILL.md           # description + instructions for Claude
├── voice_prompt.py    # cross-platform listener (~330 lines)
├── setup.sh           # per-OS dependency installer
├── launch.sh          # opens listener in a new Terminal (macOS)
└── LICENSE            # MIT
\`\`\`

## Key features

- **100% local** transcription via [faster-whisper](https://github.com/SYSTRAN/faster-whisper) (CTranslate2 backend — no torch, ~150MB model, ~5× faster than openai-whisper on CPU)
- **Cross-platform typing backend** — AppleScript on macOS, xdotool on Linux, pyautogui on Windows; picked automatically at startup
- **Voice-controlled toggles** — pause/resume listening, stop/start the self-learner, exit
- **Self-learning vocabulary** — every accepted prompt is appended to \`state/history.txt\` and fed back as Whisper's \`initial_prompt\` so accuracy improves with the user's actual terms (function names, library names, accent patterns)
- **User-editable vocab file** at \`state/vocab.txt\` for explicit domain priming
- **Privacy-first**: the learner is toggleable at runtime via voice (\"stop learning\") and on the CLI via \`--no-learn\`; the on/off state persists across restarts in \`state/learn.enabled\`

## Voice commands

| Say | Effect |
|---|---|
| any prompt + \`go\` / \`send it\` / \`submit\` / \`hit enter\` / \`do it\` | types, strips trigger, presses Enter |
| \`pause listening\` / \`mute\` / \`go to sleep\` | pauses typing, keeps mic on |
| \`resume listening\` / \`unmute\` / \`wake up\` | resumes |
| \`stop learning\` / \`pause learning\` | learner off (nothing new saved) |
| \`start learning\` / \`resume learning\` | learner on |
| \`stop listening\` / \`exit voice\` | exits |

## Testing

Tested on macOS 25.4 (Apple Silicon) with Python 3.9. Verified:
- \`setup.sh\` installs PortAudio + Python deps cleanly
- Module imports OK (\`sounddevice\`, \`faster_whisper\`, \`numpy\`)
- State files (\`vocab.txt\`, \`history.txt\`, \`learn.enabled\`) initialize correctly on first run
- Learner toggle persists across runs
- \`initial_prompt\` correctly assembled from vocab + last 80 history lines

Linux (xdotool) and Windows (pyautogui) backends are implemented and the script falls back gracefully with a clear error message if the platform-specific tool is missing.

## Standalone repo

The same code with a polished user-facing README, animated SVG demo, and badges lives at https://github.com/jayu1023/voice-prompt-skill for users who want to install it independently of this registry.

## License

MIT — included in \`skills/voice-prompt/LICENSE\`.

---

Happy to iterate on naming, structure, or instructions if anything doesn't match the registry's conventions — first-time contributor here.

🤖 Co-authored with [Claude Code](https://claude.com/claude-code).