### PR TITLE
fix(skill-creator): handle eval_id=None crash in eval-viewer sort

### DIFF
--- a/skills/skill-creator/eval-viewer/generate_review.py
+++ b/skills/skill-creator/eval-viewer/generate_review.py
@@ -61,7 +61,7 @@ def find_runs(workspace: Path) -> list[dict]:
     """Recursively find directories that contain an outputs/ subdirectory."""
     runs: list[dict] = []
     _find_runs_recursive(workspace, workspace, runs)
-    runs.sort(key=lambda r: (r.get("eval_id", float("inf")), r["id"]))
+    runs.sort(key=lambda r: (r["eval_id"] if r["eval_id"] is not None else float("inf"), r["id"]))
     return runs
 
 

--- a/skills/skill-creator/eval-viewer/viewer.html
+++ b/skills/skill-creator/eval-viewer/viewer.html
@@ -1192,7 +1192,12 @@
       // Per-eval breakdown (if runs data available)
       const runs = data.runs || [];
       if (runs.length > 0) {
-        const evalIds = [...new Set(runs.map(r => r.eval_id))].sort((a, b) => a - b);
+        const evalIds = [...new Set(runs.map(r => r.eval_id))].sort((a, b) => {
+          if (a === null && b === null) return 0;
+          if (a === null) return 1;
+          if (b === null) return -1;
+          return a - b;
+        });
 
         html += "<h3 style='font-family: Poppins, sans-serif; margin-bottom: 0.75rem;'>Per-Eval Breakdown</h3>";
 


### PR DESCRIPTION
Both Python and JS sort logic in the **skill-creator eval-viewer** crash when `eval_id` is `None`/`null`. This fix makes the sort handle that case gracefully by placing those runs last.

## Bug description

When the skill-creator eval-viewer scans a workspace, `build_run()` returns `eval_id=None` for any run directory that does not have an `eval_metadata.json` file (or the file exists but lacks an `eval_id` field). The sort code then crashes:

**Python** (`skills/skill-creator/eval-viewer/generate_review.py`):
```python
runs.sort(key=lambda r: (r.get("eval_id", float("inf")), r["id"]))
```

`r.get("eval_id", float("inf"))` returns `None` — not `inf` — because `.get()` only falls back to the default when the **key is absent**, not when it exists with a `None` value. Comparing `(1, "...") < (None, "...")` raises `TypeError: '<' not supported between instances of 'int' and 'NoneType'`.

**JS** (`skills/skill-creator/eval-viewer/viewer.html`):
```javascript
runs.map(r => r.eval_id).sort((a, b) => a - b)
```
`null - int` produces `NaN`, making the sort order unpredictable.

## Why this is not a dirty-data problem

| Scenario | eval_metadata.json exists? | eval_id | Is this dirty data? |
|---|---|---|---|
| Normal run with metadata | Yes | `1` | No |
| Manual test directory | No | `None` | **No** |
| Run shared by another team | No | `None` | **No** |
| Early version of skill-creator output | No | `None` | **No** |

The producer (`build_run()`) and consumer (`find_runs()`) are in the **same file** (`generate_review.py`). `build_run()` was explicitly designed to return `eval_id=None` as a valid output rather than raising or skipping — the author chose to treat runs without metadata as legitimate entries. This is an **internal contract**: one module produces `None`, another module does not handle it.

The fix is to make the sort defensive: handle `None` explicitly instead of assuming all `eval_id` values are integers.

## Fix

- **`skills/skill-creator/eval-viewer/generate_review.py`**: Changed to `r["eval_id"] if r["eval_id"] is not None else float("inf")`
- **`skills/skill-creator/eval-viewer/viewer.html`**: Changed to explicit null-aware comparator that places `null` values last