### PR TITLE
fix(skill-creator): match real skill name in eval trigger detection (#1338)

### DIFF
--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -32,6 +32,24 @@ def find_project_root() -> Path:
     return current
 
 
+def _skill_triggered(tool_name, tool_input, skill_name, clean_name):
+    """Whether this tool call actually invoked the target skill.
+
+    Field-scoped to avoid false positives: Claude Code invokes the skill by its
+    real name (e.g. {"skill": "<skill_name>"}); clean_name is the randomized temp
+    command filename. Read calls are matched on file_path only. Matching the whole
+    serialized input would let a short, common skill name (e.g. "test", "pdf")
+    match echoed argument text and over-count triggers.
+    """
+    if tool_name == "Skill":
+        invoked = (tool_input.get("skill") or "").strip()
+        return invoked == skill_name or invoked == clean_name
+    if tool_name == "Read":
+        fp = tool_input.get("file_path") or ""
+        return skill_name in fp or clean_name in fp
+    return False
+
+
 def run_single_query(
     query: str,
     skill_name: str,
@@ -144,12 +162,19 @@ def run_single_query(
                             delta = se.get("delta", {})
                             if delta.get("type") == "input_json_delta":
                                 accumulated_json += delta.get("partial_json", "")
-                                if clean_name in accumulated_json:
-                                    return True
 
                         elif se_type in ("content_block_stop", "message_stop"):
                             if pending_tool_name:
-                                return clean_name in accumulated_json
+                                # accumulated_json is now the complete tool input;
+                                # field-check it. Only ever early-return True so the
+                                # full-message path stays the authoritative decider.
+                                try:
+                                    parsed_input = json.loads(accumulated_json)
+                                except json.JSONDecodeError:
+                                    parsed_input = {}
+                                if _skill_triggered(pending_tool_name, parsed_input, skill_name, clean_name):
+                                    return True
+                                pending_tool_name = None
                             if se_type == "message_stop":
                                 return False
 
@@ -161,9 +186,7 @@ def run_single_query(
                                 continue
                             tool_name = content_item.get("name", "")
                             tool_input = content_item.get("input", {})
-                            if tool_name == "Skill" and clean_name in tool_input.get("skill", ""):
-                                triggered = True
-                            elif tool_name == "Read" and clean_name in tool_input.get("file_path", ""):
+                            if _skill_triggered(tool_name, tool_input, skill_name, clean_name):
                                 triggered = True
                             return triggered
 


### PR DESCRIPTION
Fixes the trigger-detection bug reported in #1338.

> Supersedes #1339, which was auto-closed after an accidental force-push corrupted its branch history (blowing the diff up to the whole tree). History rebuilt; this PR is the intended single-file change.

## Problem

`run_eval.py`'s `run_single_query()` installs the skill under a randomized command name stored in `clean_name`:

```python
clean_name = f"{skill_name}-skill-{unique_id}"   # e.g. "change-delivery-skill-38eea5"
```

Detection then checks whether **`clean_name`** appears in the skill invocation. But Claude Code invokes the skill by its **real name**, not the randomized filename. Captured `tool_use` from a real run:

```json
{"skill": "change-delivery", "args": "..."}
```

`"change-delivery-skill-38eea5"` is never a substring of `"change-delivery"`, so the match is `False` 100% of the time. Every query — including textbook matches — scores "not triggered," making `run_eval`, `run_loop`, and the description optimizer non-functional on current Claude Code: every candidate description scores identically (100% precision / 0% recall), so the optimizer has no signal.

## Fix

Add a field-scoped `_skill_triggered()` helper, used by **both** detection paths (streamed events and full assistant message):

- **Skill** calls: exact-match the real skill name (`skill_name`) — or `clean_name` — on the `skill` field.
- **Read** calls: match on `file_path`.

Field-scoping (rather than substring-matching the whole serialized input) avoids the *inverse* failure mode: a short, common skill name like `test` or `pdf` would otherwise match echoed argument text and over-count triggers. The streamed early-detection is preserved, but the stream path can now only early-return `True` — the full-message path stays authoritative, so it can't reintroduce the original false-negative.

## Verification

Claude Code `2.1.140`, model `claude-opus-4-8`, the only change being this patch:

| Matcher | should-trigger | should-not-trigger |
| --- | --- | --- |
| before (`clean_name` only) | **0 / 10** | 10 / 10 (pass only because nothing ever triggers) |
| after (this PR) | **8 / 10** | 10 / 10 |

The remaining 2 should-triggers are genuine model behavior (it self-serves those tasks), not detection misses. Additionally a topically-adjacent negative (`"rename our deliveryPlan variable to plan…"`) stays correctly untriggered, and a unit check confirms a `pdf`-named skill no longer false-positives on a `convert report.pdf` argument.

## Note for maintainers

Verified on Claude Code `2.1.140`, where the model invokes via `{"skill": "<skill_name>"}`. The helper exact-matches that field (plus `clean_name`); if other CLI versions use a different invocation shape, only `_skill_triggered()` needs adjusting.

Refs #1338