### PR TITLE
fix(skill-creator): run_eval trigger detection misses real skill name and bails on first non-Skill tool

### DIFF
--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -138,20 +138,27 @@ def run_single_query(
                                     pending_tool_name = tool_name
                                     accumulated_json = ""
                                 else:
-                                    return False
+                                    # Don't bail: other tools (Bash/WebFetch/etc.)
+                                    # may precede a later Skill/Read call. Reset the
+                                    # pending state and keep scanning.
+                                    pending_tool_name = None
 
                         elif se_type == "content_block_delta" and pending_tool_name:
                             delta = se.get("delta", {})
                             if delta.get("type") == "input_json_delta":
                                 accumulated_json += delta.get("partial_json", "")
-                                if clean_name in accumulated_json:
+                                # Also match the real skill name: an installed skill
+                                # fires under its actual name, not the temp command
+                                # name (clean_name).
+                                if clean_name in accumulated_json or skill_name in accumulated_json:
                                     return True
 
                         elif se_type in ("content_block_stop", "message_stop"):
                             if pending_tool_name:
-                                return clean_name in accumulated_json
-                            if se_type == "message_stop":
-                                return False
+                                if clean_name in accumulated_json or skill_name in accumulated_json:
+                                    return True
+                                pending_tool_name = None
+                            # Don't return False here; keep scanning until "result".
 
                     # Fallback: full assistant message
                     elif event.get("type") == "assistant":
@@ -161,11 +168,17 @@ def run_single_query(
                                 continue
                             tool_name = content_item.get("name", "")
                             tool_input = content_item.get("input", {})
-                            if tool_name == "Skill" and clean_name in tool_input.get("skill", ""):
-                                triggered = True
-                            elif tool_name == "Read" and clean_name in tool_input.get("file_path", ""):
-                                triggered = True
-                            return triggered
+                            if tool_name == "Skill" and (
+                                clean_name in tool_input.get("skill", "")
+                                or skill_name in tool_input.get("skill", "")
+                            ):
+                                return True
+                            if tool_name == "Read" and (
+                                clean_name in tool_input.get("file_path", "")
+                                or skill_name in tool_input.get("file_path", "")
+                            ):
+                                return True
+                        # No match in this message; keep scanning subsequent ones.
 
                     elif event.get("type") == "result":
                         return triggered


### PR DESCRIPTION
## Problem

`scripts/run_eval.py::run_single_query` fails to detect that a skill triggered, causing the description-optimization loop (`run_loop.py`) to report **recall=0%** for every should-trigger query. With all candidates tied at 0, the loop just returns the original description and never actually optimizes.

Two root causes in the stream detection:

1. **Only the registered command name is matched.** The function registers a temp command named `{skill}-skill-{uuid}` and only checks whether that random name (`clean_name`) appears in the tool input. But an installed skill fires under its **real name** (e.g. `cve-intel`), so the random name never matches -> always False.
2. **Bails to False on the first non-Skill/Read tool.** Real Claude Code runs often call `Bash`/`WebFetch`/etc. before consulting the skill. The `content_block_start` handler does `return False` on the first such tool, missing a later Skill/Read call.

## Fix

- Match the **real `skill_name`** in addition to the registered `clean_name`, in both the streaming path and the full-assistant-message fallback.
- Do **not** return False on the first non-Skill/Read tool. Reset the pending state and keep scanning until `type == "result"`.

Early-return on a positive match keeps positives fast; negatives run to `result` (short Q&A), bounded by `--timeout`.

## Evidence (same skill + eval set, 3 runs/query, `--model claude-sonnet-4-6 --timeout 120`)

| metric    | before | after (held-out test) |
|-----------|--------|-----------------------|
| recall    | 0%     | 100% |
| precision | 100%   | 100% |
| accuracy  | 50%    | 100% |

After the fix the loop can measure description quality as intended (held-out test 8/8).

## Notes

- No behavioral change for skills not installed locally: `clean_name` matching is preserved; `skill_name` matching is additive.
- Single-file change in `skills/skill-creator/scripts/run_eval.py`.