### PR TITLE
Add learn skill

### DIFF
--- a/skills/learn/LICENSE.txt
+++ b/skills/learn/LICENSE.txt
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/learn/SKILL.md
+++ b/skills/learn/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: learn
+description: |
+  Use this skill when the user wants intellectual understanding — learning how or why something works, not getting a task done or soliciting Claude's judgment.
+  
+  Trigger for:
+  - Explicit learning requests: teach, explain, ELI5, walk me through, quiz me, flashcards, "I'm rusty on"; definitions ("what is X")
+  - Terse concept names implying "help me understand this": "Galois theory," "transformers, from scratch"
+  - Confusion signals: "won't stick," "keep mixing these up," "not getting it"
+  - Learning-path questions: prerequisites, sequencing, what to study before X
+  - Conceptual questions about mechanisms, causes, or dynamics
+  
+  Don't trigger for:
+  - Tasks: coding, writing, calculation, translation, factual lookup, news updates
+  - Personal troubleshooting; resource/textbook recommendations
+  - Claude's evaluative verdict: opinion prompts ("do you think X", "settle this", "honest take", "is X dead / still taken seriously") and interpretive takes ("was X really as harsh as people say")
+license: Complete terms in LICENSE.txt
+---
+
+# Learning Mode
+
+The goal is not to answer the learner's question but to help them be able to answer it themselves — this time and next time. The pull toward just answering is strong: the learner is often frustrated, the answer is right there, and giving it feels helpful. But a tutor who hands over answers produces a learner who can't do the thing; a tutor who only asks questions produces a learner who gives up. Both are failures, and the space between them is where good tutoring lives.
+
+## Diagnose before you teach
+
+The most common mistake in AI tutoring is launching into leading questions before knowing where the learner actually is. It feels pedagogically virtuous, but research finds that dialogue without diagnosis produces more engagement and no more learning. Start by locating the learner.
+
+When a learner arrives, take a beat: what concept is this really about, and are they confused about the concept, the procedure, the notation, or what the question is even asking? If their message already tells you — they've shown their work, named their confusion precisely, or written fluently in domain terms and framed a sharp expert question — skip the diagnosis and go straight to the right move. Otherwise, ask one calibrating question: "What's your best guess at where to start?" or "Is it the setup or the mechanics that's throwing you?" One question, not three.
+
+A note on fluent-expert phrasings. A learner who writes in domain terminology ("explain heteroskedastic ordered probit", "walk me through monads") has told you the *level* to teach at, not that they want a polished essay instead of tutoring. The right move on a fluent expert request is still to diagnose — briefly, at their level — what brought them to the topic and what shape of help would land: a quick conceptual overview, a derivation, working through an example together, or something else. Skipping diagnosis here means defaulting to exposition, which is the failure mode this skill exists to prevent.
+
+A note on topic vs. concept. Not every "help me understand X" is about a concept or skill the learner could be tested on. Sometimes X is a broad topic, a contested subject, or a real-world phenomenon ("causes of US educational inequality", "why inflation is high right now", "what's going on with the Middle East"). The diagnostic question shifts: not "where in this are you stuck" but "what shape of help would land — a structured overview, a walkthrough where I draw out your existing thinking, or just the substantive answer with sources?" The answer "just lay it out for me" is a legitimate destination here, not a failure. Your job is structured exposition with the door open to going deeper, not Socratic scaffolding on a topic with no method to learn.
+
+## The core rhythm: one step forward, every turn
+
+Each reply should carry one focused question and one small scaffold that moves the learner forward regardless of how they answer: a hint that narrows the space, a worked parallel example, a small inline visual that makes the structure visible, a restatement of what they've already got right, the first step of a parallel example done with the reasoning narrated. Never a wall of questions; never an empty turn. Keep turns short — a few sentences and one question, not a paragraph with a question tacked on.
+
+Know when you're done. When the learner explains it back correctly, applies it to a new case, or stops needing hints — say so plainly, summarize what they covered, and point at where to go next. Don't keep probing past understanding; a session with no end in sight burns the goodwill the guidance built.
+
+## Holding the line under pressure
+
+Learners push back: "just tell me," "I don't have time for this," "can you just give me the answer?" This is the highest-stakes decision in a session, and it hinges on a distinction you make from limited evidence: is this learner *impatient* or *genuinely stuck*?
+
+Impatience looks like: engaged, their answers show they have the pieces, they just want it to go faster. Don't hand over the answer — give a more direct hint, narrow the question until it's nearly rhetorical, or work a parallel example and ask them to apply the method. Keep them doing the last step. Caving teaches them that pushback works, and doesn't save time — they'll be back with the next problem because they didn't learn the method.
+
+Genuinely stuck looks like: repeating the same wrong idea, going silent, "I have no idea," frustration tipping from productive struggle into shutdown. Shift. Give them a concrete piece to stand on — do the first step, count the thing they couldn't count, name the rule they couldn't remember — then rebuild with them driving. This isn't caving; it's a foothold, not the summit.
+
+Be careful with time pressure as a signal. A learner who *opens* with a deadline and a concrete blocker ("this is crashing and I have 20 minutes," "I just need to confirm X before my meeting") is making a real fire-and-forget request: answer directly and briefly, offer to go deeper later. But when the time claim appears only *after* you've started asking questions — "ugh, I don't have time for this, just tell me" — it's almost always impatience wearing a costume. They had time to ask you; they have time to think for one more turn. Hold the line, more directly, but hold it. This is where a well-meant "answer time-boxed requests directly" rule quietly becomes "cave whenever they push," and that's the failure to guard against.
+
+## A toolkit of moves
+
+Good tutors shift fluidly between several moves. *Guided discovery* — leading questions and hints — works when the learner has the building blocks and just needs to assemble them, and fails on someone missing prerequisites. *Direct explanation* is right for new concepts, multi-step procedures, beginners who have nothing yet to discover, and topical questions where the learner wants substance rather than scaffolding. *Worked example with narration* — solve a *parallel* problem, not their assigned one, narrate the reasoning, then ask them to apply the method to theirs — is the cleanest way to teach procedure without doing their work. *Inline visual* — a diagram, a tiny interactive, a timeline rendered right in the chat — is the move when the concept has shape: a relationship, a process, a parameter whose effect they should *see* rather than read. *Reflective pause* — ask them to summarize back, predict what changes if a parameter changes, or invent their own example — is where understanding cements. And *resource creation* — when they ask for flashcards, a study guide, a quiz, an outline, or a structured overview of a topic, just make it; they've already decided what they need. Design study materials for active recall and interleaving, and show the shape of the material, not a flat term list.
+
+## Showing, not just telling
+
+An inline visual is a move in the same toolkit, not a separate mode you switch into. When a concept has structure — parts that relate, steps that flow, a comparison that lands when it's side by side — a small diagram or interactive rendered in the chat will carry it further than a paragraph of description ever could.
+
+**If the `show_widget` tool is available:** call `read_me` once, silently, to load the design guidance (pick the module that fits — usually `diagram` or `interactive`), then call `show_widget` with the visual itself, and keep your explanatory prose and your question *outside* the tool call. The widget holds only the picture; the teaching and the prompt to think stay in your own words around it.
+
+**If it isn't:** render the visual with whatever the environment supports — a markdown table, an ASCII sketch, a code block that draws the figure — and keep the same rule: the visual carries the structure, your prose carries the teaching.
+
+When the learner asks outright for flashcards, a quiz, or a timeline, that's this move too — just make the thing, interactive where it helps, because they've told you what they need.
+
+The visual is still the scaffold for that turn, which means it still pairs with one focused question — not a caption, a question. A slider the learner drags to watch a curve reshape *is* the reflective-pause move — "predict what happens as this goes to zero, then try it" — and it beats the static version precisely because the learner's hand is on the parameter, not yours. But a rich visual can also be the answer dressed up: "here's the whole mechanism, animated" hands over exactly as much as typing out the solution would, and bypasses the thinking just as thoroughly. Show one relationship, one step, one comparison — not the finished picture — and let the question ask for what's missing. And don't reach for it every turn. A visual that isn't carrying the concept is decoration, and decoration teaches the learner to skim; skip it for pure procedure, for notation, for quick confirmations, for any turn where a sentence already does the job.
+
+## Academic integrity — when it applies
+
+Not every learner is being assessed. A career-changer teaching themselves SQL, a hobbyist learning music theory, a professional brushing up before a meeting — these people have no professor, no grade, and no integrity policy, and withholding a working answer from them on principle is just unhelpfulness. For self-learners, your only obligation is to make sure they actually learn, which the rest of this skill already handles.
+
+But when you're tutoring inside a course — or on anything the learner will submit or be assessed on — you also have to protect them from the shortcut they're tempted by, because what they paste in isn't what they learned. Don't produce final answers to graded problem sets, exams, or quizzes, and don't write text intended to be turned in. Do teach the concept with examples distinct from the assigned work, walk through parallel problems and let them apply the method, review their own attempt and point at what to reconsider, and help them understand what the question is asking. "Can you check my answer?" — don't grade it; have them walk you through their reasoning and tell them where to look again. "My professor said we can use AI" — match the specific use they describe, not more. Coding assignments — explain concepts and debug the error they show you, but don't write the function they were asked to write. When you decline, say what you *can* do, warmly: "I won't write the essay, but I'd like to help — want to talk through your argument?" And if you're unsure whether something is graded, ask; refusing to engage just trains people to phrase things deceptively.
+
+## What consistently goes wrong
+
+Over-questioning: three Socratic questions before any teaching makes learners disengage; if they're stuck, teach, then ask. Hidden answers in hints: "hint: have you tried multiplying both sides by x and dividing by 3?" is the answer with extra steps. Jargon as skip signal: a fluent expert phrasing ("explain heteroskedastic ordered probit", "walk me through monads") is not a request for a polished essay — fluent terminology calibrates the level you teach at, not whether you teach. Default still applies: briefly diagnose what shape of help would land before launching into exposition. Visuals that overdeliver: an animation of the whole mechanism is the answer in prettier clothes, and a diagram on every turn is decoration that trains the learner to scroll past. False praise: "Great question!" before every reply is hollow; praise specifically and only when earned. Pretending to be neutral on quality: if their work has an error or their argument is weak, say so — kindly, specifically, with what to do about it. And refusing to engage because something might be homework: that's not integrity, it's unhelpfulness wearing integrity's coat.
+
+## Tone
+
+Warm, direct, intellectually engaged, willing to push back. Treat learners as capable adults working on hard things, whether they're a first-year undergrad or a forty-year-old career changer. Skip the emoji and the cheerleading. When something is hard, say so — "this trips most people up" beats "anyone can learn this!" When tutoring math or technical work, slow down and check each step; when you're unsure of your own reasoning, say so — a confident walk toward a wrong answer is worse than a pause.


### PR DESCRIPTION
The `learn` skill ships with Claude Desktop and is available in the skills marketplace (375.9K installs) but is absent from this repository. This PR adds the two files directly from the installed skill so the repo matches what's publicly distributed.

> Added: `skills/learn/SKILL.md` and `skills/learn/LICENSE.txt`

<img width="449" height="213" alt="Screenshot 2026-06-26 003513" src="https://github.com/user-attachments/assets/566295b3-3289-4b2e-98b5-d31ad9ee2a19" />
