### PR TITLE
fix: Windows cp1252 encoding crashes in DOCX validator (non-ASCII print, binary XML read)

### DIFF
--- a/skills/docx/scripts/office/validators/base.py
+++ b/skills/docx/scripts/office/validators/base.py
@@ -760,7 +760,7 @@ class BaseSchemaValidator:
                 )
                 schema = lxml.etree.XMLSchema(xsd_doc)
 
-            with open(xml_file, "r") as f:
+            with open(xml_file, "rb") as f:
                 xml_doc = lxml.etree.parse(f)
 
             xml_doc, _ = self._remove_template_tags_from_text_nodes(xml_doc)

--- a/skills/docx/scripts/office/validators/docx.py
+++ b/skills/docx/scripts/office/validators/docx.py
@@ -246,7 +246,7 @@ class DOCXSchemaValidator(BaseSchemaValidator):
 
         diff = new_count - original_count
         diff_str = f"+{diff}" if diff > 0 else str(diff)
-        print(f"\nParagraphs: {original_count} → {new_count} ({diff_str})")
+        print(f"\nParagraphs: {original_count} -> {new_count} ({diff_str})")
 
     def _parse_id_value(self, val: str, base: int = 16) -> int:
         return int(val, base)


### PR DESCRIPTION
Bug 1 — docx.py line 249: The → character can't be encoded by Windows console (cp1252). Fix: use ASCII ->
Bug 2 — base.py line 763: open(xml_file, "r") with no encoding specified defaults to cp1252 on Windows. numbering.xml contains byte 0x8f (undefined in cp1252), so it crashes when reading. Fix: open in binary mode so lxml handles XML encoding detection itself.