### PR TITLE
Fix typo: 'unblids' -> 'unblinds' in analyzer.md

### DIFF
--- a/skills/skill-creator/agents/analyzer.md
+++ b/skills/skill-creator/agents/analyzer.md
@@ -4,7 +4,7 @@ Analyze blind comparison results to understand WHY the winner won and generate i
 
 ## Role
 
-After the blind comparator determines a winner, the Post-hoc Analyzer "unblids" the results by examining the skills and transcripts. The goal is to extract actionable insights: what made the winner better, and how can the loser be improved?
+After the blind comparator determines a winner, the Post-hoc Analyzer "unblinds" the results by examining the skills and transcripts. The goal is to extract actionable insights: what made the winner better, and how can the loser be improved?
 
 ## Inputs
 


### PR DESCRIPTION
Fixes a typo in `skills/skill-creator/agents/analyzer.md`: 'unblids' → 'unblinds'.