### PR TITLE
fix(skill-creator): make eval-viewer HTML escaping attribute-safe

### DIFF
--- a/skills/skill-creator/eval-viewer/viewer.html
+++ b/skills/skill-creator/eval-viewer/viewer.html
@@ -1096,10 +1096,17 @@
       return "#";
     }
 
+    // Escape for embedding in HTML markup built by string concatenation. Covers
+    // quotes as well as angle brackets and ampersand, so the result is safe in
+    // attribute values (e.g. title="...") as well as element text — the
+    // textContent round-trip does not escape quotes and is unsafe in attributes.
     function escapeHtml(text) {
-      const div = document.createElement("div");
-      div.textContent = text;
-      return div.innerHTML;
+      return String(text ?? "")
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
     }
 
     // ---- View switching ----
@@ -1129,9 +1136,9 @@
       html += "<h2 style='font-family: Poppins, sans-serif; margin-bottom: 0.5rem;'>Benchmark Results</h2>";
       html += "<p style='color: var(--text-muted); font-size: 0.875rem; margin-bottom: 1.25rem;'>";
       if (metadata.skill_name) html += "<strong>" + escapeHtml(metadata.skill_name) + "</strong> &mdash; ";
-      if (metadata.timestamp) html += metadata.timestamp + " &mdash; ";
-      if (metadata.evals_run) html += "Evals: " + metadata.evals_run.join(", ") + " &mdash; ";
-      html += (metadata.runs_per_configuration || "?") + " runs per configuration";
+      if (metadata.timestamp) html += escapeHtml(metadata.timestamp) + " &mdash; ";
+      if (metadata.evals_run) html += "Evals: " + escapeHtml(metadata.evals_run.join(", ")) + " &mdash; ";
+      html += escapeHtml(metadata.runs_per_configuration || "?") + " runs per configuration";
       html += "</p>";
 
       // Summary table
@@ -1169,14 +1176,14 @@
       html += "<tr><td><strong>Pass Rate</strong></td>";
       html += "<td>" + fmtStat(a.pass_rate, true) + "</td>";
       html += "<td>" + fmtStat(b.pass_rate, true) + "</td>";
-      html += '<td class="' + deltaClass(delta.pass_rate) + '">' + (delta.pass_rate || "—") + "</td></tr>";
+      html += '<td class="' + deltaClass(delta.pass_rate) + '">' + escapeHtml(delta.pass_rate || "—") + "</td></tr>";
 
       // Time (only show row if data exists)
       if (a.time_seconds || b.time_seconds) {
         html += "<tr><td><strong>Time (s)</strong></td>";
         html += "<td>" + fmtStat(a.time_seconds, false) + "</td>";
         html += "<td>" + fmtStat(b.time_seconds, false) + "</td>";
-        html += '<td class="' + deltaClass(delta.time_seconds) + '">' + (delta.time_seconds ? delta.time_seconds + "s" : "—") + "</td></tr>";
+        html += '<td class="' + deltaClass(delta.time_seconds) + '">' + escapeHtml(delta.time_seconds ? delta.time_seconds + "s" : "—") + "</td></tr>";
       }
 
       // Tokens (only show row if data exists)
@@ -1184,7 +1191,7 @@
         html += "<tr><td><strong>Tokens</strong></td>";
         html += "<td>" + fmtStat(a.tokens, false) + "</td>";
         html += "<td>" + fmtStat(b.tokens, false) + "</td>";
-        html += '<td class="' + deltaClass(delta.tokens) + '">' + (delta.tokens || "—") + "</td></tr>";
+        html += '<td class="' + deltaClass(delta.tokens) + '">' + escapeHtml(delta.tokens || "—") + "</td></tr>";
       }
 
       html += "</tbody></table>";
@@ -1225,7 +1232,7 @@
               const r = run.result || {};
               const prClass = r.pass_rate >= 0.8 ? "benchmark-delta-positive" : r.pass_rate < 0.5 ? "benchmark-delta-negative" : "";
               html += '<tr class="' + rowClass + '">';
-              html += "<td>" + configLabel + "</td>";
+              html += "<td>" + escapeHtml(configLabel) + "</td>";
               html += "<td>" + run.run_number + "</td>";
               html += '<td class="' + prClass + '">' + ((r.pass_rate || 0) * 100).toFixed(0) + "% (" + (r.passed || 0) + "/" + (r.total || 0) + ")</td>";
               if (hasTime) html += "<td>" + (r.time_seconds != null ? r.time_seconds.toFixed(1) : "—") + "</td>";
@@ -1238,7 +1245,7 @@
             const avgRate = rates.reduce((a, b) => a + b, 0) / rates.length;
             const avgPrClass = avgRate >= 0.8 ? "benchmark-delta-positive" : avgRate < 0.5 ? "benchmark-delta-negative" : "";
             html += '<tr class="benchmark-row-avg ' + rowClass + '">';
-            html += "<td>" + configLabel + "</td>";
+            html += "<td>" + escapeHtml(configLabel) + "</td>";
             html += "<td>Avg</td>";
             html += '<td class="' + avgPrClass + '">' + (avgRate * 100).toFixed(0) + "%</td>";
             if (hasTime) {


### PR DESCRIPTION
Fixes #1394.

### Problem

`viewer.html` assembles HTML by string concatenation and assigns it with
`innerHTML` in `renderGrades` and `renderBenchmark`, relying on `escapeHtml()`
at each interpolation. Two gaps let attacker-influenced data (grader "evidence"
and assertion text can quote a skill-under-test's output; eval and config names
are user-authored) reach the DOM as markup:

- **`escapeHtml()` was not attribute-safe.** It used the `textContent` →
  `innerHTML` round-trip, which escapes `<`, `>`, `&` but not quotes — yet it is
  used inside a `title="..."` attribute in the per-assertion table. Evidence
  containing a double quote breaks out of the attribute and can attach an event
  handler (e.g. `x" onmouseover="alert(document.domain)`).
- **Several externally-sourced strings were interpolated raw**: the config label
  in the per-eval breakdown rows (while the same value is escaped in the header),
  and `metadata.timestamp` / `metadata.evals_run` / `metadata.runs_per_configuration`
  / the `delta.*` cells.

### Fix

- Rewrite `escapeHtml()` to escape `&`, `<`, `>`, `"`, `'` explicitly, so it is
  safe in both element-text and attribute contexts.
- Route the remaining raw externally-sourced string interpolations through it, so
  every externally-sourced string rendered via `innerHTML` is escaped and only
  locally-computed numbers are interpolated directly.

The escaped forms render identically for normal data, so there is no visible
change.

### Scope / related

This is the **display path**. The **embed path** — `generate_review.py` injecting
`EMBEDDED_DATA` into the inline `<script>` without escaping `</`, which lets a
`</script>` in skill output break out of the script element (#1075) — is fixed
separately in #1393. The two together harden the viewer end to end; they touch
different files and do not conflict. The xlsx preview relies on SheetJS's own
cell-text escaping and is left as-is.
