### PR TITLE
fix(webapp-testing): discard server output to prevent PIPE deadlock

### DIFF
--- a/skills/webapp-testing/scripts/with_server.py
+++ b/skills/webapp-testing/scripts/with_server.py
@@ -66,11 +66,13 @@ def main():
             print(f"Starting server {i+1}/{len(servers)}: {server['cmd']}")
 
             # Use shell=True to support commands with cd and &&
+            # Discard server output: an unread PIPE deadlocks the server once the
+            # OS buffer fills, and inheriting our stdout would flood the caller.
             process = subprocess.Popen(
                 server['cmd'],
                 shell=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
             )
             server_processes.append(process)
 


### PR DESCRIPTION
## Problem

`skills/webapp-testing/scripts/with_server.py` starts each server with `stdout=subprocess.PIPE` / `stderr=subprocess.PIPE`, but nothing ever reads from those pipes. The server keeps running for the whole test run, so once it writes more than the OS pipe buffer holds (~64KB, a handful of request logs), its next write blocks. The server hangs, requests stop being served, and the run stalls.

## Repro

A server that keeps logging hangs the current script:

```python
# chatty_server.py — binds a port and floods stdout
import http.server, socketserver, threading, sys
threading.Thread(target=lambda: [print("log " + "x"*80) or sys.stdout.flush() for _ in range(200000)], daemon=True).start()
socketserver.TCPServer(("", 8731), http.server.SimpleHTTPRequestHandler).serve_forever()
```

```
python scripts/with_server.py --server "python3 chatty_server.py" --port 8731 -- curl localhost:8731
```

On `main` this never reaches "ready" once the buffer fills. With the fix it runs to completion.

## Fix

Use `subprocess.DEVNULL` for the server's stdout and stderr. The output is discarded, so the buffer can never fill and the server can't block.

Discarding is the right default here: this is a black-box helper that starts a server, runs a command, and tears the server down. Inheriting the caller's stdout instead would flood it with server logs (the same skill tells agents to avoid filling their context). When a server fails to start, re-running its command shows the output.
