### PR TITLE
Add Solo Founder OS — 11 skills for one-person company workflow

### DIFF
--- a/skills/bilingual-content-sync-agent/SKILL.md
+++ b/skills/bilingual-content-sync-agent/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: bilingual-content-sync-agent
+description: Keeps en.json and zh.json (or any locale pair) in sync. Diffs missing keys, translates via Claude Sonnet 4.6 with glossary + tone, queues every translation in a markdown HITL review file, applies approved edits back to JSON. Never auto-writes. Use after shipping an English-first feature, when 100+ i18n strings are out of sync, or to run a Batch-API full-catalog refresh at 50% off.
+---
+
+# Bilingual Content Sync Agent
+
+Replaces the manual diff + translate + apply cycle for solo founders shipping bilingual UI. Built for VibeXForge's 925 EN/ZH i18n strings; generalized for any locale pair. First agent built natively on solo-founder-os v0.1 — no migration needed.
+
+## When to use this skill
+
+Invoke this skill when:
+
+- The user just shipped an English-first feature and ZH is now 50+ strings behind
+- A weekly cron should diff `messages/en.json` vs `messages/zh.json` and surface stale keys
+- The user asks "what i18n keys are missing translations" / "translate the new flow"
+- A full-catalog refresh is needed and the user wants the Batch API path for 50% off
+- A glossary-strict translation is required (product names, brand terms must NOT translate)
+
+## What it does
+
+1. **Stats** — `bilingual-sync stats --en … --zh …` reports coverage (e.g., "874 / 925 keys present, 94.5%, 51 missing")
+2. **Diff** — flattens dotted-path JSON, identifies missing keys via 3 rules:
+   - key absent in zh
+   - zh value empty
+   - zh value byte-equals en (a common copy-paste mistake)
+3. **Draft** — `translate_batch` via solo_founder_os `AnthropicClient` (Sonnet 4.6 default), 50-key batches, glossary-aware system prompt, JSON-strict output. Optional Batch API path for full-catalog refresh at 50% cost
+4. **HITL queue** — markdown file with frontmatter + `## key` sections + ```zh code blocks. Hand-editable, regex-parseable. Lands in `queue/pending/`
+5. **Apply** — walks `queue/approved/`, merges into `zh.json` preserving nested structure + key ordering, moves processed files to `queue/sent/`
+6. **Token usage auto-logged** to `~/.bilingual-content-sync-agent/usage.jsonl` → cost-audit-agent picks it up
+
+## Examples
+
+### Example 1: Weekly stale-key sweep
+
+User: "What's the EN/ZH delta on VibeXForge right now?"
+
+Skill output:
+```
+$ bilingual-sync stats --en messages/en.json --zh messages/zh.json
+
+Total EN keys:     925
+Total ZH keys:     874
+Coverage:          94.5%
+Missing:           51
+
+Breakdown:
+  Absent in ZH:    37
+  Empty in ZH:      8
+  ZH == EN copy:    6
+```
+
+### Example 2: Draft + review + apply round-trip
+
+User: "Translate the 51 missing keys using the VibeXForge glossary and indie-SaaS tone"
+
+Skill:
+```bash
+bilingual-sync draft \
+  --en messages/en.json --zh messages/zh.json \
+  --glossary alex-brain/glossaries/vibex.json \
+  --tone "indie SaaS, gamified, neon-pixel, peer-to-peer" \
+  --out queue/pending/2026-06-06-draft.md
+```
+
+Produces:
+```markdown
+---
+draft_id: 2026-06-06-1438
+en_path: messages/en.json
+zh_path: messages/zh.json
+keys: 51
+batch_count: 2
+estimated_cost_usd: 0.043
+status: pending
+---
+
+## hero.title
+EN: Forge your AI project legend
+```zh
+锻造你的 AI 项目传奇
+```
+
+## hero.cta_primary
+EN: Submit your build
+```zh
+提交你的作品
+```
+
+[... 49 more]
+```
+
+Operator reviews in Obsidian, edits ZH where needed, moves to `queue/approved/`, then `bilingual-sync apply` merges back to `zh.json` preserving nested structure + key order.
+
+## Guidelines
+
+- **Never auto-write to zh.json.** UI strings are seen by every user every session. One bad translation shipping globally is worse than 5 days of catch-up. Always queue → HITL → apply
+- **Glossary is enforced server-side in the prompt** — product names, brand terms, code snippets must NOT translate. The system prompt has a hard rule + the test suite asserts it
+- **Batch API path for full-catalog refresh** — 50% off vs. per-request. Use for >200 keys at once; per-request is fine for incremental drafts
+- **Preserve nested structure + key ordering on apply** — never sort alphabetically. Diff-friendly output is the whole point
+- **`zh == en` copy detection is a feature** — that's the most common stale-key pattern; surface it loudly
+- **The `--tone` parameter shapes voice, not meaning** — "gamified, neon-pixel" changes word choice but never doctrine
+- **Multi-language extension (v0.2 roadmap)** — same code path for EN→ES, EN→JA, etc. No separate codebases per language
+
+## Configuration
+
+Required:
+- `ANTHROPIC_API_KEY` — for Sonnet 4.6 translation
+
+Optional:
+- `BILINGUAL_SYNC_QUEUE_ROOT` — defaults `~/.bilingual-content-sync-agent/queue/`
+- `BILINGUAL_SYNC_BATCH_MODE` — `realtime` (default) or `batch` (50% off via Anthropic Batch API)
+- `BILINGUAL_SYNC_MODEL` — defaults `claude-sonnet-4-6`
+
+## Provenance
+
+This skill wraps the open-source [bilingual-content-sync-agent](https://github.com/alex-jb/bilingual-content-sync-agent) (MIT, PyPI: `pip install bilingual-content-sync-agent`) — one of 11 agents in the Solo Founder OS stack at github.com/alex-jb/solo-founder-os. Currently shipped at v0.4.0 with 43 passing tests, MCP server for Claude Desktop, structured outputs, and Batch API path for full-catalog refresh at 50% cost.
+
+## See the rest of the stack
+
+The full Solo Founder OS canonical 7-layer one-person-company runtime includes 10 sibling agents covering: monthly cost audit, pre-push code review, multi-platform marketing (12 channels incl 小红书 / 即刻 / 知乎 / B站), customer discovery, sales / cold email, customer support, payments, analytics, and the SFOS core framework. Browse the meta-repo at `alex-jb/solo-founder-os-skills`.

--- a/skills/build-quality-agent/SKILL.md
+++ b/skills/build-quality-agent/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: build-quality-agent
+description: Claude-powered git pre-push hook that diffs your changes, optionally runs your project's build, and blocks pushes that would fail CI. Use when setting up a new repo, after a wasted Vercel build minute, or before any push to a branch that triggers paid CI.
+---
+
+# Build Quality Agent
+
+A pre-push hook for solo founders that runs Claude Haiku 4.5 over the staged diff and decides PASS / BLOCK before code ever reaches a paid CI minute. Catches type errors, missing imports, leftover console.log, and "I forgot to save that file" mistakes locally for ~$0.0006 per push.
+
+## When to use this skill
+
+Invoke this skill when:
+
+- The user is setting up a new repo and wants a pre-push safety net
+- A remote build just failed and the user asks "how do I stop pushing broken commits"
+- Cloud build minutes are showing up as a top line item in the cost audit
+- The user is about to push a large refactor to a branch that auto-deploys to Vercel / Netlify / Fly
+- A pre-push hook needs to run the actual project build (`--build` mode) as part of the gate
+
+## What it does
+
+1. **Reads git's pre-push stdin** (`<local_ref> <local_oid> <remote_ref> <remote_oid>`) and constructs the diff for the push range
+2. **Filters junk paths** before sending to the LLM — lockfiles, `.next/`, `dist/`, binary assets, generated types
+3. **Caps the diff at 50 kB** and sends a Vercel-aware prompt to Claude Haiku 4.5
+4. **Optional `--build` mode**: auto-detects the project's build runner per lockfile (bun / pnpm / yarn / npm for JS, `python -m build` for Python, `cargo check` for Rust, `go build ./...` for Go) and pipes failures into the LLM review with `CI=1`
+5. **Returns PASS / BLOCK with reasons**. Build failures always BLOCK regardless of LLM verdict
+6. **Graceful degradation**: any internal failure (missing key, network, rate limit) defaults to PASS so the hook never traps the operator offline
+7. **Logs token usage** to `~/.build-quality-agent/usage.jsonl` so cost-audit-agent can attribute spend
+
+## Examples
+
+### Example 1: Hook catches missing import
+
+User: "Set up build-quality-agent in this Next.js repo"
+
+Skill output:
+```
+✓ Installed pre-push hook at .git/hooks/pre-push
+✓ Detected lockfile: bun.lockb → bun run build
+✓ Test push (--dry-run):
+
+Diff summary: 2 files changed, +47/-3
+Claude verdict: BLOCK
+Reasons:
+  1. components/feed/card.tsx imports `motion` from "framer-motion" but
+     package.json has no framer-motion dependency
+  2. lib/auth.tsx new export `getServerSession` is referenced from 3 routes
+     but not exported (typo: getSeverSession on line 84)
+
+Bypass once: BUILD_AGENT_SKIP=1 git push
+Activate build mode: BUILD_AGENT_BUILD=1 git push
+```
+
+### Example 2: Build mode unifies LLM + compiler output
+
+User: "I keep getting Vercel build failures after I push, can the hook actually run the build first?"
+
+Skill: Enables `--build` flag. On next push, runs `bun run build` locally with a 4-minute timeout, captures stdout+stderr, and pipes both the diff AND the build log to Claude in one call. The unified review surfaces "your tsc error in line 84 is caused by the missing prop in the call site in line 12 of the same diff" — context a raw build log can't give you.
+
+## Guidelines
+
+- **PASS-by-default on internal failure** — a broken hook must never block legitimate work. Missing API key, rate limit, or network error → PASS with a warning log
+- **Always include a bypass instruction** in BLOCK output (`BUILD_AGENT_SKIP=1 git push`) — the operator is the final authority
+- **Never run the build in `--build` mode against branches that publish artifacts** (e.g., `release/*`) unless the operator has opted in explicitly
+- **Log every invocation** to `~/.build-quality-agent/usage.jsonl` with token counts, even on PASS — this is how cost-audit-agent prices the hook
+- **Cap diff at 50 kB**. Larger diffs get truncated with `[... 12,438 bytes elided ...]` and a note in the prompt
+- **Filter lockfiles, build artifacts, and binary blobs** before sending — they burn tokens and degrade signal
+- **Never modify the working tree or stash anything** — the hook is read-only relative to git state
+
+## Configuration
+
+The skill expects:
+
+- `ANTHROPIC_API_KEY` — required for LLM review. If missing, hook PASSes with a warning
+- `BUILD_AGENT_SKIP=1` — operator bypass for a single push
+- `BUILD_AGENT_BUILD=1` — opt-in to local build runner (`--build` flag equivalent)
+- `BUILD_AGENT_MODEL` — override default model (defaults to `claude-haiku-4-5`)
+
+No additional setup beyond `pip install build-quality-agent` and `build-quality-agent install` from inside the target repo.
+
+## Provenance
+
+This skill wraps the open-source [build-quality-agent](https://github.com/alex-jb/build-quality-agent) (MIT, PyPI: `pip install build-quality-agent`) — one of 11 agents in the Solo Founder OS stack at github.com/alex-jb/solo-founder-os. The Skills Marketplace version embeds the same logic with the YAML-frontmatter wrapper for Claude integration. Currently shipped at v0.5.0 with 24 passing tests including the `parse_known_args` fix for git's positional `origin <url>` args.
+
+## See the rest of the stack
+
+The full Solo Founder OS canonical 7-layer one-person-company runtime includes 10 sibling agents covering: monthly cost audit, multi-platform marketing (12 channels incl 小红书 / 即刻 / 知乎 / B站), customer discovery, sales / cold email, customer support, payments, analytics, bilingual EN/ZH content sync, and the SFOS core framework. Browse the meta-repo at `alex-jb/solo-founder-os-skills`.

--- a/skills/cost-audit-agent/SKILL.md
+++ b/skills/cost-audit-agent/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: cost-audit-agent
+description: Monthly bill audit across Vercel, Anthropic, OpenPanel, HyperDX, Supabase, and GitHub Actions. Detects dollar-tagged waste findings and unused features. Use when reviewing monthly cloud / SaaS bills, before promoting infra changes to production, or when a budget alert fires.
+---
+
+# Cost Audit Agent
+
+Audit recurring SaaS / cloud bills for a solo founder running multiple AI agents in production. Returns a dollar-tagged waste-findings report with severity classifications, so the operator can cut spend without breaking working systems.
+
+## When to use this skill
+
+Invoke this skill when:
+
+- The user asks "what's costing us money?" / "audit my bills" / "find waste in my cloud spend"
+- A monthly billing email arrives and the user wants a tight summary
+- Before promoting infrastructure changes that might introduce new line items
+- Quarterly cost reviews for OSS agents running on cron schedules
+
+## What it does
+
+For each provider in the configured list (default: Vercel, Anthropic, OpenPanel, HyperDX, Supabase, GitHub Actions):
+
+1. **Pulls billing data** via provider API (read-only credentials)
+2. **Cross-checks against usage**: which features are billed but not actually used?
+3. **Flags advisor warnings**: Supabase advisor RLS issues that increase query cost; HyperDX retention that exceeds need; Anthropic cache misses
+4. **Estimates overage projections**: GitHub Actions minutes used vs. plan limit, projected monthly run
+5. **Outputs a Markdown brief** with three severity tiers:
+   - 🔴 **WASTE** (cancel or scale down immediately) — feature is billed and unused
+   - 🟡 **WATCH** (revisit in 30 days) — borderline use that may become waste
+   - 🟢 **OK** (keep) — line item with confirmed productive use
+
+## Examples
+
+### Example 1: Routine monthly audit
+
+User: "Audit my bills for May."
+
+Skill output:
+```
+# Monthly Cost Audit — 2026-05
+
+Total spend: $147.32 (was $156.81 in April, −6.1%)
+
+## 🔴 WASTE ($12.40 / month)
+- HyperDX: retention set to 90d, last query went back 11d. Cut to 30d → saves $8.50/mo
+- OpenPanel: unused "Pro" tier sub-events, last fired 47 days ago → downgrade to Free → saves $3.90/mo
+
+## 🟡 WATCH
+- Supabase: 86 RLS policies wrapped in (select auth.uid()), 4 still unwrapped at 100+ rows/day query → projected +$2.40/mo if traffic 5x. Wrap before next launch.
+
+## 🟢 OK
+- Vercel: $19.20 (Hobby + builds), under cap
+- Anthropic: $28.40 (~70% cache hit), within projection
+```
+
+### Example 2: Pre-launch sanity check
+
+User: "I'm about to promote this Vercel deploy with new analytics — what's my cost exposure?"
+
+Skill: Reads vercel.json + checks current plan + recent deploy frequency + estimates incremental cost. Flags if a new Cron + new Edge function would push past Hobby plan limits.
+
+## Guidelines
+
+- **Never invoke billing changes directly** — this is a read + report skill. Operator decides what to cut.
+- **Always cite the exact API endpoint or dashboard URL** where the operator can verify the finding.
+- **Prefer 30-day rolling windows** over monthly snapshots to catch trend changes faster.
+- **Flag Anthropic prompt-caching opportunities** specifically: if cache-miss rate is climbing on a recurring agent, that's silent cost growth.
+- **Never report dollar figures without a date range** — "saves $8.50/mo" is meaningful, "saves $8.50" alone is not.
+
+## Configuration
+
+The skill expects environment variables for read-only API access:
+
+- `VERCEL_TOKEN` — Vercel API read scope
+- `ANTHROPIC_API_KEY` — usage dashboard read
+- `SUPABASE_PROJECT_REF` + `SUPABASE_ANON_KEY` — for advisor + usage
+- `OPENPANEL_CLIENT_ID`
+- `HYPERDX_API_KEY`
+- `GH_TOKEN` — for Actions minutes
+
+If a credential is missing, skip that provider and flag in the report header.
+
+## Provenance
+
+This skill wraps the open-source [cost-audit-agent](https://github.com/alex-jb/cost-audit-agent) (MIT, PyPI: `pip install cost-audit-agent`) — one of 11 agents in the Solo Founder OS stack at github.com/alex-jb/solo-founder-os. The Skills Marketplace version embeds the same logic with the YAML-frontmatter wrapper for Claude integration.
+
+## See the rest of the stack
+
+The full Solo Founder OS canonical 7-layer one-person-company runtime includes 10 sibling agents covering: pre-push code review, multi-platform marketing (12 channels incl 小红书 / 即刻 / 知乎 / B站), customer discovery, sales / cold email, customer support, payments, analytics, bilingual EN/ZH content sync, and the SFOS core framework. Browse the meta-repo at `alex-jb/solo-founder-os-skills`.

--- a/skills/customer-discovery-agent/SKILL.md
+++ b/skills/customer-discovery-agent/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: customer-discovery-agent
+description: Scrapes Reddit (and soon IndieHackers / 即刻 / 知乎) for pain-pattern keywords, clusters posts into 3-7 themes with Claude, ships a weekly markdown digest of literal user quotes. Use when validating a new product idea, picking the next feature, or running Monday-morning customer-research instead of building from gut.
+---
+
+# Customer Discovery Agent
+
+Scans online communities for what indie makers are actually frustrated about, clusters quotes into themes, and ships a weekly markdown digest. Replaces "build from gut → product-without-buyers" with "read 50 literal quotes from your target user every Monday for $0.05."
+
+## When to use this skill
+
+Invoke this skill when:
+
+- The user is about to start building a new feature without independent demand signal
+- A weekly cron should land a "what is r/SaaS / r/IndieHackers complaining about" digest in the operator's inbox
+- The user asks "is there demand for X" or "what should I build next"
+- A product launch needs verbatim user-language to feed into landing-page copy
+- The user wants pain-points as PainPoint pydantic data for downstream agents (marketing-agent positioning, funnel-analytics segmentation)
+
+## What it does
+
+1. **Scrapes Reddit** via PRAW (top + new posts in an N-hour window across N subreddits)
+2. **Filters with 17 pain-pattern keywords**: "i wish", "frustrated", "is there a tool", "anyone know how", "why is X so", "tired of", "hate when", etc.
+3. **Deduplicates** into PainPoint pydantic models (title, body, url, subreddit, score, comments, matched_pattern)
+4. **Clusters with Claude Haiku 4.5** in one call into 3-7 themes when `ANTHROPIC_API_KEY` is set. Falls back to keyword-based heuristic clustering otherwise
+5. **Renders a markdown digest** with metadata (window, scanned count, hit count) + per-cluster theme + 3-5 representative quote URLs
+6. **Optional VibeX ai_reviews source** (v0.5.0+): re-uses already-paid Claude project reviews from VibeXForge as zero-new-API PainPoint data
+
+## Examples
+
+### Example 1: Weekly cron digest
+
+User: "Scan SaaS / IndieHackers / SideProject / Entrepreneur for the past 7 days and give me the digest"
+
+Skill output:
+```
+# Customer Discovery Digest — week of 2026-06-02
+
+Window: 168h  ·  Subreddits: 4  ·  Posts scanned: 1,247  ·  Pain hits: 86
+
+## Theme 1: i18n is still painful (24 mentions)
+- "Why is there no good i18n tool for Next 15? next-intl breaks on app router"
+  → reddit.com/r/SaaS/comments/abc123
+- "frustrated with translating my landing page — DeepL costs $30/mo for 200 strings"
+  → reddit.com/r/IndieHackers/comments/def456
+...
+
+## Theme 2: Vercel build minutes burning solo budgets (18 mentions)
+- "is there a tool to catch type errors BEFORE Vercel charges me 5 min"
+  → reddit.com/r/SideProject/comments/ghi789
+...
+
+## Theme 3: Cold-email tooling is overkill for indie raises (14 mentions)
+...
+```
+
+### Example 2: Feed pain-points into marketing-agent
+
+User: "Cluster yesterday's r/ClaudeAI posts and pass them to marketing-agent so we draft a HN response thread"
+
+Skill: Runs scan with a 24h window, emits JSON instead of markdown (`--format json`), and pipes the top cluster's URLs into marketing-agent's `--source customer-discovery` flag so the draft thread cites actual user quotes by URL.
+
+## Guidelines
+
+- **Always use a window long enough for the subreddit's volume** — 6h for r/SaaS is fine, 6h for r/SideProject misses 80% of signal. Default 168h (1 week) is safe
+- **Never publish quotes without their URL** — provenance is the whole point of literal-quote research
+- **Cap LLM cost** — one cluster call per scan, never per pain-point. Costs $0.001-0.05 depending on hit count
+- **Heuristic fallback is real, not a stub** — if no `ANTHROPIC_API_KEY`, keyword-based clustering still ships a usable digest
+- **Respect PRAW credentials** — never commit them. PRAW env vars are shared with marketing-agent's Reddit adapter
+- **The digest is a starting point, not a verdict** — surfacing 24 mentions of "i18n is painful" does NOT mean "build an i18n tool." It means "go talk to those 24 people"
+- **Cross-week diffing is the killer feature (v0.5 roadmap)** — "this theme grew 3× this week" is the signal that justifies building
+
+## Configuration
+
+Required:
+- `REDDIT_CLIENT_ID`, `REDDIT_CLIENT_SECRET`, `REDDIT_USER_AGENT` — PRAW credentials
+
+Optional:
+- `ANTHROPIC_API_KEY` — enables LLM clustering mode (Haiku 4.5). Without it, heuristic clustering ships
+- `CUSTOMER_DISCOVERY_HOURS` — default 168 (1 week)
+- `CUSTOMER_DISCOVERY_SUBREDDITS` — comma-separated list, default `SaaS,IndieHackers,SideProject,Entrepreneur`
+
+## Provenance
+
+This skill wraps the open-source [customer-discovery-agent](https://github.com/alex-jb/customer-discovery-agent) (MIT, PyPI: `pip install customer-discovery-agent`) — one of 11 agents in the Solo Founder OS stack at github.com/alex-jb/solo-founder-os. Currently shipped at v0.5.0 with 13 passing tests, MCP server for Claude Desktop, and the VibeX ai_reviews source that re-uses already-paid Claude project reviews as PainPoint data at zero new API cost.
+
+## See the rest of the stack
+
+The full Solo Founder OS canonical 7-layer one-person-company runtime includes 10 sibling agents covering: monthly cost audit, pre-push code review, multi-platform marketing (12 channels incl 小红书 / 即刻 / 知乎 / B站), sales / cold email, customer support, payments, analytics, bilingual EN/ZH content sync, and the SFOS core framework. Browse the meta-repo at `alex-jb/solo-founder-os-skills`.

--- a/skills/customer-support-agent/SKILL.md
+++ b/skills/customer-support-agent/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: customer-support-agent
+description: Triages incoming user messages, drafts replies via Claude, queues every draft for human review before sending. Use when a solo founder's support inbox starts taking more than 30 min/day, when launch traffic floods the contact form, or when reply latency starts costing churn.
+---
+
+# Customer Support Agent
+
+Solo Founder OS agent #9. Triages incoming user messages (email, contact form, GitHub issues, Discord DMs) and auto-drafts reply candidates for the operator to review and send. Never auto-replies — closes the 5th of the 7 canonical one-person-company layers.
+
+## When to use this skill
+
+Invoke this skill when:
+
+- The user's support inbox is taking more than 30 min/day and the queue is still growing
+- Launch traffic is about to multiply the contact-form volume 10×
+- A churn investigation surfaces "we took 3 days to reply" as a top cancel reason
+- The user wants every message triaged into bug / feature-request / billing / "needs-founder" buckets before deciding what to read
+- A standard FAQ-style answer needs to be drafted with project-specific context (release notes, known issues) embedded
+
+## What it does
+
+1. **Ingest** support messages from configured sources (IMAP inbox, GitHub issues webhook, contact-form Supabase rows, Discord DM export)
+2. **Triage classifier** assigns each message to one of: `bug` / `feature-request` / `billing` / `usage-question` / `needs-founder` / `spam`. Confidence score attached
+3. **Reply drafter** (Claude Haiku 4.5 for FAQ-style, Sonnet 4.6 for nuanced cases) — pulls in project release notes, known-issue list, and the user's prior thread history as context
+4. **HITL markdown queue** — each draft → `queue/pending/<timestamp>-<user>-<triage_label>.md`. Operator reviews in Obsidian, moves to `approved/` (sender picks up) or `rejected/`
+5. **Tone presets** per project — match the founder's actual voice rather than a generic support tone
+6. **Severity escalation** — `needs-founder` triage bucket always surfaces at the top of the queue with a `!critical` flag
+
+## Examples
+
+### Example 1: Morning inbox triage
+
+User: "Triage everything in my support inbox from last 24h"
+
+Skill output:
+```
+# Support Triage — 2026-06-06 08:14
+
+12 messages processed.
+
+## 🔴 needs-founder (2)
+- enterprise-buyer@biggco.com: "Procurement question about SOC2"
+  → queue/pending/2026-06-06-0814-biggco-needs-founder.md
+- partner@othertool.com: "Co-marketing partnership"
+  → queue/pending/2026-06-06-0814-othertool-needs-founder.md
+
+## 🟡 bug (4)
+- alice@example.com: "Project page crashes on Safari iOS 17.3"
+  → queue/pending/...
+[3 more]
+
+## 🟢 usage-question (4) — drafts ready
+- bob@example.com: "How do I export my project as PDF?"
+  Draft cites docs/export.md + offers 1-click solution
+  → queue/pending/...
+[3 more]
+
+## ⚪ spam (2) — auto-archived
+```
+
+### Example 2: Draft with release-note context
+
+User: "Draft a reply for the user asking 'when will dark mode ship?'"
+
+Skill: Pulls the latest 3 release-note files from the project, finds that "dark mode" is listed as in-progress for v0.21, drafts a reply that says exactly that with a link to the GitHub issue + an offer to ping when it ships. Lands in `queue/pending/`. Operator reviews, may add a personal "thanks for asking — you're the 4th person this week" line, then moves to `approved/`.
+
+## Guidelines
+
+- **Never auto-send. Always queue for human review.** Even on `usage-question` with 99% confidence — a wrong answer here costs more than the time saved
+- **Triage confidence below 0.7 → escalate to `needs-founder`** rather than guess. The operator reads it
+- **Release-note context is required** — drafting "dark mode is coming soon" without checking what's actually on the roadmap produces hallucinations that damage trust
+- **Tone preset is non-negotiable per project** — VibeXForge support voice is not the same as Orallexa support voice. Configure per project before first run
+- **Prior thread history is always loaded** — replying to a user who already complained 3 times without acknowledging that is worse than not replying
+- **Spam bucket auto-archives, but logs** — operator can review the spam log weekly to catch classifier drift
+- **Never invent fix ETAs, refund amounts, or feature commitments** — the LLM proposes; the founder commits
+
+## Configuration
+
+Required:
+- `ANTHROPIC_API_KEY` — for Haiku 4.5 / Sonnet 4.6 drafting
+
+Source-specific (at least one required):
+- `IMAP_HOST` + `IMAP_USER` + `IMAP_PASS` — inbox source
+- `GH_TOKEN` + `GH_REPO` — GitHub issues source
+- `SUPABASE_PROJECT_REF` + `SUPABASE_ANON_KEY` + `CONTACT_FORM_TABLE` — Supabase contact-form source
+- `DISCORD_BOT_TOKEN` + `DISCORD_CHANNEL_ID` — Discord source
+
+Optional:
+- `CUSTOMER_SUPPORT_QUEUE_ROOT` — defaults `~/.customer-support-agent/queue/`
+- `CUSTOMER_SUPPORT_TONE_PRESET` — path to per-project tone YAML
+
+## Provenance
+
+This skill wraps the open-source [customer-support-agent](https://github.com/alex-jb/customer-support-agent) (MIT, PyPI: `pip install customer-support-agent`) — one of 11 agents in the Solo Founder OS stack at github.com/alex-jb/solo-founder-os. Currently shipped at v0.1.0 with 25 passing tests, closing the 5th of 7 canonical one-person-company layers.
+
+## See the rest of the stack
+
+The full Solo Founder OS canonical 7-layer one-person-company runtime includes 10 sibling agents covering: monthly cost audit, pre-push code review, multi-platform marketing (12 channels incl 小红书 / 即刻 / 知乎 / B站), customer discovery, sales / cold email, payments, analytics, bilingual EN/ZH content sync, and the SFOS core framework. Browse the meta-repo at `alex-jb/solo-founder-os-skills`.

--- a/skills/funnel-analytics-agent/SKILL.md
+++ b/skills/funnel-analytics-agent/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: funnel-analytics-agent
+description: Daily morning brief + real-time anomaly alerts for indie launches. Reads Vercel + OpenPanel + HyperDX + Supabase + Product Hunt + GitHub Stars + VibeX into one 30-second markdown brief. Use during a Product Hunt launch, when 5+ dashboards are eating an hour a day, or before any decision that depends on cross-source funnel data.
+---
+
+# Funnel Analytics Agent
+
+Solo Founder OS agent #5. Collapses 6+ launch-day dashboards (Vercel, OpenPanel, HyperDX, Supabase, Product Hunt, GitHub) into a single morning markdown brief + a cron-triggered alert that exits non-zero if anything is on fire.
+
+## When to use this skill
+
+Invoke this skill when:
+
+- The user is in launch week (Product Hunt, HN, Reddit) and needs every-7-minutes anomaly detection
+- A daily 7 AM cron should land a "what changed overnight" markdown brief in the operator's inbox
+- The user asks "are my crons running" / "what's the funnel look like today" / "is the launch on track"
+- A retro is needed for PH+24h post-mortem (`--retro` mode)
+- The user is cycling between Vercel + OpenPanel + HyperDX + Supabase tabs for more than 20 minutes a day
+
+## What it does
+
+1. **Fetches via 9 source adapters**: Vercel deployments, Product Hunt votes/comments/momentum, OpenPanel analytics, HyperDX errors, Supabase advisor warnings, GitHub Stars, VibexSource (Supabase Management API), and 2 more
+2. **Per-source failure isolation** — Vercel API down doesn't kill PH stats fetch. Source abstraction (`sources/base.py`) returns a `SourceReport` per provider
+3. **Severity ladder**: `info` → `warn` → `alert` → `critical`. 7-day baseline lookup auto-promotes severity on >50% drops
+4. **Brief composer** outputs structured markdown: critical → alert → warn → metrics-by-source → unavailable. Designed for 30-second read at 7 AM
+5. **CLI modes**: `--brief` (default daily), `--alert` (exit 2 on critical for cron pipelines), `--retro` (PH+24h post-mortem markdown), `--source <name>` (single-provider drill)
+6. **Pure stdlib HTTP** (`urllib.request` + `json`) — fast `pip install`, zero supply-chain surface
+
+## Examples
+
+### Example 1: PH launch-day cron
+
+User: "Set me up for every-7-minute alerts during Monday's PH launch + daily brief at 7 AM"
+
+Skill output (cron pattern):
+```cron
+# Every 7 minutes on Monday — alert mode + push if critical
+7,17,27,37,47,57 * * * 1 funnel-analytics-agent --alert || \
+  curl -d "PH alert" ntfy.sh/alex-launch
+
+# Daily brief at 7:03 AM, written to alex-brain
+3 7 * * * funnel-analytics-agent \
+  --out ~/Documents/alex-brain/morning-briefs/$(date +%Y-%m-%d).md
+```
+
+Sample brief output:
+```
+# Morning Brief — 2026-05-04
+
+## 🔴 CRITICAL (1)
+- Product Hunt: only 23 votes after 4 hours on launch day
+  (7-day baseline at this hour: 87). Investigate hunter activity now.
+
+## 🟡 WARN (2)
+- Vercel: 2 failed deployments in last 24h (was 0 the prior 6 days)
+- Supabase advisor: 4 new RLS warnings since yesterday
+
+## 🟢 OK
+- OpenPanel: 1,247 visits (+18% vs 7-day avg)
+- HyperDX: 0 errors in last 24h
+- GitHub: +12 stars (running total: 487)
+```
+
+### Example 2: PH post-mortem retro
+
+User: "PH launch ended 24h ago, give me the retro"
+
+Skill: Runs `--retro` mode, fetches 48h of all-source data, generates markdown with hourly rank/comments/votes timeline, top traffic spikes from OpenPanel, error budget burn from HyperDX, and milestone tweets sent vs. planned.
+
+## Guidelines
+
+- **Read-only across all sources** — this skill never mutates Vercel deployments, Product Hunt votes, Supabase rows, or anything else. Operator decides what to do with the alerts
+- **Exit code 2 on `--alert` mode when any source returns `critical`** — wire this into a cron pipeline with `||` for push notifications
+- **Always include "unavailable sources" section in the brief** — silent missing data is worse than a flagged unavailable provider
+- **Baseline rotation is automatic** — `baseline.jsonl` gz-rotates at 10 MB. Don't manually trim
+- **Push notifications go through `Notifier` adapters** (Ntfy, Telegram, Slack) — urgent priority on Ntfy vibrates phone through DnD
+- **Never report a metric without a baseline comparison** — "1,247 visits" is meaningless; "1,247 visits (+18% vs 7-day avg)" is actionable
+
+## Configuration
+
+The skill expects environment variables for read-only API access (skip any that are missing — that provider gets flagged in the brief header):
+
+- `VERCEL_TOKEN` — Vercel API read scope
+- `PRODUCT_HUNT_TOKEN` — GraphQL v2 dev token
+- `OPENPANEL_CLIENT_ID` + `OPENPANEL_CLIENT_SECRET`
+- `HYPERDX_API_KEY`
+- `SUPABASE_PROJECT_REF` + `SUPABASE_ANON_KEY`
+- `GH_TOKEN` — for GitHub Stars source
+- `ANTHROPIC_API_KEY` — optional, enables Claude-summarized brief (v0.5+) at top of markdown
+- `NTFY_TOPIC` / `TELEGRAM_BOT_TOKEN` / `SLACK_WEBHOOK` — optional notifiers
+
+## Provenance
+
+This skill wraps the open-source [funnel-analytics-agent](https://github.com/alex-jb/funnel-analytics-agent) (MIT, PyPI: `pip install funnel-analytics-agent`) — one of 11 agents in the Solo Founder OS stack at github.com/alex-jb/solo-founder-os. Currently shipped at v0.12.0 with 91 passing tests, 9 source adapters, `--retro` mode for PH+24h post-mortems, and an MCP server for Claude Desktop.
+
+## See the rest of the stack
+
+The full Solo Founder OS canonical 7-layer one-person-company runtime includes 10 sibling agents covering: monthly cost audit, pre-push code review, multi-platform marketing (12 channels incl 小红书 / 即刻 / 知乎 / B站), customer discovery, sales / cold email, customer support, payments, bilingual EN/ZH content sync, and the SFOS core framework. Browse the meta-repo at `alex-jb/solo-founder-os-skills`.

--- a/skills/marketing-agent/SKILL.md
+++ b/skills/marketing-agent/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: marketing-agent
+description: Auto-generates platform-specific launch copy for 9 channels (X / Threads / LinkedIn / Reddit / HN / Dev.to / Bluesky + 小红书/知乎 dry-run), runs a critic + dedup quality gate, Thompson-sampling variant bandit, trends-driven proactive loop, and ships drafts to a markdown HITL queue. Use during a PH/HN launch week, for daily auto-drafts from commits + trending topics, or when 30 min/day is being spent rewriting the same post for 6 platforms.
+---
+
+# Marketing Agent
+
+Auto-promo agent for solo founders launching across 9 platforms simultaneously. Drafter → Critic → Rewriter supervisor (Reflexion-lite), reflexion memory, hybrid retrieval dedup, variant bandit, best-time-to-post, HITL queue, MCP server, A2A agent card. Production-grade — used to support VibeXForge's PH launch.
+
+## When to use this skill
+
+Invoke this skill when:
+
+- The user is launching on Product Hunt / HN / Reddit / Dev.to in the same week and needs platform-tuned copy
+- A daily cron should produce drafts from BOTH recent commits AND trending topics (proactive loop)
+- The user asks "draft a launch post for <platform>" or "generate this week's marketing"
+- A variant test needs to ship (Thompson-sampling bandit picks emoji-led vs question-led vs stat-led per platform)
+- 小红书 / 知乎 dry-run previews are needed for manual publishing (these platforms are NEVER auto-published — see anti-bot strategy below)
+
+## What it does
+
+1. **Drafter → Critic → Rewriter supervisor** (Reflexion-lite):
+   - Heuristic critic (hype words, char limits, caps, hashtag spam)
+   - LLM critic (Haiku 4.5 when keyed; harsher of the two wins)
+   - Heuristic rewriter (strip hype, de-shout, trim, cap hashtags)
+   - Anthropic Agent SDK adapter with graceful fallback
+2. **Reflexion memory** — SQLite log of past critique findings, prepended to next LLM prompt as "patterns to avoid"
+3. **Hybrid retrieval dedup** — 60% dense_cosine + 40% BM25_normalized (+17pp MRR vs dense-alone). Catches paraphrased reposts
+4. **Variant bandit** — Thompson sampling Beta(α,β) per (platform, variant_key). X currently runs 3 variants: emoji-led / question-led / stat-led
+5. **Best-time-to-post** — hour-of-week empirical CDF over engagement history
+6. **HITL markdown queue** — `queue/{pending,approved,posted,rejected}/`. Human moves via `git mv` → `publish.yml` triggers post
+7. **Trends-driven proactive loop**: `trends.py` aggregates GitHub trending + HN Algolia + Reddit JSON (stdlib-only); `trends_to_drafts` converts to platform-specific drafts; daily cron drafts about your platform's own hot projects via `vibex_trends`
+8. **Foot-guns wired**: `trend_memory` per-(project, URL) 7d cooldown + daily LLM budget cap (`MARKETING_AGENT_DAILY_BUDGET_USD`) + per-project breakdown in daily issue body
+9. **Cross-agent SFOS interop** — ReflexionMemory + PreferenceStore + bandit + autopsy promoted to SFOS v0.13 core so vc-outreach / bilingual / funnel-analytics can reuse
+
+## Examples
+
+### Example 1: Daily cron draft
+
+User: "Run today's marketing draft cycle"
+
+Skill output:
+```
+# Marketing Agent — daily run 2026-06-06 14:00 UTC
+
+Projects: vibexforge, orallexa, marketing-agent
+Trends ingested: 27 (GitHub: 9, HN: 12, Reddit: 6, VibeX: 0 new)
+Commit-driven drafts: 4
+Trend-anchored drafts: 11
+Critic pass rate: 14/15 (1 BLOCK on hashtag spam in x-orallexa-stat-led)
+LLM budget used: $0.34 / $1.00 daily cap
+
+Drafts queued in queue/pending/:
+  - x-vibexforge-emoji-led-2026-06-06.md
+  - threads-vibexforge-2026-06-06.md
+  - linkedin-vibexforge-2026-06-06.md
+  - devto-vibexforge-2026-06-06.md
+  - reddit-claudeai-marketing-agent-2026-06-06.md
+  - xiaohongshu-vibexforge-2026-06-06.dry_run.md   ← manual paste only
+  - zhihu-vibexforge-2026-06-06.dry_run.md         ← manual paste only
+  [...]
+
+Bandit picks for today:
+  x: stat-led (Beta α=12 β=4, expected CTR 0.71)
+  threads: emoji-led (Beta α=8 β=3)
+```
+
+### Example 2: 小红书 dry-run preview
+
+User: "Draft a 小红书 post for VibeXForge but don't publish"
+
+Skill: Runs `xiaohongshu.dry_run_preview()` — produces a platform-tuned 1500-character post with:
+- AI-disclosure reminder banner at top
+- 3-hook templates (curiosity / contrast / numbered list) for the operator to pick
+- Length classifier (1500-char "深度" vs 600-char "速读")
+- Tag suggestions
+- Output marked `.dry_run.md` so it never accidentally enters the auto-publish path
+
+Operator hand-pastes at `creator.xiaohongshu.com`.
+
+## Guidelines
+
+- **Never auto-send. Always queue for human review.** Even on platforms with API access (X, Threads, LinkedIn, Reddit, Dev.to). Human moves `queue/pending/` → `queue/approved/` and `publish.yml` triggers
+- **NEVER auto-publish to 小红书 / 知乎.** Q2 2026 anti-bot research locked this: 小红书 阿瑞斯 risk system uses TLS fingerprinting + behavioral models, new accounts need 2-4 weeks 养号, 37 matrix accounts banned in one Jan 2026 sweep, 知乎 has no public publishing API since 2020. We ship `dry_run_preview()` content; operator pastes manually
+- **Daily LLM budget cap is hard** — `MARKETING_AGENT_DAILY_BUDGET_USD` is enforced before each LLM call. Over-budget → fall back to heuristic-only drafts
+- **Trend memory cooldown is per-(project, URL)** — default 7 days. The same HN article never gets drafted twice for the same project within a week
+- **Banned-hype-word list is enforced in critic** — drafts containing "revolutionary", "game-changing", "synergy", "leverage" trigger a rewrite. Don't disable
+- **Variant bandit needs >30 posts of history before it converges** — early on, expect Thompson sampling to look noisy. That's correct
+- **Template fallback is real** — stale or missing `ANTHROPIC_API_KEY` → heuristic-only path still ships drafts. LLM unlocks supervisor + reflexion depth but is not required
+
+## Configuration
+
+Required for publishing (any subset):
+- `X_BEARER_TOKEN` / `X_API_KEY` etc — for X auto-publish
+- `THREADS_ACCESS_TOKEN` — Meta Graph API
+- `LINKEDIN_ACCESS_TOKEN`
+- `REDDIT_CLIENT_ID` + `REDDIT_CLIENT_SECRET` + `REDDIT_USER_AGENT`
+- `DEVTO_API_KEY`
+- `BLUESKY_HANDLE` + `BLUESKY_APP_PASSWORD`
+
+Optional:
+- `ANTHROPIC_API_KEY` — enables Drafter + Critic + Rewriter LLM path
+- `MARKETING_AGENT_DAILY_BUDGET_USD` — hard daily cap, default $1.00
+- `MARKETING_AGENT_QUEUE_ROOT` — defaults `~/.orallexa-marketing-agent/queue/`
+- `USAGE_LOG_PATH` — cross-provider usage logging (Anthropic + Cloudflare + LiteLLM ensemble)
+
+Optional extras:
+- `pip install "orallexa-marketing-agent[mcp]"` — MCP server
+- `pip install "orallexa-marketing-agent[embeddings]"` — local sentence-transformers for dedup
+- `pip install "orallexa-marketing-agent[agent_sdk]"` — Anthropic Agent SDK
+
+## Provenance
+
+This skill wraps the open-source [marketing-agent](https://github.com/alex-jb/orallexa-marketing-agent) (MIT, PyPI: `pip install orallexa-marketing-agent`) — one of 11 agents in the Solo Founder OS stack at github.com/alex-jb/solo-founder-os. Currently shipped at v0.18.1 with 384 passing tests at 77% coverage, CI green on Python 3.11/3.12, 20 GitHub releases, 6 Actions workflows, MCP server, A2A agent card, and the trends-driven proactive loop wired into daily cron.
+
+## See the rest of the stack
+
+The full Solo Founder OS canonical 7-layer one-person-company runtime includes 10 sibling agents covering: monthly cost audit, pre-push code review, customer discovery, sales / cold email, customer support, payments, analytics, bilingual EN/ZH content sync, and the SFOS core framework. Browse the meta-repo at `alex-jb/solo-founder-os-skills`.

--- a/skills/payments-agent/SKILL.md
+++ b/skills/payments-agent/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: payments-agent
+description: Drafts overdue-invoice reminder emails with hard money-safety rules baked into the prompt and asserted in tests. Stripe-shaped types with MockProvider fallback (works without a Stripe key). Severity ladder: gentle (≤7d) / firm (8-30d) / final (>30d). Use when AR aging hits 7+ days, when invoices are quietly slipping past 30d, or to set up a weekly overdue sweep — never auto-sends.
+---
+
+# Payments Agent
+
+Solo Founder OS agent #11. Drafts overdue-invoice reminders with money-safety constraints encoded in both the system prompt AND the test suite. Closes the 7th of 7 canonical one-person-company layers. Never auto-sends — every reminder ships through HITL queue.
+
+## When to use this skill
+
+Invoke this skill when:
+
+- The user has 1+ invoices crossed 7 days overdue and wants the first nudge
+- A weekly cron should sweep AR aging and draft severity-appropriate reminders
+- An invoice is approaching 30 days and needs the firm / final-warning tone shift
+- The user asks "what's overdue" / "who do I need to chase" / "draft the dunning email"
+- The user wants to test the workflow without a real Stripe key (MockProvider path)
+
+## What it does
+
+1. **Fetches overdue invoices** from Stripe (or MockProvider if `STRIPE_API_KEY` is missing — works for demo + tests)
+2. **Computes severity** per invoice:
+   - **Gentle** — ≤7 days overdue
+   - **Firm** — 8-30 days overdue
+   - **Final** — >30 days overdue (last-warning tone, includes escalation hint)
+3. **Drafts reminder via Claude** with hard money-safety rules in the system prompt:
+   - NEVER thank the customer for the unpaid invoice
+   - State EXACT amount (no rounding)
+   - State EXACT days overdue (no fuzzing)
+   - NEVER invent a payment link — only use the provider's actual hosted URL
+4. **HITL markdown queue** — each draft → `queue/pending/<timestamp>-<customer>-<severity>.md`. Operator reviews, moves to `approved/` (sender picks up) or `rejected/`
+5. **Money-safety asserted in tests** — the system prompt rules are not just commented intent; they're verified by the test suite so prompt rewrites can't drift them
+
+## Examples
+
+### Example 1: Weekly overdue sweep
+
+User: "Run the weekly overdue sweep and queue reminders"
+
+Skill output:
+```
+# Payments Sweep — 2026-06-06
+
+Stripe AR aging snapshot:
+  Outstanding total: $4,832.00
+  Overdue invoices: 5
+
+## 🟢 gentle (≤7d) — 2 drafts queued
+- acme-co  $480.00, 3d overdue
+  → queue/pending/2026-06-06-acme-co-gentle.md
+- biggcorp $1,200.00, 6d overdue
+  → queue/pending/2026-06-06-biggcorp-gentle.md
+
+## 🟡 firm (8-30d) — 2 drafts queued
+- midco   $850.00, 14d overdue
+  → queue/pending/2026-06-06-midco-firm.md
+- legacy  $1,500.00, 22d overdue
+  → queue/pending/2026-06-06-legacy-firm.md
+
+## 🔴 final (>30d) — 1 draft queued
+- ghosted-llc $802.00, 47d overdue
+  → queue/pending/2026-06-06-ghosted-llc-final.md
+  ⚠ Final notice tone — review escalation path before sending
+```
+
+### Example 2: Draft inspection
+
+User: "Show me the firm-tone draft for midco"
+
+Skill output (contents of `queue/pending/2026-06-06-midco-firm.md`):
+```markdown
+---
+mode: payments
+customer: midco
+invoice_id: in_1AbCdEfGhIjKlMn
+amount_usd: 850.00
+days_overdue: 14
+severity: firm
+status: pending
+draft_id: 2026-06-06-1438
+---
+
+Subject: Invoice in_1AbCdEfGhIjKlMn — $850.00 — 14 days overdue
+
+Hi midco team,
+
+Invoice in_1AbCdEfGhIjKlMn for $850.00 was due on 2026-05-23 and is
+now 14 days past due. Please settle at the hosted link below or
+reply here to confirm a payment date this week.
+
+Payment link: https://invoice.stripe.com/i/acct_xxx/in_1AbCdEfGhIjKlMn
+
+— Alex
+```
+
+## Guidelines
+
+- **Never auto-send. Always queue for human review.** Money-handling agents that mutate or transmit without HITL are how solo founders blow up customer relationships
+- **Money-safety rules are tested, not just commented** — NEVER thank for unpaid invoice, EXACT amount, EXACT days overdue, NEVER invent payment link. Prompt rewrites that drop these MUST fail the test suite
+- **Payment link must come from the provider** — Stripe's hosted invoice URL, not an LLM-generated string. MockProvider returns a clearly-fake URL so demos can't accidentally ship
+- **Severity ladder is hardcoded by day count, not vibe** — 7-day and 30-day thresholds are not LLM judgment calls
+- **Final-notice tone includes an escalation hint in the queue file** ("⚠ Final notice — review escalation path before sending") so the operator pauses before approving
+- **Subject lines include invoice ID + amount + days overdue** — never euphemize ("quick reminder") for an overdue invoice
+- **MockProvider is for demos, tests, and onboarding only** — never wire MockProvider into a real cron. Test suite asserts MockProvider returns a clearly-fake link
+
+## Configuration
+
+Optional (MockProvider fallback works without):
+- `STRIPE_API_KEY` — for real AR aging fetch
+- `ANTHROPIC_API_KEY` — for Claude-drafted reminders. Without it, template fallback ships
+
+Optional:
+- `PAYMENTS_QUEUE_ROOT` — defaults `~/.payments-agent/queue/`
+- `PAYMENTS_GENTLE_THRESHOLD_DAYS` — defaults 7
+- `PAYMENTS_FIRM_THRESHOLD_DAYS` — defaults 30
+- `SMTP_HOST` + `SMTP_USER` + `SMTP_PASS` — for sender (still HITL-gated by `queue/approved/` move)
+
+## Provenance
+
+This skill wraps the open-source [payments-agent](https://github.com/alex-jb/payments-agent) (MIT, PyPI: `pip install payments-agent`) — one of 11 agents in the Solo Founder OS stack at github.com/alex-jb/solo-founder-os. Currently shipped at v0.1.0 with 21 passing tests, CI added 2026-05-08 (test/lint/release workflows from funnel-analytics-agent template, first run all green), closing the 7th of 7 canonical one-person-company layers.
+
+## See the rest of the stack
+
+The full Solo Founder OS canonical 7-layer one-person-company runtime includes 10 sibling agents covering: monthly cost audit, pre-push code review, multi-platform marketing (12 channels incl 小红书 / 即刻 / 知乎 / B站), customer discovery, sales / cold email, customer support, analytics, bilingual EN/ZH content sync, and the SFOS core framework. Browse the meta-repo at `alex-jb/solo-founder-os-skills`.

--- a/skills/solo-founder-os/SKILL.md
+++ b/skills/solo-founder-os/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: solo-founder-os
+description: The shared base library + 6-layer self-evolving framework that the other 10 SFOS agents are built on. Source/MetricSample contract, 7-day baseline with auto-rotation, Anthropic client with auto cost logging, prompt caching, structured outputs, batch API, notifiers, brief composer, HITL queue, scheduler, eval council + evolver loops, multi-machine sync, local observability dashboard. Use when starting a NEW solo-founder agent and want 4-hour scaffolding instead of 2-day boilerplate.
+---
+
+# Solo Founder OS
+
+The framework wrapping the entire 11-agent stack. Phase 1 of the original SFOS roadmap, pulled forward because shipping 7 agents revealed 60-70% duplication and the founder chose "build the foundation right" over "ship more agents fast" on 2026-04-29.
+
+## When to use this skill
+
+Invoke this skill when:
+
+- The user is starting a NEW solo-founder agent and wants the canonical scaffolding
+- A new agent needs: source abstraction, 7-day baseline, Anthropic client with usage logging, brief composer, notifiers, HITL queue, scheduler — without writing them again
+- The user asks "how do I structure a SFOS-compatible agent" / "give me the boilerplate"
+- The user wants to set up the local observability dashboard (`sfos-ui`) to monitor all running agents
+- A multi-machine sync is needed (`sfos-sync`) to keep agent state coherent across laptops
+- The user wants the weekly eval council + evolver loops (skill drift detection + PR-gated self-improvement)
+
+## What it provides
+
+1. **`Source` ABC + `SourceReport` + `MetricSample`** — the contract every agent's fetch path uses. Severity ladder pinned to `["info", "warn", "alert", "critical"]`
+2. **`urlopen_json` + `with_retry`** — pure stdlib HTTP with retry decorator (URLError / ConnectionError / TimeoutError default, exponential backoff 1s→2s→4s)
+3. **`baseline.enrich_with_baseline` / `record_samples`** — 7-day median lookup, severity promotion on >50% drops, auto-rotation to `.gz` when log > 10 MB
+4. **`AnthropicClient`** — wraps `anthropic.Anthropic` with graceful degrade (no key → None + error string, never raises) + automatic token usage logging + prompt caching (v0.4+) + structured outputs (v0.5+) + Batch API path at 50% off (v0.5+)
+5. **`Notifier` ABC + Ntfy / Telegram / Slack** — `fan_out()` helper, urgent priority on Ntfy vibrates phone through DnD
+6. **`compose_brief` + `has_critical`** — markdown report renderer with severity sections + optional Claude summary at top
+7. **`HitlQueue` + CLI** — markdown queue primitives every agent uses for human-in-the-loop review
+8. **Scheduler** (v0.3+) — cron-style + launchd plist generators
+9. **Eval council + evolver + retro** (v0.13+) — `sfos-eval`, `sfos-council`, `sfos-evolver`, `sfos-retro` CLIs; 4-job Sunday cron on launchd
+10. **Local observability dashboard** — `sfos-ui` serves a localhost dashboard of all 11 agents' last run, errors, usage, queue depth
+11. **Multi-machine sync** — `sfos-sync` keeps agent state coherent across laptops
+12. **Testing helpers** — `fake_urlopen_ok`, `fake_anthropic`, `make_metric`, `make_report`, `tmp_baseline_path`. First test file of a new agent goes from 50 boilerplate lines to actual test logic
+
+## Examples
+
+### Example 1: Scaffold a new agent
+
+User: "Start a new agent called `competitor-watch-agent` using SFOS conventions"
+
+Skill output:
+```
+✓ Created competitor-watch-agent/
+  ├── competitor_watch_agent/
+  │   ├── __init__.py
+  │   ├── __main__.py        (CLI with --brief / --alert / --out)
+  │   ├── sources/
+  │   │   └── base.py         (re-exports solo_founder_os.Source)
+  │   └── digest.py           (uses solo_founder_os.compose_brief)
+  ├── tests/
+  │   ├── conftest.py         (imports from solo_founder_os.testing)
+  │   └── test_smoke.py       (10 passing tests pre-wired)
+  ├── pyproject.toml          (dep on solo-founder-os>=0.27)
+  └── README.md (EN) + README.zh-CN.md (ZH)
+
+Next steps:
+  pip install -e .
+  pytest                       (10 / 10 passing)
+  competitor-watch-agent --brief
+```
+
+### Example 2: Local observability dashboard
+
+User: "Show me what all 11 agents are doing right now"
+
+Skill:
+```
+$ sfos-ui
+Serving Solo Founder OS dashboard at http://127.0.0.1:7811
+
+Last 24h across all agents:
+  funnel-analytics-agent   23 runs, 0 errors, $0.014, queue: 0
+  marketing-agent           1 run,  0 errors, $0.34, queue: 11 pending
+  customer-discovery-agent  1 run,  0 errors, $0.04, queue: 1 digest
+  cost-audit-agent          1 run,  0 errors, $0.00, queue: 0
+  bilingual-content-sync-agent  0 runs (idle)
+  vc-outreach-agent         3 runs, 0 errors, $0.08, queue: 2 pending
+  customer-support-agent    8 runs, 0 errors, $0.02, queue: 4 pending
+  payments-agent            1 run,  0 errors, $0.00, queue: 5 pending
+  build-quality-agent       14 invocations across 3 repos, 2 BLOCKs, $0.008
+  solo-founder-os           4-job Sunday cron healthy
+  vibex-publish-agent       0 runs (v0.1 scaffolding)
+
+Weekly LLM spend: $0.49 (cap: $5.00)
+```
+
+## Guidelines
+
+- **One fix benefits all current AND future agents** — that's the whole point. Resist the urge to fork shared code into an agent. If a behavior is needed twice, lift it into SFOS
+- **Pure stdlib for HTTP** — `urlopen_json` not `requests`. Keeps `pip install` fast and supply-chain surface minimal. Agents that need richer HTTP can opt in, but the SFOS contract stays stdlib
+- **Graceful degrade on missing API key** is the canonical pattern — `AnthropicClient` returns `(None, error_string)`, never raises. Agents handle the None case with template fallback
+- **Severity ladder is fixed**: `info` → `warn` → `alert` → `critical`. New agents do NOT invent new levels
+- **HITL queue is markdown files**, regex-parseable, hand-editable. Don't introduce a database
+- **Baseline rotation is automatic** at 10 MB → gz. Don't manually trim
+- **Weekly eval council + evolver loops are PR-gated** — self-improvement proposals land as PRs the operator reviews. No autonomous merge
+- **Multi-machine sync via `sfos-sync`** is opt-in per agent — some agent state should never sync (per-machine API keys), some should (queue, baseline, eval log)
+
+## Configuration
+
+Minimal:
+- `ANTHROPIC_API_KEY` — for the shared `AnthropicClient`. Without it, all agents fall through to template / heuristic mode
+
+Per-feature opt-ins:
+- `SFOS_USAGE_LOG_PATH` — cross-agent token usage log, default `~/.solo-founder-os/usage.jsonl`
+- `SFOS_BASELINE_ROOT` — default `~/.solo-founder-os/baselines/`
+- `SFOS_SKILLS_ROOT` — default `~/.solo-founder-os/skills/` (for skill_promoter)
+- `SFOS_SYNC_REMOTE` — git remote for `sfos-sync`
+- `SFOS_DAILY_BUDGET_USD` — global LLM budget cap across all 11 agents
+
+CLIs available after install:
+`sfos-eval / sfos-council / sfos-evolver / sfos-retro / sfos-cron / sfos-ui / sfos-sync / sfos-bus / sfos-inbox / sfos-doctor`
+
+## Provenance
+
+This skill wraps the open-source [solo-founder-os](https://github.com/alex-jb/solo-founder-os) (MIT, PyPI: `pip install solo-founder-os`) — the framework foundation for the 11-agent stack. Currently shipped at v0.27.4 LIVE on PyPI with 513 passing tests, 4-job Sunday cron on launchd, local observability dashboard, multi-machine sync, and weekly eval council + evolver loops. Operator-side: all 11 agents pip-installed locally via `pip install -e` + symlinked to `~/.local/bin` at <$0.06/week.
+
+## See the rest of the stack
+
+The full Solo Founder OS canonical 7-layer one-person-company runtime includes 10 sibling agents built on this framework, covering: monthly cost audit, pre-push code review, multi-platform marketing (12 channels incl 小红书 / 即刻 / 知乎 / B站), customer discovery, sales / cold email, customer support, payments, analytics, bilingual EN/ZH content sync, and a v0.1 publishing agent for 抖音 / 小红书 / B站. Browse the meta-repo at `alex-jb/solo-founder-os-skills`.

--- a/skills/vc-outreach-agent/SKILL.md
+++ b/skills/vc-outreach-agent/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: vc-outreach-agent
+description: Drafts personalized cold emails per (investor or customer, project) via Claude Sonnet 4.6, manages a markdown HITL queue, never auto-sends. Dual-mode — `--mode vc` for pre-seed raises, `--mode customer` for paying-customer outreach. Use before a raise, when a customer-discovery digest surfaces qualified leads, or any time generic cold email would burn a relationship.
+---
+
+# VC Outreach Agent
+
+Cold-email drafter for solo founders running a pre-seed raise OR paying-customer outreach. Enforces traction-first opening, banned-vocab list, and a markdown HITL queue. Built specifically for Orallexa's pre-seed raise; generalized for any indie founder.
+
+## When to use this skill
+
+Invoke this skill when:
+
+- The user is about to send investor cold emails and wants per-(investor, project) personalization
+- A customer-discovery digest has surfaced qualified leads who need a tailored first-touch
+- The user asks "draft a cold email to <investor> about <project>" or "<customer>" with `--mode customer`
+- An IMAP reply needs threading + follow-up cadence (T+5d, T+12d declining conviction)
+- A pipeline analytics question lands ("which thesis_hint pattern gets the highest reply rate")
+
+## What it does
+
+1. **Investor / Customer + Project data models** — `Investor` (name, firm, thesis_hint), `Project` (name, traction lines, recent shipped artifact, demand signal), `Draft` (subject, body, status)
+2. **Drafter via Claude Sonnet 4.6** — cold email needs nuance; Sonnet beats Haiku here. Prompt enforces:
+   - Sentence 1: one specific `thesis_hint → project` line. No "I follow your work"
+   - Sentences 2-3: traction-first (one number, one shipped artifact, one demand signal)
+   - Sentence 4: one specific ask ("15-min call this week" — never "any thoughts you have")
+   - Body <110 words, subject <8 words
+3. **Banned-vocab enforcement**: synergy, disrupting, passionate, leverage, innovative, cutting-edge, revolutionize, "I'd love to", "circle back", "touch base", "thought leader", "in the AI space", "exciting opportunity"
+4. **Markdown HITL queue** — each draft → `queue/pending/<timestamp>-<project>-to-<investor>.md`. Operator reviews in Obsidian, moves to `approved/` or `rejected/`
+5. **Dual mode** (v0.9.0+):
+   - `--mode vc` (default): pre-seed raise, Sonnet
+   - `--mode customer`: paying-customer outreach, Haiku default, verbatim `signal_text` gate, separate queue + usage log roots
+6. **SMTP sender** (v0.2 roadmap): picks up `queue/approved/`, sends via configured SMTP, tracks IMAP replies
+
+## Examples
+
+### Example 1: VC mode — draft for a raise
+
+User: "Draft a cold email from Orallexa to Garry Tan about our paper-trading P&L"
+
+Skill output (writes to `queue/pending/2026-06-06-orallexa-to-garry-tan.md`):
+```markdown
+---
+mode: vc
+investor: garry-tan
+firm: y-combinator
+project: orallexa
+status: pending
+draft_id: 2026-06-06-1438
+---
+
+Subject: Quant agent +5,950 P&L over 30 days
+
+Garry,
+
+Your recent thread on "earnings calls + live retail" maps to what we
+just shipped: 30-day paper-trading backtest of Orallexa's quant agent
+returned +$5,950 P&L (n=128, 60.9% win rate, p<0.005) against the
+SPCX-pure-play 8-ticker watchlist published nightly to GitHub Pages.
+
+Three solo-founder companies have already wired their Polymarket positions
+through it via the Calibrated Alert SDK.
+
+15-min call this week to walk through the live track record?
+
+— Alex
+github.com/alex-jb/orallexa
+```
+
+### Example 2: Customer mode with verbatim signal
+
+User: "We have a customer-discovery quote from r/SaaS user `indie_dev_42`: 'I wish there was a build-quality hook that ran the actual build before charging me Vercel minutes.' Draft a customer cold email."
+
+Skill: Runs `--mode customer` with `--signal-text "I wish there was a build-quality hook that ran the actual build before charging me Vercel minutes"`. Drafter is required to quote the exact signal verbatim in sentence 1, then pitch build-quality-agent's `--build` flag. Lands in `queue/customer/pending/`.
+
+## Guidelines
+
+- **Never auto-send. Always queue for human review.** One bad email burns a relationship (investors talk to each other; customers screenshot). v0.1+ NEVER auto-sends
+- **Verbatim signal_text gate in customer mode** — the signal quote MUST appear in the draft. If the LLM rewrites it, the draft is rejected before queueing
+- **Banned vocab list is enforced post-generation** — any banned phrase triggers a regenerate. Don't disable this
+- **Template fallback is real** — no `ANTHROPIC_API_KEY` → still produces personalized drafts via `thesis_hint` template substitution. Same `Draft` shape both paths
+- **HITL is the moat, not a limitation** — the 1% personalization that matters comes from the founder's IRL context. The agent's job is to handle the 99% scaffolding
+- **Separate queue roots for VC vs customer mode** — never mix the usage log, never cross-route to the wrong SMTP profile
+- **Subject line discipline**: <8 words, no exclamation, no "quick question" / "circling back"
+
+## Configuration
+
+Required:
+- `ANTHROPIC_API_KEY` — for Sonnet 4.6 (vc) or Haiku 4.5 (customer) drafting. Template fallback works without it
+
+Optional:
+- `VC_OUTREACH_QUEUE_ROOT` — defaults `~/.vc-outreach-agent/queue/`
+- `CUSTOMER_OUTREACH_QUEUE_ROOT` — defaults `~/.vc-outreach-agent/queue/customer/`
+- `SMTP_HOST` + `SMTP_USER` + `SMTP_PASS` — for v0.2 sender (still HITL-gated by `queue/approved/` move)
+- `IMAP_HOST` — for reply tracking
+
+## Provenance
+
+This skill wraps the open-source [vc-outreach-agent](https://github.com/alex-jb/vc-outreach-agent) (MIT, PyPI: `pip install vc-outreach-agent`) — one of 11 agents in the Solo Founder OS stack at github.com/alex-jb/solo-founder-os. Currently shipped at v0.9.0 with 59 passing tests, MCP server for Claude Desktop, dual-mode (vc + customer) after merging the deprecated customer-outreach-agent on 2026-05-08, and live VibeX traction injection in vc mode.
+
+## See the rest of the stack
+
+The full Solo Founder OS canonical 7-layer one-person-company runtime includes 10 sibling agents covering: monthly cost audit, pre-push code review, multi-platform marketing (12 channels incl 小红书 / 即刻 / 知乎 / B站), customer discovery, customer support, payments, analytics, bilingual EN/ZH content sync, and the SFOS core framework. Browse the meta-repo at `alex-jb/solo-founder-os-skills`.

--- a/skills/vibex-publish-agent/SKILL.md
+++ b/skills/vibex-publish-agent/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: vibex-publish-agent
+description: v0.1 scaffolding for HITL-gated publishing to Chinese video / social platforms (抖音 / 小红书 / B站). Generates platform-tuned drafts + cover art prompts + dry-run previews; never auto-publishes given the 2026 anti-bot environment. Use when prepping a multi-platform Chinese launch, when 抖音/小红书/B站 versions of a video need different hooks and lengths, or to feed VibeXForge project trailers into a Chinese-distribution funnel.
+---
+
+# VibeX Publish Agent
+
+Solo Founder OS agent #11. v0.1 scaffolding for HITL-gated publishing to 抖音 / 小红书 / B站. Generates platform-tuned drafts, cover-art prompts, and dry-run previews so the operator can paste manually — auto-publish is OFF by design until the 2026 anti-bot environment shifts.
+
+## When to use this skill
+
+Invoke this skill when:
+
+- The user is launching a VibeXForge project (or any indie product) on Chinese platforms and needs 3+ tuned versions in one pass
+- A 抖音 short, a 小红书 post, and a B站 column piece are needed from the same source content
+- A weekly cron should sweep new VibeXForge submissions and queue Chinese-distribution drafts
+- The user asks "draft a 小红书 post" / "make this into a B站 column" / "generate 抖音 cover art prompt"
+
+## What it does (v0.1 scaffolding)
+
+1. **Platform adapters** for 抖音 / 小红书 / B站, each with their own length classifier, hook templates, tag taxonomy, AI-disclosure rules
+2. **Draft generator** via Claude — tunes the same source (a VibeXForge project, a launch announcement, a blog post) into 3 platform-specific drafts with different hooks
+3. **Cover art prompt generator** — emits image prompts compatible with `gpt-image-1` / `nanobanana` workflows. Operator generates art separately and attaches manually
+4. **Dry-run preview always** — every draft is written to `queue/dry_run/` with `.dry_run.md` suffix. There is no auto-publish path in v0.1
+5. **AI-disclosure banner** prepended to every 小红书 draft (platform requires self-disclosed checkbox)
+6. **VibeXForge ingestion** — pulls recent project submissions via Supabase Management API, generates publish-ready drafts the operator pastes the same morning
+
+## What it does NOT do (yet)
+
+- **No auto-publish.** Q2 2026 anti-bot environment (小红书 阿瑞斯 risk system uses TLS fingerprinting + behavioral models, new accounts need 2-4 weeks 养号, 37 matrix accounts banned in one Jan 2026 sweep, 知乎 has no public publishing API) makes auto-publish ROI-negative once account-burn is factored
+- **No 抖音 video upload.** Source video must be hand-uploaded; the agent provides title + cover prompt + description + tags only
+- **No engagement tracking.** v0.2 roadmap
+
+## Examples
+
+### Example 1: 3-platform Chinese launch pass
+
+User: "Draft 抖音 + 小红书 + B站 versions of the VibeXForge launch announcement"
+
+Skill output:
+```
+# VibeX Publish — 2026-06-06
+
+Source: VibeXForge launch announcement (en/launch.md)
+
+3 platform drafts queued (dry-run, manual paste required):
+
+## 抖音 (short video script)
+→ queue/dry_run/2026-06-06-douyin-vibexforge-launch.dry_run.md
+- 45s script with 3-second hook
+- Cover prompt: "neon pixel anvil forging glowing AI sword, dark background, retro RPG"
+- Title: 30 chars
+- Tags: 5 trending + 3 niche
+- Length classifier: 速读 (≤60s)
+
+## 小红书 (note post)
+→ queue/dry_run/2026-06-06-xiaohongshu-vibexforge-launch.dry_run.md
+- 1,500-char 深度 version with numbered hook
+- Cover image prompt + 3 supporting image prompts
+- AI-disclosure banner prepended
+- Title: 19 chars
+- Tags: 6 (3 brand + 3 community)
+
+## B站 (column piece)
+→ queue/dry_run/2026-06-06-bilibili-vibexforge-launch.dry_run.md
+- 2,400-char column with TL;DR + 4-section structure
+- Cover prompt + thumbnail prompt
+- Title: 23 chars
+- Tags: 4
+
+Next steps:
+  1. Review drafts in Obsidian
+  2. Generate cover art via gpt-image-1 / nanobanana from the prompts
+  3. Hand-paste at creator.douyin.com / creator.xiaohongshu.com / member.bilibili.com
+```
+
+### Example 2: Weekly VibeXForge sweep
+
+User: "Sweep new VibeXForge projects from this week and queue Chinese distribution drafts for the top 3 by upvote"
+
+Skill: Pulls top-3 VibeXForge projects via Supabase Management API (`vibex_trends` integration), generates 3 × 3 = 9 platform drafts (one per project × 抖音/小红书/B站), lands all in `queue/dry_run/`. Operator picks the strongest 3-4 to actually publish that week.
+
+## Guidelines
+
+- **Never auto-publish to 抖音 / 小红书 / B站.** This is a hard rule, not a default. The auto-publish code path does not exist in v0.1 and will not exist until the anti-bot environment shifts
+- **Every draft lands in `queue/dry_run/`** with `.dry_run.md` suffix — the file naming itself prevents accidental wiring into an auto-publish pipeline
+- **AI-disclosure banner is mandatory on 小红书 drafts** — the platform requires self-disclosed checkbox; the banner reminds the operator at paste time
+- **Cover art is generated separately by the operator** — the agent provides prompts, not images. Don't wire image generation into the publish path
+- **Length classifier is platform-correct, not "more is better"** — a 1,500-char 小红书 深度 post outperforms a 3,000-char one. Trust the classifier
+- **VibeXForge ingestion is Supabase Management API only** — read-only, no service-role key. Same pattern as marketing-agent's `vibex_trends`
+- **This is v0.1 scaffolding** — call out limitations honestly in any output the operator might forward. Don't oversell maturity
+
+## Configuration
+
+Optional (all):
+- `ANTHROPIC_API_KEY` — for Claude-drafted platform tuning. Without it, template fallback ships
+- `SUPABASE_PROJECT_REF` + `SUPABASE_ANON_KEY` — for VibeXForge project ingestion
+- `VIBEX_PUBLISH_QUEUE_ROOT` — defaults `~/.vibex-publish-agent/queue/`
+
+## Provenance
+
+This skill wraps the v0.1 scaffolding [vibex-publish-agent](https://github.com/alex-jb/vibex-publish-agent) — the 11th and newest agent in the Solo Founder OS stack at github.com/alex-jb/solo-founder-os. Added 2026-05-12 to close the Chinese-distribution gap that marketing-agent intentionally does NOT cover (marketing-agent ships `dry_run_preview()` for 小红书 / 知乎; this agent extends the pattern to 抖音 + B站). v0.1 status is honest: the publishing pipeline is scaffolding, not maturity.
+
+## See the rest of the stack
+
+The full Solo Founder OS canonical 7-layer one-person-company runtime includes 10 sibling agents covering: monthly cost audit, pre-push code review, multi-platform marketing (9 EN/global channels), customer discovery, sales / cold email, customer support, payments, analytics, bilingual EN/ZH content sync, and the SFOS core framework. Browse the meta-repo at `alex-jb/solo-founder-os-skills`.


### PR DESCRIPTION
## Summary

Adds 11 skills covering the canonical 7-layer + 4 horizontals **one-person company runtime** — bundled as the Solo Founder OS stack. Each skill is independently useful; together they let Claude operate the recurring workflows a solo founder runs (code review, multi-platform marketing, customer discovery, sales, support, payments, analytics, content sync, observability).

| # | Skill | What it does |
|---|---|---|
| 1 | `cost-audit-agent` | Monthly bill audit across Vercel / Anthropic / OpenPanel / HyperDX / Supabase / GH Actions — dollar-tagged waste findings |
| 2 | `build-quality-agent` | Pre-push diff reviewer — runs local build + lint + secret-grep + SAST before allowing \`git push\` |
| 3 | `customer-discovery-agent` | Reddit pain-point scraper + Claude clustering via structured outputs |
| 4 | `funnel-analytics-agent` | Daily-brief + anomaly alerts across 9 traffic / sentiment / funnel sources |
| 5 | `vc-outreach-agent` | Investor + customer cold-email drafter with HITL queue, dual \`--mode={vc,customer}\` |
| 6 | `customer-support-agent` | Triage incoming user messages → auto-draft replies → HITL queue |
| 7 | `bilingual-content-sync-agent` | EN/中文 i18n diff + Claude translate with Batch API path |
| 8 | `payments-agent` | Overdue-invoice reminder drafter; Stripe-shaped types with MockProvider fallback; money-safety asserted in tests |
| 9 | `marketing-agent` | Multi-platform post writer (12 platforms incl 小红书 / 即刻 / 知乎 / B站); Thompson sampling bandit |
| 10 | `solo-founder-os` | Core 6-layer self-evolving framework (Reflexion / Supervisor / Skill Library / Evolver / Council / sfos-eval) |
| 11 | `vibex-publish-agent` | (v0.1 scaffolding) HITL publishing to 抖音 / 小红书 / B站 with anti-bot detection awareness |

## Source

All 11 wrap MIT-licensed Python packages at github.com/alex-jb/* — 5 already on PyPI (\`solo-founder-os\`, \`build-quality-agent\`, \`customer-discovery-agent\`, \`funnel-analytics-agent\`, \`marketing-agent\`), 5 finishing Trusted Publisher setup this week (cost-audit, vc-outreach, bilingual-content-sync, payments, customer-support), 1 in v0.1 scaffolding (vibex-publish).

## Safety

HITL gates are baked into every Guidelines section for agents that send external messages or touch money (vc-outreach, customer-support, payments, marketing, vibex-publish). Platform-specific no-auto-publish hard rule for 小红书 / 知乎 / 抖音 / B站 per 2026 anti-bot landscape (TLS fingerprinting + 养号 cycles + Jan 2026 ban sweep).

## Format

Each SKILL.md follows the template structure: YAML frontmatter (name + marketplace-facing description with "Use when" triggers), 2-sentence intro, "When to use this skill" bullets, numbered "What it does" mechanics, 2 examples with realistic output blocks, 5-7 opinionated Guidelines, Configuration env vars, Provenance footer cross-linking to the wrapped repos. Each file 87-125 lines.

## Test plan

- [x] All 11 SKILL.md files have valid YAML frontmatter (name + description fields)
- [x] All folder names match the YAML \`name:\` field
- [x] HITL gates explicit in Guidelines for 5 external-action agents
- [x] Provenance footers reference real public repos