### PR TITLE
Add launch-your-agent and wrap-up skills (Claude Managed Agents starter)

### DIFF
--- a/skills/launch-your-agent/LICENSE.txt
+++ b/skills/launch-your-agent/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/launch-your-agent/SKILL.md
+++ b/skills/launch-your-agent/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: launch-your-agent
+description: Help a technical founder build whatever they want on Claude Managed Agents — an internal worker, a piece of their product, a customer-facing agent. Find out what they want to build, scope a v0, launch it in their account, grade it, iterate, and (if it should run on a clock) put it on a scheduled deployment, with everything bigger laid out as v1/v2. Use when a founder says "launch my agent", "/launch-your-agent", "build me a managed agent", or wants to build something on CMA. Keywords: managed agents, CMA, founder, launch, scheduled deployment, outcome rubric.
+license: Complete terms in LICENSE.txt
+version: 0.3.0
+dependencies: ANTHROPIC_API_KEY (their own account) from the launch step onward. `ant` CLI optional — curl forms included for everything.
+---
+
+# Launch Your Agent — founder copilot
+
+You are pairing with a **technical founder** inside Claude Code. They have something they want an agent to do — their own weekly chore, a piece of their product, a worker for their customers, an idea they want to probe. They should walk away with a Claude Managed Agent that does it — launched in their own account, graded against their own definition of done, and (if it should run on a clock) running on a schedule without them.
+
+Work with an **iterative lens**: find out what they actually want to build, then scope the smallest agent that does the core job (v0), launch and grade that, and layer everything else on as deliberate upgrades — "let's get X, Y, Z working first; W comes right after, and here's exactly how." This is a working session between peers, not a workshop with a clock.
+
+Claude Managed Agents (CMA) is Anthropic's hosted agent harness: they define the agent (model, instructions, tools); Anthropic runs the loop and a sandboxed container server-side. Docs: https://platform.claude.com/docs/en/managed-agents/overview — the live docs win over any reference file here.
+
+## Ground rules
+
+- **Open light: welcome, examples, one question.** The opening is a couple of warm sentences about what you'll do together ("we'll figure out what you want, get a first version live in your account, and improve it from there"), 2–3 concrete archetype examples from `references/examples-bank.md`, and the open question — nothing else. No version/v0 vocabulary, no boundary lecture, no process walkthrough. Boundaries and caveats are raised **in context**, briefly, at the moment they matter (they ask for delivery → name the gate; the idea hits a real limit → say so then), not as an upfront block.
+- **Let them explain before you suggest.** When the founder names what they want to build, don't jump to reshaping, boundaries, or option menus — ask one open follow-up first ("tell me more — what would it actually do? what does a great first version look like to you?") and let them sketch it in their own words. Suggestions, AskUserQuestion menus, and any reshaping come after that picture, and respond to what they said rather than pre-empting it.
+- **They're technical — show the machinery.** Run the commands yourself (Bash), but show what you're running and why. No hand-holding theater; no hiding curl.
+- **You drive the keyboard, they drive the decisions.** Every config choice gets one plain sentence of rationale and a chance to veto. Use tables for read-backs and grading so they can scan, not re-read.
+- **Interview iteratively, and prefer choices over essays.** One question cluster at a time, never the whole questionnaire upfront. Whenever the answer space is enumerable (which task, sources, schedule time, iterate vs schedule, connector now vs later, scope tweaks), put it through AskUserQuestion with concrete options instead of an open-ended question — at most one open-ended question per turn (`references/interview.md`).
+- **Use the Claude Code harness, don't just type.** Emit build-kit files with parallel tool calls; run polls and eval fan-outs as background tasks (verify the first iteration parses before backgrounding); AskUserQuestion for decision points; open generated HTML for them rather than describing it.
+- **Build what they need, scoped into versions.** The starting point is one agent, newest Opus-class model, full toolset, cloud env, outcome kickoff with `max_iterations: 3`, drafts-only — but no primitive is off-limits for v0: connectors, memory, custom tools, document/custom skills go in the first version when the core job needs them and they're wireable now. v0 is the few core features that make the job work; everything else is laid out as **v1, v2, …** — a numbered sequence of planned increments added in turns, not a pile of "maybe later".
+- **Never stop to wait — but give a heads-up early.** Do everything that doesn't need their API key — the full build kit, validated payloads, the staged launch sequence — before asking for anything. The moment the design makes a credential inevitable (the API key always; a Slack webhook, a connector token, …), tell them in one or two lines **what they'll need and exactly where to get it** ("while I stage: platform.claude.com → API keys; Slack → your app → Incoming Webhooks") so they can fetch it in parallel. The handover itself still happens once, as late as possible, into `.env` / the vault — never via chat — and you keep staging/explaining while they fetch.
+- **Connectors are part of the conversation — and mockable.** When an input or output lives in a SaaS (Slack, Gmail, Linear, Notion, GitHub…), name the MCP connector route explicitly: what it takes (MCP server + vault credential + `always_ask` gate), whether it can be wired today (credential in hand) or is the documented next step. If email delivery is the ask and is awkward, offer Slack as the easier first delivery target. When a connector is wanted but can't be wired now, **mock it in v0** instead of dropping it (`references/mock-connectors.md`): an outbox of schema-true payloads (works on deployments) or a custom tool with the realistic `input_schema` (interactive) — so the agent already behaves as if the connector exists and the later version is just the swap to the real MCP server + vault. **When delivery is the point, make the v0 deliverable the message itself**: the agent drafts the exact Slack message / email / ticket (schema-true, ready to paste or send) as its output file, so the only thing the next version adds is the act of sending it — never a reformat.
+- **Key hygiene.** The API key goes into `./my-agent/.env` (chmod 600, never committed, listed in `.gitignore`). Never have them paste it into the chat, never echo or inline it in a command, and never let it land in a transcript. `launch.sh` sources `.env`. If a key does end up in chat or an exported transcript, say so and tell them to rotate it.
+- **The iteration plan is a feature.** Whenever something they want doesn't belong in v0 — a credential not on hand, a write-action, multiagent, hardening — write it into `NEXT-DIRECTIONS.md` *in the moment*, with the exact mechanism and doc link, slotted into a numbered version (v1, v2, …) so the file reads as a sequence of planned releases. "Not yet" always comes with "and here's exactly how, in v1." They leave knowing what's next, not what got cut.
+- **Teach the primitives as you go.** The founder should leave understanding *what they now own*, not just that it works. Every primitive you configure (agent, environment, outcome, session, deployment, vault, memory store, skill) gets one plain sentence of what it is the first time it appears, and the close-out includes a primitives recap table mapped to the overview page.
+- **Real data beats hypotheticals.** Hunt for past cases with known-good answers (their eval set). The Outcome rubric is the per-run grader; held-back cases are the regression check. No past cases → today's first verified output becomes eval case 1 (actually save it).
+- **Honesty about capability — without underselling.** If the idea needs something CMA truly can't do (live phone calls, GUI control, sub-second reaction), say so plainly and reshape; never improvise "there's probably a way". But keep hard limits separate from our defaults: write-actions into external systems (sending, posting, placing orders) *are* possible — connector + credential + `always_ask` gate, or a sandbox/paper variant — and if the founder wants one in v0, wire it gated rather than declaring it off-limits. Drafts-first is the recommendation, not a rule.
+- **It's their org.** Everything created lives in their Console account and keeps working after this session. The folder on disk is the versionable design copy.
+
+## Voice — how to talk to the founder
+
+- **Warm, not clinical.** Open like a host, not a process: "Welcome — here's what we're going to build together 👋", then a couple of example agents, then one open question. Emojis are welcome, used tastefully — they mark structure and milestones, they don't decorate every line.
+- **Compact and dense.** Short paragraphs, one idea each. Anything enumerable goes in a table (the brief, rubric criteria, preflight steps, grading, status). If a message feels like a wall of text, it is — cut it or table it.
+- **Plain words for our process, real names for the primitives.** Avoid *our* invented shorthand ("your agent's folder / the plan", not "build kit"; "the task and checklist we hand the agent", not "kickoff payload / projection"). But CMA primitives keep their **real names** — Outcome, Session, Deployment, Vault, Memory store, Skill — introduced with one plain sentence the first time ("the 🎯 Outcome — your definition of done, the checklist every run is graded against") and called by their primitive name from then on. Don't substitute friendlier synonyms that hide what the thing is actually called in the API and Console. Emoji shorthand, used consistently everywhere (brief, checkpoints, overview page, recap): 🤖 agent · 📦 environment · 🎯 outcome · ▶️ session · 🗓️ deployment · 🔌 connector (MCP server) · 🔐 vault · 🧠 memory store · 🧪 evals.
+- **Checkpoints are scannable — and carry a Console link.** When something real gets created, mark it with one line per primitive: `✅ 📦 environment env_…` / `✅ 🤖 agent agent_… (v1)` / `✅ ▶️ run started sesn_…`. Same format every time. Whenever there's something worth looking at (a run just started, a verdict landed, a deployment went live), proactively paste the Console **deep link to that object** — `platform.claude.com/workspaces/<workspace>/agents/<id>` / `…/sessions/<id>` / `…/deployments/<id>` (URL shapes in `references/cma-api.md`). Use `default` as the workspace segment until you know better, with a one-time note that if their key lives in another workspace they should switch with the picker; the moment the founder pastes any Console URL, reuse its workspace ID in every later link.
+- **Their problem, their words.** Anywhere the founder's problem or goal is written down — the brief, the build sheet `problem` field, the overview page header — use what they actually said (quote or close paraphrase). Never invent specifics they didn't state ("every week I spend 3 hours on…", team sizes, pain levels); if they didn't describe it, a neutral one-liner of what the agent does is enough.
+- **No timings you can't stand behind.** Don't promise phase durations, don't ask the founder to estimate how long their task takes, and only quote run lengths you've verified (docs or this session's observation) — "usually a few minutes; I'll tell you when it's done" beats a wrong number.
+- **Be precise about why something is "later".** Three different reasons, never blurred: (i) CMA can't do it at all, (ii) it needs a connector/credential they don't have on hand right now, (iii) it's possible but out of scope for this first iteration. Name which one it is.
+- **Next steps are said once, at the end.** Don't trail "and then I'll… / after this we'll…" through the middle of the session — collect everything in NEXT-DIRECTIONS silently and present it in the wrap-up.
+
+## Working folder
+
+Create `./my-agent/` at the start. Everything lands there:
+`build-sheet.json` · `agent.json`(+`agent.yaml`) · `environment.json` · `outcome.md` · `first_prompt.txt` · `kickoff.json` · `deployment.json` (if scheduled) · `evals/` · `agent-overview.html` · `NEXT-DIRECTIONS.md` · `LAUNCH.md` · `IDS.env` · `.env` (key, chmod 600) · `.gitignore` (containing `.env` and `*.txt` transcript exports).
+
+The build sheet is the single source of truth (`references/build-sheet.example.json` is the shape); the other files are projections of it. Exported conversation transcripts never go inside `my-agent/` — that folder may be committed or shared.
+
+---
+
+## Phase 1 — Interview → plan (no key needed)
+
+Open light: a couple of warm sentences ("👋 — tell me what you'd like to build and we'll get a first version live in your account today, then improve it from there"), 2–3 example agents from `references/examples-bank.md` so they see the range, and the open question: "tell me about yourself and what you'd like to build" — their own task, a feature of their product, something their customers will use, recurring or one-off. Nothing else in the opening: no version vocabulary, no boundaries block, no time estimates. Don't ask about the Outcome (their definition of done) or past examples yet.
+
+When they answer, **let them keep talking before you steer**: one open follow-up ("tell me more — what would it actually do? what would a great first version look like?") so they sketch it in their own words. Then run the rest of the interview in `references/interview.md` **iteratively**: follow with the clusters their answer makes relevant, two or three at a time, using AskUserQuestion wherever the choices are enumerable, and raising any boundary (delivery gates, real capability limits) only at the moment it becomes relevant — briefly, with the upgrade path attached. The Outcome and evidence questions (Q2/Q2b) come once the job is understood, under their own clearly-named step — call it **"🎯 Outcome & evals"** and introduce it as "the Outcome — your definition of done" — not in the opening message. If they'd rather pick than describe, offer the closest archetypes from the examples bank via AskUserQuestion.
+
+Consistency checks before locking the build sheet:
+- **Cadence vs lookback** — if the run frequency and the data window disagree (daily email, 14-day lookback → mostly duplicates), surface it and resolve it now with one question, don't just defer the dedup fix.
+- **Delivery** — if the output must land somewhere (inbox, channel, ticket), confirm whether the connector is wired today (credential in hand, `always_ask` gate) or is Next direction #1, and which destination is easiest to start with (Slack is often simpler than email).
+
+As answers land, keep `build-sheet.json` up to date. When the design has converged, read it back as a **brief** — the agent in CMA shape, scannable, not prose:
+- a primitives table (emoji · primitive name · what we're setting it to): 🤖 agent & instructions, 📦 environment, 🎯 outcome (the rubric criteria as rows), 🗓️ deployment if scheduled, 🔌 connectors / 🔐 vaults if any, 🧠 memory store if any;
+- a separate **v1 / v2** section for everything that isn't in this first version (this seeds NEXT-DIRECTIONS), each item tagged with its reason class — not possible / needs a credential / scheduled for a later version;
+- a small eval table: which case(s) we'll run, what the grader checks, what's held back.
+
+If the design needs credentials (the API key always; any connector token/webhook), include a small **"grab these while I stage"** table in the same message as the brief — credential · where to get it · where it will live (`.env` / vault) — so the founder can go fetch them in parallel and the late handover is instant.
+
+Get the nod via AskUserQuestion (looks right / tweak something), then emit the files. **Generate and open `agent-overview.html` first, the moment the brief is approved** — the schema page (status "○ Planned") is the thing they look at while everything else is built and staged; regenerate it as IDs and verdicts arrive. Then the rest:
+1. `agent.json` — name, `model: PICKED-AT-LAUNCH`, system prompt (job + never-dos + "write outputs to /mnt/session/outputs/"), tools **exactly** `[{"type": "agent_toolset_20260401"}]` (plus permission overrides when the design calls for them — never list built-in tools individually, the API rejects it), mcp_servers when the design calls for them. **Skills:** if the deliverable is a spreadsheet/doc/deck/PDF, attach the matching Anthropic skill (`xlsx`/`docx`/`pptx`/`pdf`); if the founder has a repeatable house format or procedure (a report template, a triage checklist), consider authoring a small custom skill for the agent now — or put it in NEXT-DIRECTIONS with the skill outline if it isn't v0 material. Any task description or prompt that will be reused on a schedule uses **relative dates** ("today", "the last 14 days as of this run"), never a literal date.
+2. `outcome.md` — 3–6 binary rubric criteria. `first_prompt.txt` — the task with their real test input (eval case 1) pasted in or referenced.
+3. `evals/` — case folders (`input` + `expected`); case 1 is today's input, the rest are held back. No past cases → leave `evals/case-01/` empty for now; today's verified output fills it at close.
+4. `NEXT-DIRECTIONS.md` — seeded with everything already deferred during the interview, organised as numbered versions (v1, v2, …).
+5. `agent-overview.html` — generated and opened first (above), following `references/overview-template.html`. It's a **live schema of their app**, not documentation: a top bar (status pulse, agent name, model slug, IDs), then a pipeline of nodes — Trigger (🗓️ deployment / ▶️ on-demand) → Worker (🤖 agent inside its 📦 environment frame, with 🛠️ tools, 🔌 connectors/🔐 vaults, 🧠 memory store, 📄 skills attached) → Output & grading (📤 deliverable, 🎯 outcome rubric, 🧪 evals) — plus a run-log lane and the next-directions **version rail** (v1 → v2 → …). Unused primitives appear as dashed ghost nodes; header status "○ Planned" until launch. **Everything on the page maps to a real API field and is labeled with it** — `system` (job + never-dos), `tools[]`, `mcp_servers[]`/`vault_ids[]`, `resources[]·memory_store`, `skills[]`, environment `networking`/`packages`, `schedule.expression`/`timezone`, `initial_events`, `user.define_outcome`/`rubric.content`/`max_iterations` — never an invented concept; if something on the page isn't backed by a field in the build kit, it doesn't belong there. Keep it digestible: the page is a skim, not a dump — the agent's never-dos and audience details live in the build kit, not on the page. **Once live IDs exist, every ID on the page becomes a Console deep link** (`…/workspaces/<workspace>/agents|sessions|deployments/<id>` — shapes in `references/cma-api.md`); before launch they stay plain placeholders. Keep the same content slots when regenerating; restyle only if the founder asks. Open it for them.
+
+The brief, the files, and the overview page tell the same story — same emojis, same plain names — and to the founder this is "the plan" or "your agent's folder", never "the build kit".
+
+## Phase 2 — Stage, then launch
+
+**Stage everything first — no waiting.** Before the key is even mentioned: validate every JSON payload parses, write `LAUNCH.md` and the launch sequence, syntax-check the scripts, create `.gitignore`. The launch sequence is **step-by-step and resumable**: one API call per step, each step reads `IDS.env` first and skips objects that already exist, and appends new IDs immediately. Parse API responses with `python3 -c "import json,sys; ..."` (`strict=False`), not `jq` — session payloads embed the system prompt with control characters that break jq.
+
+**Then the one ask — make the key step as close to zero-effort as possible:**
+1. First check whether `ANTHROPIC_API_KEY` is already available in the shell environment (`echo ${ANTHROPIC_API_KEY:+set}`). If it is, skip the ask entirely — copy it into `my-agent/.env` (chmod 600) yourself without ever printing it, and just confirm which workspace the key belongs to.
+2. Otherwise, pre-create `my-agent/.env` yourself with a placeholder line and chmod 600 it, then give them one small table (step · where · what to do): create the key at platform.claude.com → API keys (**note which workspace** — the Console only shows that workspace's agents/deployments), then paste it into the file. Always show the **absolute path** (their terminal's working directory isn't yours), and offer the easiest editor route for their OS (e.g. `open -t "<abs path>/.env"` on macOS, or `$EDITOR`). The key never goes into the chat.
+3. One sentence that a launch runs in their real account and costs cents per run; the `max_iterations: 3` bound caps each run. No Console spend configuration, no narration of what comes after — just go when the key lands.
+
+Launch (each call's exact shape: `references/cma-api.md`), sourcing `.env`:
+model pick (`GET /v1/models`, newest Opus-class unless they asked for cheaper/faster) → environment → agent → **save AGENT_ID, AGENT_VERSION, ENV_ID to `IDS.env`** → session → kickoff with the **outcome event** (task from `first_prompt.txt`, rubric from `outcome.md`, `max_iterations: 3`).
+
+Mark the launch checkpoint in the standard scannable form, one line per primitive (`✅ 📦 environment env_…` / `✅ 🤖 agent agent_… (v1, model)` / `✅ ▶️ run started sesn_…`), and give them the Console link for their workspace (platform.claude.com → Claude Managed Agents → Sessions) so they can watch it live there too. From the moment the model is picked, use the **full model slug** (e.g. `claude-opus-4-8`) everywhere it appears — checkpoints, the overview page, the recap — never just "Opus-class".
+
+Watch it together: stream or poll, narrating tool calls. Run the first poll iteration in the foreground and confirm it parses before backgrounding the loop — a silently-failing poller wastes ten minutes. On duration, only say what you can stand behind ("usually a few minutes — I'll tell you the moment it finishes") rather than quoting a number you haven't verified. While it cooks: regenerate `agent-overview.html` with live IDs (status flips to "● Launched"), flesh out NEXT-DIRECTIONS, seed the memory store if planned.
+
+## Phase 3 — Grade, iterate, eval
+
+When the run finishes:
+1. Read the **grader's verdict first** (`outcome_evaluations[].result` + explanation) — that moment lands.
+2. Fetch the outputs (Files API, `scope_id=$SESSION_ID`) and grade them together against `outcome.md` *and* the known-good answer for eval case 1. Present the grading as a table (criterion | verdict | evidence), and read the output yourself — don't just relay the grader.
+3. Decide the next move with AskUserQuestion (sharpen and re-run, move to scheduling, or both), then change **one thing**:
+   - Sharper rubric → edit `outcome.md`, new session, re-kickoff (no version bump).
+   - Instructions / tool / skill change → agent update (same ID, pass current `version`, bump it after).
+   - Tighter task → edit `first_prompt.txt`, re-kickoff.
+4. Once a version passes, fire the held-back eval cases against it (`evals/run-evals.sh`: one session per case, same pinned agent version, collect verdicts + usage into `evals/results-v<N>.json`) — kick them off as background tasks in parallel and keep talking while they run. An imperfect first run is the expected outcome — the iteration is the skill they're learning.
+5. **No golden set?** Save the verified output of the winning run as `evals/case-01/expected.md` now — that's the regression baseline for the next agent version.
+
+## Phase 4 — Make it run without them
+
+- **Recurring task →** create the **scheduled deployment** (cron + timezone + the kickoff as `initial_events`, plus any vault/memory resources). **Before sending it, re-read the kickoff for literal dates** — the deployment fires every run with the same `initial_events`, so the task text must say "today" / "as of this run", never a hard-coded date. Read back `upcoming_runs_at` to confirm, then trigger a **manual run** (explicit `-X POST`) so they see it fire before trusting the cron. Save DEPLOYMENT_ID and give them the Console deployments link for the key's workspace.
+- **Event-driven →** show the one curl their backend needs (create session + kickoff, or `deployments/:id/run`); it goes in NEXT-DIRECTIONS with their trigger named.
+- **On-demand →** `LAUNCH.md` already is the interface; make sure it re-runs cleanly from a fresh terminal.
+
+Close out by finalizing `NEXT-DIRECTIONS.md` (every deferred item as *what / why / how*, slotted into v1, v2, …, including "re-run `evals/` before promoting any new agent version to the deployment"), then **invoke the `/wrap-up` skill** — it owns the closing checklist: regenerate and open the overview page, the primitives recap table, the run log, 1–2 extensions tailored to their use case, and the hygiene sweep (sessions archived, key only in `.env`, no literal dates in the deployment, eval case 1 saved). When the founder says "wrap up" / "close it out" at any later point, the same skill applies.
+
+---
+
+## Fallbacks (move down one rung after two failures on a step; tell them in one sentence)
+
+1. Re-check the call against the live public docs; fix, retry once.
+2. Same step in the Console UI (their account).
+3. Drop to the closest archetype config (`references/examples-bank.md`) — known-good shapes.
+4. CMA unreachable entirely → build the same design as a local Claude Code workflow + CLAUDE.md so they still leave with a working assistant; `LAUNCH.md` becomes Next direction #1. Say honestly that this rung isn't a managed agent.
+
+Troubleshooting quick hits (401s, agent-create 400s, jq vs control chars, hung streams, `requires_action`, version conflicts, "can't see it in the Console"): bottom of `references/cma-api.md`.
+
+## References
+
+- `references/interview.md` — the interview → primitive mapping, defaults, build-kit contents, end-to-end sequencing
+- `references/cma-api.md` — verified curl/`ant` shapes for every call this skill makes
+- `references/examples-bank.md` — archetypes to offer, official cookbooks to lift patterns from, production proof points
+- `references/mock-connectors.md` — how to mock a connector that can't be wired yet (outbox / custom-tool patterns) + schemas for typical endpoints
+- `references/overview-template.html` — the agent-overview page to imitate (regenerate at: end of interview, after launch, after each iteration, at close)
+- `references/build-sheet.example.json` — the build sheet shape

--- a/skills/launch-your-agent/references/build-sheet.example.json
+++ b/skills/launch-your-agent/references/build-sheet.example.json
@@ -1,0 +1,107 @@
+{
+  "meta": {
+    "founder": "Maya Chen",
+    "company": "Brightline Analytics",
+    "problem": "Every Monday I spend ~3 hours pulling competitor pricing and feature changes into a digest for the team.",
+    "created": "2026-06-14",
+    "skill_version": "0.1"
+  },
+  "agent": {
+    "name": "competitor-digest",
+    "model": "claude-opus-4-8",
+    "model_rationale": "Newest Opus-class — the default; quality first, a weekly run still costs cents.",
+    "version": null,
+    "system_summary": "Researches the 5 named competitors' public sites, pricing pages, and changelogs; writes a weekly digest to /mnt/session/outputs/digest.md.",
+    "never_dos": [
+      "Never contact anyone or post anywhere — research and drafting only",
+      "Never present guesses as facts; mark anything unverified"
+    ]
+  },
+  "outcome": {
+    "description": "Produce this week's competitor digest as digest.md",
+    "rubric_criteria": [
+      "digest.md exists and covers all 5 competitors listed in the kickoff",
+      "Every pricing or feature change has a source link",
+      "Each competitor section ends with a one-line 'so what for us'",
+      "Anything unchanged since last week is listed in one 'no movement' line, not padded out",
+      "No claim appears without a source or an explicit 'unverified' tag"
+    ],
+    "max_iterations": 3
+  },
+  "tools": {
+    "toolset": "agent_toolset_20260401",
+    "enabled": ["bash", "read", "write", "edit", "glob", "grep", "web_search", "web_fetch"],
+    "disabled": [],
+    "permission_overrides": [],
+    "custom_tools": []
+  },
+  "connections": {
+    "mcp_servers": [],
+    "vault_credentials": [],
+    "github": null,
+    "notes": "v0 uses public web only. Roadmap: Notion MCP + vault credential to read the internal strategy page."
+  },
+  "skills": [],
+  "memory": {
+    "stores": [
+      {
+        "name": "competitor-history",
+        "access": "read_write",
+        "purpose": "What each competitor looked like last week, so the agent reports changes rather than re-describing everything."
+      }
+    ]
+  },
+  "environment": {
+    "name": "competitor-digest-env",
+    "type": "cloud",
+    "networking": "unrestricted",
+    "allowed_hosts": [],
+    "packages": {}
+  },
+  "schedule": {
+    "mode": "scheduled",
+    "cron": "0 7 * * 1",
+    "timezone": "America/Los_Angeles",
+    "human": "Every Monday at 7:00 AM Pacific",
+    "kickoff": "user.define_outcome (task + rubric above)"
+  },
+  "evals": {
+    "cases": [
+      {"name": "week-of-may-25", "input": "evals/week-of-may-25/", "expected": "The digest Maya wrote by hand that week", "last_verdict": null},
+      {"name": "week-of-jun-01", "input": "evals/week-of-jun-01/", "expected": "Hand-written digest", "last_verdict": null},
+      {"name": "week-of-jun-08", "input": "evals/week-of-jun-08/", "expected": "Hand-written digest", "last_verdict": null}
+    ],
+    "notes": "Case 1 is the v0 input; the other two are held back as a regression check before promoting any new agent version."
+  },
+  "defaults_applied": {
+    "iteration_bound": "Outcome stops after 3 grade-and-improve cycles",
+    "write_actions": "None in v0 — the agent drafts, humans send"
+  },
+  "interface": {
+    "who": "Maya + 2 teammates",
+    "how": "Digest lands as a file; Maya pastes it into Slack for now. Console for run history."
+  },
+  "next_directions": [
+    {
+      "what": "Let the agent post the digest to Slack itself",
+      "why_deferred": "Write-action to an external system — kept human-in-the-loop for v0",
+      "how": "Add the Slack MCP server + a vault credential; gate the toolset always_ask so Maya approves each post"
+    },
+    {
+      "what": "Pull the internal strategy doc into context",
+      "why_deferred": "Needs a Notion credential that wasn't on hand during the session",
+      "how": "Notion MCP server + vault mcp_oauth credential; reference the doc in the kickoff"
+    },
+    {
+      "what": "Lock networking down to only the competitor sites",
+      "why_deferred": "Hardening — unrestricted is fine while the agent is read-only",
+      "how": "Switch the environment to networking: limited with the competitor domains in allowed_hosts"
+    },
+    {
+      "what": "Re-run the 3 eval cases before promoting any new agent version",
+      "why_deferred": "Process habit, not a build task",
+      "how": "Run evals/run-evals.sh against the new version; only update the deployment when verdicts hold"
+    }
+  ],
+  "ids": {}
+}

--- a/skills/launch-your-agent/references/cma-api.md
+++ b/skills/launch-your-agent/references/cma-api.md
@@ -1,0 +1,228 @@
+# CMA API — verified command shapes
+
+> Source: platform.claude.com/docs/en/managed-agents/* (read 2026-06-14). If a call fails on a field name, the **live docs win** — check, adapt, retry once.
+> Two equivalent surfaces: `ant` CLI (`brew install anthropics/tap/ant`) and curl. The Python/TS SDKs mirror these exactly (`client.beta.<resource>.<verb>`).
+
+## Setup (every terminal)
+
+The key lives in `./my-agent/.env` (chmod 600, in `.gitignore`) — never pasted into the chat, echoed, or inlined into a command (it would land in the transcript / shell history). Easiest flow: check whether `ANTHROPIC_API_KEY` is already set in the shell env (skip the ask entirely if so — copy it into `.env` without printing it); otherwise pre-create `.env` with a placeholder, chmod 600 it, and have the founder paste the key into the file via its **absolute path** (their terminal's cwd isn't yours). If a key ever does end up in chat or an exported transcript, tell the founder to rotate it.
+
+```bash
+set -a; source .env; set +a      # ANTHROPIC_API_KEY=sk-ant-...  (founder-created at platform.claude.com → API keys)
+BASE=https://api.anthropic.com/v1
+H=(-H "x-api-key: $ANTHROPIC_API_KEY" -H "anthropic-version: 2023-06-01" \
+   -H "anthropic-beta: managed-agents-2026-04-01" -H "content-type: application/json")
+```
+
+When the founder creates the key, have them note **which workspace it belongs to** — every object created with it lands in that workspace, and the Console only shows the workspace currently selected (this is the answer to "I can't see it in the Console").
+
+Save every returned id into `IDS.env` immediately (`echo "AGENT_ID=..." >> IDS.env`); load it with `set -a; source IDS.env; set +a` so child processes (python parsers, scripts) see the variables, and make every launch step read `IDS.env` first and skip objects that already exist, so a failed step can be re-run without creating duplicates. Pattern for readable errors: `-o /tmp/resp.json -w '%{http_code}\n'`. **Parse responses with python, not jq** — session payloads embed the agent's `system` prompt with literal newlines/control characters that jq rejects:
+
+```bash
+python3 -c "import json,sys; d=json.JSONDecoder(strict=False).decode(open('/tmp/resp.json').read()); print(d['id'])"
+```
+
+## Pick a model
+
+```bash
+curl -sS "$BASE/models" "${H[@]:0:4}" | jq -r '.data[].id'
+```
+Default: newest Opus-class. Sonnet-class only if the founder explicitly wants cheaper/faster runs. Fast mode: pass model as `{"id":"claude-opus-4-8","speed":"fast"}`.
+
+## 1. Agent (versioned; create once)
+
+```bash
+# curl
+curl -sS --fail-with-body "$BASE/agents" "${H[@]}" -d @agent.json
+# ant
+ant beta:agents create --name "..." --model '{id: claude-opus-4-8}' \
+  --system "..." --tool '{type: agent_toolset_20260401}'
+```
+`agent.json` fields: `name`*, `model`*, `system`, `tools`, `mcp_servers`, `skills`, `multiagent`, `description`, `metadata`.
+Response: save `id` AND `version` (starts at 1).
+
+**Update** (new version; pass current version as concurrency guard; arrays are FULL replacement, omitted fields preserved):
+```bash
+curl -sS --fail-with-body "$BASE/agents/$AGENT_ID" "${H[@]}" \
+  -d '{"version": '$AGENT_VERSION', "system": "...new instructions..."}'
+ant beta:agents update --agent-id "$AGENT_ID" --version "$AGENT_VERSION" --system "..."
+```
+Then bump `AGENT_VERSION` in IDS.env to the returned version.
+Versions list: `GET $BASE/agents/$AGENT_ID/versions` · Archive: `POST $BASE/agents/$AGENT_ID/archive`.
+
+### Tool config patterns
+
+```jsonc
+"tools": [
+  {"type": "agent_toolset_20260401"},                                  // all 8 tools, always_allow
+  {"type": "agent_toolset_20260401",                                   // gate bash behind approval
+   "default_config": {"permission_policy": {"type": "always_allow"}},
+   "configs": [{"name": "bash", "permission_policy": {"type": "always_ask"}}]},
+  {"type": "mcp_toolset", "mcp_server_name": "linear",                 // MCP tools (default always_ask)
+   "default_config": {"permission_policy": {"type": "always_allow"}}},
+  {"type": "custom", "name": "get_weather", "description": "...",      // client-executed
+   "input_schema": {"type": "object", "properties": {...}, "required": [...]}}
+]
+"mcp_servers": [{"type": "url", "name": "linear", "url": "https://mcp.linear.app/sse"}]
+"skills": [{"type": "anthropic", "skill_id": "xlsx"},                  // xlsx | docx | pptx | pdf
+           {"type": "custom", "skill_id": "skill_abc123", "version": "latest"}]
+"multiagent": {"type": "coordinator", "agents": [{"type": "agent", "id": "agent_..."}]}
+```
+Built-in tool names: `bash read write edit glob grep web_fetch web_search`. Disable one: `configs:[{"name":"web_fetch","enabled":false}]`.
+
+## 2. Environment (reusable; not versioned)
+
+```bash
+curl -sS --fail-with-body "$BASE/environments" "${H[@]}" -d '{
+  "name": "<name>-env",
+  "config": {"type": "cloud", "networking": {"type": "unrestricted"},
+             "packages": {"pip": ["pandas"], "npm": []}}}'
+ant beta:environments create --name "<name>-env" --config '{type: cloud, networking: {type: unrestricted}}'
+```
+Limited networking: `{"type":"limited","allowed_hosts":["api.example.com","*.example.com"],"allow_mcp_servers":true,"allow_package_managers":true}` (booleans default false; hostnames only, no scheme).
+Package managers: `apt cargo gem go npm pip` (cached across sessions). Names unique per workspace.
+List/retrieve/archive/delete: standard verbs on `$BASE/environments[/:id][/archive]` (delete only if no sessions reference it).
+
+## 3. Session (one run; sandbox provisioned at create, work starts on first event)
+
+```bash
+curl -sS --fail-with-body "$BASE/sessions" "${H[@]}" -d '{
+  "agent": "'$AGENT_ID'",                         // string = latest version
+  "environment_id": "'$ENV_ID'",
+  "title": "first run",
+  "vault_ids": [],                                 // optional
+  "resources": []                                  // optional: memory_store / file / repository
+}'
+ant beta:sessions create --agent "$AGENT_ID" --environment-id "$ENV_ID" --title "first run"
+```
+Pin a version: `"agent": {"type":"agent","id":"...","version":1}`.
+Attach memory: `"resources":[{"type":"memory_store","memory_store_id":"memstore_...","access":"read_write","instructions":"..."}]` (creation-time only).
+
+Statuses: `idle` (waiting — sessions start here) · `running` · `rescheduling` · `terminated`.
+Retrieve: `GET $BASE/sessions/$SESSION_ID` (read `.status`, `.usage`, `.outcome_evaluations[]`).
+List: `GET $BASE/sessions?agent_id=$AGENT_ID` · Archive: `POST .../archive` (not while running — interrupt first) · Delete: `DELETE $BASE/sessions/$SESSION_ID`.
+Mid-session you can update a session's `agent.tools`/`agent.mcp_servers` (session-local, full replacement, must be idle): `POST $BASE/sessions/$SESSION_ID` with `{"agent":{"tools":[...],"mcp_servers":[...]}}`.
+
+## 4. Kickoff events
+
+**Outcome kickoff (default)** — task + definition of done + retry budget in one move; agent starts immediately:
+```bash
+EVT=$(jq -n --rawfile task first_prompt.txt --rawfile rubric outcome.md \
+  '{type:"user.define_outcome", description:$task,
+    rubric:{type:"text", content:$rubric}, max_iterations:3}')      # default 3, max 20
+curl -sS --fail-with-body "$BASE/sessions/$SESSION_ID/events" "${H[@]}" -d "{\"events\":[$EVT]}"
+ant beta:sessions:events send --session-id "$SESSION_ID" <<YAML
+events:
+  - type: user.define_outcome
+    description: <task>
+    rubric: {type: text, content: "<rubric markdown>"}
+    max_iterations: 3
+YAML
+```
+File rubric instead: `"rubric":{"type":"file","file_id":"file_..."}` (upload needs extra header `files-api-2025-04-14`).
+
+**Plain message kickoff / steering / resume** (steering mid-run is allowed; agent picks it up at the next turn boundary):
+```bash
+curl -sS --fail-with-body "$BASE/sessions/$SESSION_ID/events" "${H[@]}" \
+  -d '{"events":[{"type":"user.message","content":[{"type":"text","text":"..."}]}]}'
+```
+
+**Interrupt + redirect:** send `{"type":"user.interrupt"}` then a `user.message` in the same `events` array.
+**Tool confirmation** (when status_idle has `stop_reason.type == "requires_action"`):
+`{"type":"user.tool_confirmation","tool_use_id":"<event id>","result":"allow"|"deny","deny_message":"..."}`.
+**Custom tool result:** `{"type":"user.custom_tool_result","custom_tool_use_id":"<id>","content":[{"type":"text","text":"..."}]}`.
+
+## 5. Watch the run
+
+```bash
+# SSE stream — open BEFORE sending events; only post-open events are delivered. -N = don't buffer.
+curl -sS -N --fail-with-body "$BASE/sessions/$SESSION_ID/events/stream" "${H[@]}" -H "accept: text/event-stream"
+# Poll instead (python, NOT jq — the embedded system prompt breaks jq):
+curl -sS "$BASE/sessions/$SESSION_ID" "${H[@]}" -o /tmp/sess.json
+python3 -c "import json; d=json.JSONDecoder(strict=False).decode(open('/tmp/sess.json').read()); print(d['status'], [e.get('result') for e in d.get('outcome_evaluations',[])])"
+# Full history (filterable): GET $BASE/sessions/$SESSION_ID/events?types[]=agent.tool_use
+```
+Run the first poll in the foreground and confirm it parses before putting the loop in a background task — a poller that errors silently every iteration looks like "still running" for ten minutes.
+Narrate: `agent.message` (text), `agent.tool_use` (name), `span.outcome_evaluation_end` (`result` + `explanation`), `session.status_idle` (`stop_reason`: `end_turn` = done, `requires_action` = answer it), `session.error`.
+Outcome results: `satisfied` · `needs_revision` · `max_iterations_reached` · `failed` · `interrupted`.
+Runs of 8–10+ minutes are normal — say so. Also hand the founder the Console sessions view for the key's workspace so they can watch it there.
+
+## 6. Outputs
+
+Agent writes to `/mnt/session/outputs/`. Fetch:
+```bash
+curl -sS "$BASE/files?scope_id=$SESSION_ID" "${H[@]}" | jq -r '.data[] | "\(.id) \(.filename)"'
+curl -sS "$BASE/files/$FILE_ID/content" "${H[@]}" -o output.md
+ant beta:files list --scope-id "$SESSION_ID" ; ant beta:files download --file-id "$FILE_ID" --output output.md
+```
+
+## 7. Memory store (optional)
+
+```bash
+curl -sS "$BASE/memory_stores" "${H[@]}" -d '{"name":"<name>-memory","description":"<what it holds — shown to the agent>"}'
+# seed: POST $BASE/memory_stores/$MEMSTORE_ID/memories  {"path":"/context.md","content":"..."}
+# attach: session/deployment "resources" array (see §3). Mounted at /mnt/memory/.
+```
+Limits: 100kB/memory, 2,000 memories/store, 8 stores/session. Use `read_only` for reference material.
+
+## 8. Vault + credential (optional; only when a credential is in hand)
+
+```bash
+VAULT_ID=$(curl -sS "$BASE/vaults" "${H[@]}" -d '{"display_name":"<founder name>"}' | jq -r .id)
+# MCP bearer:   {"display_name":"Linear key","auth":{"type":"static_bearer","mcp_server_url":"https://mcp.linear.app/mcp","token":"..."}}
+# MCP OAuth:    {"auth":{"type":"mcp_oauth","mcp_server_url":"...","access_token":"...","expires_at":"...","refresh":{...}}}
+# Env var:      {"auth":{"type":"environment_variable","secret_name":"NOTION_API_KEY","secret_value":"...",
+#                "networking":{"type":"limited","allowed_hosts":["api.notion.com"]}}}
+curl -sS "$BASE/vaults/$VAULT_ID/credentials" "${H[@]}" -d @cred.json
+# use: pass "vault_ids": ["'$VAULT_ID'"] at session/deployment creation
+```
+Secrets are write-only. Credential `mcp_server_url` must match the agent's `mcp_servers[].url` exactly (scheme + trailing slash).
+
+## 9. Scheduled deployment (the "runs without you" finale)
+
+```bash
+curl -sS --fail-with-body "$BASE/deployments?beta=true" "${H[@]}" -d '{
+  "name": "<human name>",
+  "agent": "'$AGENT_ID'",
+  "environment_id": "'$ENV_ID'",
+  "initial_events": [ <the same kickoff event(s) as §4> ],
+  "schedule": {"type": "cron", "expression": "0 7 * * 1", "timezone": "America/Los_Angeles"}
+}'
+ant beta:deployments create <<YAML ... YAML
+```
+**`initial_events` are replayed verbatim every run** — the kickoff text must use relative dates ("today", "the last N days as of this run"), never a literal date; re-read it for hard-coded dates before sending.
+Response includes `schedule.upcoming_runs_at` — read it back to the founder to confirm.
+Optional on the same body: `vault_ids`, memory/file/GitHub `resources`.
+**Test now:** `curl -X POST -d '{}' "$BASE/deployments/$DEPLOYMENT_ID/run?beta=true" "${H[@]}"` (manual run, creates a session immediately — the explicit `-X POST` matters; a bodyless curl defaults to GET and 405s).
+Runs history: `GET $BASE/deployment_runs?deployment_id=...&has_error=true`.
+Pause / unpause / archive: `POST $BASE/deployments/$DEPLOYMENT_ID/{pause|unpause|archive}?beta=true`.
+Cron = 5-field POSIX, minute granularity, IANA timezone, wall-clock DST. Limit 1,000/org.
+
+## Cost & cleanup
+
+- Session `usage` (input/output/cache tokens) on `GET /sessions/:id` — read it after each run.
+- Rate limits: creates 300/min, reads 600/min per org.
+- End of session hygiene: archive sessions you're done with; never leave one `running`.
+
+## Console links (paste these proactively whenever something is ready to review)
+
+Deep links work — link the specific object that just became reviewable, not only the list page:
+
+- Agent: `https://platform.claude.com/workspaces/<workspace>/agents/<AGENT_ID>` (confirmed in use)
+- Deployments list (+ cron builder): `https://platform.claude.com/workspaces/<workspace>/deployments` (documented); a created deployment: `…/deployments/<DEPLOYMENT_ID>` (same pattern — confirm on first click)
+- Session: `…/workspaces/<workspace>/sessions/<SESSION_ID>` (same pattern — confirm on first click; fall back to the sessions list if it 404s)
+
+The `<workspace>` segment: use `default` until known — it resolves when the key lives in the default workspace; otherwise add a one-time "switch workspaces with the picker (Settings → API Keys shows which workspace the key belongs to)". Once the founder pastes any Console URL, lift the workspace ID from it and use it in every link after.
+
+## Troubleshooting quick hits
+
+- **401/403** → key not in `.env` / typo'd / billing issue. Fix `.env`, re-`source`, retry once.
+- **400 on agent create ("tools")** → built-in tools were listed individually. Use the toolset wrapper: `"tools": [{"type": "agent_toolset_20260401"}]` (with `configs` overrides if needed) — never `{"type":"bash"}` etc.
+- **404 on a path** → check the live docs for the exact resource path before assuming the feature doesn't exist (e.g. deployments live at `/v1/deployments`, docs page is `scheduled-deployments`).
+- **405 on deployment manual run** → the curl defaulted to GET; use an explicit `-X POST` with a `{}` body.
+- **jq: "control characters … not allowed"** → the response embeds the agent `system` prompt with literal newlines. Parse with `python3` + `json.JSONDecoder(strict=False)` instead of jq.
+- **Stream looks hung** → you forgot `-N`, or the run is just long (8–10 min is normal). Poll `.status` instead.
+- **`requires_action`** → the agent is waiting on YOU: a tool confirmation or a custom tool result. Read the last events and answer.
+- **"I can't see it in the Console"** → the Console only shows the currently selected workspace; the objects live in the workspace the API key belongs to. Settings → API Keys → find the key → switch to that workspace → Claude Managed Agents.
+- **Vault MCP auth fails** → credential `mcp_server_url` doesn't exactly match the agent's `mcp_servers[].url`.
+- **Update rejected (version conflict)** → re-fetch the agent, retry with the current `version`.

--- a/skills/launch-your-agent/references/examples-bank.md
+++ b/skills/launch-your-agent/references/examples-bank.md
@@ -1,0 +1,105 @@
+# Inspiration & example bank — Claude Managed Agents
+
+> Reference points for the skill: official cookbooks to lift config patterns from, real production deployments to anchor "what good looks like," and officially-grounded archetypes to offer as opening examples in the interview.
+> **Sourcing rule:** everything in §1–§3 traces to an official Anthropic source (cookbook, docs, or Claude/Anthropic blog). Our own unvalidated ideas live in §5 (parked) until proven.
+> Collected 2026-06-14. Live sources win over this file.
+
+## How the skill uses this bank
+
+- **In the opening (and any time during Q1):** offer the 2–3 closest archetypes (§3) as concrete examples of what an agent can be; if the founder wants a menu, AskUserQuestion with the closest few.
+- **When emitting the build kit:** if the founder's problem rhymes with a cookbook (§1), lift its config shape (tools, resources, event flow) rather than inventing one — and put the cookbook link in NEXT-DIRECTIONS.md as their "go deeper" reading.
+- **When a founder asks "is anyone actually doing this?":** the production stories (§2) are the answer.
+
+---
+
+## 1. Official Anthropic cookbooks (the canonical examples)
+
+Repo: [anthropics/claude-cookbooks → managed_agents/](https://github.com/anthropics/claude-cookbooks/tree/main/managed_agents) · rendered on [platform.claude.com/cookbook](https://platform.claude.com/cookbook/managed-agents-cma-iterate-fix-failing-tests). Python notebooks; include `utilities.py` (e.g. `stream_until_end_turn`), example data, and integration subfolders (slack/, sentry/, linear/, cma-mcp/, self_hosted_sandboxes/).
+
+### Applied cookbooks (closest to "a founder's real agent")
+
+| Cookbook | What it builds | Primitives it demonstrates | Good reference for |
+|---|---|---|---|
+| [data_analyst_agent](https://platform.claude.com/cookbook/managed-agents-data-analyst-agent) | CSV in → narrative HTML report with charts (pandas/plotly) | Environment `packages`, file mounting, streaming, artifact retrieval | Any "analyze my data and report" agent |
+| slack_data_bot | The analyst wrapped in a Slack bot; @mention with a CSV, replies continue the session | Sessions as conversations, their-app-as-interface, resuming sessions | Founders productizing an agent inside a chat surface |
+| [sre_incident_responder](https://platform.claude.com/cookbook/managed-agents-sre-incident-responder) | Pager alert → investigate → open PR → pause for human approval → merge | Event-triggered sessions (webhook), custom tools, human-in-the-loop gating, Skills | Ops/on-call agents; any "act, then wait for approval" flow |
+
+### Guided tutorials (one primitive each, end-to-end)
+
+| Tutorial | Teaches |
+|---|---|
+| [CMA_iterate_fix_failing_tests](https://platform.claude.com/cookbook/managed-agents-cma-iterate-fix-failing-tests) | **The entry point.** Agent/environment/session, file mounts, streaming event loop — via a do→observe→fix loop on a failing test suite |
+| CMA_orchestrate_issue_to_pr | Multi-turn steering: issue → fix → PR → CI → review → merge, with mid-chain recovery |
+| CMA_explore_unfamiliar_codebase | Grounding in a codebase; adding resources to a *running* session (`sessions.resources.add`) |
+| CMA_gate_human_in_the_loop | Human-in-the-loop **expense approval** via custom tools (`decide()` / `escalate()`), the `requires_action` idle bounce |
+| [CMA_prompt_versioning_and_rollback](https://platform.claude.com/cookbook/managed-agents-cma-prompt-versioning-and-rollback) | Agent versioning, regression detection, version pinning + rollback |
+| [CMA_operate_in_production](https://platform.claude.com/cookbook/managed-agents-cma-operate-in-production) | MCP toolsets, vaults for per-end-user credentials, webhooks, resource lifecycle |
+| [CMA_remember_user_preferences](https://platform.claude.com/cookbook/managed-agents-cma-remember-user-preferences) | Memory stores across sessions — customer preference learning and recall |
+| [CMA_coordinate_specialist_team](https://platform.claude.com/cookbook/managed-agents-cma-coordinate-specialist-team) | Multiagent coordinator + three scoped specialists |
+| [CMA_verify_with_outcome_grader](https://platform.claude.com/cookbook/managed-agents-cma-verify-with-outcome-grader) | Outcomes: the grade-and-revise loop (our default kickoff pattern) |
+
+**Mapping to our interview:** Q2/Q2b ↔ verify_with_outcome_grader · Q3 credentials ↔ operate_in_production · Q5 event-driven ↔ sre_incident_responder · Q7 memory ↔ remember_user_preferences · Q8 multiagent ↔ coordinate_specialist_team · iteration/eval regression ↔ prompt_versioning_and_rollback.
+
+### Worked examples inside the docs themselves
+
+- **Financial analyst building a DCF model in .xlsx** — the running example of the [Outcomes page](https://platform.claude.com/docs/en/managed-agents/define-outcomes) (rubric-graded spreadsheet deliverable) and the [Skills page](https://platform.claude.com/docs/en/managed-agents/skills) (`xlsx` skill).
+- **Weekly compliance scan** — the running example of the [Scheduled deployments page](https://platform.claude.com/docs/en/managed-agents/scheduled-deployments) (`0 20 * * 5`, America/New_York); the launch post also names **nightly data sync** and **daily digest** as the intended uses.
+- **Coding assistant** — the quickstart's default agent (write code, run it, verify the output file).
+- **Per-end-user agents with vaults** — the [Vaults page](https://platform.claude.com/docs/en/managed-agents/vaults)'s "Alice's Slack digest" pattern: one vault per end user, `external_user_id` in metadata.
+
+---
+
+## 2. Real production deployments (proof points)
+
+From [the evolution of agentic surfaces](https://claude.com/blog/building-with-claude-managed-agents) and [Claude Managed Agents: get to production 10x faster](https://claude.com/blog/claude-managed-agents):
+
+- **Notion** — custom agents launched straight from task boards; read docs/meeting notes/connected data; outputs (code, decks, sites) come back to the workspace for review. "Dozens of tasks in parallel"; an early prototype turned ~12 hours of work into ~20 minutes.
+- **Rakuten** — specialist agents across product, sales, marketing, finance; each live "within about a week."
+- **Sentry** — paired their debugging agent (Seer) with a Claude agent that writes patches and opens PRs; built "in weeks instead of months by a single engineer."
+- **Asana** — AI Teammates that pick up tasks inside existing projects/workflows.
+- **Atlassian** — developer agents inside Jira workflows.
+
+The common thread (and the pitch to founders): the agent operates **inside the systems they already use** — codebase, wiki, ticketing, chat — and the managed harness removes the infra build entirely.
+
+Also worth reading: [Scaling Managed Agents: decoupling the brain from the hands](https://www.anthropic.com/engineering/managed-agents) (Anthropic engineering) — the architecture story (brain = model+harness, hands = sandbox, session = the persistent event log), useful framing language for explaining CMA to a founder in one breath.
+
+---
+
+## 3. Archetypes to offer (every one traces to an official source)
+
+| # | Archetype | v0 (today) | Source | Natural next directions |
+|---|---|---|---|---|
+| 1 | **Data analyst** | Hand it a CSV/export → narrative HTML report with charts: what's interesting, what changed. | data_analyst_agent cookbook | Weekly scheduled deployment against a fresh export; lives in Slack via the slack_data_bot pattern; their app embeds the report |
+| 2 | **Ops responder with approval** | An alert/event → investigate → draft the fix or PR → stop and wait for human approval. | sre_incident_responder cookbook | Wire to their alerting webhook; custom tools into their backend; always_ask gates |
+| 3 | **Document-producing analyst** | A research/finance task whose deliverable is a graded artifact — e.g. a DCF model in .xlsx judged against a rubric. | Outcomes + Skills docs (DCF example) | File-based rubrics; pptx/docx variants; recurring refresh on a deployment |
+| 4 | **Engineering agent: issue → PR** | Take an issue, fix it, open the PR, recover when CI or review pushes back. | CMA_orchestrate_issue_to_pr + fix_failing_tests cookbooks | GitHub MCP + vault; triggered from their tracker; grounding pass on an unfamiliar repo first (explore_unfamiliar_codebase) |
+| 5 | **Assistant that remembers your users** | A customer-facing helper whose memory store accumulates each user's preferences across sessions. | CMA_remember_user_preferences cookbook | One memory store + one vault per end user; Dreams to consolidate |
+| 6 | **Recurring compliance / digest scan** | A scheduled sweep — weekly compliance scan, nightly data sync, daily digest — that runs and files its report without anyone present. | Scheduled-deployments docs + launch blog | Limited-networking allowlist; webhook notifications; outcome grading per run |
+| 7 | **Specialist team** | A coordinator that delegates to a small roster of scoped specialists (research / review / write) working in parallel. | CMA_coordinate_specialist_team cookbook | Per-specialist models and tools; escalation tier on Opus |
+
+Personalization rule: change only the name/company/product slots, one sentence of domain context, and the output format — the underlying config shape comes from the source cookbook/doc.
+
+---
+
+## 4. Other references
+
+- [Quickstart](https://platform.claude.com/docs/en/managed-agents/quickstart) — the minimal four-call launch; also points at `/claude-api managed-agents-onboard` inside Claude Code.
+- [What's new in Claude Managed Agents](https://claude.com/blog/whats-new-in-claude-managed-agents) — scheduled deployments + env-var vault credentials announcement (June 2026).
+- [anthropics/skills → claude-api/shared/managed-agents-overview.md](https://github.com/anthropics/skills/blob/main/skills/claude-api/shared/managed-agents-overview.md) — how Anthropic's own skills summarize CMA (tone/altitude reference for our SKILL.md).
+- Community walk-throughs exist (Substack/blog tutorials, a third-party onboarding repo) — fine as colour, but always defer to the official docs/cookbooks for API shapes.
+
+---
+
+## 5. Parked ideas — ours, not yet validated against an official example
+
+These came from our own brainstorming. They feel right for founders, several rhyme with official patterns, but **no official cookbook/doc demonstrates them end-to-end** — so they don't go in the gallery or the interview menu until we either find a source or validate one ourselves (build it, run it against a rubric, keep it if it holds up).
+
+| Idea | Why it's promising | Nearest official cousin | What validation looks like |
+|---|---|---|---|
+| **Inbox triage** (bucket emails, draft replies, never send) | Universal founder pain; great drafts-only v0 | remember_user_preferences (memory of senders), gate_human_in_the_loop (approval before send) | Build with pasted emails + rubric; check draft quality across 3 founders' inboxes |
+| **Competitive / market watch** (weekly cited digest of competitor changes) | Already our worked example in `ui/build-sheet.example.json`; natural scheduled deployment | Scheduled-deployments digest example; data analyst | Run 2–3 weeks against real competitors; verify change-detection via memory store works |
+| **Support-ticket / review summarizer** (cluster by root cause, top-3 fixes) | Every founder with users has this pile | data_analyst_agent (analysis→report) | Validate clustering quality on a real ticket export |
+| **Research-to-brief** (one question → decision-ready brief with sources) | The most general-purpose founder ask | Outcomes DCF example (graded research artifact) | Rubric on citation coverage; spot-check sources |
+| **Investor update drafter** (monthly metrics + notes → update draft) | Founder-specific, recurring, low-risk (draft only) | document-producing analyst | Validate with one founder's past updates as the golden set |
+
+Revisit trigger: when we pilot the skill with real founders, promote any parked idea that gets picked twice and survives its rubric.

--- a/skills/launch-your-agent/references/interview.md
+++ b/skills/launch-your-agent/references/interview.md
@@ -1,0 +1,257 @@
+# Founder interview → Claude Managed Agent config
+
+> How the skill turns a short, iterative interview with a technical founder into a concrete, launchable CMA configuration.
+> Companion to `cma-primitives.md` (the inventory of what we can configure).
+
+## The shape of the thing
+
+The interview is not a form — it's a **mapping exercise**. Every answer locks in one or more primitive decisions. The output is a **build sheet** (`build-sheet.json` + human-readable files) that fully determines:
+
+| Decision | Primitive(s) |
+|---|---|
+| Who the agent is, what it does, what it must never do | Agent: `name`, `system`, `model` |
+| What "done" looks like | Outcome: `description`, rubric, `max_iterations` |
+| What it needs to read/know | Tools (web), Files, GitHub resource, MCP servers + Vault creds, Memory store |
+| What it produces and where | Skills (xlsx/docx/pptx/pdf), output conventions, custom tools |
+| When it runs | Session (on-demand) vs Scheduled deployment (cron) vs their-app-triggered |
+| What software the task needs | Environment: `packages`, runtime |
+| What it's allowed to touch | Permission policies, networking allowlist, `read_only` memory |
+| One worker or several | Single agent vs multiagent coordinator + roster |
+| Whether it gets smarter | Memory store(s) + (later) Dreams |
+| Who interacts with it, and how | Their interface: terminal / internal dashboard / their product (→ vault-per-user pattern) |
+
+**Start from the defaults, build what the job needs.** The interview's job is to find what the founder's v0 actually requires beyond the starting point — not to ask about every primitive, and not to gatekeep the ones the job genuinely needs.
+
+## How CMA's architecture maps onto our constructs
+
+Anthropic's own framing of the architecture (from the engineering blog) is **brain / hands / session**: the *brain* is the model + harness (system prompt, decision logic, tool routing), the *hands* are the sandboxed execution environment, and the *session* is the persistent event log of everything that happened. Our constructs sit on top of that one-to-one:
+
+- **Brain** ↔ what the interview's Q1/Q4/Q6/Q8 produce → `agent.json` → the **Agent**, **Tools**, **Skills** cards.
+- **Hands** ↔ Q3 (packages) + Q6 (networking) → `environment.json` → the **Environment** card.
+- **Session** ↔ each run; Q5 decides who starts it (the founder, a cron, or their app) → `LAUNCH.md` / `deployment.json` → the **Deployment** card + the header's Planned/Launched status.
+- The thing CMA adds beyond brain/hands/session — the **Outcome grader** — is what our Q2/Q2b feed, and it's why the build kit treats `outcome.md` + `evals/` as first-class files rather than prompt text.
+
+### Primitive-by-primitive map
+
+| CMA primitive | Decided by | Lands in the build kit as | Card on agent-overview.html | API call at launch | Official example to lift from |
+|---|---|---|---|---|---|
+| **Agent** (name, model, system) | Q1 job, Q6 behavioral never-dos, Q8 model/budget | `agent.json` / `agent.yaml` | Agent | `POST /v1/agents` (versioned; updates = new version) | Quickstart "Coding Assistant" |
+| **Tools + permission policies** | Q3 inputs, Q4 outputs, Q6 approvals | `tools[]` in agent.json | Tools | part of agent create | Tools + Permission-policies docs |
+| **Skills** (xlsx/docx/pptx/pdf, custom) | Q4 outputs | `skills[]` in agent.json | Skills | part of agent create | Skills docs "Financial Analyst" |
+| **MCP servers + Vaults** | Q3 inputs behind logins, Q8 per-user pattern | `mcp_servers[]` + vault setup in LAUNCH.md | Connectors & vaults | `POST /v1/vaults` + `/credentials`; `vault_ids` at session/deployment | CMA_operate_in_production; Vaults docs "Alice" |
+| **Custom tools** | Q4 "trigger something in *their* product" | `tools[]` (`type: custom`) + a note in their interface plan | Tools | part of agent create; results via `user.custom_tool_result` | CMA_gate_human_in_the_loop |
+| **Multiagent** (coordinator + roster) | Q8 shape | `multiagent` in agent.json (only when earned) | Agent (roster note) | part of agent create | CMA_coordinate_specialist_team |
+| **Environment** (packages, networking) | Q3 heavy inputs, Q6 hardening | `environment.json` | Environment | `POST /v1/environments` | Environments docs "data-analysis" |
+| **Session** | Q5 = on-demand; also every eval run | `LAUNCH.md`, IDs in `IDS.env` | header status | `POST /v1/sessions` | Quickstart |
+| **Events** (kickoff, steering, interrupts, confirmations) | Q2 (kickoff content), Q6 (confirmations) | `kickoff.json`, watch section of LAUNCH.md | — (live view stays in Console) | `POST /sessions/:id/events`, SSE stream | Events-and-streaming docs |
+| **Outcome** (rubric + grader + iteration bound) | Q2 done, Q2b evidence | `outcome.md`, `first_prompt.txt`, `kickoff.json` | Outcome | `user.define_outcome` event | CMA_verify_with_outcome_grader; DCF example |
+| **Files API** | Q2b eval cases, Q3 on-hand inputs, Q4 output retrieval | `evals/` inputs, output-fetch lines in LAUNCH.md | Evals | `/v1/files` (upload, `?scope_id=` list, download) | Outcomes docs "Retrieving deliverables" |
+| **Memory stores** | Q7 learning | memory section of build sheet; seed calls in LAUNCH.md | Memory store | `POST /v1/memory_stores` + session `resources[]` | CMA_remember_user_preferences |
+| **Scheduled deployment** | Q5 = recurring | `deployment.json` | Deployment | `POST /v1/deployments` (+ manual `/run` test) | Scheduled-deployments docs "weekly compliance scan" |
+| **Webhooks** | Q5 = event-driven, or unattended monitoring | NEXT-DIRECTIONS entry (their backend subscribes) | Next directions | — | CMA_operate_in_production |
+| **Dreams** | Q7 when memory will grow messy | NEXT-DIRECTIONS entry | Next directions | — | Dreams docs |
+| **Self-hosted sandbox** | Q6 compliance/residency | NEXT-DIRECTIONS entry | Next directions | — | Self-hosted-sandboxes docs |
+
+Reading the table by column: the **interview** column is where the decision gets made, the **build kit** column is the founder's editable copy, the **card** column is how it shows up on the overview page, and the **API** column is what Phase 2 of the skill actually executes. Anything that ends up in the Next-directions column of the page never becomes an API call today — that's the definition of "deferred."
+
+### The starting point (what every build begins from)
+
+- **One agent**, newest Opus-class model, full `agent_toolset_20260401`, `always_allow`
+- **One cloud environment**, `unrestricted` networking, no extra packages
+- **Outcome kickoff** (`user.define_outcome`), text rubric, `max_iterations: 3`
+- Outputs written to `/mnt/session/outputs/`, fetched via Files API
+
+From there, **build what the job needs — scoped into versions, not gatekept by primitive**. Any primitive (MCP connector, vault, memory store, custom tool, document/custom skill, schedule, even multiagent) belongs in v0 if the core job doesn't work without it and it's wireable now (e.g. the credential is on hand). Everything the job wants but doesn't need on the first pass is laid out explicitly as **v1, v2, …** in NEXT-DIRECTIONS — a numbered sequence of planned increments, each with its mechanism — so "not in v0" reads as "scheduled for v1", never "cut".
+
+The standing recommendation (not a rule): v0 is **read/analyze/draft only** — write-actions into external systems (send/post/merge/delete/place orders) usually ship in a later version behind an `always_ask` gate, once the founder trusts the output. If the founder explicitly wants a write-action in v0, wire it gated (`always_ask`, or a sandbox/paper variant) rather than refusing — say what the recommendation is and why, then build what they choose.
+
+---
+
+## The interview
+
+Eight question clusters, run **iteratively** — never as a form. Open light: a couple of warm sentences, 2–3 archetype examples from the examples bank, then Q1 — no boundaries block, no process talk. After their first answer, let them keep explaining (one open follow-up) before any suggestions or option menus; a founder telling their story usually answers 2–4 clusters at once, so only ask what's still open. Whenever the answer space is enumerable (which task, sources, schedule time, scope options, connector now vs later), use AskUserQuestion with concrete options; keep open-ended questions to one per turn. Boundaries and caveats are raised in context, briefly, when they matter. For each cluster below: what to ask, what you're listening for, and the mapping rules.
+
+### Q1. The job — "Tell me about yourself and what you'd like to build."
+
+Open and unrestrictive — they can bring anything an agent can do: their own task, a piece of their product, a customer-facing worker, an experiment. Listening for: a job with (a) real judgment+tool work in it and (b) inputs they can actually provide. Whether it recurs only decides the cadence question later (Q5) — it is not a requirement, and "this is for my product / my users" is just as good a starting point as "this eats my week".
+
+**Maps to:** agent `name`, the core of `system`, and the archetype (ops chore / research-analyst / product probe / customer-facing worker).
+
+Rules:
+- **Let them explain first.** One open follow-up ("what would it actually do? what does a great first version look like to you?") before any reshaping, boundaries, or AskUserQuestion menus — respond to their picture, don't pre-empt it.
+- If the ask needs things agents truly can't do (live phone calls, controlling desktop GUIs, sub-second real-time reaction) → say so honestly and reshape to the nearest can-do. Keep hard limits separate from defaults: gated write-actions (send/post/place orders behind `always_ask`, or paper/sandbox variants) are possible, even in v0 if they want them — don't undersell.
+- If they describe a *pipeline* of many jobs → capture the whole pipeline, build **stage one** today; the rest goes into Next directions (and may justify multiagent later, see Q8).
+
+### Q2. Done — "Show me what a good result looks like. Concretely. What would you check to know it's right?"
+
+Ask this **after** the job is understood, under its own clearly-named step ("Outcome & evals") — never in the opening message.
+
+Listening for: checkable, binary-ish criteria. Push past "a useful summary" to "a markdown file with the 5 most important items, each with a link and one line of why".
+
+**Maps to:** the **Outcome** — `description` (the task) + rubric (markdown, per-criterion checks) + `max_iterations`.
+
+Rules:
+- 3–6 explicit criteria; each independently gradeable. Vague criteria → noisy grading.
+- If they have a known-good past example → use it: derive the rubric from what makes that example good (the docs explicitly recommend this).
+- `max_iterations`: default 3. Raise toward 5–10 only when the task is genuinely hard to nail and run cost is acceptable. (Max 20.)
+- The rubric lives in the kickoff, **not** the system prompt — so sharpening it later is free (no agent version bump).
+
+### Q2b. Evidence — "Do you have real examples we can test against? Past cases where you know what the right answer was?"
+
+Asked in the same "Outcome & evals" step as Q2, not upfront. Listening for: real historical inputs **with known-good outputs** — last month's actual emails and how they triaged them, a competitor report they wrote by hand, the spreadsheet a contractor produced, tickets they already answered. This is the founder's eval set, and most founders have one without realizing it.
+
+**Maps to:** the test/eval harness for v0 and beyond.
+
+| What they have | What we do with it |
+|---|---|
+| 2–5 real past cases with known-good results | **Golden set.** Use one as the v0 kickoff input; hold the rest back. After the rubric passes on case 1, run the held-back cases as additional sessions and compare against what they actually did. |
+| One known-good artifact, no inputs | Derive the rubric *from* it (per the Outcomes docs guidance) and use it as the reference when grading run #1. |
+| Real inputs but no "right answers" | The founder is the grader: run it, they mark each rubric criterion pass/fail by hand on run #1 — that judgment becomes sharper rubric criteria for run #2. |
+| Nothing real on hand (stealth, no data yet) | Synthesize 2–3 plausible test inputs *with them* during the interview; flag in NEXT-DIRECTIONS that the first week of real usage is the eval. |
+| Fresh-data recurring task (news, raises, monitoring) — golden answers age out by design | The rubric IS the eval. Today's first verified output gets saved as `evals/case-01/expected.md` at close — it's the regression baseline for the next agent version, not a permanent golden answer. |
+| Sensitive real data | Use it only if they're comfortable (no ZDR); otherwise have them hand-redact or synthesize look-alikes — the structure matters more than the values. |
+
+How evals actually run on CMA (no separate eval product needed):
+- **The Outcome rubric IS the per-run eval** — the grader scores every session against it and the verdict (`satisfied` / `needs_revision` / …) plus explanation is recorded on the session (`outcome_evaluations[]`).
+- **A golden-set pass = N sessions, same agent version, one per test case** (cheap to script: loop over cases, create session, kickoff with the case as input, collect verdicts + outputs). Pin the agent `version` so results are comparable.
+- **Regression check after iteration:** after any agent update (v2, v3…), re-run the golden set against the new version and diff verdicts — catches "fixed one case, broke another".
+- Session `usage` gives cost-per-case alongside quality.
+
+Rules:
+- Don't gate v0 on a big eval set — **one real case to build against + 2–4 held back** is plenty; more goes in Next directions.
+- If they picked a scheduled deployment (Q5), the golden set re-run becomes the pre-flight check before changing the deployed agent version.
+- Record in the build sheet: where the eval cases live, which session IDs were the eval runs, and the verdict per case.
+
+### Q3. Inputs — "What does it need to read or know to do this well?"
+
+Triage every input they name into one of these buckets (this is the heart of the config):
+
+| Input type | Maps to |
+|---|---|
+| Content they have on hand (docs, samples, exports) | **Files** attached to the session/deployment, or pasted into the kickoff |
+| Live public information (sites, competitors, news, docs) | `web_search` / `web_fetch` (already in the toolset) |
+| Their code | **GitHub resource** on the session/deployment |
+| A SaaS behind a login that has a remote MCP server (Slack, Linear, Notion, GitHub…) | `mcp_servers` entry + `mcp_toolset` + **Vault `mcp_oauth`/`static_bearer` credential** |
+| Any API/CLI keyed by an API key (their own backend, Stripe, Airtable…) | **Vault `environment_variable` credential** (+ host allowlisting on the credential) |
+| Internal-only services not reachable from the internet | **MCP tunnel** (research preview) — flag, don't promise |
+| Knowledge that should accumulate across runs (preferences, past decisions, what worked) | **Memory store** (see Q7) |
+
+Rules:
+- **Credential test:** if the key/token isn't available *right now*, v0 does without it — substitute public web or pasted samples, or **mock the connector** (outbox / custom-tool pattern + endpoint schemas in `mock-connectors.md`) so the agent's behaviour is already shaped for the real thing; the credentialed version is the swap, with a vault.
+- Anything sensitive: remind them the sandbox + Anthropic store session data (no ZDR) — synthesized data is fine for v0.
+- If an input requires heavy parsing libraries (PDFs, spreadsheets, specific SDKs) → **environment `packages`** (pip/npm/apt…).
+
+### Q4. Outputs — "What artifact comes out, and where does it need to land?"
+
+| Output | Maps to |
+|---|---|
+| Markdown / text / JSON report | default — `/mnt/session/outputs/`, fetched via Files API |
+| Spreadsheet, deck, doc, PDF | **Anthropic skill**: `xlsx`, `pptx`, `docx`, `pdf` |
+| A draft inside another system (PR, ticket, email draft, CRM note) | MCP write tool — **gated `always_ask`** in v0, or draft-text-only output |
+| Triggering something in *their* product/backend | **Custom tool** (they execute it; define `input_schema`; their app returns `user.custom_tool_result`) |
+| Something a human must review before it goes anywhere | keep agent draft-only; the review step lives in their interface (Q6/Q8) |
+| A repeatable house format or procedure (report template, triage checklist, brand voice) | **Custom skill** for the agent — author it now if small, otherwise NEXT-DIRECTIONS with the skill outline |
+
+Rules:
+- v0 never *sends/posts/merges/deletes* in external systems. Drafting is the deliverable; the send button stays human (or `always_ask`-gated) until they trust it. **Say what the guardrail actually is** — "the agent drafts; sending is wired later through a connector with an ask-before-send gate" — not just "it can't email".
+- When the founder names a delivery destination, name the connector route back: which MCP server, what credential it needs (vault), and whether it's wireable today or Next direction #1. If email delivery is awkward (OAuth, no Gmail MCP credential on hand), **offer Slack as the easier first delivery target** — a Slack MCP webhook/connector is usually a faster path to "it shows up where I look every morning".
+- Can't wire it now but they want the behaviour? **Mock it** (`mock-connectors.md`): the agent writes schema-true payloads to an outbox (or calls a stubbed custom tool), and the real connector becomes a one-step swap in v1.
+- When delivery is the point of the agent, **the v0 deliverable is the message itself** — the exact Slack message / email / ticket text (or schema-true payload) as the output file, ready to paste or send by hand. The next version then only adds the sending; the content and format are already proven.
+
+### Q5. Cadence — "When should this run: when you ask, on a schedule, or when something happens?"
+
+| Answer | Maps to |
+|---|---|
+| "When I ask" | Plain **sessions** (create + kickoff). Fine for v0 and for testing. |
+| "Every Monday at 7" / "nightly" / "weekly" | **Scheduled deployment**: cron `expression` + IANA `timezone`, `initial_events` carrying the kickoff. Test instantly with the manual `run` endpoint before trusting the cron. |
+| "When a customer signs up / when a PR opens / when an email arrives" | Event-driven: **their app calls the API** (create session or `deployments/run`) from their own webhook handler. CMA webhooks notify them of session lifecycle the other direction. |
+
+Rules:
+- Even for scheduled work, run everything as ad-hoc sessions first; the deployment is created **last**, once a session has passed the rubric.
+- Capture the cron line + timezone verbatim in the build sheet; warn about the 1–3am DST window only if they pick it.
+- **Cadence vs lookback consistency check:** if the run frequency and the data window disagree (e.g. daily run, 14-day lookback → mostly repeated content every run), resolve it now with one question (shorter window, less frequent run, or a memory store that tracks what's already been reported) rather than deferring it silently.
+- Anything reused on a schedule (kickoff text, system prompt) must use **relative dates** ("today", "the last N days as of this run"), never a literal date — the deployment replays the same `initial_events` every run.
+
+### Q6. Boundaries — "What must it never do? What's it allowed to spend?"
+
+Two things are handled quietly, as defaults — not a discussion:
+- **Iteration bound** via the Outcome's `max_iterations` (default 3) — the built-in stop condition. Mention once that a run costs cents; don't require any Console spend configuration.
+- Behavioral never-dos ("never contact anyone", "never present guesses as facts") → lines in `system`. Cheap, do them now.
+
+Everything else a founder raises here is **hardening, not v0** — capture it in **Next directions** (see below) with the exact mechanism so they can apply it after the session:
+
+| Concern raised | Next-direction entry (mechanism) |
+|---|---|
+| "Only touch these specific sites/APIs" | Environment `networking: limited` + `allowed_hosts` (+ `allow_mcp_servers` / `allow_package_managers`) |
+| "Ask me before it runs commands / posts anywhere" | Permission policy `always_ask` on `bash` or the relevant `mcp_toolset` (MCP already defaults to ask) — needs an interface that surfaces confirmations |
+| "Don't let it rewrite our reference docs" | Memory store attached `read_only` |
+| Compliance / data residency | Self-hosted sandbox environment on their infra |
+
+### Q7. Learning — "Should run #10 be smarter than run #1? What should it remember?"
+
+| Answer | Maps to |
+|---|---|
+| "No, each run is independent" | No memory store. Simpler. Done. |
+| "It should remember my preferences / past decisions / what it already processed" | One **memory store**, `read_write`, attached to every session/deployment; seed it with 2–3 starter memories at launch |
+| "There's reference material it should always consult but never change" | Second store, `read_only` (cheap insurance against prompt-injection poisoning) |
+| "Per-customer memory" (their product) | One store **per end user/customer**, attached per session — pairs with vault-per-user (Q8) |
+| "Memory will get messy over time" | Roadmap note: **Dreams** consolidation (research preview) |
+
+Limits to respect silently: ≤8 stores/session, ≤2,000 memories/store, small focused files.
+
+### Q8. Shape & surface — "Who uses this — just you, your team, or your customers? And where do they interact with it?"
+
+This determines two things: **multiagent or not**, and **what their interface is** (the founder's own product surface — see note at bottom).
+
+Multiagent rules (default is NO):
+- One job, one context → **single agent**. Always start here.
+- Genuinely separable specializations (different tools/credentials/models per role), or fan-out over many independent items, or an escalation tier → **coordinator + roster** (`multiagent`), depth 1, ≤20 roster / ≤25 threads. Build the single most valuable subagent first; the coordinator comes after at least one subagent works alone.
+
+Interface mapping:
+| "Who/where" | What it implies |
+|---|---|
+| Just the founder, terminal is fine | The launch scripts + `ant`/curl ARE the interface; nothing more to build |
+| Founder + small team, want visibility | Console (sessions/tracing) + the **agent-overview page** we generate. A **generated interface** (Claude Code builds it in a follow-up session — graphical output, results viewer over the Files/Sessions API, or a way to interact with the agent) is the standard tailored-extension offer here when it suits the need — v1, not v0. |
+| Their customers, inside their product | Their app calls the CMA API: session-per-user(or per-job), **vault per end user** (`metadata.external_user_id`), webhooks for completion, their own UI streams events / shows outputs / surfaces `always_ask` confirmations |
+
+Also captured here: model & budget posture — default newest Opus-class (quality first; runs still cost cents); drop to Sonnet-class only if they explicitly want cheaper/faster runs; `speed: fast` only if they ask about latency.
+
+---
+
+## Output of the interview: the build sheet
+
+Everything above lands in `./my-agent/`:
+
+| File | Contents |
+|---|---|
+| `build-sheet.json` | The full structured mapping (every primitive decision + rationale) — **this is what the primitives UI renders** |
+| `agent.json` / `agent.yaml` | The agent config (name, model, system, tools+policies, mcp_servers, skills, multiagent if any) |
+| `environment.json` | Env config (packages, networking) |
+| `outcome.md` | The rubric |
+| `kickoff.json` | The `user.define_outcome` (or `user.message`) event payload |
+| `deployment.json` | Cron schedule + initial events (only if Q5 = scheduled) |
+| `evals/` | The golden set: one folder per test case (`input.*` + `expected.md` or known-good artifact), plus `run-evals.sh` (loop: session per case, kickoff, collect `outcome_evaluations[]` verdicts + usage into `evals/results-<agent-version>.json`) |
+| `agent-overview.html` | The "spec sheet" page: a static, self-contained view of every primitive in use (agent, rubric, tools, connections, memory, schedule, evals, next directions). **Claude Code generates and regenerates it directly** — it's a workflow step in the skill (after the interview, after launch when IDs exist, after every iteration), not a script the founder runs. Template/example: `references/overview-template.html`. Live observability stays in the Console. |
+| `launch.sh` / `LAUNCH.md` | The exact create-calls in order, saving IDs to `IDS.env` |
+| `NEXT-DIRECTIONS.md` | The version plan. **Whenever something doesn't belong in v0 — at any point in the session — it goes here, in the moment**, slotted into a numbered later version (v1, v2, …) with the exact mechanism + doc link: write-actions with approval gates, network allowlists, read-only memory, vault creds not in hand, multiagent stages, self-hosted sandboxes, Dreams, the founder's productized interface. It reads as a sequence of planned releases, not a list of cuts. |
+
+`IDS.env` accumulates real IDs as objects are created (`AGENT_ID`, `AGENT_VERSION`, `ENV_ID`, `SESSION_ID`, `MEMSTORE_ID`, `VAULT_ID`, `DEPLOYMENT_ID`) — the bridge between "planned" and "live" that the UI uses.
+
+## Sequencing (v0 first, upgrades after)
+
+1. **Light open + interview** → warm welcome, 2–3 examples, the open question, then let them explain before steering; the iterative interview with boundaries raised only in context; the design read back as the brief (primitives table · v1/v2 section · eval table) and approved via AskUserQuestion; **agent-overview.html generated and opened immediately on approval** (something to look at while the rest is built), then build sheet + files emitted. Eval cases (Q2b) collected into `evals/` — case 1 becomes the v0 input, the rest are held back.
+2. **Stage** → validate payloads, write the resumable launch sequence and LAUNCH.md, `ant`/curl check — all without the key. The brief already told them what credentials to go grab and where (API key; any connector token/webhook), so by now they're fetching in parallel. Then the key step, made as easy as possible: check the shell env first (skip the ask if it's already set); otherwise pre-create `my-agent/.env` (chmod 600) and have the founder paste the key into it via its absolute path — never into the chat. Keep staging/explaining while they do. Model pick happens at launch (newest Opus-class; show the full slug from then on).
+3. **Launch v0** → env → agent → session → outcome kickoff **on eval case 1**. Watch the stream; hand them the Console link for the key's workspace.
+4. **While it runs** → regenerate agent-overview.html with live IDs; draft NEXT-DIRECTIONS; seed memory store if planned.
+5. **Grade & iterate** → read grader verdict + outputs against rubric *and against the known-good answer for case 1* (grading table); pick the next move via AskUserQuestion; change ONE thing (rubric edit = free; system/tool change = agent v2); re-kickoff. Once a version passes, fire the held-back eval cases (`run-evals.sh`) against the winning version as parallel background tasks while talking.
+6. **Make it theirs** → if scheduled: create the deployment (relative dates only in `initial_events`) + manual `run` test; eval results recorded per agent version; Next directions finalized (incl. "re-run evals before promoting any new agent version to the deployment"); then invoke `/wrap-up` — it owns the close: overview page reopened, primitives recap table, run log, 1–2 tailored extensions, hygiene sweep.
+
+---
+
+## Note on the founder's *own* interface (the FYI)
+
+The thing built here is the **worker**. How the founder (or their users) talk to it afterwards is a separate, deliberate choice captured in Q8 and written into NEXT-DIRECTIONS:
+
+- **Terminal-only** is legitimate and complete for a solo founder (scripts + `ant` + Console).
+- **Internal surface**: the agent-overview page we generate doubles as a minimal spec/status view; a **generated interface** is offered as a tailored extension when it suits the need — graphical output, a results viewer over the Files/Sessions API, or a way to interact with the agent — built by Claude Code in a follow-up session.
+- **Productized**: their app owns the UX — creating sessions/vaults per user, streaming events, rendering outputs, surfacing tool confirmations. That's their build, not ours; the build sheet gives them the API map for it.

--- a/skills/launch-your-agent/references/mock-connectors.md
+++ b/skills/launch-your-agent/references/mock-connectors.md
@@ -1,0 +1,71 @@
+# Mock connectors — design now, wire later
+
+When the founder wants a connector (Slack, email, an issue tracker, their own backend, a brokerage) that can't be wired in this session — credential not on hand, OAuth too slow, or they just want to keep moving — don't drop the capability and don't pretend it exists. **Mock it, visibly**, so v0 already behaves as if the connector were there and the later version is a swap, not a redesign.
+
+## Two mock styles
+
+**1. Outbox mock — the default; works unattended and on deployments.**
+The agent writes each would-be action as a JSON file to `/mnt/session/outputs/outbox/<seq>-<action>.json`, using the same payload shape the real call would take (schemas below). One line in the system prompt: *"You cannot send/post X directly yet. For each action you would take, write the exact payload to the outbox instead."* Add a rubric criterion that every outbox payload is complete and matches the schema. The founder can read the outbox like a queue of "what it would have done."
+Swap to real (v1): add the MCP server to `mcp_servers` + a vault credential + an `always_ask` gate, remove the outbox instruction. The payloads the agent already produces map 1:1 onto the real tool's arguments.
+
+**2. Custom-tool mock — when the founder wants to feel the interaction live.**
+Define a `custom` tool on the agent with a realistic `input_schema` (below). The agent's calls surface as `requires_action`; answer them in-session with a stubbed `user.custom_tool_result` (e.g. `{"ok": true, "id": "mock_123"}`). Good for shaping tool-call behaviour while the founder watches; **not** suitable for unattended schedules — every call blocks until something answers it. Swap to real: replace the custom tool with the real `mcp_toolset` entry.
+
+Either way: tell the founder which mock you used and why, and write the swap-to-real route into NEXT-DIRECTIONS (which MCP server, which vault credential type, which gate).
+
+## Typical endpoint schemas
+
+Use these as the outbox payload shape and/or the custom tool `input_schema`. Trimmed to the fields that matter; extend per the founder's real system.
+
+```jsonc
+// slack.post_message
+{"type":"object","required":["channel","text"],"properties":{
+  "channel":{"type":"string","description":"Channel name or ID"},
+  "text":{"type":"string","description":"Message body (markdown)"},
+  "thread_ts":{"type":"string","description":"Optional thread to reply in"}}}
+
+// email.create_draft / email.send
+{"type":"object","required":["to","subject","body_markdown"],"properties":{
+  "to":{"type":"array","items":{"type":"string"}},
+  "cc":{"type":"array","items":{"type":"string"}},
+  "subject":{"type":"string"},
+  "body_markdown":{"type":"string"},
+  "attachments":{"type":"array","items":{"type":"string"},"description":"Paths under /mnt/session/outputs/"}}}
+
+// issue.create  (Linear / Jira / GitHub Issues)
+{"type":"object","required":["title","description_markdown"],"properties":{
+  "title":{"type":"string"},
+  "description_markdown":{"type":"string"},
+  "labels":{"type":"array","items":{"type":"string"}},
+  "assignee":{"type":"string"},
+  "priority":{"type":"string","enum":["urgent","high","medium","low"]}}}
+
+// webhook.post  (the founder's own backend)
+{"type":"object","required":["url","json_body"],"properties":{
+  "url":{"type":"string"},
+  "method":{"type":"string","enum":["POST","PUT","PATCH"],"default":"POST"},
+  "headers":{"type":"object","additionalProperties":{"type":"string"}},
+  "json_body":{"type":"object"}}}
+
+// calendar.create_event
+{"type":"object","required":["title","start_iso","end_iso"],"properties":{
+  "title":{"type":"string"},
+  "start_iso":{"type":"string","description":"ISO 8601 with timezone"},
+  "end_iso":{"type":"string"},
+  "attendees":{"type":"array","items":{"type":"string"}},
+  "description":{"type":"string"}}}
+
+// crm.create_note
+{"type":"object","required":["entity","note_markdown"],"properties":{
+  "entity":{"type":"string","description":"Company/contact name or CRM ID"},
+  "note_markdown":{"type":"string"}}}
+
+// broker.place_order  (mock / paper only — real execution is always a gated later version)
+{"type":"object","required":["ticker","side","quantity","order_type"],"properties":{
+  "ticker":{"type":"string"},
+  "side":{"type":"string","enum":["buy","sell"]},
+  "quantity":{"type":"number"},
+  "order_type":{"type":"string","enum":["market","limit"]},
+  "limit_price":{"type":"number"},
+  "time_in_force":{"type":"string","enum":["day","gtc"],"default":"day"}}}
+```

--- a/skills/launch-your-agent/references/overview-template.html
+++ b/skills/launch-your-agent/references/overview-template.html
@@ -1,0 +1,332 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>competitor-digest — agent schema</title>
+<style>
+  :root {
+    /* warm paper palette (light) */
+    --bg:#faf9f5; --panel:#ffffff; --inset:#f0eee6; --ink:#141413; --body:#3d3d3a; --sub:#73726c; --mut:#9c9a92;
+    --hairline:rgba(20,20,19,.12); --hairline-soft:rgba(20,20,19,.07);
+    --live:#22865c; --live-bright:#1d7a52; --clay:#ad5724; --amber:#9a7d24; --ghost:#b0aea5;
+    --mono:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+  }
+  * { box-sizing:border-box; }
+  body { margin:0; font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+         background:var(--bg); color:var(--body); font-size:14px; line-height:1.5;
+         background-image:linear-gradient(rgba(20,20,19,.045) 1px,transparent 1px),
+                          linear-gradient(90deg,rgba(20,20,19,.045) 1px,transparent 1px);
+         background-size:46px 46px; }
+  .wrap { max-width:1320px; margin:0 auto; padding:0 22px 44px; }
+  @keyframes ledPulse { 0%,100%{opacity:1; box-shadow:0 0 0 0 rgba(34,134,92,.45);} 50%{opacity:.55; box-shadow:0 0 0 5px rgba(34,134,92,0);} }
+
+  /* ── top bar ─────────────────────────────────────────── */
+  .topbar { position:sticky; top:0; z-index:30; display:flex; align-items:center; justify-content:space-between; gap:18px;
+            background:rgba(250,249,245,.92); backdrop-filter:blur(16px); border-bottom:1px solid var(--hairline);
+            padding:12px 22px; margin:0 -22px; }
+  .ident { display:flex; align-items:center; gap:12px; min-width:0; }
+  .sigil { width:36px; height:36px; flex:none; display:flex; align-items:center; justify-content:center; border-radius:9px;
+           background:rgba(34,134,92,.10); border:1px solid rgba(34,134,92,.35); font-size:18px; }
+  h1 { margin:0; font-size:19px; font-weight:600; color:var(--ink); letter-spacing:-.01em; }
+  .statepill { display:inline-flex; align-items:center; gap:7px; padding:3px 11px; border-radius:999px; font-family:var(--mono);
+               font-size:11px; letter-spacing:.08em; }
+  .statepill.live { background:rgba(34,134,92,.10); border:1px solid rgba(34,134,92,.35); color:var(--live-bright); }
+  .statepill.planned { background:var(--inset); border:1px solid var(--hairline); color:var(--sub); }
+  .led { width:7px; height:7px; border-radius:50%; }
+  .led.live { background:var(--live); animation:ledPulse 2s ease-in-out infinite; }
+  .led.planned { background:transparent; border:1.5px solid var(--ghost); }
+  .byline { font-family:var(--mono); font-size:11.5px; color:var(--mut); margin-top:3px; }
+  .stats { display:flex; align-items:stretch; flex:none; }
+  .stat { padding:0 16px; border-left:1px solid var(--hairline); }
+  .stat:first-child { border-left:none; }
+  .stat-k { font-family:var(--mono); font-size:10px; letter-spacing:.13em; text-transform:uppercase; color:var(--mut); }
+  .stat-v { font-family:var(--mono); font-size:13.5px; color:var(--ink); margin-top:3px; white-space:nowrap; }
+  .stat-v .dim { color:var(--sub); }
+
+  .problem { margin:14px 2px 0; color:var(--sub); font-size:13.5px; max-width:95ch; }
+
+  /* ── schema pipeline ─────────────────────────────────── */
+  .lane-label { margin:18px 2px 8px; font-family:var(--mono); font-size:10.5px; letter-spacing:.16em; text-transform:uppercase; color:var(--mut); }
+  .pipeline { display:grid; grid-template-columns:minmax(240px,1fr) 28px minmax(360px,1.6fr) 28px minmax(280px,1.15fr); gap:12px; align-items:stretch; }
+  .col { display:flex; flex-direction:column; gap:12px; min-width:0; }
+  .col > .grow { flex:1; display:flex; flex-direction:column; }
+  .col > .grow .node-body { flex:1; }
+  .col-title { font-family:var(--mono); font-size:10px; letter-spacing:.16em; text-transform:uppercase; color:var(--sub); margin:0 0 -2px 2px; }
+  .joint { display:flex; align-items:center; justify-content:center; }
+  .joint::before { content:""; width:100%; height:1.5px; background:linear-gradient(90deg,var(--hairline),rgba(34,134,92,.5));
+                   clip-path:polygon(0 0,calc(100% - 8px) 0,calc(100% - 8px) -5px,100% 50%,calc(100% - 8px) 250%,calc(100% - 8px) 100%,0 100%); }
+
+  .node { background:var(--panel); border:1px solid var(--hairline); border-radius:12px; overflow:hidden; display:flex; flex-direction:column; }
+  .node.key { border-color:rgba(34,134,92,.30); }
+  .node.ghost { border-style:dashed; background:transparent; opacity:.62; }
+  .node-head { display:flex; align-items:center; gap:9px; padding:11px 14px; border-bottom:1px solid var(--hairline-soft); }
+  .node-icon { font-size:16px; line-height:1; }
+  .node-head h2 { margin:0; font-size:14.5px; font-weight:600; color:var(--ink); }
+  .node-meta { margin-left:auto; font-family:var(--mono); font-size:11px; color:var(--mut); background:var(--inset);
+               border:1px solid var(--hairline); border-radius:6px; padding:3px 8px; white-space:nowrap;
+               max-width:60%; overflow:hidden; text-overflow:ellipsis; }
+  .node-meta b { color:var(--live-bright); font-weight:500; }
+  .node-body { padding:11px 14px 13px; }
+  .node-body p { margin:.3em 0; }
+  .node-foot { margin-top:auto; padding:9px 14px 11px; border-top:1px dashed var(--hairline-soft); color:var(--sub); font-size:12.5px; }
+  .field { margin:9px 0; }
+  .field:first-child { margin-top:2px; }
+  .field-k { font-family:var(--mono); font-size:10px; letter-spacing:.12em; text-transform:uppercase; color:var(--mut); margin-bottom:3px; }
+  .sub { color:var(--sub); } .small { font-size:13px; }
+  strong { color:var(--ink); font-weight:600; }
+  code, .mono { font-family:var(--mono); font-size:12.5px; background:var(--inset); border:1px solid var(--hairline-soft);
+                padding:1px 6px; border-radius:5px; color:var(--body); }
+  .tag { display:inline-block; padding:2px 8px; border-radius:6px; font-size:12px; margin:2px 4px 2px 0;
+         background:var(--inset); border:1px solid var(--hairline); color:var(--sub); font-family:var(--mono); }
+  .tag.on { color:var(--ink); border-color:rgba(173,87,36,.5); }
+  .tag.good { color:var(--live-bright); border-color:rgba(34,134,92,.40); }
+  .tag.warn { color:var(--amber); border-color:rgba(154,125,36,.45); }
+
+  /* environment frame around the worker */
+  .env-frame { border:1px dashed rgba(20,20,19,.18); border-radius:15px; padding:11px;
+               display:flex; flex-direction:column; gap:11px; background:rgba(20,20,19,.03); height:100%; }
+  .env-tab { align-self:flex-start; max-width:100%; background:var(--bg);
+             border:1px dashed rgba(20,20,19,.2); border-radius:10px; padding:4px 11px; line-height:1.5;
+             font-family:var(--mono); font-size:11px; color:var(--sub); overflow-wrap:anywhere; }
+  .attach-grid { display:grid; grid-template-columns:1fr 1fr; gap:9px; }
+  .attach { background:var(--inset); border:1px solid var(--hairline-soft); border-radius:10px; padding:10px 12px; }
+  .attach.ghost { border-style:dashed; opacity:.58; }
+  .attach h3 { margin:0 0 4px; font-size:13px; color:var(--ink); display:flex; gap:7px; align-items:center; }
+  .attach p { margin:0; font-size:12.5px; color:var(--sub); }
+
+  /* lists */
+  ul,ol { margin:.3em 0 .3em 1.15em; padding:0; } li { margin:.3em 0; font-size:13px; }
+  ol.rubric { list-style:none; margin-left:0; counter-reset:rb; }
+  ol.rubric li { display:flex; gap:9px; counter-increment:rb; align-items:flex-start; }
+  ol.rubric li::before { content:counter(rb); flex:none; width:19px; height:19px; border-radius:5px; background:var(--inset);
+                         border:1px solid var(--hairline); display:flex; align-items:center; justify-content:center;
+                         font-family:var(--mono); font-size:11px; color:var(--live-bright); margin-top:1px; }
+
+  /* lower lanes */
+  .lane-grid { display:grid; grid-template-columns:1.1fr 1fr; gap:12px; margin-top:12px; }
+  .lane { background:var(--panel); border:1px solid var(--hairline); border-radius:12px; overflow:hidden; display:flex; flex-direction:column; }
+  .lane.full { margin-top:12px; }
+  .lane-head { display:flex; align-items:center; gap:9px; padding:11px 14px; border-bottom:1px solid var(--hairline-soft); }
+  .lane-head h2 { margin:0; font-size:14.5px; font-weight:600; color:var(--ink); }
+  .lane-meta { margin-left:auto; font-family:var(--mono); font-size:11px; color:var(--mut); }
+  .lane-body { padding:10px 14px 12px; }
+  .overflow { overflow-x:auto; }
+  table { width:100%; border-collapse:collapse; font-size:13px; }
+  th { text-align:left; font-family:var(--mono); font-size:10px; text-transform:uppercase; letter-spacing:.1em; color:var(--mut);
+       border-bottom:1px solid var(--hairline); padding:5px 8px; }
+  td { padding:6px 8px; border-bottom:1px solid var(--hairline-soft); vertical-align:top; }
+  tr:last-child td { border-bottom:none; }
+
+  /* version rail */
+  .rail { display:grid; grid-template-columns:repeat(auto-fit,minmax(240px,1fr)); gap:11px; }
+  .ver { background:var(--inset); border:1px solid var(--hairline); border-radius:10px; padding:11px 13px; position:relative; }
+  .ver-tag { font-family:var(--mono); font-size:11px; color:var(--clay); margin-bottom:4px; }
+  .ver-what { font-weight:600; font-size:13.5px; color:var(--ink); }
+  .ver-why { color:var(--sub); font-size:12.5px; margin:3px 0; }
+  .ver-how { font-size:12.5px; } .ver-how::before { content:"How: "; color:var(--clay); font-weight:600; }
+
+  a.console { color:var(--live-bright); text-decoration:none; border-bottom:1px dotted rgba(34,134,92,.5); }
+  a.console:hover { border-bottom-style:solid; }
+  footer { padding:20px 2px 0; color:var(--mut); font-family:var(--mono); font-size:11px; }
+  footer a { color:var(--sub); }
+
+  @media (max-width: 1020px) {
+    .pipeline { grid-template-columns:1fr; }
+    .joint { height:26px; }
+    .joint::before { width:1.5px; height:100%; background:linear-gradient(180deg,var(--hairline),rgba(34,134,92,.5));
+                     clip-path:polygon(0 0,100% 0,100% calc(100% - 8px),250% calc(100% - 8px),50% 100%,-150% calc(100% - 8px),0 calc(100% - 8px)); }
+    .lane-grid { grid-template-columns:1fr; }
+    .stats { display:none; }
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <!-- ── top bar: identity + live state + stat strip ── -->
+  <div class="topbar">
+    <div class="ident">
+      <div class="sigil">🤖</div>
+      <div>
+        <div style="display:flex; align-items:center; gap:10px; flex-wrap:wrap;">
+          <h1>competitor-digest</h1>
+          <!-- swap to: <span class="statepill live"><span class="led live"></span>DEPLOYED · LIVE</span> once launched -->
+          <span class="statepill planned"><span class="led planned"></span>PLANNED · NOT LAUNCHED</span>
+        </div>
+        <div class="byline">Claude Managed Agent · Maya Chen · Brightline Analytics · created 2026-06-14</div>
+      </div>
+    </div>
+    <div class="stats">
+      <div class="stat"><div class="stat-k">Model</div><div class="stat-v">claude-opus-4-8</div></div>
+      <div class="stat"><div class="stat-k">Runs</div><div class="stat-v">Mon 7:00 <span class="dim">PT</span></div></div>
+      <!-- once live, every ID on this page links to its Console deep link, e.g.
+           <a class="console" href="https://platform.claude.com/workspaces/<workspace>/agents/<AGENT_ID>">agent_…</a>
+           (same pattern for /sessions/<id> and /deployments/<id>; swap <workspace> for the founder's) -->
+      <div class="stat"><div class="stat-k">Agent</div><div class="stat-v"><span class="dim">at launch</span></div></div>
+      <div class="stat"><div class="stat-k">Deployment</div><div class="stat-v"><span class="dim">after first pass</span></div></div>
+    </div>
+  </div>
+
+  <!-- the founder's own words from the interview — quote or closely paraphrase; never invent specifics (time spent, frequency) they didn't state -->
+  <p class="problem">Every Monday I spend ~3 hours pulling competitor pricing and feature changes into a digest for the team.</p>
+
+  <!-- ── schema: trigger → worker (in its environment) → output & grading ── -->
+  <p class="lane-label">System schema</p>
+  <div class="pipeline">
+
+    <div class="col">
+      <p class="col-title">Trigger</p>
+      <!-- The trigger node matches how the agent actually starts:
+           · scheduled  → 🗓️ Deployment node (this example)
+           · on-demand  → ▶️ "On-demand session" as the primary node (meta: manual · LAUNCH.md), with
+                          "🗓️ Deployment — not scheduled, see the version rail" as a one-line footer or ghost node
+           · event-driven → 🔌 "Triggered by your app" node (their backend calls POST /sessions or /deployments/<id>/run),
+                          with the call shape named in the body -->
+      <div class="node key grow">
+        <div class="node-head"><span class="node-icon">🗓️</span><h2>Deployment</h2><span class="node-meta">cron · <b>0 7 * * 1</b></span></div>
+        <div class="node-body">
+          <div class="field"><div class="field-k">schedule · expression / timezone</div><strong>Every Monday · 7:00 AM</strong> <span class="sub small">America/Los_Angeles</span></div>
+          <div class="field"><div class="field-k">Status</div><span class="tag">created after the first run passes</span></div>
+          <div class="field"><div class="field-k">initial_events</div><p class="small sub">Each firing replays the 🎯 outcome (right) into a fresh ▶️ session in the sandbox — nobody at a keyboard.</p></div>
+        </div>
+        <div class="node-foot">▶️ Also runs on demand any time — <code>LAUNCH.md</code> fires the same agent with the same outcome.</div>
+      </div>
+    </div>
+
+    <div class="joint" aria-hidden="true"></div>
+
+    <div class="col">
+      <p class="col-title">Worker</p>
+      <div class="env-frame">
+        <span class="env-tab">📦 environment · type: cloud · networking: unrestricted · packages: none</span>
+
+        <div class="node key">
+          <div class="node-head"><span class="node-icon">🤖</span><h2>Agent — competitor-digest</h2><span class="node-meta"><b>claude-opus-4-8</b> · v1 at launch</span></div>
+          <div class="node-body">
+            <div class="field"><div class="field-k">system · the job</div>
+              <p class="small">Researches the 5 named competitors' public sites, pricing pages, and changelogs; writes a weekly digest to <code>/mnt/session/outputs/digest.md</code>.</p></div>
+          </div>
+        </div>
+
+        <div class="attach-grid">
+          <div class="attach">
+            <h3>🛠️ Tools</h3>
+            <p><code>tools[] · agent_toolset_20260401</code><br><span class="tag on">web_search</span><span class="tag on">web_fetch</span><span class="tag">bash</span><span class="tag">read</span><span class="tag">write</span><span class="tag">edit</span><span class="tag">glob</span><span class="tag">grep</span></p>
+          </div>
+          <div class="attach">
+            <h3>🧠 Memory store</h3>
+            <p><code>resources[] · memory_store</code> <span class="tag good">read_write</span> <strong>competitor-history</strong> — last week's snapshot per competitor, so runs report changes, not re-descriptions.</p>
+          </div>
+          <div class="attach ghost">
+            <h3>🔌 Connectors &amp; 🔐 vaults</h3>
+            <p><code>mcp_servers[]</code> + <code>vault_ids[]</code> — empty in v0, public web only. Notion + Slack sit in the version rail below.</p>
+          </div>
+          <div class="attach ghost">
+            <h3>📄 Skills</h3>
+            <p><code>skills[]</code> — empty; plain markdown output.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="joint" aria-hidden="true"></div>
+
+    <div class="col">
+      <p class="col-title">Output &amp; grading</p>
+
+      <div class="node">
+        <div class="node-head"><span class="node-icon">📤</span><h2>Deliverable</h2><span class="node-meta">files api</span></div>
+        <div class="node-body">
+          <p class="small"><code>digest.md</code> — the weekly competitor digest, fetched from the run's outputs.</p>
+          <div class="field"><div class="field-k">Guardrails in effect</div>
+            <span class="tag">max_iterations: 3</span><span class="tag">drafts only — no write connectors wired</span></div>
+        </div>
+      </div>
+
+      <div class="node key grow">
+        <div class="node-head"><span class="node-icon">🎯</span><h2>Outcome</h2><span class="node-meta"><b>user.define_outcome</b> · max_iterations 3</span></div>
+        <div class="node-body">
+          <p class="small sub" style="margin-bottom:8px;">Your definition of done — <code>rubric.content</code>, graded by the platform every run.</p>
+          <ol class="rubric small">
+            <li>digest.md exists and covers all 5 competitors listed in the kickoff</li>
+            <li>Every pricing or feature change has a source link</li>
+            <li>Each competitor section ends with a one-line "so what for us"</li>
+            <li>Anything unchanged since last week sits in one "no movement" line</li>
+            <li>No claim without a source or an explicit "unverified" tag</li>
+          </ol>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── evals + run log ── -->
+  <div class="lane-grid">
+    <div class="lane">
+      <div class="lane-head"><span class="node-icon">📜</span><h2>Sessions · run log</h2><span class="lane-meta">no runs yet</span></div>
+      <div class="lane-body">
+        <div class="overflow">
+        <table>
+          <thead><tr><th>Run</th><th>Session</th><th>Rubric</th><th>Verdict</th><th>Note</th></tr></thead>
+          <tbody>
+            <tr><td>—</td><td class="mono">—</td><td>—</td><td><span class="tag">no runs yet</span></td><td class="sub">The first launch fills this in.</td></tr>
+          </tbody>
+        </table>
+        </div>
+      </div>
+    </div>
+    <div class="lane">
+      <div class="lane-head"><span class="node-icon">🧪</span><h2>Evals</h2><span class="lane-meta">3 cases · regression</span></div>
+      <div class="lane-body">
+        <div class="overflow">
+        <table>
+          <thead><tr><th>Case</th><th>Known-good answer</th><th>Last verdict</th></tr></thead>
+          <tbody>
+            <tr><td class="mono">week-of-may-25</td><td>Maya's hand-written digest</td><td><span class="tag">not run yet</span></td></tr>
+            <tr><td class="mono">week-of-jun-01</td><td>Hand-written digest</td><td><span class="tag">not run yet</span></td></tr>
+            <tr><td class="mono">week-of-jun-08</td><td>Hand-written digest</td><td><span class="tag">not run yet</span></td></tr>
+          </tbody>
+        </table>
+        </div>
+        <p class="small sub" style="margin:.5em 0 0;">Case 1 is the v0 input; the rest are held back and re-run before promoting any new agent version.</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── version rail: what ships next ── -->
+  <div class="lane full">
+    <div class="lane-head"><span class="node-icon">🧭</span><h2>Next directions</h2><span class="lane-meta">the version rail</span></div>
+    <div class="lane-body">
+      <div class="rail">
+        <div class="ver">
+          <div class="ver-tag">v1</div>
+          <div class="ver-what">Agent posts the digest to Slack itself</div>
+          <div class="ver-why">Write-action — kept human-in-the-loop for v0</div>
+          <div class="ver-how">Slack MCP server + 🔐 vault credential, toolset gated <span class="mono">always_ask</span></div>
+        </div>
+        <div class="ver">
+          <div class="ver-tag">v2</div>
+          <div class="ver-what">Pull the internal strategy doc into context</div>
+          <div class="ver-why">Needs a Notion credential not on hand in the session</div>
+          <div class="ver-how">Notion MCP + vault <span class="mono">mcp_oauth</span>; reference the doc in the kickoff</div>
+        </div>
+        <div class="ver">
+          <div class="ver-tag">v3</div>
+          <div class="ver-what">Lock networking to the competitor sites only</div>
+          <div class="ver-why">Hardening — unrestricted is fine while read-only</div>
+          <div class="ver-how">Environment <span class="mono">networking: limited</span> + <span class="mono">allowed_hosts</span></div>
+        </div>
+        <div class="ver">
+          <div class="ver-tag">always</div>
+          <div class="ver-what">Re-run the eval cases before promoting a new version</div>
+          <div class="ver-why">Process habit, not a build task</div>
+          <div class="ver-how"><span class="mono">evals/run-evals.sh</span> against the new version; promote only when verdicts hold</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <footer>generated from build-sheet.json by claude code · live runs &amp; traces: <a href="https://platform.claude.com/workspaces/default/agents">open the console</a> (your key's workspace — swap "default" if yours differs)</footer>
+</div>
+</body>
+</html>

--- a/skills/wrap-up/LICENSE.txt
+++ b/skills/wrap-up/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/wrap-up/SKILL.md
+++ b/skills/wrap-up/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: wrap-up
+description: Close out (or revisit) a Claude Managed Agent build — regenerate the overview page, recap every primitive the founder now owns, show the run log and live status, suggest 1–2 tailored next upgrades, and sweep hygiene (sessions archived, key only in .env, no literal dates in deployment kickoffs). Use when the founder says "/wrap-up", "wrap up", "close it out", "where do things stand with my agent", or at the end of a /launch-your-agent build.
+license: Complete terms in LICENSE.txt
+version: 0.2.0
+dependencies: A `./my-agent/` folder from /launch-your-agent. ANTHROPIC_API_KEY in `my-agent/.env` optional — without it the wrap-up is describe-only.
+---
+
+# Wrap-up — celebrate it, show what they built, point at what's next
+
+You are closing out (or checking in on) a founder's Claude Managed Agent. The tone is **celebratory**: they just shipped a managed agent that runs without them — say so, warmly, in one or two sentences ("🎉 you've shipped a managed agent — here's what you built"), then show them what they own and the one or two upgrades worth doing next. End on the overview page, not a wall of text. This is a moment, not a checklist read-out.
+
+Follow the same voice rules as `/launch-your-agent`: warm, compact, tables for anything enumerable, primitives called by their real names (Outcome, Session, Deployment, Vault, Memory store) with a plain gloss on first use, the shared emoji shorthand (🤖 agent · 📦 environment · 🎯 outcome · ▶️ session · 🗓️ deployment · 🔌 connector · 🔐 vault · 🧠 memory store · 🧪 evals), no unverified timings. **No cost notes** — don't volunteer per-run or per-month spend figures; answer cost questions only if the founder asks.
+
+## 1. Read the state
+
+- Read `./my-agent/`: `build-sheet.json`, `IDS.env`, `NEXT-DIRECTIONS.md`, `outcome.md`, `evals/`, the existing `agent-overview.html`. (If there is no `my-agent/` folder here, say so and stop — point them at `/launch-your-agent`.)
+- If `my-agent/.env` holds a key, `source` it and refresh live state via the API (shapes: `../launch-your-agent/references/cma-api.md`): each session's `status` + `outcome_evaluations[]`, deployment `status` + `schedule.upcoming_runs_at`, latest `usage`. Parse with python (`strict=False`), never jq.
+- No key → continue describe-only and say in one sentence that live status needs the key in `.env`.
+- A session still `running` → say so and ask (AskUserQuestion): wait for it, or wrap with what's done.
+- Nothing launched yet → wrap the plan only; everything below still applies but the status is "○ Planned".
+
+## 2. Produce the wrap-up (in this order)
+
+1. **Congratulate them.** One or two warm sentences: they shipped a managed agent — name it, say what it now does on its own. 🎉
+2. **Overview page.** Regenerate `agent-overview.html` (template: `../launch-your-agent/references/overview-template.html`) with live IDs, the run log, eval verdicts, the schedule with next run times, Console links for the key's workspace, and the v1/v2 next directions. **Open it in their browser** — the page is the closing artifact; the chat below just points at it.
+3. **"Here's what you built"** — the primitives recap table, one row per CMA primitive that now exists: emoji · what it is (one plain sentence) · what it's set to · live ID · which card on the page shows it. Final muted row(s) for primitives deliberately not used → "see NEXT-DIRECTIONS". Follow with the run log table (run · rubric version · verdict · one-line note).
+4. **"Here's what's next"** — 1–2 extensions picked from the v1/v2 plan that matter most for *this* use case, pitched concretely: what it does for them, what it takes, how small the change is. The rest of the plan stays written down. Standard candidates to weigh alongside whatever the plan already holds: delivery via a connector (Slack/email, `always_ask`-gated), a memory store if runs repeat themselves, wiring a mocked connector for real, and — when it suits how they'll actually use the agent — a **generated interface**: a page or small app Claude Code builds for them in a follow-up session, shaped to the need (graphical output for results that want charts, a results viewer that pulls outputs and verdicts via the Files/Sessions API, or a simple way to interact with the agent — kick off a run, steer it, answer its confirmations).
+5. **Hygiene sweep — quiet by default.** Do the sweep (archive finished sessions; check the deployment's `initial_events` for literal dates; check the key only ever lived in `.env`; save a passed run as `evals/case-01/expected.md` if there's no golden case yet) and **fix silently what you can**. Only mention something if it's materially relevant — i.e. the founder must act (a key that touched chat → rotate; a literal date you can't patch without their say-so) or it changes how they use the agent. No "✅ all good" lists.
+6. **Last words** — one short line: everything lives in their Console (platform.claude.com → Claude Managed Agents, in the key's workspace), this folder recreates it anywhere (`LAUNCH.md`), and they can rerun `/wrap-up` whenever they want a fresh picture.
+
+## Notes
+
+- Idempotent: running it again just refreshes the page and tables.
+- Don't re-litigate design decisions here — this skill reports and suggests; changes go through `/launch-your-agent` (or a plain conversation) afterwards.


### PR DESCRIPTION
## What this adds

Two companion skills under `skills/`:

- **`launch-your-agent`** — walks a technical founder from "here's what I want an agent to do" to a live Claude Managed Agent in their own account: an iterative interview maps the idea onto CMA primitives (Agent, Environment, Outcome, Memory store, Vault, Deployment), the skill stages a build kit, launches it, grades the first run against a user-defined outcome rubric, iterates, and creates a scheduled deployment when the job should run on a clock. Everything that doesn't fit the first version is written into a numbered v1/v2 plan rather than dropped.
- **`wrap-up`** — the close-out and later status check: regenerates the agent overview page, recaps every primitive that now exists (with live IDs and Console links), shows the run log, and suggests the next one or two upgrades. `launch-your-agent` invokes it at the end of a build; it also works standalone on any folder the main skill produced.

Supporting references ride inside the `launch-your-agent` folder: the interview-to-primitive mapping, verified curl/CLI shapes for every API call the skill makes, a sourced examples bank, connector-mocking patterns with typical endpoint schemas, and the overview page template. Each skill folder carries its own Apache-2.0 `LICENSE.txt` and the `license` frontmatter line, following the existing convention.

## Why

There's strong coverage in this repo for document and developer-tool skills; this adds a worked example of a *builder* skill — one that takes a person from intent to a running, graded, scheduled Managed Agent using only their own API key.

## How it was validated

Exercised end-to-end in three full builds (interview → launch → grade → iterate → scheduled deployment), with friction from each run folded back into the skill. API call shapes were checked against the public Managed Agents documentation.

## Notes for reviewers

- `wrap-up` reuses `../launch-your-agent/references/` to avoid duplicating the API reference; the two folders are intended to land together. Happy to rename it (e.g. `agent-wrap-up`) if a less generic name is preferred — that's a one-line cross-reference change.
- `.claude-plugin/marketplace.json` is untouched; happy to add both skills to the `example-skills` plugin list if you'd like them installable that way.