### PR TITLE
Add compuute-scan skill — MCP server security scanner

### DIFF
--- a/skills/compuute-scan/SKILL.md
+++ b/skills/compuute-scan/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: compuute-scan
+description: Scan a public GitHub MCP-server repository for security issues before installing or connecting to it. Calls the hosted compuute-scan API at scan.compuute.se and returns severity counts, a 0-100 score, the most severe findings, and an honest triage disclaimer. Use BEFORE recommending or installing an unfamiliar MCP server, BEFORE wiring an agent to an unknown server, or as supply-chain due diligence on agent tooling. Do NOT use as a confirmed-vulnerability list — raw output has ~90% false-positive rate by design; treat findings as a triage queue.
+---
+
+# compuute-scan — MCP server security scanner
+
+This skill calls the hosted compuute-scan API to statically analyze a public GitHub MCP-server repository against 37 L1 rules across TypeScript/JavaScript, Python, Go, Rust, C#, Java, and Kotlin.
+
+## When to use
+
+- Before installing or connecting an agent to an MCP server you do not own
+- Before recommending an MCP server to a user
+- As part of supply-chain due diligence on third-party agent tooling
+- For procurement or compliance evidence on MCP code under review
+
+## When NOT to use
+
+- For private repositories — the hosted API only accepts public GitHub URLs
+- As a confirmed-vulnerability list — the scanner is a pattern-breadth detector, not an exploitability oracle; raw output has ~90% false-positive rate before manual triage
+- For non-MCP code — rules are tuned for MCP server patterns; for general code use a generic SAST tool
+
+## How to invoke
+
+The skill calls a single HTTP endpoint. No API key needed for the free tier.
+
+```bash
+bash scan.sh https://github.com/<org>/<repo>
+```
+
+The script wraps `curl` and pretty-prints the JSON response. It returns:
+
+- `summary` — counts of critical / high / medium / low findings + files scanned
+- `score` — 0-100 (higher = safer)
+- `recommendation` — short string verdict ("AVOID", "REVIEW", "OK")
+- `top_findings` — up to 10 most severe with file + line + rule ID
+- `performance` — clone seconds + scan seconds
+- `_disclaimer` — explicit pattern-match-not-exploitability framing
+
+## Honest framing
+
+compuute-scan is open-source MIT (Apache-compatible) and run by Compuute AB (Stockholm). Historical false-positive rate is ~90% on raw output, anchored against the modelcontextprotocol/servers reference repo (138 raw → 13 confirmed after triage). Per-rule FP rates are published at https://github.com/Compuute/compuute-scan-api/blob/main/docs/FP-RATES.md.
+
+Treat the output as a triage queue: high-severity findings are signals worth reviewing, not confirmed vulnerabilities. The `_disclaimer` field in every response repeats this.
+
+## Examples
+
+Scan the reference MCP servers repo:
+
+```bash
+bash scan.sh https://github.com/modelcontextprotocol/servers
+```
+
+Expected: a high finding count (the repo deliberately contains intentionally-permissive examples) and a low score. Triage the top findings against the threat model of the specific server you would actually deploy.
+
+Scan a specific vendor's MCP server before installing:
+
+```bash
+bash scan.sh https://github.com/microsoft/azure-devops-mcp
+```
+
+Expected: a focused, low-noise report. If the score is high and recommendation is "OK", the server passed the breadth check — but still review the top findings before connecting an agent to it.
+
+## Paid tier (for autonomous agents)
+
+For agents that need to scan without account setup, the same scanner is available via x402 micropayments at $0.10 USDC per scan on Base L2:
+
+```
+POST https://scan.compuute.se/v1/scan/pay
+X-Payment: <signed x402 payment payload>
+```
+
+The 402 challenge tells the agent what scheme, network, asset, and amount are required. Settlement is verified by Coinbase x402 facilitator.
+
+## Source and methodology
+
+- Hosted API source: https://github.com/Compuute/compuute-scan-api (MIT)
+- Scanner source: https://github.com/Compuute/compuute-scan (MIT)
+- Methodology paper: https://github.com/Compuute/compuute-scan-api/tree/main/docs/whitepaper
+- SOC 2 readiness statement: https://github.com/Compuute/compuute-scan-api/blob/main/docs/compliance/soc2-readiness.md
+- A2A Agent Card: https://scan.compuute.se/.well-known/agent.json
+
+## Provider
+
+Compuute AB, Stockholm. Contact: daniel@compuute.se. Security disclosure: security@compuute.se (90-day coordinated disclosure window).

--- a/skills/compuute-scan/scan.sh
+++ b/skills/compuute-scan/scan.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# compuute-scan skill — thin wrapper around the hosted scan API.
+#
+# Usage:
+#   bash scan.sh <github_url>
+#
+# Returns: pretty-printed JSON report from scan.compuute.se with severity
+# counts, score, top findings, and the honest-framing _disclaimer field.
+#
+# Exit codes:
+#   0 — scan completed (report printed to stdout)
+#   1 — bad usage (missing or malformed URL argument)
+#   2 — API error (HTTP non-2xx)
+set -euo pipefail
+
+REPO_URL="${1:-}"
+if [ -z "$REPO_URL" ]; then
+  echo "usage: bash scan.sh <github_url>" >&2
+  echo "example: bash scan.sh https://github.com/modelcontextprotocol/servers" >&2
+  exit 1
+fi
+
+case "$REPO_URL" in
+  https://github.com/*) ;;
+  *)
+    echo "error: only public GitHub HTTPS URLs are supported" >&2
+    exit 1
+    ;;
+esac
+
+API="https://scan.compuute.se/v1/scan"
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+
+HTTP_CODE="$(curl -sS -o "$TMP" -w '%{http_code}' \
+  -X POST "$API" \
+  -H 'Content-Type: application/json' \
+  -H 'User-Agent: compuute-scan-skill/0.1' \
+  --data "{\"repo_url\": \"$REPO_URL\"}")"
+
+if [ "$HTTP_CODE" != "200" ]; then
+  echo "error: scan API returned HTTP $HTTP_CODE" >&2
+  cat "$TMP" >&2
+  exit 2
+fi
+
+if command -v jq >/dev/null 2>&1; then
+  jq . "$TMP"
+else
+  cat "$TMP"
+fi


### PR DESCRIPTION
## Summary

Adds a new skill, `skills/compuute-scan/`, that calls the hosted compuute-scan API (open-source MIT) to triage public GitHub MCP-server repos against 37 L1 rules across TypeScript/JavaScript, Python, Go, Rust, C#, Java, and Kotlin.

The skill is small and self-contained:
- `SKILL.md` — frontmatter (name + description) + when-to-use, when-NOT-to-use, examples, honest framing
- `scan.sh` — thin curl wrapper around `POST https://scan.compuute.se/v1/scan`

## Why this fits the skill model

Claude calls scan.compuute.se directly via the wrapper script; no SDK install, no server-side credentials. Returns JSON the model can reason over.

Use cases the description targets:
- Before connecting an agent to an MCP server you do not own
- Supply-chain due diligence on third-party MCP tooling
- Procurement / compliance evidence

## Honest framing built in

The scanner is a pattern-breadth detector, not an exploitability oracle. Raw FP rate is ~90% (anchored on modelcontextprotocol/servers: 138 raw → 13 confirmed). The skill description AND every API response carry that disclaimer so Claude treats results as a triage queue, not a confirmed-vulnerability list. Per-rule FP rates are published at [docs/FP-RATES.md](https://github.com/Compuute/compuute-scan-api/blob/main/docs/FP-RATES.md).

## Background

- Hosted API source (MIT): https://github.com/Compuute/compuute-scan-api
- Scanner source (MIT): https://github.com/Compuute/compuute-scan
- Live service: https://scan.compuute.se
- A2A Agent Card: https://scan.compuute.se/.well-known/agent.json
- Methodology paper: https://github.com/Compuute/compuute-scan-api/tree/main/docs/whitepaper
- Operator: Compuute AB, Stockholm; daniel@compuute.se

## Test plan

- [ ] Smoke-tested locally: `bash skills/compuute-scan/scan.sh https://github.com/Compuute/compuute-scan` returns the expected JSON report from the live API (verified 2026-06-24).
- [ ] Frontmatter parses (`name` + `description` per template/SKILL.md).
- [ ] Script handles bad input (non-GitHub URL → exit 1, API error → exit 2).