### PR TITLE
[FEAT] : Skill for react query ease

### DIFF
--- a/skills/react-query-ease/LICENSE.txt
+++ b/skills/react-query-ease/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/react-query-ease/SKILL.md
+++ b/skills/react-query-ease/SKILL.md
@@ -1,0 +1,352 @@
+---
+name: react-query-ease
+description: Sets up react-query-ease — a typed Axios + React Query wrapper — with API clients, typed useQuery/useMutation hooks, auto-invalidation, auth token refresh, and streaming hooks. Use this skill whenever the user asks about data fetching, API client setup, React Query, Axios, token refresh, auth interceptors, streaming/SSE hooks, or typed HTTP hooks in React or Next.js — even if they don't mention "react-query-ease" by name. Trigger on phrases like "set up API calls", "how do I fetch data in Next.js", "React Query setup", "Axios interceptor", "refresh token logic", "typed fetch hook", "useQuery hook", "useMutation hook", "streaming response React", "SSE hook", or "API client TypeScript".
+license: MIT
+---
+
+# react-query-ease
+
+Minimal typed wrapper combining Axios + React Query. Create per-service API clients and use `client.useQuery` / `client.useMutation` without repeating Axios boilerplate.
+
+## Core Workflow
+
+1. **Install** — add package + peer deps
+2. **Create client** — `createApiClient` with `baseURL` in `src/config/apiClients.ts`
+3. **Write typed hooks** — `useQuery` / `useMutation` wrappers in `src/hooks/`
+4. **Add auth** — `createAuthInterceptor` in `configure` callback
+5. **Add streaming** — `useStream` for chunked/SSE endpoints
+
+## Installation
+
+```bash
+npm install react-query-ease @tanstack/react-query
+```
+
+Wrap app in `QueryClientProvider`:
+
+```tsx
+// src/components/providers/QueryProvider.tsx
+"use client"; // required in Next.js App Router
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const queryClient = new QueryClient();
+
+export function QueryProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+```
+
+**Next.js App Router** — add `QueryProvider` to your root layout:
+
+```tsx
+// app/layout.tsx
+import { QueryProvider } from "@/components/providers/QueryProvider";
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>
+        <QueryProvider>{children}</QueryProvider>
+      </body>
+    </html>
+  );
+}
+```
+
+> All hooks and client files must include `"use client"` at the top. Server Components cannot use React Query hooks.
+
+## Client Setup
+
+Create one client per API service. Keep clients in `lib/api/config.ts`:
+
+```ts
+// lib/api/config.ts
+import { createApiClient } from "react-query-ease";
+
+export const api = createApiClient({
+  baseURL: "https://api.example.com",
+});
+```
+
+`createApiClient` accepts all standard Axios config (`headers`, `timeout`, `withCredentials`, etc.) plus an optional `configure` callback for interceptors.
+
+## useQuery
+
+```ts
+// lib/api/hooks/useTodo.ts
+import { api } from "../config";
+
+export interface ApiError {
+  message: string;
+  status: number;
+}
+
+export interface Todo {
+  id: number;
+  title: string;
+  completed: boolean;
+}
+
+export const useTodos = () => {
+  const query = api.useQuery<Todo[]>({
+    url: "/todos",
+    key: ["todos"],
+    // Optional:
+    method: "GET", // defaults to GET
+    params: { page: 1 }, // query string params
+    staleTime: 5 * 60_000, // React Query options pass through
+    enabled: true,
+  });
+  return {
+    todos: query.data ?? [],
+    isLoadingTodos: query.isLoading,
+    ...query,
+  };
+};
+
+const { todos, isLoadingTodos } = useTodos();
+```
+
+**Key rules:**
+
+- `key` — React Query cache key; use arrays for namespacing
+- `url` — resolved against client `baseURL`
+- All Axios config props (`headers`, `params`, `timeout`) and React Query options (`staleTime`, `enabled`, `retry`, `select`, etc.) pass through directly
+
+## useMutation
+
+```ts
+// lib/api/hooks/useTodo.ts
+export interface NewTodo {
+  title: string;
+}
+
+export interface UpdateInput {
+  id: number;
+  title?: string;
+  completed?: boolean;
+}
+
+export const useCreateTodo = () => {
+  const mutation = api.useMutation<Todo, ApiError, NewTodo>({
+    url: "/todos",
+    method: "POST",
+    keyToInvalidate: ["todos"], // auto-invalidates after success
+  });
+  return {
+    createTodo: mutation.mutate,
+    isCreatingTodo: mutation.isPending,
+    ...mutation,
+  };
+};
+
+const { createTodo, isCreatingTodo } = useCreateTodo();
+createTodo({ title: "Buy milk" });
+```
+
+**Dynamic URL** — pass a function when the URL depends on variables:
+
+```ts
+// lib/api/hooks/useTodo.ts
+export const useUpdateTodo = () => {
+  const mutation = api.useMutation<Todo, ApiError, UpdateInput>({
+    url: (variables) => `/todos/${variables.id}`,
+    method: "PATCH",
+    keyToInvalidate: ["todos"],
+  });
+  return {
+    updateTodo: mutation.mutate,
+    isUpdatingTodo: mutation.isPending,
+    ...mutation,
+  };
+};
+```
+
+**Key rules:**
+
+- If `data` is not set, mutation variables become the request body automatically
+- `keyToInvalidate` accepts a single key, a string, or an array of keys/strings — e.g. `keyToInvalidate: [["todos"], ["stats"]]` to bust multiple caches at once
+- All React Query mutation options (`onSuccess`, `onError`, `onSettled`, `retry`) pass through
+
+**Using `mutateAsync`** — for async/await with try/catch:
+
+```ts
+const { mutateAsync: createTodo, isPending } = useCreateTodo();
+
+const handleSubmit = async () => {
+  try {
+    const newTodo = await createTodo({ title: "Buy milk" });
+    console.log("Created:", newTodo);
+  } catch (err) {
+    console.error("Failed:", err);
+  }
+};
+```
+
+## Auth Interceptor
+
+Wire up token auth in `configure`:
+
+```ts
+// lib/api/config.ts
+import { createApiClient, createAuthInterceptor } from "react-query-ease";
+
+const authInterceptor = createAuthInterceptor({
+  getAccessToken: () => localStorage.getItem("accessToken"),
+  getRefreshToken: () => localStorage.getItem("refreshToken"),
+  refreshTokens: async ({ refreshToken }) => {
+    const res = await fetch("/auth/refresh", {
+      method: "POST",
+      body: JSON.stringify({ refresh_token: refreshToken }),
+    }).then((r) => r.json());
+    localStorage.setItem("accessToken", res.accessToken);
+    localStorage.setItem("refreshToken", res.refreshToken);
+    return res; // must return { accessToken, refreshToken? }
+  },
+  onRefreshFailure: () => {
+    window.location.assign("/login?session_expired=true");
+  },
+});
+
+export const api = createApiClient({
+  baseURL: "https://api.example.com",
+  configure: authInterceptor,
+});
+```
+
+`createAuthInterceptor` coalesces concurrent 401s into one refresh, retries queued requests with the fresh token, and covers both Axios requests and `useStream` calls.
+
+See `references/auth-interceptor.md` for all options and chaining multiple interceptors.
+
+## useStream
+
+For LLM/SSE/chunked endpoints:
+
+```tsx
+// lib/api/hooks/useChat.ts
+export const useChat = () => {
+  const stream = api.useStream<{ prompt: string }>({
+    url: "/chat",
+    method: "POST",
+    onComplete: () => console.log("Done"),
+    onError: (err) => console.error(err),
+  });
+  return {
+    chatData: stream.data,
+    isChatLoading: stream.isLoading,
+    isChatStreaming: stream.isStreaming,
+    ...stream,
+  };
+};
+
+const { chatData, isChatLoading, start, abort } = useChat();
+await start({ prompt: "Hello" });
+abort();
+```
+
+Return values:
+
+- `data` — accumulated text from all chunks
+- `isLoading` — connecting / auth checks
+- `isStreaming` — active byte transmission
+- `error` — connection error (abort does NOT set error)
+- `start(variables?)` — launches stream; `variables` become request body
+- `abort()` — cancels stream safely, releases reader lock
+
+See `references/streaming.md` for full API table and async iterator usage.
+
+## Recommended Project Structure
+
+```
+lib/
+  api/
+    config.ts              ← createApiClient instance (+ auth interceptor)
+    hooks/
+      useTodo.ts           ← typed hook wrappers (useQuery / useMutation)
+src/
+  components/
+    Todos.tsx              ← UI; imports hooks, not clients directly
+```
+
+See `references/examples.md` for a complete CRUD walkthrough.
+
+## QueryClient Config + DevTools
+
+```tsx
+// src/components/providers/QueryProvider.tsx
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 5 * 60_000,
+      gcTime: 10 * 60_000,
+      retry: 2,
+      refetchOnWindowFocus: false,
+    },
+    mutations: { retry: 0 },
+  },
+});
+
+export function QueryProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
+  );
+}
+```
+
+Install: `npm install @tanstack/react-query-devtools`
+
+See `references/query-client-config.md` for full defaults table and global error handler setup.
+
+## Error Handling
+
+```ts
+export const useTodos = () => {
+  const query = api.useQuery<Todo[], ApiError>({
+    url: "/todos",
+    key: ["todos"],
+  });
+  return {
+    todos: query.data ?? [],
+    todosError: query.error, // typed as ApiError | null
+    isTodosError: query.isError,
+    isLoadingTodos: query.isLoading,
+    ...query,
+  };
+};
+```
+
+See `references/error-handling.md` for `mutateAsync` try/catch and `QueryErrorResetBoundary`.
+
+## Optimistic Updates
+
+```ts
+onMutate: async (variables) => {
+  await queryClient.cancelQueries({ queryKey: ["todos"] });
+  const previousTodos = queryClient.getQueryData<Todo[]>(["todos"]);
+  queryClient.setQueryData<Todo[]>(["todos"], (old = []) =>
+    old.map((t) => t.id === variables.id ? { ...t, ...variables } : t)
+  );
+  return { previousTodos };
+},
+onError: (_err, _vars, context) => {
+  queryClient.setQueryData(["todos"], context?.previousTodos);
+},
+onSettled: () => {
+  queryClient.invalidateQueries({ queryKey: ["todos"] });
+},
+```
+
+See `references/optimistic-updates.md` for full create/toggle/delete patterns.

--- a/skills/react-query-ease/references/auth-interceptor.md
+++ b/skills/react-query-ease/references/auth-interceptor.md
@@ -1,0 +1,147 @@
+# createAuthInterceptor — Full Reference
+
+Built-in utility that wires up Bearer token auth on every request, coalesces concurrent 401s into one refresh, retries queued requests with the fresh token, and handles logout on failure.
+
+## Options
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `getAccessToken` | `() => string \| null \| Promise<string \| null>` | Yes | Returns current access token |
+| `getRefreshToken` | `() => string \| null \| Promise<string \| null>` | No | Returns current refresh token |
+| `refreshTokens` | `(ctx: { refreshToken, error }) => Promise<{ accessToken, refreshToken? }>` | Yes | Async refresh routine; **must return `{ accessToken }`** |
+| `setTokens` | `(tokens) => void \| Promise<void>` | No | Persist tokens after refresh |
+| `headerName` | `string` | No | Auth header name (default: `"Authorization"`) |
+| `formatToken` | `(token: string) => string` | No | Token formatter (default: `t => "Bearer " + t`) |
+| `shouldSkipAuth` | `(config) => boolean` | No | Skip auth for matched endpoints |
+| `shouldRefresh` | `(error) => boolean` | No | Trigger refresh on this error (default: 401) |
+| `onRefreshSuccess` | `(tokens) => void \| Promise<void>` | No | Hook after successful refresh |
+| `onRefreshFailure` | `(error) => void \| Promise<void>` | No | Hook after failed refresh (use for logout) |
+
+## Production Setup
+
+```typescript
+import { createApiClient, createAuthInterceptor } from "react-query-ease";
+import axios from "axios";
+
+interface TokenStore {
+  accessToken: string | null;
+  refreshToken: string | null;
+}
+
+const tokens: TokenStore = {
+  accessToken: localStorage.getItem("accessToken"),
+  refreshToken: localStorage.getItem("refreshToken"),
+};
+
+const saveTokens = (accessToken: string, refreshToken?: string | null) => {
+  tokens.accessToken = accessToken;
+  localStorage.setItem("accessToken", accessToken);
+  if (refreshToken) {
+    tokens.refreshToken = refreshToken;
+    localStorage.setItem("refreshToken", refreshToken);
+  }
+};
+
+const clearTokens = () => {
+  tokens.accessToken = null;
+  tokens.refreshToken = null;
+  localStorage.removeItem("accessToken");
+  localStorage.removeItem("refreshToken");
+};
+
+const authInterceptor = createAuthInterceptor({
+  getAccessToken: () => tokens.accessToken,
+  getRefreshToken: () => tokens.refreshToken,
+
+  refreshTokens: async ({ refreshToken, error }) => {
+    // Use raw axios/fetch — NOT the api client (avoids recursion)
+    const response = await axios.post<{
+      accessToken: string;
+      refreshToken: string;
+    }>("https://auth.example.com/oauth/refresh", {
+      refresh_token: refreshToken,
+    });
+    saveTokens(response.data.accessToken, response.data.refreshToken);
+    return response.data;
+  },
+
+  headerName: "Authorization",
+  formatToken: (token) => `Bearer ${token}`,
+
+  shouldSkipAuth: (config) =>
+    !!config.url &&
+    ["/login", "/register", "/oauth/token"].some((p) => config.url!.includes(p)),
+
+  shouldRefresh: (error) => error.response?.status === 401,
+
+  onRefreshSuccess: (result) => {
+    console.log("Tokens refreshed");
+  },
+
+  onRefreshFailure: (error) => {
+    console.error("Refresh failed, logging out", error);
+    clearTokens();
+    if (typeof window !== "undefined") {
+      window.location.assign("/login?session_expired=true");
+    }
+  },
+});
+
+export const api = createApiClient({
+  baseURL: "https://api.example.com/v1",
+  configure: authInterceptor,
+});
+```
+
+## Chaining Multiple Interceptors
+
+Use the `configure` callback to apply multiple interceptors in order:
+
+```typescript
+import { createApiClient, createAuthInterceptor } from "react-query-ease";
+
+const headerInterceptor = (instance: any) => {
+  instance.interceptors.request.use((config: any) => {
+    config.headers["X-Correlation-ID"] = crypto.randomUUID();
+    config.headers["X-Tenant-ID"] = "tenant_12345";
+    return config;
+  });
+};
+
+const loggingInterceptor = (instance: any) => {
+  instance.interceptors.request.use((config: any) => {
+    console.log(`[REQ] ${config.method?.toUpperCase()} ${config.url}`);
+    return config;
+  });
+  instance.interceptors.response.use(
+    (res: any) => {
+      console.log(`[RES] ${res.status} ${res.config.url}`);
+      return res;
+    },
+    (err: any) => {
+      console.error(`[ERR] ${err.response?.status} ${err.config?.url}`);
+      return Promise.reject(err);
+    }
+  );
+};
+
+export const api = createApiClient({
+  baseURL: "https://api.example.com",
+  configure: (instance) => {
+    headerInterceptor(instance);  // 1. trace headers
+    loggingInterceptor(instance); // 2. logging
+    authInterceptor(instance);    // 3. auth last
+  },
+});
+```
+
+## How Concurrency Coalescing Works
+
+When multiple requests get a 401 simultaneously:
+
+1. First 401 triggers a refresh; sets an in-flight promise
+2. All subsequent 401s queue behind that same promise (no duplicate refresh calls)
+3. Once refresh resolves, all queued requests retry with the new token
+4. If refresh fails, all queued requests reject and `onRefreshFailure` fires once
+
+This works for both Axios requests (`useQuery`/`useMutation`) and native Fetch streaming (`useStream`).

--- a/skills/react-query-ease/references/error-handling.md
+++ b/skills/react-query-ease/references/error-handling.md
@@ -1,0 +1,126 @@
+# Error Handling Patterns
+
+## Error State in Hooks
+
+Always type `TError` on `useQuery` and `useMutation`:
+
+```ts
+// lib/api/hooks/useTodo.ts
+export interface ApiError {
+  message: string;
+  status: number;
+  code?: string;
+}
+
+export const useTodos = () => {
+  const query = api.useQuery<Todo[], ApiError>({
+    url: "/todos",
+    key: ["todos"],
+  });
+  return {
+    todos: query.data ?? [],
+    todosError: query.error,       // typed as ApiError | null
+    isTodosError: query.isError,
+    isLoadingTodos: query.isLoading,
+    ...query,
+  };
+};
+```
+
+Consume in component:
+
+```tsx
+export function Todos() {
+  const { todos, isLoadingTodos, isTodosError, todosError } = useTodos();
+
+  if (isLoadingTodos) return <p>Loading...</p>;
+  if (isTodosError) return <p>Error: {todosError?.message}</p>;
+
+  return <ul>{todos.map(t => <li key={t.id}>{t.title}</li>)}</ul>;
+}
+```
+
+## Mutation Error Handling
+
+```ts
+export const useCreateTodo = () => {
+  const mutation = api.useMutation<Todo, ApiError, NewTodo>({
+    url: "/todos",
+    method: "POST",
+    keyToInvalidate: ["todos"],
+    onError: (error) => {
+      // Runs on this mutation only; does not suppress global handler
+      console.error("Create failed:", error.message);
+    },
+  });
+  return {
+    createTodo: mutation.mutate,
+    createTodoAsync: mutation.mutateAsync, // throws — use in try/catch
+    createTodoError: mutation.error,
+    isCreateTodoError: mutation.isError,
+    isCreatingTodo: mutation.isPending,
+    ...mutation,
+  };
+};
+```
+
+Using `mutateAsync` for inline error handling:
+
+```tsx
+const { createTodoAsync } = useCreateTodo();
+
+const handleSubmit = async () => {
+  try {
+    const newTodo = await createTodoAsync({ title: "Buy milk" });
+    toast.success(`Created: ${newTodo.title}`);
+  } catch (err) {
+    const apiErr = err as ApiError;
+    if (apiErr.status === 409) {
+      toast.error("Todo already exists");
+    } else {
+      toast.error(apiErr.message);
+    }
+  }
+};
+```
+
+## QueryErrorResetBoundary
+
+Wrap a subtree so users can retry after error:
+
+```tsx
+import { QueryErrorResetBoundary } from "@tanstack/react-query";
+import { ErrorBoundary } from "react-error-boundary";
+
+export function TodosPage() {
+  return (
+    <QueryErrorResetBoundary>
+      {({ reset }) => (
+        <ErrorBoundary
+          onReset={reset}
+          fallbackRender={({ resetErrorBoundary, error }) => (
+            <div>
+              <p>Failed to load: {error.message}</p>
+              <button onClick={resetErrorBoundary}>Retry</button>
+            </div>
+          )}
+        >
+          <Todos />
+        </ErrorBoundary>
+      )}
+    </QueryErrorResetBoundary>
+  );
+}
+```
+
+Install peer dep: `npm install react-error-boundary`
+
+For `ErrorBoundary` to catch query errors, queries must use `throwOnError: true`:
+
+```ts
+api.useQuery<Todo[]>({
+  url: "/todos",
+  key: ["todos"],
+  throwOnError: true, // propagates to nearest ErrorBoundary
+});
+```

--- a/skills/react-query-ease/references/examples.md
+++ b/skills/react-query-ease/references/examples.md
@@ -1,0 +1,194 @@
+# Full CRUD Example
+
+Complete Todo app demonstrating the recommended project structure with `react-query-ease`.
+
+## Project Structure
+
+```
+src/
+  config/
+    apiClients.ts    ← client instances
+  hooks/
+    todos.ts         ← typed hook wrappers
+  components/
+    Todos.tsx        ← UI
+```
+
+## 1. Client (`src/config/apiClients.ts`)
+
+```ts
+import { createApiClient } from "react-query-ease";
+
+export const todosApi = createApiClient({
+  baseURL: "https://api.example.com",
+});
+```
+
+## 2. Types + Hooks (`src/hooks/todos.ts`)
+
+```ts
+import { todosApi } from "../config/apiClients";
+
+export type ApiError = {
+  message: string;
+  status: number;
+};
+
+export type Todo = {
+  id: string;
+  title: string;
+  completed: boolean;
+};
+
+export type NewTodo = Pick<Todo, "title">;
+export type UpdateTodoInput = Partial<Omit<Todo, "id">> & { id: string };
+export type TodoSearchFilters = { query: string };
+
+export const useTodos = () => {
+  const query = todosApi.useQuery<Todo[]>({
+    url: "/todos",
+    key: ["todos"],
+  });
+  return {
+    todos: query.data ?? [],
+    isTodoLoading: query.isLoading,
+    ...query,
+  };
+};
+
+export const useSearchTodos = (filters: TodoSearchFilters) => {
+  const query = todosApi.useQuery<Todo[]>({
+    url: "/todos/search",
+    key: ["todos", "search", filters.query],
+    params: { q: filters.query },
+    enabled: filters.query.length > 0,
+  });
+  return {
+    searchResults: query.data ?? [],
+    isSearchLoading: query.isLoading,
+    ...query,
+  };
+};
+
+export const useCreateTodo = () => {
+  const { mutate, isPending, ...rest } = todosApi.useMutation<
+    Todo,
+    ApiError,
+    NewTodo
+  >({
+    url: "/todos",
+    method: "POST",
+    keyToInvalidate: ["todos"],
+  });
+  return { createTodo: mutate, isCreatingTodo: isPending, ...rest };
+};
+
+export const useUpdateTodo = () => {
+  const { mutate, isPending, ...rest } = todosApi.useMutation<
+    Todo,
+    ApiError,
+    UpdateTodoInput
+  >({
+    url: (variables) => `/todos/${variables.id}`,
+    method: "PATCH",
+    keyToInvalidate: ["todos"],
+  });
+  return { updateTodo: mutate, isUpdatingTodo: isPending, ...rest };
+};
+
+export const useDeleteTodo = () => {
+  const { mutate, isPending, ...rest } = todosApi.useMutation<
+    void,
+    ApiError,
+    { id: string }
+  >({
+    url: (variables) => `/todos/${variables.id}`,
+    method: "DELETE",
+    keyToInvalidate: ["todos"],
+  });
+  return { deleteTodo: mutate, isDeletingTodo: isPending, ...rest };
+};
+```
+
+## 3. Component (`src/components/Todos.tsx`)
+
+```tsx
+import { useState } from "react";
+import {
+  useTodos,
+  useCreateTodo,
+  useUpdateTodo,
+  useDeleteTodo,
+  useSearchTodos,
+} from "../hooks/todos";
+
+export function Todos() {
+  const [search, setSearch] = useState("");
+  const { todos, isTodoLoading } = useTodos();
+  const { createTodo, isCreatingTodo } = useCreateTodo();
+  const { updateTodo, isUpdatingTodo } = useUpdateTodo();
+  const { deleteTodo, isDeletingTodo } = useDeleteTodo();
+  const { searchResults, isSearchLoading } = useSearchTodos({ query: search });
+
+  if (isTodoLoading) return <p>Loading...</p>;
+
+  return (
+    <>
+      <button
+        disabled={isCreatingTodo}
+        onClick={() => createTodo({ title: "New todo" })}
+      >
+        Add Todo
+      </button>
+
+      <input
+        value={search}
+        placeholder="Search todos"
+        onChange={(e) => setSearch(e.target.value)}
+      />
+
+      {search &&
+        (isSearchLoading ? (
+          <p>Searching...</p>
+        ) : (
+          <ul>
+            {searchResults.map((todo) => (
+              <li key={todo.id}>{todo.title}</li>
+            ))}
+          </ul>
+        ))}
+
+      <ul>
+        {todos.map((todo) => (
+          <li key={todo.id}>
+            <span>{todo.title}</span>
+            <button
+              disabled={isUpdatingTodo}
+              onClick={() =>
+                updateTodo({ id: todo.id, completed: !todo.completed })
+              }
+            >
+              Toggle
+            </button>
+            <button
+              disabled={isDeletingTodo}
+              onClick={() => deleteTodo({ id: todo.id })}
+            >
+              Delete
+            </button>
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+}
+```
+
+## Key Patterns
+
+- **Clients in `config/`** — one file per service, export named clients
+- **Hooks in `hooks/`** — rename mutation/query values to domain names (`createTodo` not `mutate`)
+- **Components only import hooks** — never import clients directly in components
+- **`keyToInvalidate`** — use the same key string you pass to `useQuery`'s `key`
+- **Dynamic URLs** — pass `(variables) => string` function when URL contains variable segments
+- **TypeScript generics** — `useMutation<TData, TError, TVariables>` gives full type safety on `mutate` call sites

--- a/skills/react-query-ease/references/optimistic-updates.md
+++ b/skills/react-query-ease/references/optimistic-updates.md
@@ -1,0 +1,136 @@
+# Optimistic Updates
+
+Update the cache immediately on mutate; roll back on error.
+
+## Toggle (single item update)
+
+```ts
+// lib/api/hooks/useTodo.ts
+import { useQueryClient } from "@tanstack/react-query";
+
+export const useToggleTodo = () => {
+  const queryClient = useQueryClient();
+
+  const mutation = api.useMutation<Todo, ApiError, { id: string; completed: boolean }>({
+    url: (variables) => `/todos/${variables.id}`,
+    method: "PATCH",
+    // No keyToInvalidate — we manage cache manually below
+    onMutate: async (variables) => {
+      // Cancel any in-flight refetches for this key
+      await queryClient.cancelQueries({ queryKey: ["todos"] });
+
+      // Snapshot current value for rollback
+      const previousTodos = queryClient.getQueryData<Todo[]>(["todos"]);
+
+      // Optimistically update
+      queryClient.setQueryData<Todo[]>(["todos"], (old = []) =>
+        old.map((t) =>
+          t.id === variables.id ? { ...t, completed: variables.completed } : t
+        )
+      );
+
+      return { previousTodos }; // context passed to onError
+    },
+    onError: (_error, _variables, context) => {
+      // Roll back on failure
+      if (context?.previousTodos) {
+        queryClient.setQueryData(["todos"], context.previousTodos);
+      }
+    },
+    onSettled: () => {
+      // Sync with server regardless of outcome
+      queryClient.invalidateQueries({ queryKey: ["todos"] });
+    },
+  });
+
+  return {
+    toggleTodo: mutation.mutate,
+    isTogglingTodo: mutation.isPending,
+    ...mutation,
+  };
+};
+```
+
+## Delete (remove from list)
+
+```ts
+export const useDeleteTodo = () => {
+  const queryClient = useQueryClient();
+
+  const mutation = api.useMutation<void, ApiError, { id: string }>({
+    url: (variables) => `/todos/${variables.id}`,
+    method: "DELETE",
+    onMutate: async ({ id }) => {
+      await queryClient.cancelQueries({ queryKey: ["todos"] });
+      const previousTodos = queryClient.getQueryData<Todo[]>(["todos"]);
+
+      queryClient.setQueryData<Todo[]>(["todos"], (old = []) =>
+        old.filter((t) => t.id !== id)
+      );
+
+      return { previousTodos };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previousTodos) {
+        queryClient.setQueryData(["todos"], context.previousTodos);
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["todos"] });
+    },
+  });
+
+  return {
+    deleteTodo: mutation.mutate,
+    isDeletingTodo: mutation.isPending,
+    ...mutation,
+  };
+};
+```
+
+## Create (append to list)
+
+```ts
+export const useCreateTodo = () => {
+  const queryClient = useQueryClient();
+
+  const mutation = api.useMutation<Todo, ApiError, NewTodo>({
+    url: "/todos",
+    method: "POST",
+    onMutate: async (newTodo) => {
+      await queryClient.cancelQueries({ queryKey: ["todos"] });
+      const previousTodos = queryClient.getQueryData<Todo[]>(["todos"]);
+
+      // Append temp item with placeholder id
+      queryClient.setQueryData<Todo[]>(["todos"], (old = []) => [
+        ...old,
+        { id: `temp-${Date.now()}`, ...newTodo, completed: false },
+      ]);
+
+      return { previousTodos };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previousTodos) {
+        queryClient.setQueryData(["todos"], context.previousTodos);
+      }
+    },
+    onSettled: () => {
+      // Replace temp item with real server response
+      queryClient.invalidateQueries({ queryKey: ["todos"] });
+    },
+  });
+
+  return {
+    createTodo: mutation.mutate,
+    isCreatingTodo: mutation.isPending,
+    ...mutation,
+  };
+};
+```
+
+## Key Rules
+
+- Always `cancelQueries` before `setQueryData` — prevents in-flight refetch overwriting your optimistic state
+- Always snapshot before update — `getQueryData` before `setQueryData`
+- Return snapshot from `onMutate` — React Query passes it as `context` to `onError`/`onSettled`
+- Always `invalidateQueries` in `onSettled` — syncs temp state with real server data

--- a/skills/react-query-ease/references/query-client-config.md
+++ b/skills/react-query-ease/references/query-client-config.md
@@ -1,0 +1,91 @@
+# QueryClient Config + DevTools
+
+## Production QueryClient Setup
+
+```tsx
+// src/components/providers/QueryProvider.tsx
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 5 * 60_000,   // 5 min — data stays fresh, no background refetch
+      gcTime: 10 * 60_000,     // 10 min — keep unused cache before GC (was cacheTime pre-v5)
+      retry: 2,                // retry failed queries twice
+      refetchOnWindowFocus: false, // disable noisy refetch on tab switch
+    },
+    mutations: {
+      retry: 0, // never retry mutations by default
+    },
+  },
+});
+
+export function QueryProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
+  );
+}
+```
+
+Install DevTools:
+
+```bash
+npm install @tanstack/react-query-devtools
+```
+
+`ReactQueryDevtools` tree-shakes out of production builds automatically — no `NODE_ENV` guard needed.
+
+## Key Defaults Explained
+
+| Option | Default | Recommended | Why |
+|--------|---------|-------------|-----|
+| `staleTime` | `0` (always stale) | `5 * 60_000` | Prevents background refetch on every mount |
+| `gcTime` | `5 * 60_000` | `10 * 60_000` | Keeps cache longer for fast back-navigation |
+| `retry` | `3` | `2` | 3 retries on flaky networks adds ~15s delay |
+| `refetchOnWindowFocus` | `true` | `false` | Eliminates surprise re-fetches in most SPAs |
+
+## Per-Query Override
+
+Override defaults on individual hooks when needed:
+
+```ts
+export const useUserProfile = (id: string) => {
+  const query = api.useQuery<UserProfile>({
+    url: `/users/${id}`,
+    key: ["user", id],
+    staleTime: 0,            // always fresh
+    retry: 0,                // fail fast
+    refetchOnWindowFocus: true,
+  });
+  return { profile: query.data, isLoadingProfile: query.isLoading, ...query };
+};
+```
+
+## Global Error Handler
+
+Attach once to the QueryClient to handle all query/mutation errors centrally (e.g. toast notifications):
+
+```tsx
+import { QueryCache, MutationCache, QueryClient } from "@tanstack/react-query";
+import toast from "react-hot-toast";
+
+const queryClient = new QueryClient({
+  queryCache: new QueryCache({
+    onError: (error, query) => {
+      // Only show toast for background refetch errors (not initial load)
+      if (query.state.data !== undefined) {
+        toast.error(`Refresh failed: ${(error as Error).message}`);
+      }
+    },
+  }),
+  mutationCache: new MutationCache({
+    onError: (error) => {
+      toast.error((error as Error).message ?? "Something went wrong");
+    },
+  }),
+});
+```

--- a/skills/react-query-ease/references/streaming.md
+++ b/skills/react-query-ease/references/streaming.md
@@ -1,0 +1,131 @@
+# useStream — Full Reference
+
+`api.useStream` is a React hook for consuming chunked/streaming endpoints (LLMs, SSE, OpenAI-style responses). It handles state management, auth token attachment + refresh, and safe cleanup on unmount.
+
+## Hook Signature
+
+```typescript
+const result = api.useStream<TVariables = void>(config: UseStreamOptions);
+```
+
+## Options (`UseStreamOptions`)
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `url` | `string` | Yes | Endpoint path; resolved against client `baseURL` |
+| `method` | `string` | No | HTTP method (default: `"GET"`) |
+| `headers` | `Record<string, string>` | No | Custom headers for the fetch request |
+| `credentials` | `RequestCredentials` | No | CORS credentials (`omit`, `same-origin`, `include`) |
+| `onChunk` | `(chunk: string) => void` | No | Called for each received text fragment |
+| `onComplete` | `() => void` | No | Called when stream terminates successfully |
+| `onError` | `(error: unknown) => void` | No | Called on connection/network error |
+
+## Return Values
+
+| Value | Type | Description |
+|-------|------|-------------|
+| `data` | `string` | Accumulated text from all chunks received so far |
+| `isLoading` | `boolean` | `true` while connecting or while auth interceptor checks/refreshes tokens |
+| `isStreaming` | `boolean` | `true` while bytes are actively being received |
+| `error` | `unknown \| null` | Connection error state — **not set on user-initiated abort** |
+| `start` | `(variables?: TVariables) => Promise<StreamController>` | Launch the stream; `variables` map to request body |
+| `abort` | `() => void` | Cancel active stream, release reader lock, clear loading flags |
+
+## Production Example — AI Chat
+
+```tsx
+import { useState } from "react";
+import { api } from "./config/apiClients";
+
+interface ChatPayload {
+  prompt: string;
+  temperature?: number;
+}
+
+export function AIAssistant() {
+  const [prompt, setPrompt] = useState("");
+
+  const { data, isLoading, isStreaming, error, start, abort } =
+    api.useStream<ChatPayload>({
+      url: "/chat",
+      method: "POST",
+      onComplete: () => console.log("Done generating"),
+      onError: (err) => console.error("Stream error:", err),
+    });
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!prompt.trim() || isStreaming) return;
+    try {
+      await start({ prompt: prompt.trim(), temperature: 0.7 });
+      setPrompt("");
+    } catch (err) {
+      console.warn("Stream stopped:", err);
+    }
+  };
+
+  return (
+    <div>
+      <form onSubmit={handleSubmit}>
+        <input
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          disabled={isLoading || isStreaming}
+          placeholder="Ask anything..."
+        />
+        <button type="submit" disabled={isLoading || isStreaming || !prompt.trim()}>
+          Send
+        </button>
+        {(isLoading || isStreaming) && (
+          <button type="button" onClick={abort}>Stop</button>
+        )}
+      </form>
+
+      {isLoading && <p>Connecting...</p>}
+      {error && <p style={{ color: "red" }}>{String(error)}</p>}
+      <pre style={{ whiteSpace: "pre-wrap" }}>{data}</pre>
+    </div>
+  );
+}
+```
+
+## Lower-Level: `api.stream` (async iterator)
+
+For non-React code or manual control:
+
+```typescript
+const controller = await api.stream({
+  url: "/chat",
+  method: "POST",
+  data: { prompt: "Hello" },
+});
+
+// Async iteration
+for await (const chunk of controller) {
+  process.stdout.write(chunk);
+}
+
+// Or manual abort
+setTimeout(() => controller.abort(), 5000);
+```
+
+`StreamController` interface:
+- `abort(): void` — cancel the stream
+- `signal: AbortSignal` — standard Web API abort signal
+- `[Symbol.asyncIterator]()` — iterate chunks as strings
+
+## Auth Integration
+
+If the client uses `createAuthInterceptor`, `useStream` participates in the same refresh lifecycle:
+
+1. Before fetch, the hook resolves and attaches the access token header
+2. If the stream endpoint returns 401, the auth interceptor's refresh queue is invoked
+3. Concurrent refresh requests from other queries coalesce — one network call refreshes all
+4. Stream retries once with the new token automatically
+
+## Safe Cleanup
+
+On component unmount mid-stream:
+1. Active fetch connection is aborted via `AbortController`
+2. `ReadableStream` reader lock is released and cancelled
+3. Pending state updates are dropped (no React "update on unmounted component" warnings)


### PR DESCRIPTION
## Summary

- Adds [`react-query-ease`](https://www.npmjs.com/package/react-query-ease) skill — typed Axios + React Query wrapper that eliminates boilerplate for API clients, hooks, and token refresh
- Covers full workflow: install → client setup → `useQuery` / `useMutation` → auth interceptor → streaming (`useStream`)
- Includes 6 reference docs for error handling, optimistic updates, streaming, auth interceptor, QueryClient config, and full CRUD examples

## What is react-query-ease?

[`react-query-ease`](https://www.npmjs.com/package/react-query-ease) wraps Axios + React Query into a single typed client. One `createApiClient` call gives you `.useQuery`, `.useMutation`, and `.useStream` — no repeated Axios config, no manual cache invalidation wiring, built-in 401 token refresh.

## Files added

| File | Purpose |
|------|---------|
| `SKILL.md` | Core skill: install, client setup, hooks, auth, streaming |
| `references/auth-interceptor.md` | `createAuthInterceptor` full options + chaining |
| `references/error-handling.md` | `mutateAsync` try/catch, `QueryErrorResetBoundary` |
| `references/examples.md` | Full CRUD walkthrough (list/create/update/delete) |
| `references/optimistic-updates.md` | Create/toggle/delete optimistic patterns |
| `references/query-client-config.md` | `QueryClient` defaults table + global error handler |
| `references/streaming.md` | `useStream` full API + async iterator usage |
