### PR TITLE
fix(skill-creator): escape HTML in eval-viewer embedded JSON

### DIFF
--- a/skills/skill-creator/eval-viewer/generate_review.py
+++ b/skills/skill-creator/eval-viewer/generate_review.py
@@ -276,7 +276,22 @@ def generate_html(
     if benchmark:
         embedded["benchmark"] = benchmark
 
-    data_json = json.dumps(embedded)
+    # Escape the characters that are unsafe to embed in the viewer's <script>
+    # block. json.dumps does not escape "<", so an embedded string containing
+    # "</script>" (common, since runs carry the raw outputs a skill under test
+    # produced) would close the script element early — blanking the viewer and
+    # allowing markup injection. U+2028/U+2029 are valid in JSON but were illegal
+    # in JS string literals before ES2019, and EMBEDDED_DATA is consumed as a JS
+    # object literal. This mirrors Flask's htmlsafe_dumps / Django's json_script;
+    # each escape parses back to the original character, so the data is unchanged.
+    data_json = (
+        json.dumps(embedded)
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+        .replace("\u2028", "\\u2028")
+        .replace("\u2029", "\\u2029")
+    )
 
     return template.replace("/*__EMBEDDED_DATA__*/", f"const EMBEDDED_DATA = {data_json};")
 


### PR DESCRIPTION
Fixes #1075.

### Problem

`eval-viewer/generate_review.py` builds the standalone results viewer by
embedding the eval data into `viewer.html` inside a `<script>` block:

```python
data_json = json.dumps(embedded)
return template.replace("/*__EMBEDDED_DATA__*/", f"const EMBEDDED_DATA = {data_json};")
```

`json.dumps` escapes for JSON, but does **not** escape `<`. The `embedded`
payload includes `runs`, which carry the **raw outputs each skill under test
produced** — frequently HTML, code, or markdown. As soon as any embedded
string contains `</script>` (or `</` in general, or `<!--`, or `<script`), the
browser's HTML tokenizer closes the inline `<script>` element early, before the
JS parser ever sees the string context. Two consequences:

- **Breakage:** `EMBEDDED_DATA` is never fully assigned, the viewer's JS throws,
  and the page renders blank — the reviewer sees nothing.
- **Injection:** output such as `</script><img src=x onerror=alert(1)>` becomes
  live DOM and executes.

For skill-creator this is a likely hit rather than a corner case: any skill
being evaluated that emits an HTML file — or code that merely mentions a script
tag — poisons its own results viewer.

### Fix

Escape `<`, `>`, `&`, U+2028, and U+2029 to their JSON unicode-escape forms
after `json.dumps` — the same HTML-safe-JSON technique used by Flask's
`htmlsafe_dumps` and Django's `json_script`. The escaped forms parse back to
the identical characters, so the embedded data is unchanged; the HTML tokenizer
simply never sees a `<` again. U+2028/U+2029 are included because
`EMBEDDED_DATA` is consumed as a JS **object literal** (not `JSON.parse`), where
those two separators were illegal in string literals before ES2019.

### Verification

Round-tripping a payload whose output contains a `</script>` breakout, an
`<img onerror>` injection, `A&B`, and literal U+2028/U+2029:

- before: serialized JSON contains a literal `</` and breaks the `<script>` block
- after: contains no literal `<`, `>`, `</`, or line separators, and the escaped
  string parses back equal to the original payload — data preserved exactly

Verified under both `ensure_ascii=True` (current) and `ensure_ascii=False`, so
it composes cleanly with #1040 (which changes the same line to
`ensure_ascii=False` for non-ASCII readability — a complementary fix).
`python -m py_compile` passes on the changed file.
