### PR TITLE
Update mcp-builder + skill-creator model defaults to claude-sonnet-5

### DIFF
--- a/skills/mcp-builder/reference/evaluation.md
+++ b/skills/mcp-builder/reference/evaluation.md
@@ -485,7 +485,7 @@ positional arguments:
 optional arguments:
   -h, --help            Show help message
   -t, --transport       Transport type: stdio, sse, or http (default: stdio)
-  -m, --model           Claude model to use (default: claude-3-7-sonnet-20250219)
+  -m, --model           Claude model to use (default: claude-sonnet-5)
   -o, --output          Output file for report (default: print to stdout)
 
 stdio options:
@@ -596,7 +596,7 @@ If many evaluations fail:
 ### Timeout Issues
 
 If tasks are timing out:
-- Use a more capable model (e.g., `claude-3-7-sonnet-20250219`)
+- Use a more capable model (e.g., `claude-sonnet-5`)
 - Check if tools are returning too much data
 - Verify pagination is working correctly
 - Consider simplifying complex questions

--- a/skills/mcp-builder/scripts/evaluation.py
+++ b/skills/mcp-builder/scripts/evaluation.py
@@ -220,7 +220,7 @@ TASK_TEMPLATE = """
 async def run_evaluation(
     eval_path: Path,
     connection: Any,
-    model: str = "claude-3-7-sonnet-20250219",
+    model: str = "claude-sonnet-5",
 ) -> str:
     """Run evaluation with MCP server tools."""
     print("🚀 Starting Evaluation")
@@ -315,13 +315,13 @@ Examples:
   python evaluation.py -t sse -u https://example.com/mcp -H "Authorization: Bearer token" eval.xml
 
   # Evaluate an HTTP MCP server with custom model
-  python evaluation.py -t http -u https://example.com/mcp -m claude-3-5-sonnet-20241022 eval.xml
+  python evaluation.py -t http -u https://example.com/mcp -m claude-sonnet-5 eval.xml
         """,
     )
 
     parser.add_argument("eval_file", type=Path, help="Path to evaluation XML file")
     parser.add_argument("-t", "--transport", choices=["stdio", "sse", "http"], default="stdio", help="Transport type (default: stdio)")
-    parser.add_argument("-m", "--model", default="claude-3-7-sonnet-20250219", help="Claude model to use (default: claude-3-7-sonnet-20250219)")
+    parser.add_argument("-m", "--model", default="claude-sonnet-5", help="Claude model to use (default: claude-sonnet-5)")
 
     stdio_group = parser.add_argument_group("stdio options")
     stdio_group.add_argument("-c", "--command", help="Command to run MCP server (stdio only)")

--- a/skills/skill-creator/references/schemas.md
+++ b/skills/skill-creator/references/schemas.md
@@ -225,7 +225,7 @@ Output from Benchmark mode. Located at `benchmarks/<timestamp>/benchmark.json`.
   "metadata": {
     "skill_name": "pdf",
     "skill_path": "/path/to/pdf",
-    "executor_model": "claude-sonnet-4-20250514",
+    "executor_model": "claude-sonnet-5",
     "analyzer_model": "most-capable-model",
     "timestamp": "2026-01-15T10:30:00Z",
     "evals_run": [1, 2, 3],


### PR DESCRIPTION
## What

Update the sample/default model strings in `mcp-builder` and `skill-creator` from older Sonnet snapshots to the current first-party alias `claude-sonnet-5`:

- **`skills/mcp-builder/scripts/evaluation.py`** — `run_evaluation(model=...)` default and the `-m/--model` argparse default: `claude-3-7-sonnet-20250219` → `claude-sonnet-5`; the usage example's `-m claude-3-5-sonnet-20241022` → `claude-sonnet-5`.
- **`skills/mcp-builder/reference/evaluation.md`** — the two doc references to the default / suggested model.
- **`skills/skill-creator/references/schemas.md`** — the `executor_model` example `claude-sonnet-4-20250514` → `claude-sonnet-5`.

No logic changes — only the default/example model identifiers.

## Why

`claude-sonnet-5` is the current first-party Sonnet alias, so `evaluation.py` runs on the latest Sonnet out of the box and the reference docs stay accurate.

Background on how we ran into it: we're [Tallyfy](https://tallyfy.com), and we operate a public, Claude-powered MCP server ([mcp.tallyfy.com](https://mcp.tallyfy.com) · [docs](https://tallyfy.com/products/pro/integrations/mcp-server/) · [public source](https://github.com/tallyfy/mcp-public)). While migrating our own Claude Sonnet usage to Sonnet 5 across our stack, we re-validated our server with `mcp-builder`'s `evaluation.py` and noticed it still defaulted to `claude-3-7-sonnet-20250219`. This PR just brings the sample defaults current.

## Scope / non-goals

Intentionally does **not** touch the `claude-api` skill — that one documents old→new model *migration paths* and needs to keep the historical model IDs to stay useful. Only `mcp-builder` and `skill-creator` sample defaults are updated here.
