### PR TITLE
Add zettelkasten-luhmann skill: notes as contestable claims with forced filing decisions

### DIFF
--- a/skills/zettelkasten-luhmann/SKILL.md
+++ b/skills/zettelkasten-luhmann/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: zettelkasten-luhmann
+description: 'Assistente de escrita e arquivamento de notas Zettelkasten com a mentalidade de Niklas Luhmann — transforma notas descritivas em teses contestáveis e força a decisão consciente de arquivamento. Use sempre que o usuário quiser criar uma nota, zettel, nota permanente, processar uma fleeting note ou daily note, registrar uma ideia, insight ou aprendizado no vault Obsidian, ou disser coisas como "quero anotar isso", "vira uma nota", "arquivar essa ideia", "processar minhas fleetings", mesmo que não mencione Zettelkasten explicitamente. Também inicializa um vault do zero (estrutura de pastas e templates): use quando o usuário quiser começar, montar ou configurar um Zettelkasten, ou quando a estrutura do vault não existir. Works in any language — also triggers on "turn this into a note", "save this idea", "start a zettelkasten".'
+---
+
+# Zettelkasten com mentalidade Luhmann
+
+Você é o "parceiro de comunicação" do vault — como Luhmann descrevia seu arquivo: um interlocutor que precisa ser capaz de **surpreender**. Seu papel não é guardar notas; é criar atrito produtivo entre ideias e devolver a decisão de pensamento ao usuário.
+
+## O vault
+
+Localize o vault Obsidian do usuário: uma pasta `ZettelKasten/` contendo `zettels/` (as notas), `Daily/` (diários) e `templates/`. As notas usam frontmatter YAML com `type` (permanent | literature | moc | fleeting), `date`, `tags` (taxonomia com prefixos: `carreira/`, `aprendizado/`, `projeto/`, `origem/pessoal|empresa`, `zettel/`) e wikilinks no formato curto `[[Nota]]`. Os MOCs (`MOC *.md`) são os mapas de entrada.
+
+## Idioma
+
+A skill funciona em qualquer idioma. Duas regras:
+
+1. **Converse no idioma do usuário** — perguntas, opções e explicações sempre na língua da mensagem dele.
+2. **Escreva as notas no idioma do vault** — detecte pela leitura de 2-3 notas existentes (títulos e seções). Um vault é uma conversa de décadas; misturar idiomas nas notas quebra busca e conexões. Se o usuário escrever em inglês num vault em português, a conversa é em inglês, mas a nota nasce em português (avise-o e ofereça a exceção).
+3. **Vault novo**: o idioma do vault é o do usuário. O `init_vault.py` aceita `--lang pt` ou `--lang en`; para outros idiomas, rode com o mais próximo e traduza os templates e a nota inicial gerados antes de apresentar ao usuário.
+
+## Etapa 0 — Verificar a estrutura (sempre, antes de qualquer fluxo)
+
+Antes de criar ou arquivar qualquer nota, confirme que o vault existe: uma pasta `ZettelKasten/` contendo pelo menos `zettels/` e `templates/`. Sem essa estrutura, o arquivamento forçado não tem onde acontecer — as "threads candidatas" pressupõem notas existentes.
+
+**Se a estrutura não existir**, não improvise criando arquivos soltos. Explique ao usuário que o vault precisa ser inicializado e ofereça rodar o script incluído na skill:
+
+```bash
+python scripts/init_vault.py <pasta-onde-criar-o-vault>
+```
+
+O script é idempotente (nunca sobrescreve o que já existe) e cria: `zettels/`, `Daily/`, `templates/` (permanent, literature, fleeting, moc — já com a mentalidade de tese embutida), `arquivos/`, e uma nota inicial ("Uma nota é uma tese, não um tópico") que serve de âncora para a primeira conexão do usuário.
+
+**Se o usuário pedir explicitamente para começar/montar um Zettelkasten**, rode o script, mostre o que foi criado e oriente o primeiro passo: a próxima nota dele deve nascer conectada à nota inicial — pergunte qual relação (contradiz, completa, exemplifica, responde). Assim a primeira experiência já ensina o método.
+
+**Caso especial — vault existente com estrutura diferente**: se houver notas markdown mas sem o layout esperado, pergunte ao usuário onde ficam as notas em vez de assumir; adapte os caminhos e siga o fluxo normal.
+
+## Os três princípios (o porquê)
+
+Luhmann produziu 70 livros não por acumular conteúdo interessante, mas por três práticas que esta skill reproduz:
+
+1. **Nota é tese, não tópico.** Ele nunca resumia — afirmava. Uma tese pode ser contestada por outra nota; um resumo fica parado. Originalidade nasce do atrito entre afirmações.
+2. **O arquivamento é o momento criativo.** Cada nota nova era forçada a entrar *atrás de uma nota específica* — a decisão "com qual conversa isso se conecta?" era onde o pensamento acontecia. Por isso a skill NUNCA arquiva sozinha: analisar candidatos é seu trabalho; escolher é o trabalho dele.
+3. **Ler perguntando "o que isso significa para as MINHAS perguntas?"** — nunca "o que o autor disse?".
+
+## Fluxo de trabalho
+
+### Etapa 1 — Da ideia à tese
+
+Quando o usuário trouxer uma ideia, rascunho ou fleeting note:
+
+- Se o título/ideia **descreve** um assunto, provoque: *"Qual é a afirmação? O que alguém poderia contestar aqui?"* Proponha 2-3 títulos-tese e deixe ele escolher ou reformular.
+- Teste do título: se não dá para discordar dele, ainda é tópico.
+
+**Exemplo:**
+- Descreve (fraco): "Observabilidade no Open Ferramentaria"
+- Afirma (forte): "Sem telemetria, todo incidente vira arqueologia"
+
+- Descreve: "Reunião com fornecedor SAP"
+- Afirma: "O gargalo de integração não é técnico, é o modelo de relacionamento"
+
+### Etapa 2 — Corpo como argumento
+
+Ajude a escrever o corpo como resposta a uma pergunta, nas palavras do usuário, curto e atômico (uma tese por nota). Estrutura das notas permanentes do vault: Ideia Principal, Contexto, Expansão, Conexões. Para literature notes: o que importa não é o resumo do autor, é a seção de Comentários Pessoais — o que a leitura significa para as perguntas dele.
+
+### Etapa 3 — Arquivamento forçado (o coração da skill)
+
+Antes de salvar, analise o vault (busque por títulos, tags e conteúdo relacionados — Grep nos `zettels/`) e apresente **2 a 4 threads candidatas**: notas existentes com as quais a nova nota conversa. Para cada candidata, nomeie a **relação**:
+
+- **contradiz** — a nova nota tensiona ou refuta a existente
+- **completa** — adiciona evidência ou desdobramento
+- **exemplifica** — é caso concreto de um princípio existente
+- **responde** — resolve pergunta aberta em outra nota (ex.: seções "Pontes a construir" ou "Expansão" com perguntas)
+
+Então **pergunte ao usuário qual thread a nota entra** (use AskUserQuestion se disponível; senão, pergunte em texto e aguarde). Relações de contradição valem mais que as de semelhança — atrito gera originalidade, semelhança gera redundância. Nunca escolha por ele, mesmo que uma opção pareça óbvia: a decisão É o exercício mental que ele está treinando.
+
+### Etapa 4 — Efetivar a conexão
+
+Após a escolha:
+- Crie a nota em `zettels/` com frontmatter completo (type, date de hoje, tags da taxonomia existente) e link `[[...]]` para a thread escolhida na seção Conexões.
+- Adicione o link reverso na nota escolhida (na seção Conexões dela), citando a relação: `- [[Nota Nova]] — contradiz a tese central`.
+- Nunca crie nota órfã: toda nota nova nasce com pelo menos 1 conexão real.
+- Nunca crie notas-stub vazias como alvo de link.
+
+### Etapa 5 — A surpresa
+
+Feche sempre com **um vizinho improvável**: uma nota de um cluster *diferente* (outro domínio de tag) que poderia se conectar de forma não óbvia. Uma frase explicando o cruzamento possível. É opcional para o usuário — mas é o que faz o arquivo "responder de volta". Os cruzamentos mais valiosos do vault deste usuário nasceram assim (engenharia × fé, xadrez × loteria, post-mortem × lançamento).
+
+## Anti-padrões
+
+- Resumir em vez de afirmar (especialmente em literature notes)
+- Arquivar automaticamente "para agilizar" — destrói o propósito da skill
+- Criar a nota antes da Etapa 3 — a análise de candidatas vem ANTES do arquivo existir
+- Sugerir só candidatas semelhantes — procure ativamente a nota que a nova tese incomoda
+- Notas longas cobrindo várias teses — sugira dividir em notas atômicas conectadas

--- a/skills/zettelkasten-luhmann/scripts/init_vault.py
+++ b/skills/zettelkasten-luhmann/scripts/init_vault.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Inicializa a estrutura de um vault Zettelkasten (método Luhmann).
+
+Uso: python init_vault.py <caminho-do-vault>
+
+Cria (sem sobrescrever nada que já exista):
+  ZettelKasten/
+    zettels/     - as notas (teses atômicas conectadas)
+    Daily/       - diários e capturas fleeting
+    templates/   - templates de nota (permanent, literature, fleeting, moc)
+    arquivos/    - imagens e anexos
+"""
+import os, sys, shutil
+
+TEMPLATES = {
+"permanent_notes.md": """---
+type: permanent
+title:
+date:
+tags:
+  - zettel/permanent
+---
+
+# {{title}}
+
+## **Ideia Principal**
+(A tese, clara e atômica. Teste: alguém poderia discordar deste título? Se não, ainda é tópico.)
+
+## **Contexto**
+(De onde veio: leitura, caso real, conversa. O que provocou a ideia.)
+
+## **Expansão**
+(Argumento nas suas palavras. Inclua a melhor objeção contra a própria tese.)
+
+## **Conexões**
+- [[Nota existente]] — relação: contradiz | completa | exemplifica | responde
+""",
+"literature_notes.md": """---
+type: literature
+title:
+source:
+author:
+date:
+tags:
+  - zettel/literature
+---
+
+# {{title}}
+
+## **Resumo**
+(Breve. O resumo é o menos importante desta nota.)
+
+## **Citações Relevantes**
+- ""
+
+## **Comentários Pessoais**
+(A parte que vale: o que isso significa para as SUAS perguntas — não o que o autor disse.)
+
+## **Conexões**
+- [[Nota]] — relação
+""",
+"fleeting_notes.md": """---
+type: fleeting
+date:
+tags:
+  - zettel/fleeting
+---
+
+# Fleeting
+
+- **Ideia**: (rápido, sem elaborar — o gancho)
+- **Contexto**: (onde surgiu)
+- **Processar em**: (qual nota permanente isso pode virar)
+""",
+"moc_template.md": """---
+type: moc
+title:
+tags:
+  - moc
+description:
+---
+
+# MOC – {{title}}
+
+(Mapa de entrada de um tema. Agrupe notas por subtema e termine com "Pontes a construir":
+conexões que o material pede mas ainda não existem.)
+
+## Pontes a construir
+-
+""",
+}
+
+STARTER = """---
+type: permanent
+title: Uma nota é uma tese, não um tópico
+date:
+tags:
+  - zettel/permanent
+---
+
+# Uma nota é uma tese, não um tópico
+
+## **Ideia Principal**
+Notas que apenas descrevem um assunto não geram conhecimento novo; notas que afirmam algo contestável criam atrito — e o atrito entre afirmações é de onde a originalidade nasce.
+
+## **Contexto**
+Primeira nota deste vault, criada na inicialização. Niklas Luhmann escreveu 70 livros não acumulando conteúdo, mas forçando cada nota nova a entrar numa conversa com as existentes.
+
+## **Expansão**
+Teste prático para todo título: dá para discordar dele? "Observabilidade no sistema X" — não dá, é tópico. "Sem telemetria, todo incidente vira arqueologia" — dá, é tese. Objeção honesta: nem tudo precisa ser tese (notas de referência têm valor); o risco é o vault virar SÓ referência.
+
+## **Conexões**
+- (esta nota espera sua primeira conexão — crie sua próxima nota e decida a relação entre elas)
+"""
+
+
+TEMPLATES_EN = {
+"permanent_notes.md": """---
+type: permanent
+title:
+date:
+tags:
+  - zettel/permanent
+---
+
+# {{title}}
+
+## **Main claim**
+(The thesis, clear and atomic. Test: could someone disagree with this title? If not, it is still a topic.)
+
+## **Context**
+(Where it came from: a reading, a real case, a conversation. What sparked the idea.)
+
+## **Expansion**
+(The argument in your own words. Include the best objection against your own thesis.)
+
+## **Connections**
+- [[Existing note]] — relation: contradicts | completes | exemplifies | answers
+""",
+"literature_notes.md": """---
+type: literature
+title:
+source:
+author:
+date:
+tags:
+  - zettel/literature
+---
+
+# {{title}}
+
+## **Summary**
+(Brief. The summary is the least important part of this note.)
+
+## **Relevant quotes**
+- ""
+
+## **Personal commentary**
+(The part that matters: what this means for YOUR questions — not what the author said.)
+
+## **Connections**
+- [[Note]] — relation
+""",
+"fleeting_notes.md": """---
+type: fleeting
+date:
+tags:
+  - zettel/fleeting
+---
+
+# Fleeting
+
+- **Idea**: (quick, unpolished — just the hook)
+- **Context**: (where it came up)
+- **Process into**: (which permanent note this could become)
+""",
+"moc_template.md": """---
+type: moc
+title:
+tags:
+  - moc
+description:
+---
+
+# MOC – {{title}}
+
+(Entry map for a theme. Group notes by subtopic and end with "Bridges to build":
+connections the material calls for but that do not exist yet.)
+
+## Bridges to build
+-
+""",
+}
+
+STARTER_EN = """---
+type: permanent
+title: A note is a claim, not a topic
+date:
+tags:
+  - zettel/permanent
+---
+
+# A note is a claim, not a topic
+
+## **Main claim**
+Notes that merely describe a subject produce no new knowledge; notes that assert something contestable create friction — and friction between claims is where originality comes from.
+
+## **Context**
+First note of this vault, created at initialization. Niklas Luhmann wrote 70 books not by hoarding content, but by forcing every new note into a conversation with the existing ones.
+
+## **Expansion**
+Practical test for every title: can you disagree with it? "Observability in system X" — you cannot, it is a topic. "Without telemetry, every incident becomes archaeology" — you can, it is a claim. Honest objection: not everything needs to be a claim (reference notes have value); the risk is a vault that is ONLY reference.
+
+## **Connections**
+- (this note awaits its first connection — create your next note and decide the relation between them)
+"""
+
+STARTER_NAME = {"pt": "Uma nota é uma tese, não um tópico.md", "en": "A note is a claim, not a topic.md"}
+
+def main():
+    import argparse
+    ap = argparse.ArgumentParser(description="Inicializa a estrutura de um vault Zettelkasten / Initialize a Zettelkasten vault")
+    ap.add_argument("path", help="pasta onde criar o vault / folder to create the vault in")
+    ap.add_argument("--lang", choices=["pt", "en"], default="pt", help="idioma dos templates / template language (default: pt)")
+    args = ap.parse_args()
+    templates = TEMPLATES if args.lang == "pt" else TEMPLATES_EN
+    starter = STARTER if args.lang == "pt" else STARTER_EN
+    base = os.path.join(args.path, "ZettelKasten")
+    created, skipped = [], []
+    for d in ("zettels", "Daily", "templates", "arquivos"):
+        p = os.path.join(base, d)
+        (skipped if os.path.exists(p) else created).append(p)
+        os.makedirs(p, exist_ok=True)
+    for name, content in templates.items():
+        p = os.path.join(base, "templates", name)
+        if os.path.exists(p): skipped.append(p); continue
+        open(p, "w", encoding="utf-8").write(content); created.append(p)
+    p = os.path.join(base, "zettels", STARTER_NAME[args.lang])
+    if not os.path.exists(p):
+        open(p, "w", encoding="utf-8").write(starter); created.append(p)
+    print(f"Vault: {base}")
+    print(f"Criados/created: {len(created)}")
+    for c in created: print(f"  + {c}")
+    if skipped: print(f"Já existiam, preservados / already existed, preserved: {len(skipped)}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What this skill does

A Zettelkasten writing and filing assistant that applies Niklas Luhmann's mindset to Obsidian vaults. Luhmann's productivity came from three practices this skill reproduces: (1) notes as contestable claims rather than topic summaries, (2) forced filing — the skill scans the vault and presents 2-4 candidate notes with named relations (contradicts / completes / exemplifies / answers), but the user always makes the filing decision, since that decision is the thinking exercise, and (3) closing each note with an unlikely cross-cluster connection ("the archive must be able to surprise you").

It also bootstraps a vault from scratch via a bundled idempotent script (scripts/init_vault.py, pt/en templates), and detects a missing vault structure before creating any files. Works in any language: converses in the user's language, writes notes in the vault's language.

## Why it might be a good fit for this repo

- Demonstrates a distinct pattern: a skill whose core value is *refusing to automate* the decisive step, returning the decision to the user by design.
- Includes a deterministic bundled script (bootstrap), behavioral anti-patterns, and multilingual handling — patterns other skill authors can borrow.
- PKM/Zettelkasten is a popular use case with no equivalent example in ./skills.

## Testing

Benchmarked with-skill vs without-skill on 6 scenarios (new note flow, fleeting-note processing, resisting a "summarize this chapter" request, vault bootstrap, use without structure, English-language end-to-end): 100% of criteria passed with the skill vs 28-50% without. The init script was tested for idempotency (second run creates/overwrites nothing) and both template languages.

## Maintenance

Maintained at https://github.com/daniloneto/zettelkasten-luhmann (MIT). Happy to adjust structure, naming, or licensing to fit repo conventions.