### PR TITLE
fix(skill-creator): isolate trigger-eval command files from the live project registry

### DIFF
--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -56,7 +56,9 @@ def run_single_query(
     """
     unique_id = uuid.uuid4().hex[:8]
     clean_name = f"{skill_name}-skill-{unique_id}"
-    eval_root = Path(tempfile.mkdtemp(prefix=f"skill-eval-{unique_id}-"))
+    # Include the skill name in the prefix so any tempdir stranded by a
+    # killed worker (rmtree never runs on SIGKILL) is attributable.
+    eval_root = Path(tempfile.mkdtemp(prefix=f"skill-eval-{skill_name}-{unique_id}-"))
     command_file = eval_root / ".claude" / "commands" / f"{clean_name}.md"
 
     try:

--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -9,8 +9,10 @@ import argparse
 import json
 import os
 import select
+import shutil
 import subprocess
 import sys
+import tempfile
 import time
 import uuid
 from concurrent.futures import ProcessPoolExecutor, as_completed
@@ -42,19 +44,23 @@ def run_single_query(
 ) -> bool:
     """Run a single query and return whether the skill was triggered.
 
-    Creates a command file in .claude/commands/ so it appears in Claude's
-    available_skills list, then runs `claude -p` with the raw query.
+    Creates a command file in an isolated throwaway project root so it
+    appears in Claude's available_skills list for the `claude -p` subprocess
+    only — never in the user's live .claude/commands/, where concurrent
+    Claude Code sessions would see the synthetic variant during the parallel
+    eval window. `claude -p` discovers commands from its cwd's .claude/;
+    global auth/config in ~/.claude are unaffected by cwd.
     Uses --include-partial-messages to detect triggering early from
     stream events (content_block_start) rather than waiting for the
     full assistant message, which only arrives after tool execution.
     """
     unique_id = uuid.uuid4().hex[:8]
     clean_name = f"{skill_name}-skill-{unique_id}"
-    project_commands_dir = Path(project_root) / ".claude" / "commands"
-    command_file = project_commands_dir / f"{clean_name}.md"
+    eval_root = Path(tempfile.mkdtemp(prefix=f"skill-eval-{unique_id}-"))
+    command_file = eval_root / ".claude" / "commands" / f"{clean_name}.md"
 
     try:
-        project_commands_dir.mkdir(parents=True, exist_ok=True)
+        command_file.parent.mkdir(parents=True, exist_ok=True)
         # Use YAML block scalar to avoid breaking on quotes in description
         indented_desc = "\n  ".join(skill_description.split("\n"))
         command_content = (
@@ -86,7 +92,7 @@ def run_single_query(
             cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
-            cwd=project_root,
+            cwd=str(eval_root),
             env=env,
         )
 
@@ -177,8 +183,7 @@ def run_single_query(
 
         return triggered
     finally:
-        if command_file.exists():
-            command_file.unlink()
+        shutil.rmtree(eval_root, ignore_errors=True)
 
 
 def run_eval(

--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -7,6 +7,7 @@ for a set of queries. Outputs results as JSON.
 
 import argparse
 import json
+import logging
 import os
 import select
 import shutil
@@ -19,6 +20,8 @@ from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
 
 from scripts.utils import parse_skill_md
+
+logger = logging.getLogger(__name__)
 
 
 def find_project_root() -> Path:
@@ -59,6 +62,11 @@ def run_single_query(
     # Include the skill name in the prefix so any tempdir stranded by a
     # killed worker (rmtree never runs on SIGKILL) is attributable.
     eval_root = Path(tempfile.mkdtemp(prefix=f"skill-eval-{skill_name}-{unique_id}-"))
+    # Make the hermetic-by-design intent explicit for anyone reading eval logs:
+    # the synthetic variant lives only under this throwaway root, never the live
+    # project. Silent by default (no handler configured); emits when the caller
+    # turns logging on.
+    logger.info("Isolated eval root: %s (cleaned on exit)", eval_root)
     command_file = eval_root / ".claude" / "commands" / f"{clean_name}.md"
 
     try:


### PR DESCRIPTION
## Summary

Fixes #1260 — the trigger eval writes its synthetic `{skill}-skill-{8hex}.md` command files
into the **user's live project** `.claude/commands/` (via `find_project_root()` + `cwd=project_root`),
so during the parallel eval window (default 10 workers) every concurrent Claude Code session
rooted at that project sees up to ~10 phantom hash-suffixed skill variants in its registry,
typeahead, and system-reminder skill listings.

This change isolates each eval variant in a per-query throwaway project root:

- variant command file is written under `tempfile.mkdtemp()/.claude/commands/`
- the `claude -p` subprocess runs with `cwd=eval_root` (it discovers commands from its cwd's
  `.claude/`; global auth/config in `~/.claude` are unaffected by cwd)
- `finally` removes the whole temp root (`shutil.rmtree`, replacing the per-file `unlink`)

The eval becomes hermetic: no live-registry pollution at any worker count, and project-level
commands/skills in the user's repo can no longer confound the trigger measurement. (This also
resolves the project-level case of anthropics/claude-plugins-official#632; skills installed
globally in `~/.claude/skills/` are still loaded regardless of cwd and would need a HOME
override — out of scope here.)

`run_loop.py` inherits the fix — it delegates to `run_eval()`. `find_project_root()` and the
`project_root` parameter are now unused for command placement; left intact to keep this diff
minimal, happy to remove them here or in a follow-up if preferred.

## Test plan

- [x] `python3 -m py_compile scripts/run_eval.py`
- [x] Ran the patched eval from a directory inside a live Claude Code project (where the old
  code reproducibly wrote variants into the project's `.claude/commands/`):
  1-query eval set, `--num-workers 1 --runs-per-query 1` → **1/1 PASS** (variant discovered and
  triggered from the isolated root), the live project's `.claude/commands/` was never created,
  and no `skill-eval-*` temp dirs were left behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
