### PR TITLE
fix(skill-creator): harden eval tooling against metadata layout and missing prompts

### DIFF
--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -196,6 +196,13 @@ Write an `eval_metadata.json` for each test case (assertions can be empty for no
 }
 ```
 
+> **Stop-gate before continuing**: confirm that every eval directory in this
+> iteration contains a valid `eval_metadata.json` with at minimum `eval_id`,
+> `eval_name`, and `prompt`. If any is missing, write it now — the prompt
+> cannot be recovered later from anywhere else. `aggregate_benchmark.py` will
+> refuse to run, and `generate_review.py` will print a loud warning and show
+> "(No prompt found)" in the viewer if you skip this.
+
 ### Step 2: While runs are in progress, draft assertions
 
 Don't just wait for the runs to finish — you can use this time productively. Draft quantitative assertions for each test case and explain them to the user. If assertions already exist in `evals/evals.json`, review them and explain what they check.

--- a/skills/skill-creator/eval-viewer/generate_review.py
+++ b/skills/skill-creator/eval-viewer/generate_review.py
@@ -21,11 +21,17 @@ import re
 import signal
 import subprocess
 import sys
+import textwrap
 import time
 import webbrowser
 from functools import partial
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from pathlib import Path
+
+# Sentinel value used in run["prompt"] when no prompt source can be located.
+# Kept as a module-level constant so other code paths (e.g. the post-scan
+# warning in main()) can compare against the exact same string.
+NO_PROMPT_SENTINEL = "(No prompt found)"
 
 # Files to exclude from output listings
 METADATA_FILES = {"transcript.md", "user_notes.md", "metrics.json"}
@@ -87,8 +93,21 @@ def build_run(root: Path, run_dir: Path) -> dict | None:
     prompt = ""
     eval_id = None
 
-    # Try eval_metadata.json
-    for candidate in [run_dir / "eval_metadata.json", run_dir.parent / "eval_metadata.json"]:
+    # Walk up from run_dir toward the workspace root looking for eval_metadata.json.
+    # Handles arbitrary nesting (e.g. iteration-N/eval-N/<condition>/run-N/) instead of
+    # assuming a single-parent layout — the canonical location per SKILL.md is eval-N/,
+    # which sits above the condition directory so prompt/assertions are shared across
+    # with_skill/without_skill runs.
+    candidates: list[Path] = []
+    current = run_dir.resolve()
+    root_resolved = root.resolve()
+    while True:
+        candidates.append(current / "eval_metadata.json")
+        if current == root_resolved or current.parent == current:
+            break
+        current = current.parent
+
+    for candidate in candidates:
         if candidate.exists():
             try:
                 metadata = json.loads(candidate.read_text())
@@ -114,7 +133,7 @@ def build_run(root: Path, run_dir: Path) -> dict | None:
                     break
 
     if not prompt:
-        prompt = "(No prompt found)"
+        prompt = NO_PROMPT_SENTINEL
 
     run_id = str(run_dir.relative_to(root)).replace("/", "-").replace("\\", "-")
 
@@ -384,6 +403,52 @@ class ReviewHandler(BaseHTTPRequestHandler):
         pass
 
 
+def _warn_missing_prompts(runs: list[dict]) -> None:
+    """Print a stderr warning listing every run whose prompt could not be located.
+
+    A missing prompt usually means `eval_metadata.json` was never written for
+    that eval directory (SKILL.md Step 1). The prompt is otherwise unrecoverable,
+    so surface the omission loudly instead of silently rendering "(No prompt
+    found)" in the report.
+    """
+    missing = [r for r in runs if r.get("prompt") == NO_PROMPT_SENTINEL]
+    if not missing:
+        return
+
+    n = len(missing)
+    if n == 1:
+        noun, verb, dem = "run", "has", "this"
+    else:
+        noun, verb, dem = "runs", "have", "these"
+    header = textwrap.dedent(f"""
+        ======================================================================
+          WARNING: {n} {noun} {verb} no recoverable prompt
+        ======================================================================
+          The eval prompt was not found in eval_metadata.json or transcript.md
+          for {dem} {noun}. The review page will show '(No prompt found)'.
+          Per SKILL.md Step 1, write eval_metadata.json BEFORE spawning runs.
+
+          Missing {noun}:
+    """).rstrip()
+    trailer = textwrap.dedent("""
+          Expected metadata format (one per eval directory):
+            {
+              "eval_id": 0,
+              "eval_name": "<descriptive-name>",
+              "prompt": "<the actual prompt used>",
+              "assertions": []
+            }
+        ======================================================================
+    """).rstrip()
+
+    print(header, file=sys.stderr)
+    for run in missing:
+        print(f"    - {run.get('id', '?')}", file=sys.stderr)
+    print("", file=sys.stderr)
+    print(trailer, file=sys.stderr)
+    print("", file=sys.stderr)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Generate and serve eval review")
     parser.add_argument("workspace", type=Path, help="Path to workspace directory")
@@ -412,6 +477,8 @@ def main() -> None:
     if not runs:
         print(f"No runs found in {workspace}", file=sys.stderr)
         sys.exit(1)
+
+    _warn_missing_prompts(runs)
 
     skill_name = args.skill_name or workspace.name.replace("-workspace", "")
     feedback_path = workspace / "feedback.json"

--- a/skills/skill-creator/scripts/aggregate_benchmark.py
+++ b/skills/skill-creator/scripts/aggregate_benchmark.py
@@ -38,8 +38,33 @@ import argparse
 import json
 import math
 import sys
+import textwrap
 from datetime import datetime, timezone
 from pathlib import Path
+
+
+# Canonical names for the per-condition subdirectories inside an eval directory.
+# An eval directory is identified by containing at least one of these.
+CONDITION_NAMES = ("with_skill", "without_skill", "old_skill", "new_skill")
+
+
+def _find_eval_dirs(search_dir: Path) -> list[Path]:
+    """Return all directories under search_dir that look like eval directories.
+
+    An eval directory is identified by containing at least one condition
+    subdirectory (with_skill / without_skill / old_skill / new_skill). This
+    accepts both the canonical "eval-N/" naming and descriptive names like
+    "my-eval-name/" (per SKILL.md line 188).
+    """
+    if not search_dir.is_dir():
+        return []
+    eval_dirs: list[Path] = []
+    for child in sorted(search_dir.iterdir()):
+        if not child.is_dir():
+            continue
+        if any((child / cond).is_dir() for cond in CONDITION_NAMES):
+            eval_dirs.append(child)
+    return eval_dirs
 
 
 def calculate_stats(values: list[float]) -> dict:
@@ -71,11 +96,13 @@ def load_run_results(benchmark_dir: Path) -> dict:
     Returns dict keyed by config name (e.g. "with_skill"/"without_skill",
     or "new_skill"/"old_skill"), each containing a list of run results.
     """
-    # Support both layouts: eval dirs directly under benchmark_dir, or under runs/
+    # Support both layouts: eval dirs directly under benchmark_dir, or under
+    # benchmark_dir/runs/. Detection uses the condition-subdir signature so
+    # descriptive eval names ("my-eval-name/") work as well as "eval-N/".
     runs_dir = benchmark_dir / "runs"
-    if runs_dir.exists():
+    if runs_dir.exists() and _find_eval_dirs(runs_dir):
         search_dir = runs_dir
-    elif list(benchmark_dir.glob("eval-*")):
+    elif _find_eval_dirs(benchmark_dir):
         search_dir = benchmark_dir
     else:
         print(f"No eval directories found in {benchmark_dir} or {benchmark_dir / 'runs'}")
@@ -83,19 +110,71 @@ def load_run_results(benchmark_dir: Path) -> dict:
 
     results: dict[str, list] = {}
 
-    for eval_idx, eval_dir in enumerate(sorted(search_dir.glob("eval-*"))):
-        metadata_path = eval_dir / "eval_metadata.json"
-        if metadata_path.exists():
-            try:
-                with open(metadata_path) as mf:
-                    eval_id = json.load(mf).get("eval_id", eval_idx)
-            except (json.JSONDecodeError, OSError):
-                eval_id = eval_idx
-        else:
-            try:
-                eval_id = int(eval_dir.name.split("-")[1])
-            except ValueError:
-                eval_id = eval_idx
+    # Per SKILL.md Step 1, every eval directory must carry eval_metadata.json
+    # with at minimum {eval_id, eval_name, prompt}. The prompt cannot be
+    # recovered from anywhere else, so refuse to aggregate if any file is
+    # missing, unreadable, or has empty required fields.
+    eval_dirs = _find_eval_dirs(search_dir)
+    metadata_by_dir: dict[Path, dict] = {}
+    problems: list[str] = []
+    for d in eval_dirs:
+        metadata_path = d / "eval_metadata.json"
+        if not metadata_path.exists():
+            problems.append(f"missing file: {metadata_path}")
+            continue
+        try:
+            with open(metadata_path) as mf:
+                metadata = json.load(mf)
+        except (json.JSONDecodeError, OSError) as e:
+            problems.append(f"unreadable ({e.__class__.__name__}): {metadata_path}")
+            continue
+        empty_fields = []
+        for field in ("eval_id", "eval_name", "prompt"):
+            val = metadata.get(field)
+            if val is None or val == "":
+                empty_fields.append(field)
+        if empty_fields:
+            problems.append(
+                f"missing or empty {empty_fields} in: {metadata_path}"
+            )
+            continue
+        metadata_by_dir[d] = metadata
+
+    if problems:
+        n = len(problems)
+        noun = "problem" if n == 1 else "problems"
+        header = textwrap.dedent(f"""
+            ======================================================================
+              ERROR: {n} eval metadata {noun} detected
+            ======================================================================
+              Per SKILL.md Step 1, every eval directory must contain
+              eval_metadata.json with at minimum eval_id, eval_name, and prompt
+              written BEFORE spawning runs. The prompt cannot be recovered
+              from anywhere else.
+
+              Problems:
+        """).rstrip()
+        trailer = textwrap.dedent("""
+              Expected content template:
+                {
+                  "eval_id": 0,
+                  "eval_name": "<descriptive-name>",
+                  "prompt": "<the actual prompt used for this eval>",
+                  "assertions": []
+                }
+            ======================================================================
+        """).rstrip()
+
+        print(header, file=sys.stderr)
+        for p in problems:
+            print(f"    - {p}", file=sys.stderr)
+        print("", file=sys.stderr)
+        print(trailer, file=sys.stderr)
+        print("", file=sys.stderr)
+        sys.exit(1)
+
+    for eval_idx, eval_dir in enumerate(eval_dirs):
+        eval_id = metadata_by_dir[eval_dir].get("eval_id", eval_idx)
 
         # Discover config directories dynamically rather than hardcoding names
         for config_dir in sorted(eval_dir.iterdir()):


### PR DESCRIPTION
## What

The skill-creator eval scripts make brittle assumptions about the eval directory layout and silently lose the eval prompt when `eval_metadata.json` is missing. This hardens both the aggregator and the review viewer.

## Why

- **`generate_review.py`** only looked for `eval_metadata.json` in `run_dir` and its immediate parent. With the nested layout described in SKILL.md (`eval-N/<condition>/run-N/`), the canonical `eval-N/eval_metadata.json` sits two levels up and was never found, so the viewer rendered `(No prompt found)`. It now walks up to the workspace root, and prints a stderr warning listing any run whose prompt couldn't be recovered instead of failing silently.
- **`aggregate_benchmark.py`** hardcoded `eval-*` globbing and silently fell back to a directory index when metadata was missing, so a forgotten `eval_metadata.json` produced a benchmark with no recoverable prompt. It now detects eval directories by their condition subdirs (`with_skill` / `without_skill` / `old_skill` / `new_skill`) — which also lets descriptive eval names work, not just `eval-N/` — and exits non-zero with a clear diagnostic if any eval is missing or has invalid/empty `eval_id` / `eval_name` / `prompt`.
- **`SKILL.md`** gains a Step 1 stop-gate reminding you to write `eval_metadata.json` before spawning runs, since the prompt can't be recovered afterwards.

## Testing

- Ran `aggregate_benchmark.py` against workspaces using both `eval-N/` and descriptive directory names, and with deliberately missing/empty `eval_metadata.json` — confirms it exits 1 with the diagnostic instead of producing a promptless benchmark.
- Ran `generate_review.py` against a nested `eval-N/<condition>/run-N/` layout — confirms prompts resolve and the missing-prompt warning fires when metadata is absent.