### PR TITLE
fix(skill-creator): read skill metadata as UTF-8

### DIFF
--- a/skills/skill-creator/scripts/test_utf8_io.py
+++ b/skills/skill-creator/scripts/test_utf8_io.py
@@ -1,0 +1,49 @@
+"""Tests for portable UTF-8 text IO in skill-creator scripts."""
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.utils import parse_skill_md
+
+
+class SkillCreatorUtf8IOTest(unittest.TestCase):
+    def test_parse_skill_md_reads_utf8_skill_when_default_encoding_is_cp1252(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_path = Path(tmpdir)
+            (skill_path / "SKILL.md").write_text(
+                "---\n"
+                "name: utf8-skill\n"
+                "description: Handles music symbol 𝄞 in UTF-8 metadata\n"
+                "---\n\n"
+                "Body with UTF-8 content: 𝄞\n",
+                encoding="utf-8",
+            )
+
+            concrete_path_class = type(skill_path / "SKILL.md")
+            original_read_text = concrete_path_class.read_text
+
+            def cp1252_default_read_text(
+                self,
+                encoding=None,
+                errors=None,
+                newline=None,
+            ):
+                if encoding is None:
+                    encoding = "cp1252"
+                return original_read_text(self, encoding=encoding, errors=errors, newline=newline)
+
+            with patch.object(concrete_path_class, "read_text", cp1252_default_read_text):
+                name, description, content = parse_skill_md(skill_path)
+
+        self.assertEqual(name, "utf8-skill")
+        self.assertEqual(description, "Handles music symbol 𝄞 in UTF-8 metadata")
+        self.assertIn("Body with UTF-8 content: 𝄞", content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/skill-creator/scripts/utils.py
+++ b/skills/skill-creator/scripts/utils.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 def parse_skill_md(skill_path: Path) -> tuple[str, str, str]:
     """Parse a SKILL.md file, returning (name, description, full_content)."""
-    content = (skill_path / "SKILL.md").read_text()
+    content = (skill_path / "SKILL.md").read_text(encoding="utf-8")
     lines = content.split("\n")
 
     if lines[0].strip() != "---":


### PR DESCRIPTION
## Summary

- read `skill-creator` shared `SKILL.md` metadata with explicit UTF-8 encoding
- add a regression test that simulates a Windows cp1252 default text encoding

## Context

This addresses the shared parser path from #1271 without touching the already-overlapping `quick_validate.py` and write-side changes covered by other open PRs.

## Test plan

- `python -m unittest discover -s skills/skill-creator/scripts -p "test_*.py"`
- `python -m py_compile skills/skill-creator/scripts/utils.py skills/skill-creator/scripts/test_utf8_io.py`
- `git diff --check HEAD~1..HEAD`