### PR TITLE
skill-creator: fix silent benchmark failures and Windows trigger evals

### DIFF
--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -376,6 +376,8 @@ This step matters — bad eval queries lead to bad descriptions.
 
 Tell the user: "This will take some time — I'll run the optimization loop in the background and check on it periodically."
 
+Before running: if the skill under test is installed at `~/.claude/skills/<name>`, temporarily move that folder away (and restore it afterwards). An installed copy is visible to every `claude -p` subprocess and shadows the synthetic test skill — the model triggers the real skill under its real name, the eval cannot attribute that to the candidate description, and every should-trigger query reads as a false negative.
+
 Save the eval set to the workspace, then run in the background:
 
 ```bash

--- a/skills/skill-creator/scripts/aggregate_benchmark.py
+++ b/skills/skill-creator/scripts/aggregate_benchmark.py
@@ -85,10 +85,16 @@ def load_run_results(benchmark_dir: Path) -> dict:
 
     for eval_idx, eval_dir in enumerate(sorted(search_dir.glob("eval-*"))):
         metadata_path = eval_dir / "eval_metadata.json"
+        eval_name = ""
         if metadata_path.exists():
             try:
                 with open(metadata_path) as mf:
-                    eval_id = json.load(mf).get("eval_id", eval_idx)
+                    metadata = json.load(mf)
+                eval_id = metadata.get("eval_id", eval_idx)
+                # pass eval_name through to the
+                # benchmark runs — schemas.md documents it and the viewer
+                # shows it as the eval heading
+                eval_name = metadata.get("eval_name", "")
             except (json.JSONDecodeError, OSError):
                 eval_id = eval_idx
         else:
@@ -101,15 +107,25 @@ def load_run_results(benchmark_dir: Path) -> dict:
         for config_dir in sorted(eval_dir.iterdir()):
             if not config_dir.is_dir():
                 continue
-            # Skip non-config directories (inputs, outputs, etc.)
-            if not list(config_dir.glob("run-*")):
-                continue
+            run_dirs = [
+                (run_dir, int(run_dir.name.split("-")[1]))
+                for run_dir in sorted(config_dir.glob("run-*"))
+            ]
+            # SKILL.md's workflow produces a flat
+            # layout without a run-N level (eval-N/<config>/outputs + grading
+            # .json). Treat such a config dir as a single run instead of
+            # silently skipping it. Dirs with neither run-* nor grading.json/
+            # outputs (e.g. inputs/) are still skipped.
+            if not run_dirs:
+                if (config_dir / "grading.json").exists() or (config_dir / "outputs").is_dir():
+                    run_dirs = [(config_dir, 1)]
+                else:
+                    continue
             config = config_dir.name
             if config not in results:
                 results[config] = []
 
-            for run_dir in sorted(config_dir.glob("run-*")):
-                run_number = int(run_dir.name.split("-")[1])
+            for run_dir, run_number in run_dirs:
                 grading_file = run_dir / "grading.json"
 
                 if not grading_file.exists():
@@ -126,6 +142,7 @@ def load_run_results(benchmark_dir: Path) -> dict:
                 # Extract metrics
                 result = {
                     "eval_id": eval_id,
+                    "eval_name": eval_name,
                     "run_number": run_number,
                     "pass_rate": grading.get("summary", {}).get("pass_rate", 0.0),
                     "passed": grading.get("summary", {}).get("passed", 0),
@@ -180,7 +197,19 @@ def aggregate_results(results: dict) -> dict:
     Returns run_summary with stats for each configuration and delta.
     """
     run_summary = {}
+    # fixed priority order instead of discovery
+    # order — configs are discovered alphabetically, which puts old_skill
+    # before with_skill and flips the delta sign in the improve flow
+    # (an improvement then reads as a regression). The skill/candidate
+    # config is always primary, the baseline second.
+    primary_names = ("with_skill", "new_skill")
+    baseline_names = ("without_skill", "old_skill", "baseline")
     configs = list(results.keys())
+    primary = next((c for c in configs if c in primary_names), None)
+    baseline = next((c for c in configs if c in baseline_names), None)
+    if primary and baseline:
+        rest = [c for c in configs if c not in (primary, baseline)]
+        configs = [primary, baseline] + rest
 
     for config in configs:
         runs = results.get(config, [])
@@ -237,6 +266,7 @@ def generate_benchmark(benchmark_dir: Path, skill_name: str = "", skill_path: st
         for result in results[config]:
             runs.append({
                 "eval_id": result["eval_id"],
+                "eval_name": result.get("eval_name", ""),
                 "configuration": config,
                 "run_number": result["run_number"],
                 "result": {
@@ -368,6 +398,18 @@ def main():
 
     # Generate benchmark
     benchmark = generate_benchmark(args.benchmark_dir, args.skill_name, args.skill_path)
+
+    # fail loudly instead of writing an empty
+    # benchmark.json — a silent empty benchmark reads as "0% pass rate,
+    # delta +0.00" and misleads the iteration decision
+    if not benchmark["runs"]:
+        print(
+            f"Error: no runs found under {args.benchmark_dir}. "
+            f"Expected eval-*/<config>/run-N/grading.json or "
+            f"eval-*/<config>/grading.json. Nothing was written.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     # Determine output paths
     output_json = args.output or (args.benchmark_dir / "benchmark.json")

--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -8,9 +8,10 @@ for a set of queries. Outputs results as JSON.
 import argparse
 import json
 import os
-import select
+import queue
 import subprocess
 import sys
+import threading
 import time
 import uuid
 from concurrent.futures import ProcessPoolExecutor, as_completed
@@ -30,6 +31,24 @@ def find_project_root() -> Path:
         if (parent / ".claude").is_dir():
             return parent
     return current
+
+
+def _pump_stdout(stream, chunks: "queue.Queue") -> None:
+    """Read chunks from a subprocess pipe into a queue, ending with None.
+
+    select() cannot watch pipes on Windows (only sockets), so a blocking
+    reader thread is used instead of select-based polling.
+    """
+    try:
+        while True:
+            chunk = stream.read1(8192)
+            if not chunk:
+                break
+            chunks.put(chunk)
+    except (OSError, ValueError):
+        pass
+    finally:
+        chunks.put(None)
 
 
 def run_single_query(
@@ -97,20 +116,19 @@ def run_single_query(
         pending_tool_name = None
         accumulated_json = ""
 
+        chunks: queue.Queue = queue.Queue()
+        reader = threading.Thread(
+            target=_pump_stdout, args=(process.stdout, chunks), daemon=True
+        )
+        reader.start()
+
         try:
             while time.time() - start_time < timeout:
-                if process.poll() is not None:
-                    remaining = process.stdout.read()
-                    if remaining:
-                        buffer += remaining.decode("utf-8", errors="replace")
-                    break
-
-                ready, _, _ = select.select([process.stdout], [], [], 1.0)
-                if not ready:
+                try:
+                    chunk = chunks.get(timeout=1.0)
+                except queue.Empty:
                     continue
-
-                chunk = os.read(process.stdout.fileno(), 8192)
-                if not chunk:
+                if chunk is None:
                     break
                 buffer += chunk.decode("utf-8", errors="replace")
 
@@ -279,6 +297,22 @@ def main():
     name, original_description, content = parse_skill_md(skill_path)
     description = args.description or original_description
     project_root = find_project_root()
+
+    # a globally installed copy of the skill shadows
+    # the synthetic test command in every `claude -p` subprocess — the model
+    # then triggers the real skill under its real name, which this eval cannot
+    # attribute to the candidate description. Positive queries read as false
+    # negatives and the optimization loop scores garbage.
+    installed_copy = Path.home() / ".claude" / "skills" / name
+    if installed_copy.exists():
+        print(
+            f"WARNING: '{name}' is installed at {installed_copy} and visible to "
+            f"every `claude -p` subprocess. It will shadow the synthetic test "
+            f"skill and distort trigger rates (positives read as false negatives). "
+            f"Temporarily move it away (e.g. rename the folder) before running "
+            f"trigger evals, then restore it.",
+            file=sys.stderr,
+        )
 
     if args.verbose:
         print(f"Evaluating: {description}", file=sys.stderr)


### PR DESCRIPTION
Fixes points 1-5 of #1383 (point 6, the missing `encoding="utf-8"` across all file I/O, is left out to keep this PR focused — happy to follow up).

## Changes

**`scripts/aggregate_benchmark.py`**
- Accept the flat `eval-N/<config>/` layout that SKILL.md instructs subagents to produce: a config dir containing `grading.json` or `outputs/` but no `run-*` subdirectories is now treated as a single run. Previously such dirs were silently skipped and the benchmark came out empty with exit code 0.
- Exit 1 with a clear error when zero runs are found, instead of writing an empty `benchmark.json` that reads as "0% pass rate, delta +0.00".
- Use a fixed configuration priority for the delta (`with_skill`/`new_skill` primary; `without_skill`/`old_skill`/`baseline` as baseline). Configs were discovered in alphabetical order, so in the improve flow (`old_skill` baseline) the delta sign flipped: with_skill=100%, old_skill=0% reported `Delta: -1.00`.
- Propagate `eval_name` from `eval_metadata.json` into the `runs[]` entries — schemas.md documents the field and viewer.html shows it as the eval heading, but it was never passed through (the Benchmark tab always showed "Eval 0").

**`scripts/run_eval.py`**
- Replace `select.select()` on subprocess pipes with a blocking reader thread feeding a queue. On Windows, `select()` only supports sockets; every worker raised `OSError: [WinError 10093]`, which the parent swallowed and recorded as "not triggered" — the optimization loop then scored garbage with exit code 0.
- Warn when the skill under test is also installed at `~/.claude/skills/<name>`: the installed copy is visible to every `claude -p` subprocess and shadows the synthetic test skill (captured stream-json shows the model invoking the real skill under its real name, which the eval cannot attribute to the candidate description), so every should-trigger query reads as a false negative.

**`SKILL.md`**
- Short note in the description-optimization section about moving an installed copy of the skill away before running trigger evals (matches the new warning).

## Testing

- Fixtures for all four benchmark cases: flat layout (previously empty → now aggregates correctly), `run-N` layout (regression, unchanged), `old_skill` improve flow (delta now `+1.00` instead of `-1.00`), empty workspace (now exit 1, nothing written).
- The thread-reader was exercised end-to-end on Windows 11 (Python 3.12.9, Claude Code CLI 2.1.198) with live `claude -p` runs: no `WinError`, stream events parsed, negative queries correctly scored; the shadowing warning fires when the tested skill is installed.
- Viewer compatibility verified: with the flat layout, `generate_review.py` now also finds prompt and benchmark data, so the SKILL.md-documented workflow works across both tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
