### PR TITLE
Add mermaid-diagram skill: dependency-free Mermaid authoring, validation & rendering

### DIFF
--- a/skills/mermaid-diagram/LICENSE.txt
+++ b/skills/mermaid-diagram/LICENSE.txt
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/skills/mermaid-diagram/SKILL.md
+++ b/skills/mermaid-diagram/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: mermaid-diagram
+description: Create, validate, and render Mermaid diagrams (flowcharts, sequence, class, state, ER, Gantt, mindmaps, and more) from a description or rough notes. Includes a dependency-free syntax validator and an optional image renderer. Use when a user asks to "make a diagram", "draw a flowchart", "visualize this process/architecture/workflow", "create a sequence/ER/class diagram", or convert notes into a Mermaid chart.
+---
+
+# Mermaid Diagram
+
+A toolkit for turning ideas, notes, or specifications into correct, renderable
+[Mermaid](https://mermaid.js.org) diagrams. The emphasis is on **producing valid
+syntax on the first try** — the included validator catches the mistakes that most
+commonly break rendering, so you don't ship a diagram that fails to draw.
+
+## When to Use This Skill
+
+Use this skill when the user wants any kind of diagram-as-code, for example:
+- "Draw a flowchart of the login process."
+- "Turn these steps into a diagram."
+- "Make a sequence diagram for this API call."
+- "Visualize this database schema as an ER diagram."
+- "Create a class diagram / state machine / Gantt chart / mindmap for X."
+
+## Core Workflow
+
+1. **Pick the diagram type** that matches the user's intent. If they don't say,
+   infer it (see the decision guide below) and briefly state your choice.
+2. **Write the Mermaid source** to a `.mmd` file.
+3. **Validate it** before doing anything else:
+   ```bash
+   python3 scripts/validate.py diagram.mmd
+   ```
+   The validator has **no dependencies** and always runs. Fix every `ERROR`
+   before continuing; review `WARNING`s.
+4. **(Optional) Render to an image** if the user wants a picture, not just code:
+   ```bash
+   python3 scripts/render.py diagram.mmd -o diagram.png
+   ```
+5. **Deliver** the Mermaid code block to the user (it renders inline in most
+   Markdown/chat surfaces), plus the rendered image if one was produced.
+
+## Choosing the Diagram Type
+
+| User is describing... | Use |
+|---|---|
+| A process, decision tree, or workflow | `flowchart` |
+| Messages/calls exchanged between actors over time | `sequenceDiagram` |
+| Object-oriented structure, classes, inheritance | `classDiagram` |
+| States and transitions of a system | `stateDiagram-v2` |
+| Database tables and relationships | `erDiagram` |
+| Project schedule / timeline with durations | `gantt` |
+| Hierarchical brainstorm of one central idea | `mindmap` |
+| Proportions of a whole | `pie` |
+| Git branch/merge history | `gitGraph` |
+
+When unsure between a flowchart and a sequence diagram: use a **sequence diagram**
+if the *order of interactions between distinct participants* is the point;
+otherwise use a **flowchart**.
+
+See `references/diagram-types.md` for the syntax of each type, and
+`examples/` for complete, validated samples you can adapt.
+
+## Authoring Rules That Prevent Broken Diagrams
+
+These are the failures the validator is built to catch — avoid them up front:
+
+- **Quote labels with special characters.** Any node label containing
+  `()[]{}`, punctuation, or `<br>` must be wrapped in double quotes:
+  `A["User (admin)"]` not `A[User (admin)]`.
+- **Balance every bracket and quote.** Each `(`, `[`, `{`, and `"` needs its
+  partner. This is the single most common parse error.
+- **Close every block.** Every `subgraph` needs an `end`; every sequence
+  `loop`/`alt`/`opt`/`par`/`critical`/`rect` needs an `end`.
+- **Use spaces, not tabs**, for indentation.
+- **Give nodes stable IDs.** Reference a node by its ID (`A`, `login`), define
+  its label once: `login["Log in"]`, then reuse `login` elsewhere.
+- **Pick a valid flowchart direction**: `TD`, `TB`, `BT`, `LR`, or `RL`.
+
+## Scripts
+
+### `scripts/validate.py` — syntax linter (no dependencies)
+Static checks that run anywhere Python 3 is available. Detects unknown diagram
+types, unbalanced brackets/quotes, unterminated strings, missing `end` blocks,
+bad flowchart directions, and tab indentation.
+```bash
+python3 scripts/validate.py diagram.mmd        # human-readable report
+python3 scripts/validate.py diagram.mmd --json  # machine-readable
+cat diagram.mmd | python3 scripts/validate.py - # read from stdin
+```
+Exit code is `0` when there are no errors, `1` when there are.
+
+### `scripts/render.py` — image renderer (optional)
+Thin wrapper around the Mermaid CLI. Produces PNG/SVG/PDF.
+```bash
+python3 scripts/render.py diagram.mmd -o diagram.png -t dark -b transparent
+```
+If the CLI is missing it prints exact install instructions and exits without
+crashing — rendering is optional, validation is not.
+
+## Rendering Dependencies
+
+Validation needs only Python 3 (standard library). Rendering to an image needs
+the Mermaid CLI:
+```bash
+npm install -g @mermaid-js/mermaid-cli
+# or, with no install:
+npx -p @mermaid-js/mermaid-cli mmdc -i diagram.mmd -o diagram.png
+```
+
+## Guidelines
+
+- Always validate before rendering or delivering.
+- Keep diagrams readable: prefer several small, focused diagrams over one giant
+  one. Group related nodes with `subgraph` in flowcharts.
+- Echo the Mermaid source back to the user in a fenced ```mermaid block so it
+  renders inline; attach an image only when explicitly useful.
+- When converting unstructured notes, restate the structure you inferred (nodes,
+  edges, actors) so the user can correct you, then produce the diagram.

--- a/skills/mermaid-diagram/examples/er-ecommerce.mmd
+++ b/skills/mermaid-diagram/examples/er-ecommerce.mmd
@@ -1,0 +1,28 @@
+erDiagram
+    CUSTOMER ||--o{ ORDER : places
+    ORDER ||--|{ LINE_ITEM : contains
+    PRODUCT ||--o{ LINE_ITEM : "appears in"
+
+    CUSTOMER {
+        int id PK
+        string name
+        string email UK
+        datetime created_at
+    }
+    ORDER {
+        int id PK
+        int customer_id FK
+        string status
+        datetime placed_at
+    }
+    LINE_ITEM {
+        int id PK
+        int order_id FK
+        int product_id FK
+        int quantity
+    }
+    PRODUCT {
+        int id PK
+        string name
+        decimal price
+    }

--- a/skills/mermaid-diagram/examples/flowchart-login.mmd
+++ b/skills/mermaid-diagram/examples/flowchart-login.mmd
@@ -1,0 +1,11 @@
+flowchart TD
+    A[User opens app] --> B{Has session?}
+    B -->|Yes| C[Load dashboard]
+    B -->|No| D[Show login form]
+    D --> E["Enter email & password"]
+    E --> F{Credentials valid?}
+    F -->|Yes| G[Create session]
+    G --> C
+    F -->|No| H[Show error]
+    H --> D
+    C --> I[End]

--- a/skills/mermaid-diagram/examples/sequence-api-auth.mmd
+++ b/skills/mermaid-diagram/examples/sequence-api-auth.mmd
@@ -1,0 +1,18 @@
+sequenceDiagram
+    participant U as User
+    participant W as Web App
+    participant A as Auth Service
+    participant D as Database
+
+    U->>W: Submit login form
+    W->>A: POST /authenticate
+    A->>D: SELECT user WHERE email = ?
+    D-->>A: user record
+    alt password matches
+        A->>A: Issue JWT
+        A-->>W: 200 OK + token
+        W-->>U: Redirect to dashboard
+    else password invalid
+        A-->>W: 401 Unauthorized
+        W-->>U: Show error message
+    end

--- a/skills/mermaid-diagram/references/diagram-types.md
+++ b/skills/mermaid-diagram/references/diagram-types.md
@@ -1,0 +1,148 @@
+# Mermaid Diagram Types Reference
+
+A quick syntax reference for the most common Mermaid diagram types. For the full
+specification see <https://mermaid.js.org>. Each snippet below validates cleanly
+with `scripts/validate.py`.
+
+## Flowchart
+
+Best for processes, decision trees, and workflows.
+
+```mermaid
+flowchart TD
+    A[Start] --> B{Authenticated?}
+    B -->|Yes| C[Load dashboard]
+    B -->|No| D[Show login]
+    D --> E["Enter credentials"]
+    E --> B
+    C --> F[End]
+```
+
+- Directions: `TD`/`TB` (top-down), `BT` (bottom-up), `LR` (left-right), `RL`.
+- Node shapes: `A[rect]`, `B(rounded)`, `C([stadium])`, `D{diamond}`,
+  `E((circle))`, `F[/parallelogram/]`.
+- Edges: `-->` arrow, `---` line, `-.->` dotted, `==>` thick, `-->|label|` labeled.
+- Group with `subgraph Name ... end`.
+
+## Sequence Diagram
+
+Best for interactions between participants over time.
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant API
+    participant DB
+    U->>API: POST /login
+    API->>DB: SELECT user
+    DB-->>API: row
+    alt valid password
+        API-->>U: 200 + token
+    else invalid
+        API-->>U: 401
+    end
+```
+
+- Arrows: `->>` solid, `-->>` dashed (reply), `-x` lost message.
+- Blocks: `loop`, `alt`/`else`, `opt`, `par`, `critical`, `rect` — each closed by `end`.
+- Lifelines: `activate X` / `deactivate X` (or `+`/`-` shorthand on arrows).
+
+## Class Diagram
+
+Best for object-oriented structure.
+
+```mermaid
+classDiagram
+    class Animal {
+        +String name
+        +int age
+        +makeSound() void
+    }
+    class Dog {
+        +fetch() void
+    }
+    Animal <|-- Dog
+```
+
+- Relationships: `<|--` inheritance, `*--` composition, `o--` aggregation,
+  `-->` association, `..>` dependency.
+- Visibility: `+` public, `-` private, `#` protected.
+
+## State Diagram
+
+Best for state machines.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Running : start
+    Running --> Paused : pause
+    Paused --> Running : resume
+    Running --> [*] : stop
+```
+
+- `[*]` marks start and end states.
+- Composite states: `state Name { ... }`.
+
+## Entity Relationship Diagram
+
+Best for database schemas.
+
+```mermaid
+erDiagram
+    CUSTOMER ||--o{ ORDER : places
+    ORDER ||--|{ LINE_ITEM : contains
+    CUSTOMER {
+        int id PK
+        string name
+        string email
+    }
+    ORDER {
+        int id PK
+        int customer_id FK
+    }
+```
+
+- Cardinality: `||` exactly one, `o{` zero-or-many, `|{` one-or-many.
+- Keys: `PK`, `FK`, `UK` in the attribute block.
+
+## Gantt Chart
+
+Best for project schedules.
+
+```mermaid
+gantt
+    title Project Plan
+    dateFormat YYYY-MM-DD
+    section Design
+    Wireframes      :a1, 2025-01-01, 5d
+    Review          :after a1, 2d
+    section Build
+    Implementation  :2025-01-10, 10d
+```
+
+## Mindmap
+
+Best for hierarchical brainstorming around one idea.
+
+```mermaid
+mindmap
+  root((Product))
+    Discovery
+      Interviews
+      Surveys
+    Delivery
+      MVP
+      Launch
+```
+
+## Pie Chart
+
+Best for proportions of a whole.
+
+```mermaid
+pie title Traffic sources
+    "Organic" : 45
+    "Paid" : 30
+    "Referral" : 25
+```

--- a/skills/mermaid-diagram/scripts/render.py
+++ b/skills/mermaid-diagram/scripts/render.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""
+Render a Mermaid diagram to an image (PNG/SVG/PDF).
+
+This is a thin, dependency-light wrapper around the Mermaid CLI
+(`@mermaid-js/mermaid-cli`, command name `mmdc`). The validator (validate.py)
+has no dependencies and always runs; rendering is the *optional* step that
+needs the CLI.
+
+Usage:
+    python3 render.py diagram.mmd                 # -> diagram.png
+    python3 render.py diagram.mmd -o out.svg      # explicit output / format
+    python3 render.py diagram.mmd -t dark -b transparent
+
+Install the CLI (one-time) if it is missing:
+    npm install -g @mermaid-js/mermaid-cli
+    # or run without installing:  npx -p @mermaid-js/mermaid-cli mmdc ...
+
+Exit codes:
+    0  rendered successfully
+    1  render failed
+    2  CLI not found / usage error
+"""
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+
+
+def _find_cli():
+    """Return an argv prefix that invokes mmdc, or None if unavailable."""
+    if shutil.which("mmdc"):
+        return ["mmdc"]
+    if shutil.which("npx"):
+        # npx can fetch the package on demand; -y avoids the install prompt.
+        return ["npx", "-y", "-p", "@mermaid-js/mermaid-cli", "mmdc"]
+    return None
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Render a Mermaid diagram to an image.")
+    parser.add_argument("input", help="Path to the .mmd source file.")
+    parser.add_argument("-o", "--output",
+                        help="Output file. Extension sets the format "
+                             "(.png/.svg/.pdf). Defaults to <input>.png.")
+    parser.add_argument("-t", "--theme", default="default",
+                        choices=["default", "dark", "forest", "neutral"],
+                        help="Mermaid theme (default: default).")
+    parser.add_argument("-b", "--background", default="white",
+                        help="Background color or 'transparent' (default: white).")
+    parser.add_argument("-s", "--scale", default="2",
+                        help="Output scale factor for crisp PNGs (default: 2).")
+    args = parser.parse_args(argv)
+
+    if not os.path.isfile(args.input):
+        print(f"error: input not found: {args.input}", file=sys.stderr)
+        return 2
+
+    output = args.output or (os.path.splitext(args.input)[0] + ".png")
+
+    cli = _find_cli()
+    if cli is None:
+        print(
+            "error: Mermaid CLI (mmdc) not found.\n"
+            "  Validation works without it, but rendering needs the CLI.\n"
+            "  Install:  npm install -g @mermaid-js/mermaid-cli\n"
+            "  Or run:   npx -p @mermaid-js/mermaid-cli mmdc -i {inp} -o {out}".format(
+                inp=args.input, out=output),
+            file=sys.stderr,
+        )
+        return 2
+
+    cmd = cli + [
+        "-i", args.input,
+        "-o", output,
+        "-t", args.theme,
+        "-b", args.background,
+        "-s", str(args.scale),
+    ]
+
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError as exc:
+        print(f"error: render failed (exit {exc.returncode}). "
+              "Run validate.py first to catch syntax issues.", file=sys.stderr)
+        return 1
+
+    print(f"Rendered: {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/mermaid-diagram/scripts/validate.py
+++ b/skills/mermaid-diagram/scripts/validate.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""
+Mermaid diagram validator (pure standard library, no dependencies).
+
+Performs lightweight static checks on Mermaid source so common mistakes are
+caught *before* attempting to render. This is intentionally a linter, not a full
+parser: it favors actionable warnings over strict spec compliance.
+
+Usage:
+    python3 validate.py diagram.mmd
+    python3 validate.py diagram.mmd --json
+    cat diagram.mmd | python3 validate.py -
+
+Exit codes:
+    0  no errors (warnings may still be printed)
+    1  one or more errors found
+    2  usage / file error
+"""
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field, asdict
+from typing import List
+
+# Diagram-type keywords that may legally start a Mermaid definition.
+# A leading "%%{ ... }%%" init directive or "---" front-matter block is allowed
+# before these; that is handled in _find_diagram_type().
+DIAGRAM_TYPES = {
+    "graph": "flowchart",
+    "flowchart": "flowchart",
+    "sequenceDiagram": "sequence",
+    "classDiagram": "class",
+    "stateDiagram": "state",
+    "stateDiagram-v2": "state",
+    "erDiagram": "entity-relationship",
+    "journey": "user-journey",
+    "gantt": "gantt",
+    "pie": "pie",
+    "mindmap": "mindmap",
+    "timeline": "timeline",
+    "quadrantChart": "quadrant",
+    "gitGraph": "git-graph",
+    "C4Context": "c4",
+    "sankey-beta": "sankey",
+    "xychart-beta": "xychart",
+    "block-beta": "block",
+    "requirementDiagram": "requirement",
+}
+
+# Valid flowchart orientations after "graph"/"flowchart".
+FLOWCHART_DIRECTIONS = {"TB", "TD", "BT", "RL", "LR"}
+
+
+@dataclass
+class Issue:
+    severity: str          # "error" | "warning"
+    line: int              # 1-based; 0 == file-level
+    message: str
+    hint: str = ""
+
+
+@dataclass
+class Report:
+    ok: bool = True
+    diagram_type: str = "unknown"
+    issues: List[Issue] = field(default_factory=list)
+
+    def add(self, severity, line, message, hint=""):
+        self.issues.append(Issue(severity, line, message, hint))
+        if severity == "error":
+            self.ok = False
+
+
+def _strip_comments(line: str) -> str:
+    """Remove Mermaid line comments (%% ...) but keep init directives intact."""
+    if line.lstrip().startswith("%%{"):
+        return line  # init directive, not a comment
+    idx = line.find("%%")
+    return line[:idx] if idx != -1 else line
+
+
+def _find_diagram_type(lines: List[str]) -> (str, int):
+    """Return (diagram_type, line_index) of the first declaration line."""
+    in_frontmatter = False
+    for i, raw in enumerate(lines):
+        stripped = raw.strip()
+        if not stripped:
+            continue
+        # YAML front-matter block delimited by --- ... ---
+        if stripped == "---":
+            in_frontmatter = not in_frontmatter
+            continue
+        if in_frontmatter:
+            continue
+        # Skip init directives like %%{init: {...}}%%
+        if stripped.startswith("%%{") and stripped.endswith("}%%"):
+            continue
+        if stripped.startswith("%%"):
+            continue
+        first_token = stripped.split()[0]
+        for kw, kind in DIAGRAM_TYPES.items():
+            if first_token == kw or stripped.startswith(kw):
+                return kind, i
+        return "unknown", i
+    return "unknown", -1
+
+
+# In erDiagram, "{" / "}" appear inside cardinality glyphs such as "||--o{",
+# "}o--||", "|{", "}|" — there they are notation, not brackets. We strip the
+# relationship glyphs before counting so the balance check does not false-positive.
+def _check_balanced(text: str, report: Report, diagram_type: str = ""):
+    """Check bracket / parenthesis / quote balance across the whole document."""
+    pairs = {")": "(", "]": "[", "}": "{"}
+    openers = set(pairs.values())
+    stack = []
+    in_quote = False
+    lines = text.splitlines()
+
+    for raw in lines:
+        line = raw
+        # For ER relationship lines, remove cardinality braces around "--".
+        if diagram_type == "entity-relationship" and "--" in line:
+            line = re.sub(r"[|o}{]+--[|o}{]+", "--", line)
+        for ch in line:
+            if ch == '"':
+                in_quote = not in_quote
+                continue
+            if in_quote:
+                continue
+            if ch in openers:
+                stack.append(ch)
+            elif ch in pairs:
+                if not stack or stack[-1] != pairs[ch]:
+                    report.add("error", 0,
+                               f"Unbalanced bracket: unexpected '{ch}'.",
+                               "Every '(', '[', '{' must be matched by a closing partner.")
+                    return
+                stack.pop()
+
+    if in_quote:
+        report.add("error", 0, 'Unterminated double-quote (") in document.',
+                   'Node labels with special characters must be wrapped in "..." and closed.')
+    if stack:
+        report.add("error", 0,
+                   f"Unbalanced bracket: {len(stack)} unclosed '{stack[-1]}'.",
+                   "Check for a missing closing bracket on a node or subgraph.")
+
+
+def _check_flowchart(lines: List[str], decl_idx: int, report: Report):
+    decl = _strip_comments(lines[decl_idx]).strip()
+    tokens = decl.split()
+    if len(tokens) >= 2:
+        direction = tokens[1].rstrip(";")
+        if direction not in FLOWCHART_DIRECTIONS:
+            report.add("warning", decl_idx + 1,
+                       f"Unknown flowchart direction '{direction}'.",
+                       f"Use one of: {', '.join(sorted(FLOWCHART_DIRECTIONS))}.")
+
+    # subgraph / end balance
+    depth = 0
+    for i, raw in enumerate(lines):
+        s = _strip_comments(raw).strip()
+        if re.match(r"^subgraph\b", s):
+            depth += 1
+        elif s == "end":
+            depth -= 1
+            if depth < 0:
+                report.add("error", i + 1,
+                           "'end' without a matching 'subgraph'.",
+                           "Remove the stray 'end' or add the opening 'subgraph'.")
+                depth = 0
+    if depth > 0:
+        report.add("error", 0,
+                   f"{depth} 'subgraph' block(s) missing a closing 'end'.",
+                   "Each 'subgraph' must be terminated with 'end'.")
+
+
+def _check_sequence(lines: List[str], report: Report):
+    activate, deactivate = 0, 0
+    block_openers = ("loop", "alt", "opt", "par", "critical", "rect", "break")
+    block_depth = 0
+    for i, raw in enumerate(lines):
+        s = _strip_comments(raw).strip()
+        if s.startswith("activate "):
+            activate += 1
+        elif s.startswith("deactivate "):
+            deactivate += 1
+        first = s.split()[0] if s else ""
+        if first in block_openers:
+            block_depth += 1
+        elif first == "end":
+            block_depth -= 1
+            if block_depth < 0:
+                report.add("error", i + 1,
+                           "'end' without a matching block (loop/alt/opt/par/...).")
+                block_depth = 0
+    if block_depth > 0:
+        report.add("error", 0,
+                   f"{block_depth} sequence block(s) missing 'end'.",
+                   "loop/alt/opt/par/critical/rect blocks each need an 'end'.")
+    if activate != deactivate:
+        report.add("warning", 0,
+                   f"activate ({activate}) / deactivate ({deactivate}) counts differ.",
+                   "Each 'activate X' usually pairs with a 'deactivate X'.")
+
+
+def validate(text: str) -> Report:
+    report = Report()
+    lines = text.splitlines()
+
+    if not text.strip():
+        report.add("error", 0, "Empty diagram source.")
+        return report
+
+    diagram_type, decl_idx = _find_diagram_type(lines)
+    report.diagram_type = diagram_type
+
+    if diagram_type == "unknown":
+        report.add("error", max(decl_idx + 1, 0),
+                   "Could not detect a valid diagram type on the first non-comment line.",
+                   "Start with one of: " + ", ".join(sorted(DIAGRAM_TYPES.keys())) + ".")
+        return report
+
+    _check_balanced(text, report, diagram_type)
+
+    if diagram_type == "flowchart":
+        _check_flowchart(lines, decl_idx, report)
+    elif diagram_type == "sequence":
+        _check_sequence(lines, report)
+
+    # Tabs are a frequent silent cause of parse errors in Mermaid.
+    for i, raw in enumerate(lines):
+        if "\t" in raw:
+            report.add("warning", i + 1,
+                       "Tab character found; Mermaid prefers spaces for indentation.",
+                       "Replace tabs with spaces to avoid parser quirks.")
+            break
+
+    return report
+
+
+def _format_text(report: Report, source_name: str) -> str:
+    out = []
+    status = "OK" if report.ok else "FAILED"
+    out.append(f"[{status}] {source_name}  (type: {report.diagram_type})")
+    if not report.issues:
+        out.append("  No issues found.")
+    for it in report.issues:
+        loc = f"line {it.line}" if it.line else "file"
+        out.append(f"  {it.severity.upper():7} {loc}: {it.message}")
+        if it.hint:
+            out.append(f"          hint: {it.hint}")
+    return "\n".join(out)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Validate a Mermaid diagram.")
+    parser.add_argument("path", help="Path to .mmd file, or '-' to read stdin.")
+    parser.add_argument("--json", action="store_true", help="Emit a JSON report.")
+    args = parser.parse_args(argv)
+
+    if args.path == "-":
+        text = sys.stdin.read()
+        name = "<stdin>"
+    else:
+        try:
+            with open(args.path, "r", encoding="utf-8") as fh:
+                text = fh.read()
+        except OSError as exc:
+            print(f"error: cannot read {args.path}: {exc}", file=sys.stderr)
+            return 2
+        name = args.path
+
+    report = validate(text)
+
+    if args.json:
+        payload = asdict(report)
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+    else:
+        print(_format_text(report, name))
+
+    return 0 if report.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

This PR adds a new example skill, **`mermaid-diagram`**, under `skills/`. It helps
Claude turn descriptions, rough notes, or specs into **correct, renderable
[Mermaid](https://mermaid.js.org) diagrams** — flowcharts, sequence, class, state,
ER, Gantt, mindmaps, pie, and more.

The skill is "validation-first": it ships a **zero-dependency syntax validator**
that catches the mistakes which most commonly break Mermaid rendering, so a diagram
is checked *before* it is delivered or rendered.

This fills a gap in the current skill set — there is no diagram-as-code example
skill in the repository today.

## Why

Diagram generation is one of the most frequent "visualize this" requests, but
hand-written Mermaid frequently fails to render due to small, repeatable mistakes
(unbalanced brackets, missing `end` on a `subgraph`/`loop`, unquoted labels with
special characters, invalid flowchart direction, tab indentation). A skill that
encodes the authoring rules *and* statically lints the output produces a correct
diagram on the first try far more reliably than freeform generation.

## What's included

```
skills/mermaid-diagram/
├── LICENSE.txt                 # Apache 2.0 license
├── SKILL.md                    # Frontmatter + workflow, type-selection guide, anti-error rules
├── scripts/
│   ├── validate.py             # Zero-dependency static linter (stdlib only)
│   └── render.py               # Optional PNG/SVG/PDF renderer (mmdc / npx wrapper)
├── references/
│   └── diagram-types.md        # Syntax cheatsheet for 8 diagram types
└── examples/
    ├── flowchart-login.mmd
    ├── sequence-api-auth.mmd
    └── er-ecommerce.mmd
```

## Design principles

- **Self-contained.** The core validator (`validate.py`) uses only the Python
  standard library — no installs, runs anywhere. Rendering is the *optional* step;
  when the Mermaid CLI is absent, `render.py` prints exact install instructions and
  exits gracefully instead of crashing.
- **Validation-first workflow.** `SKILL.md` instructs Claude to validate before
  rendering or delivering, so syntax errors are caught early.
- **Actionable diagnostics.** The validator reports `ERROR`/`WARNING` with a line
  number and a fix hint, and supports `--json` for programmatic use and stdin
  (`-`) for piping.

## What the validator catches

- Unknown / missing diagram type on the first line
- Unbalanced brackets `() [] {}` and unterminated `"` strings
  (ER cardinality glyphs like `||--o{` are correctly excluded from the check)
- Missing `end` for `subgraph` (flowchart) and `loop`/`alt`/`opt`/`par`/`critical`/`rect` (sequence)
- Invalid flowchart direction (anything outside `TD`/`TB`/`BT`/`LR`/`RL`)
- Mismatched `activate`/`deactivate` lifelines
- Tab indentation (a common silent cause of parse errors)

## Testing

Validated locally with a small harness:
- All **3 example `.mmd` files** pass (`exit 0`).
- All **8 fenced `mermaid` blocks** embedded in `references/diagram-types.md` pass.
- `python3 -m py_compile` passes for both scripts.

Try it:
```bash
python3 skills/mermaid-diagram/scripts/validate.py skills/mermaid-diagram/examples/flowchart-login.mmd
# [OK] ... (type: flowchart)  ->  No issues found.

python3 skills/mermaid-diagram/scripts/render.py skills/mermaid-diagram/examples/flowchart-login.mmd -o flowchart.png
# requires: npm install -g @mermaid-js/mermaid-cli  (or npx, no install)
```

## Notes

- Follows the repository's `template/SKILL.md` frontmatter format (`name`,
  `description`).
- Includes Apache 2.0 `LICENSE.txt`, matching the existing example skill layout.
- No changes to existing files; the skill is fully additive.
