### PR TITLE
fix: make web-artifacts-builder work on pnpm >=10.1 with font inlining

### DIFF
--- a/skills/web-artifacts-builder/scripts/bundle-artifact.sh
+++ b/skills/web-artifacts-builder/scripts/bundle-artifact.sh
@@ -16,9 +16,11 @@ if [ ! -f "index.html" ]; then
   exit 1
 fi
 
+PNPM_CONFIG_ARGS=(--config.strict-dep-builds=false --config.verify-deps-before-run=false)
+
 # Install bundling dependencies
 echo "📦 Installing bundling dependencies..."
-pnpm add -D parcel @parcel/config-default parcel-resolver-tspaths html-inline
+pnpm "${PNPM_CONFIG_ARGS[@]}" add -D parcel @parcel/config-default parcel-resolver-tspaths html-inline
 
 # Create Parcel config with tspaths resolver
 if [ ! -f ".parcelrc" ]; then
@@ -37,11 +39,101 @@ rm -rf dist bundle.html
 
 # Build with Parcel
 echo "🔨 Building with Parcel..."
-pnpm exec parcel build index.html --dist-dir dist --no-source-maps
+pnpm "${PNPM_CONFIG_ARGS[@]}" exec parcel build index.html --dist-dir dist --no-source-maps
 
 # Inline everything into single HTML
 echo "🎯 Inlining all assets into single HTML file..."
-pnpm exec html-inline dist/index.html > bundle.html
+pnpm "${PNPM_CONFIG_ARGS[@]}" exec html-inline dist/index.html > bundle.html
+
+echo "🔤 Inlining font assets..."
+node <<'EOF'
+const fs = require("fs");
+const path = require("path");
+
+const htmlPath = path.resolve("bundle.html");
+const distDir = path.resolve("dist");
+const fontMimeTypes = {
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+};
+
+if (!fs.existsSync(htmlPath) || !fs.existsSync(distDir)) {
+  process.exit(0);
+}
+
+function walk(dir) {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = path.join(dir, entry.name);
+    return entry.isDirectory() ? walk(fullPath) : [fullPath];
+  });
+}
+
+const fontFiles = new Map();
+for (const file of walk(distDir)) {
+  const ext = path.extname(file).toLowerCase();
+  if (!fontMimeTypes[ext]) {
+    continue;
+  }
+
+  const relativePath = path.relative(distDir, file).split(path.sep).join("/");
+  fontFiles.set(relativePath, file);
+  fontFiles.set(path.basename(file), file);
+}
+
+if (fontFiles.size === 0) {
+  console.log("   No emitted font files found.");
+  process.exit(0);
+}
+
+let inlinedCount = 0;
+const html = fs.readFileSync(htmlPath, "utf8");
+const updatedHtml = html.replace(/@font-face\s*{[^}]*}/g, (fontFaceBlock) =>
+  fontFaceBlock.replace(/url\((['"]?)([^'")]+)\1\)/g, (match, _quote, rawUrl) => {
+    const url = rawUrl.trim();
+    if (/^(?:data:|https?:|\/\/|#)/i.test(url)) {
+      return match;
+    }
+
+    const urlPath = url.split(/[?#]/)[0];
+    const ext = path.extname(urlPath).toLowerCase();
+    if (!fontMimeTypes[ext]) {
+      return match;
+    }
+
+    let decodedPath;
+    try {
+      decodedPath = decodeURIComponent(urlPath);
+    } catch {
+      decodedPath = urlPath;
+    }
+
+    const normalizedPath = decodedPath.replace(/^\/+/, "");
+    const candidates = [
+      path.resolve(distDir, normalizedPath),
+      fontFiles.get(normalizedPath),
+      fontFiles.get(path.basename(normalizedPath)),
+    ].filter(Boolean);
+
+    const fontPath = candidates.find((candidate) => fs.existsSync(candidate));
+    if (!fontPath) {
+      return match;
+    }
+
+    const fontExt = path.extname(fontPath).toLowerCase();
+    const fontData = fs.readFileSync(fontPath).toString("base64");
+    inlinedCount += 1;
+    return `url("data:${fontMimeTypes[fontExt]};base64,${fontData}")`;
+  }),
+);
+
+if (updatedHtml !== html) {
+  fs.writeFileSync(htmlPath, updatedHtml);
+}
+
+console.log(
+  `   Inlined ${inlinedCount} font file reference${inlinedCount === 1 ? "" : "s"}.`,
+);
+EOF
 
 # Get file size
 FILE_SIZE=$(du -h bundle.html | cut -f1)

--- a/skills/web-artifacts-builder/scripts/init-artifact.sh
+++ b/skills/web-artifacts-builder/scripts/init-artifact.sh
@@ -61,8 +61,13 @@ pnpm create vite "$PROJECT_NAME" --template react-ts
 # Navigate into project directory
 cd "$PROJECT_NAME"
 
+cat > pnpm-workspace.yaml << 'EOF'
+strictDepBuilds: false
+verifyDepsBeforeRun: false
+EOF
+
 echo "🧹 Cleaning up Vite template..."
-$SED_INPLACE '/<link rel="icon".*vite\.svg/d' index.html
+$SED_INPLACE '/<link rel="icon"/d' index.html
 $SED_INPLACE 's/<title>.*<\/title>/<title>'"$PROJECT_NAME"'<\/title>/' index.html
 
 echo "📦 Installing base dependencies..."


### PR DESCRIPTION
## Summary
On pnpm >= 10.1 the web-artifacts-builder scripts broke: `pnpm add`/`exec` now fail on unbuilt dependencies unless configured, and bundled artifacts dropped their fonts (only the favicon path was handled).

## Changes
Pass `--config.strict-dep-builds=false --config.verify-deps-before-run=false` to the pnpm invocations so bundling works on pnpm >= 10.1, broaden the favicon-link removal, and inline emitted `woff`/`woff2` font files into `bundle.html` as base64 data URIs so the single-file artifact renders fonts. External/`data:`/absolute URLs are left untouched.

Fixes #1362
