### PR TITLE
fix(pdf): create output directory in convert_pdf_to_images

### DIFF
--- a/skills/pdf/scripts/convert_pdf_to_images.py
+++ b/skills/pdf/scripts/convert_pdf_to_images.py
@@ -7,6 +7,8 @@ from pdf2image import convert_from_path
 
 
 def convert(pdf_path, output_dir, max_dim=1000):
+    os.makedirs(output_dir, exist_ok=True)
+
     images = convert_from_path(pdf_path, dpi=200)
 
     for i, image in enumerate(images):

--- a/skills/pdf/scripts/test_convert_pdf_to_images.py
+++ b/skills/pdf/scripts/test_convert_pdf_to_images.py
@@ -1,0 +1,59 @@
+"""Tests for convert_pdf_to_images output handling."""
+
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+# Stub pdf2image before importing the script so the test needs neither
+# pdf2image nor a poppler install — convert_from_path is replaced per-test.
+if "pdf2image" not in sys.modules:
+    _stub = types.ModuleType("pdf2image")
+    _stub.convert_from_path = lambda *args, **kwargs: []
+    sys.modules["pdf2image"] = _stub
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import convert_pdf_to_images  # noqa: E402
+
+
+class _FakeImage:
+    """Minimal stand-in for a PIL image.
+
+    save() writes a real file, mirroring PIL's behaviour of raising
+    FileNotFoundError when the destination directory does not exist.
+    """
+
+    size = (100, 100)
+
+    def resize(self, size):
+        return self
+
+    def save(self, path):
+        Path(path).write_bytes(b"\x89PNG\r\n")
+
+
+class ConvertOutputDirTest(unittest.TestCase):
+    def test_creates_output_directory_when_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = os.path.join(tmp, "missing", "pages")
+            self.assertFalse(os.path.exists(output_dir))
+
+            original = convert_pdf_to_images.convert_from_path
+            convert_pdf_to_images.convert_from_path = (
+                lambda *args, **kwargs: [_FakeImage(), _FakeImage()]
+            )
+            try:
+                convert_pdf_to_images.convert("input.pdf", output_dir)
+            finally:
+                convert_pdf_to_images.convert_from_path = original
+
+            self.assertTrue(os.path.isdir(output_dir))
+            self.assertTrue(os.path.isfile(os.path.join(output_dir, "page_1.png")))
+            self.assertTrue(os.path.isfile(os.path.join(output_dir, "page_2.png")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #1025.

`skills/pdf/scripts/convert_pdf_to_images.py` writes each rendered page to
`os.path.join(output_dir, f"page_{i+1}.png")` but never creates `output_dir`.
If the directory does not already exist, `image.save(...)` raises
`FileNotFoundError` and no pages are written.

## Fix

Create the output directory at the start of `convert()`:

```python
os.makedirs(output_dir, exist_ok=True)
```

`exist_ok=True` keeps the existing-directory case a no-op, so behaviour is
unchanged when the directory is already present.

## Test

Adds `skills/pdf/scripts/test_convert_pdf_to_images.py`, a dependency-free
`unittest` (stubs `pdf2image`, so neither pdf2image nor poppler is required):
it converts into a not-yet-existing nested directory using a fake image whose
`save()` writes a real file, and asserts the directory and `page_1.png` /
`page_2.png` are created. The test fails before the fix (the original
`FileNotFoundError`) and passes after.

Run:

```
python -m unittest test_convert_pdf_to_images -v
```
