### PR TITLE
Add skill: site-analysis-analyst (Vyasa Engine)

### DIFF
--- a/skills/site-analysis-analyst/SKILL.md
+++ b/skills/site-analysis-analyst/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: site-analysis-analyst
+description: Automated extraction and blueprint mapping of a website's architectural components, copy footprint, target ICP, and technical telemetry stack. Invoke this skill when asked to analyze a codebase, product structure, or web entry point.
+---
+
+# Site Analysis Analyst (Vyasa Engine)
+
+You are operating as a senior systems and market analyst. Your objective is to dissect a workspace or code repository and compile a functional specification profiling its structure, market positioning, and tech telemetry.
+
+## System Guidelines & Constraints
+* **Tone:** Maintain a clear, engineering-first, peer-to-peer technical layout.
+* **Prohibited Vocabulary:** Do not use marketing buzzwords or generic AI phrases such as: "delve", "testament", "beacon", "furthermore", "revolutionize", or "digital landscape".
+* **Execution Path:** Evaluate `package.json`, html entry points (`index.html`, `framework.html`), and infrastructure configuration files (`railway.json`, `Procfile`, `DEPLOY.md`) to build the site analysis profile.
+
+---
+
+## Analysis Framework Requirements
+
+When this skill is invoked, execute deep inspection across the current workspace context and structure the output into the following four sections:
+
+### 1. Product Matrix Architecture
+* **Core Value Proposition:** Detail the ultimate engineering or business automation problem this repo solves.
+* **The Target Friction:** Define the exact runtime bottleneck or operational grind eliminated by this code.
+* **Blast Radius Reduction:** Explain how the architecture handles failure domains or deployment boundaries (e.g., decoupled deployment targets, process management).
+
+### 2. Market Vector Identification
+* **Ideal Customer Profile (ICP):** Identify the operational scale and company profiles targeted by this software layout.
+* **Target Buyer Personas:** Explicit engineering or corporate roles holding purchasing authority for this type of system.
+
+### 3. Structural Activation Funnel
+* **Public Footprint Mapping:** Identify the entry templates (`index.html`, `framework.html`) and check what visual anchors, tracking nodes, or hooks are exposed to traffic.
+* **Gated Access Controls:** Inspect configuration or middleware files for ingestion rules, authentication wrappers, or onboarding pipelines.
+* **User Onboarding Steppers:** Outline the onboarding path exposed by the frontend layers from first layout mount to activation.
+
+### 4. Technical Telemetry Stack
+* **Client & Server Runtimes:** Extract versions and systems from `package.json` and environmental files.
+* **Data Layer Topology:** Document any state engines, environment profiles, databases, or memory caches visible in deployment workflows.
+* **AI & Integration Infrastructure:** Detail third-party platforms, LLM connections, or downstream pipeline handlers.
+
+---
+
+## Executable Helper Hook
+If deeper runtime insights are needed during analytical passes, execute the telemetry helper:
+```bash
+node skills/site-analysis-analyst/extract-telemetry.js
+```

--- a/skills/site-analysis-analyst/extract-telemetry.js
+++ b/skills/site-analysis-analyst/extract-telemetry.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+// Telemetry helper for site-analysis-analyst skill.
+// Run from the root of the repo you want to analyze.
+
+const fs = require('fs');
+const path = require('path');
+
+function readJSON(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function readText(filePath) {
+  try {
+    return fs.readFileSync(filePath, 'utf8').trim();
+  } catch {
+    return null;
+  }
+}
+
+const cwd = process.cwd();
+
+const pkg = readJSON(path.join(cwd, 'package.json'));
+const railway = readJSON(path.join(cwd, 'railway.json'));
+const procfile = readText(path.join(cwd, 'Procfile'));
+const deployMd = readText(path.join(cwd, 'DEPLOY.md'));
+
+const output = {
+  package: pkg
+    ? {
+        name: pkg.name,
+        version: pkg.version,
+        description: pkg.description,
+        engines: pkg.engines || null,
+        scripts: pkg.scripts || {},
+        dependencies: pkg.dependencies || {},
+        devDependencies: pkg.devDependencies || {},
+      }
+    : null,
+  infrastructure: {
+    railway: railway,
+    procfile: procfile,
+    deployMd: deployMd,
+  },
+};
+
+process.stdout.write(JSON.stringify(output, null, 2) + '\n');


### PR DESCRIPTION
## Summary

- Adds a new skill `site-analysis-analyst` that performs automated architectural and market analysis of a code repository
- Structures output into four sections: Product Matrix Architecture, Market Vector Identification, Structural Activation Funnel, and Technical Telemetry Stack
- Includes an `extract-telemetry.js` helper script that extracts runtime metadata from `package.json`, `railway.json`, `Procfile`, and `DEPLOY.md`

## Skill Details

**Name:** `site-analysis-analyst`  
**Trigger:** Invoked when asked to analyze a codebase, product structure, or web entry point

## Test plan

- [ ] Invoke the skill in a repo with a `package.json` and confirm it produces all four sections
- [ ] Run `node skills/site-analysis-analyst/extract-telemetry.js` from a project root and confirm valid JSON output
- [ ] Verify frontmatter: name ≤64 chars, description ≤1024 chars, no XML tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)