### PR TITLE
Fix mcp-builder evaluation harness: handle parallel tool calls and missing text responses

### DIFF
--- a/skills/mcp-builder/scripts/evaluation.py
+++ b/skills/mcp-builder/scripts/evaluation.py
@@ -100,9 +100,10 @@ async def execute_tool_use(
     connection: Any,
     tool_metrics: dict[str, Any],
 ) -> dict[str, Any]:
-    """Execute one tool call and return the MCP tool_result block."""
+    """Execute one tool call and return the tool_result content block."""
     tool_name = tool_use.name
     tool_input = tool_use.input
+
     tool_start_ts = time.time()
     try:
         tool_result = await connection.call_tool(tool_name, tool_input)
@@ -111,10 +112,12 @@ async def execute_tool_use(
         tool_response = f"Error executing tool {tool_name}: {str(e)}\n"
         tool_response += traceback.format_exc()
     tool_duration = time.time() - tool_start_ts
+
     if tool_name not in tool_metrics:
         tool_metrics[tool_name] = {"count": 0, "durations": []}
     tool_metrics[tool_name]["count"] += 1
     tool_metrics[tool_name]["durations"].append(tool_duration)
+
     return {
         "type": "tool_result",
         "tool_use_id": tool_use.id,

--- a/skills/mcp-builder/scripts/evaluation.py
+++ b/skills/mcp-builder/scripts/evaluation.py
@@ -76,11 +76,50 @@ def parse_evaluation_file(file_path: Path) -> list[dict[str, Any]]:
         return []
 
 
-def extract_xml_content(text: str, tag: str) -> str | None:
+def extract_xml_content(text: str | None, tag: str) -> str | None:
     """Extract content from XML tags."""
+    if not text:
+        return None
     pattern = rf"<{tag}>(.*?)</{tag}>"
     matches = re.findall(pattern, text, re.DOTALL)
     return matches[-1].strip() if matches else None
+
+
+def response_text_from_content(content: list[Any]) -> str:
+    """Concatenate all text blocks from an assistant message."""
+    text_parts = [
+        block.text
+        for block in content
+        if getattr(block, "type", None) == "text" and block.text
+    ]
+    return "\n".join(text_parts)
+
+
+async def execute_tool_use(
+    tool_use: Any,
+    connection: Any,
+    tool_metrics: dict[str, Any],
+) -> dict[str, Any]:
+    """Execute one tool call and return the MCP tool_result block."""
+    tool_name = tool_use.name
+    tool_input = tool_use.input
+    tool_start_ts = time.time()
+    try:
+        tool_result = await connection.call_tool(tool_name, tool_input)
+        tool_response = json.dumps(tool_result) if isinstance(tool_result, (dict, list)) else str(tool_result)
+    except Exception as e:
+        tool_response = f"Error executing tool {tool_name}: {str(e)}\n"
+        tool_response += traceback.format_exc()
+    tool_duration = time.time() - tool_start_ts
+    if tool_name not in tool_metrics:
+        tool_metrics[tool_name] = {"count": 0, "durations": []}
+    tool_metrics[tool_name]["count"] += 1
+    tool_metrics[tool_name]["durations"].append(tool_duration)
+    return {
+        "type": "tool_result",
+        "tool_use_id": tool_use.id,
+        "content": tool_response,
+    }
 
 
 async def agent_loop(
@@ -107,33 +146,15 @@ async def agent_loop(
     tool_metrics = {}
 
     while response.stop_reason == "tool_use":
-        tool_use = next(block for block in response.content if block.type == "tool_use")
-        tool_name = tool_use.name
-        tool_input = tool_use.input
-
-        tool_start_ts = time.time()
-        try:
-            tool_result = await connection.call_tool(tool_name, tool_input)
-            tool_response = json.dumps(tool_result) if isinstance(tool_result, (dict, list)) else str(tool_result)
-        except Exception as e:
-            tool_response = f"Error executing tool {tool_name}: {str(e)}\n"
-            tool_response += traceback.format_exc()
-        tool_duration = time.time() - tool_start_ts
-
-        if tool_name not in tool_metrics:
-            tool_metrics[tool_name] = {"count": 0, "durations": []}
-        tool_metrics[tool_name]["count"] += 1
-        tool_metrics[tool_name]["durations"].append(tool_duration)
-
+        tool_uses = [block for block in response.content if block.type == "tool_use"]
+        tool_results = await asyncio.gather(*[
+            execute_tool_use(tool_use, connection, tool_metrics)
+            for tool_use in tool_uses
+        ])
         messages.append({
             "role": "user",
-            "content": [{
-                "type": "tool_result",
-                "tool_use_id": tool_use.id,
-                "content": tool_response,
-            }]
+            "content": tool_results,
         })
-
         response = await asyncio.to_thread(
             client.messages.create,
             model=model,
@@ -144,11 +165,7 @@ async def agent_loop(
         )
         messages.append({"role": "assistant", "content": response.content})
 
-    response_text = next(
-        (block.text for block in response.content if hasattr(block, "text")),
-        None,
-    )
-    return response_text, tool_metrics
+    return response_text_from_content(response.content), tool_metrics
 
 
 async def evaluate_single_task(


### PR DESCRIPTION
## Summary
Fixes two bugs in `skills/mcp-builder/scripts/evaluation.py`.

## Bug 1: Parallel tool call handling
When Claude returns multiple `tool_use` blocks in one turn, the harness only executed the first (`next(...)`) and sent a single `tool_result`. The API requires a `tool_result` for every `tool_use`, so the next request failed with a 400.

**Fix:** Collect all `tool_use` blocks, execute them concurrently with `asyncio.gather`, and return all `tool_result` blocks in one user message. This is safe over a single connection: `mcp.ClientSession` multiplexes concurrent requests by request ID.

## Bug 2: Missing text response crash
When the final assistant message has no text block, `response_text` was `None`. `extract_xml_content(None, ...)` then raised `TypeError`.

**Fix:** Join all text blocks via `response_text_from_content()` (empty string fallback) and guard `extract_xml_content` against `None`/empty input. Joining all text blocks (instead of taking only the first) also means `<response>` tags split across multiple text blocks are found, and `agent_loop`'s declared `tuple[str, ...]` return type is now accurate.

## Testing
- `python3 -m py_compile skills/mcp-builder/scripts/evaluation.py`
- The repo has no test harness for these scripts; verified by syntax check and review against the Messages API tool-use contract.