### PR TITLE
Add codeact skill — sandboxed Python execution (50–70% token savings)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -38,7 +38,8 @@
         "./skills/slack-gif-creator",
         "./skills/theme-factory",
         "./skills/web-artifacts-builder",
-        "./skills/webapp-testing"
+        "./skills/webapp-testing",
+        "./skills/codeact"
       ]
     }
     ,

--- a/skills/codeact/LICENSE.txt
+++ b/skills/codeact/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Anthropic, PBC.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/codeact/SKILL.md
+++ b/skills/codeact/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: codeact
+description: |
+  Collapse multi-step tool chains into a single sandboxed Python run.
+  Use instead of chained tool calls when a task reads 8+ files,
+  cross-references multiple file sets, or needs 5+ sequential tool calls.
+  NOT beneficial for simple grep-then-view workflows (≤5 files).
+  ESPECIALLY valuable when MCP servers are loaded — fewer turns means the
+  MCP tool catalog context is replayed fewer times.
+  Trigger on: "codeact", "sandbox execution", "batch file ops",
+  "collapse tool calls", "for each file", "chain tools".
+---
+
+# CodeAct — Sandboxed Python Execution
+
+Collapse multi-step tool chains into a single sandboxed Python run. Instead
+of N sequential tool calls (model → tool → model → tool …), write one Python
+program that chains all the work together and executes it in one turn.
+
+## Why
+
+Each tool call replays the full conversation context — system prompt, tool
+definitions, prior messages. With MCP servers loaded, every server's tool
+catalog adds to that overhead. Collapsing N calls into one program eliminates
+the replay.
+
+Measured savings on real tasks:
+
+| Task | Turns | Input tokens | Savings |
+|------|:-----:|:------------:|:-------:|
+| Test coverage + 4 MCP servers | 6 → 2 | 335K → 103K | **69%** |
+| Full project function index | 4 → 2 | 130K → 57K | **57%** |
+| Docstring coverage | 3 → 2 | 86K → 56K | **49%** |
+
+## Prerequisites
+
+Install the plugin first. Add to `~/.claude/settings.json`:
+
+```jsonc
+{
+  "extraKnownMarketplaces": {
+    "codeact-rajatverma-p": {
+      "source": {
+        "source": "github",
+        "repo": "RajatVerma-p/claude-codeact-plugin"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "codeact@codeact-rajatverma-p": true
+  }
+}
+```
+
+Then run `/codeact-install` in Claude Code. It auto-detects the best backend
+for your machine and writes the instructions file. Restart the session to load.
+
+## Backends
+
+| Backend | Startup | Python | Requires |
+|---------|:-------:|:------:|:---------|
+| **monty** | ~1ms | Subset (no classes, no match/case) | Python 3.10+ |
+| **hyperlight** | ~680ms | Full 3.10–3.13 | Python 3.10–3.13, `/dev/kvm` on Linux |
+
+Auto-detection picks hyperlight on Linux with KVM, monty everywhere else.
+Force a specific backend with `/codeact-install-monty` or
+`/codeact-install-hyperlight`.
+
+## Usage
+
+Once installed, write a single Python program using sandbox functions instead
+of individual tool calls.
+
+### Monty backend — functions called directly
+
+```python
+for f in glob(pattern="**/*.py", paths="src"):
+    try:
+        content = view(path=f)
+    except Exception:
+        continue
+    todos = [l for l in content.split("\n") if "TODO" in l]
+    if todos:
+        print(f + ": " + str(len(todos)) + " TODOs")
+```
+
+### Hyperlight backend — functions via `call_tool()`
+
+```python
+for f in call_tool('glob', pattern='**/*.py', paths='src'):
+    try:
+        content = call_tool('view', path=f)
+    except Exception:
+        continue
+    todos = [l for l in content.splitlines() if 'TODO' in l]
+    if todos:
+        print(f"{f}: {len(todos)} TODOs")
+```
+
+## Sandbox tools
+
+`view`, `create`, `edit`, `glob`, `bash`, `sql`, `web_fetch`, `github_api`,
+`mcp_call` — auto-discovered at install time based on what's available on
+the host.
+
+## Rules
+
+- **One bash call, one program.** Do not scout with separate tool calls first.
+  Write one program that globs, reads, analyzes, and prints results.
+- **Wrap file reads in try/except.** One bad file should not abort the run.
+- **Keep output minimal.** Print summaries and key findings only — not raw
+  file contents. Output must fit in a single tool response (~5 KB).
+- **Skip for small tasks.** Direct tool calls have less overhead for ≤5 files
+  or single grep → view → done workflows.
+
+## Return types (critical — wrong assumptions cause retries)
+
+- `glob` → **list of strings** like `["src/app.py", "src/utils.py"]`
+- `view` → **string** (full file content)
+- `bash` → **dict** with `stdout`, `stderr`, `returncode`
+- `mcp_call` → **string**
+
+## Source
+
+Plugin repo: [RajatVerma-p/claude-codeact-plugin](https://github.com/RajatVerma-p/claude-codeact-plugin)  
+Adapted from: [jsturtevant/copilot-codeact-plugin](https://github.com/jsturtevant/copilot-codeact-plugin)


### PR DESCRIPTION
## What this adds

A `codeact` skill that teaches Claude to collapse multi-step tool chains into a
single sandboxed Python execution instead of N sequential tool calls.

## Why it matters

Each tool call replays the full conversation context — system prompt, tool
definitions, prior messages. With MCP servers loaded, every server's tool
catalog adds to that overhead. One program eliminates the replay.

Measured savings on real tasks:

| Task | Turns | Input tokens | Savings |
|------|:-----:|:------------:|:-------:|
| Test coverage + 4 MCP servers | 6 → 2 | 335K → 103K | **69%** |
| Full project function index | 4 → 2 | 130K → 57K | **57%** |
| Docstring coverage | 3 → 2 | 86K → 56K | **49%** |

Savings compound when MCP servers are loaded.

## Design

The skill is a single `SKILL.md` — no scripts in this repo. It covers:
- When to use codeact vs direct tool calls (the ≥8 files / ≥5 tool calls threshold)
- Both backends (Monty and Hyperlight) with syntax examples for each
- Return type gotchas that cause retries if wrong
- A prerequisite install step pointing to the plugin repo

The backends (sandboxed Python runtimes) live at
[RajatVerma-p/claude-codeact-plugin](https://github.com/RajatVerma-p/claude-codeact-plugin),
itself adapted from [@jsturtevant](https://github.com/jsturtevant)'s original
Copilot CLI plugin under MIT.

## Files changed

- `skills/codeact/SKILL.md` — skill instructions
- `skills/codeact/LICENSE.txt` — Apache 2.0
- `.claude-plugin/marketplace.json` — adds `./skills/codeact` to `example-skills`

cc @rlancemartin — happy to adjust scope, wording, or placement based on your feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)