### PR TITLE
fix(skill-creator): trim overlong description and remove hardcoded download path

### DIFF
--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-creator
-description: Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, edit, or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or optimize a skill's description for better triggering accuracy.
+description: Create, modify, and evaluate Claude skills. Use when the user wants to author a new skill from scratch, iterate on an existing one, or run evals to measure and improve trigger accuracy.
 ---
 
 # Skill Creator
@@ -368,7 +368,7 @@ Present the eval set to the user for review using the HTML template:
    - `__SKILL_DESCRIPTION_PLACEHOLDER__` → the skill's current description
 3. Write to a temp file (e.g., `/tmp/eval_review_<skill-name>.html`) and open it: `open /tmp/eval_review_<skill-name>.html`
 4. The user can edit queries, toggle should-trigger, add/remove entries, then click "Export Eval Set"
-5. The file downloads to `~/Downloads/eval_set.json` — check the Downloads folder for the most recent version in case there are multiple (e.g., `eval_set (1).json`)
+5. The file downloads to the user's default browser download folder. Ask the user for the path if unclear, and check for the most recent version in case multiple exist (e.g., `eval_set (1).json`).
 
 This step matters — bad eval queries lead to bad descriptions.
 


### PR DESCRIPTION
This PR resolves two quality issues in `skills/skill-creator/SKILL.md`:

1. **Description length.** The `description` field was 319 characters, exceeding the ~250-character guideline in the [best-practices doc](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/best-practices). Trimmed to 187 characters while preserving the three core use-cases (create, modify, evaluate). The explicit trigger phrase remains.

2. **Hardcoded user path.** Line 371 referenced `~/Downloads/eval_set.json`, which assumes macOS conventions and that the browser writes to the user's Downloads folder. On Windows and Linux browsers default elsewhere; the exact path also varies per browser and configuration. Reworded to describe the intent without assuming a location, so the guidance stays portable.

## How I found these

Static analysis with [doodle](https://github.com/krishyaid-coder/doodle), a small MIT-licensed linter for `SKILL.md` files grounded in the failure modes discussed in #267. Findings correspond to the `desc/too-long` and `body/absolute-user-path` rules.

For context, I ran the same tool across 62 published skills as a validation exercise, and the patterns are common enough that it seemed worth surfacing directly against the reference skill authors will most often study when writing their own. Full report: https://github.com/krishyaid-coder/doodle/blob/main/docs/QUALITY_REPORT.md

Happy to close if the direction isn't wanted, or to split into two commits if a smaller-per-commit unit reviews better. Not attached to the specific wording of either replacement but the goal is just alignment with the documented guidelines.