### PR TITLE
fix(skill-creator): make eval-viewer escapeHtml attribute-safe

### DIFF
--- a/skills/skill-creator/eval-viewer/viewer.html
+++ b/skills/skill-creator/eval-viewer/viewer.html
@@ -1097,9 +1097,12 @@
     }
 
     function escapeHtml(text) {
-      const div = document.createElement("div");
-      div.textContent = text;
-      return div.innerHTML;
+      return String(text)
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
     }
 
     // ---- View switching ----
@@ -1129,9 +1132,9 @@
       html += "<h2 style='font-family: Poppins, sans-serif; margin-bottom: 0.5rem;'>Benchmark Results</h2>";
       html += "<p style='color: var(--text-muted); font-size: 0.875rem; margin-bottom: 1.25rem;'>";
       if (metadata.skill_name) html += "<strong>" + escapeHtml(metadata.skill_name) + "</strong> &mdash; ";
-      if (metadata.timestamp) html += metadata.timestamp + " &mdash; ";
-      if (metadata.evals_run) html += "Evals: " + metadata.evals_run.join(", ") + " &mdash; ";
-      html += (metadata.runs_per_configuration || "?") + " runs per configuration";
+      if (metadata.timestamp) html += escapeHtml(metadata.timestamp) + " &mdash; ";
+      if (metadata.evals_run) html += "Evals: " + escapeHtml(metadata.evals_run.join(", ")) + " &mdash; ";
+      html += escapeHtml(metadata.runs_per_configuration || "?") + " runs per configuration";
       html += "</p>";
 
       // Summary table
@@ -1169,14 +1172,14 @@
       html += "<tr><td><strong>Pass Rate</strong></td>";
       html += "<td>" + fmtStat(a.pass_rate, true) + "</td>";
       html += "<td>" + fmtStat(b.pass_rate, true) + "</td>";
-      html += '<td class="' + deltaClass(delta.pass_rate) + '">' + (delta.pass_rate || "—") + "</td></tr>";
+      html += '<td class="' + deltaClass(delta.pass_rate) + '">' + escapeHtml(delta.pass_rate || "—") + "</td></tr>";
 
       // Time (only show row if data exists)
       if (a.time_seconds || b.time_seconds) {
         html += "<tr><td><strong>Time (s)</strong></td>";
         html += "<td>" + fmtStat(a.time_seconds, false) + "</td>";
         html += "<td>" + fmtStat(b.time_seconds, false) + "</td>";
-        html += '<td class="' + deltaClass(delta.time_seconds) + '">' + (delta.time_seconds ? delta.time_seconds + "s" : "—") + "</td></tr>";
+        html += '<td class="' + deltaClass(delta.time_seconds) + '">' + (delta.time_seconds ? escapeHtml(delta.time_seconds + "s") : "—") + "</td></tr>";
       }
 
       // Tokens (only show row if data exists)
@@ -1184,7 +1187,7 @@
         html += "<tr><td><strong>Tokens</strong></td>";
         html += "<td>" + fmtStat(a.tokens, false) + "</td>";
         html += "<td>" + fmtStat(b.tokens, false) + "</td>";
-        html += '<td class="' + deltaClass(delta.tokens) + '">' + (delta.tokens || "—") + "</td></tr>";
+        html += '<td class="' + deltaClass(delta.tokens) + '">' + escapeHtml(delta.tokens || "—") + "</td></tr>";
       }
 
       html += "</tbody></table>";
@@ -1225,7 +1228,7 @@
               const r = run.result || {};
               const prClass = r.pass_rate >= 0.8 ? "benchmark-delta-positive" : r.pass_rate < 0.5 ? "benchmark-delta-negative" : "";
               html += '<tr class="' + rowClass + '">';
-              html += "<td>" + configLabel + "</td>";
+              html += "<td>" + escapeHtml(configLabel) + "</td>";
               html += "<td>" + run.run_number + "</td>";
               html += '<td class="' + prClass + '">' + ((r.pass_rate || 0) * 100).toFixed(0) + "% (" + (r.passed || 0) + "/" + (r.total || 0) + ")</td>";
               if (hasTime) html += "<td>" + (r.time_seconds != null ? r.time_seconds.toFixed(1) : "—") + "</td>";
@@ -1238,7 +1241,7 @@
             const avgRate = rates.reduce((a, b) => a + b, 0) / rates.length;
             const avgPrClass = avgRate >= 0.8 ? "benchmark-delta-positive" : avgRate < 0.5 ? "benchmark-delta-negative" : "";
             html += '<tr class="benchmark-row-avg ' + rowClass + '">';
-            html += "<td>" + configLabel + "</td>";
+            html += "<td>" + escapeHtml(configLabel) + "</td>";
             html += "<td>Avg</td>";
             html += '<td class="' + avgPrClass + '">' + (avgRate * 100).toFixed(0) + "%</td>";
             if (hasTime) {


### PR DESCRIPTION
Fixes #1394.

## The bug

`escapeHtml()` in `skills/skill-creator/eval-viewer/viewer.html` used the `textContent` → `innerHTML` round-trip, which escapes `<`, `>`, and `&` but **not** `"` or `'`. It's used inside an HTML attribute in `renderBenchmark`'s per-assertion table (`title="Run N: <evidence>"`), so grader evidence containing a double quote breaks out of the attribute and can attach an event handler:

```
evidence = `x" onmouseover="alert(document.domain)`
→ title="Run 1: x" onmouseover="alert(document.domain)"
```

`EMBEDDED_DATA` carries assertion text, eval/skill names, and grader "evidence" — none of it is trusted markup.

Several other externally-sourced strings were also interpolated raw with no `escapeHtml()` at all: `metadata.timestamp`, `metadata.evals_run`, `metadata.runs_per_configuration`, the `delta.*` cells, and the per-eval-breakdown `configLabel` (inconsistently — the *same* computed value was already escaped in the assertion-table header two call sites away, just not in the breakdown rows).

## The fix

- Rewrite `escapeHtml()` to explicitly escape `&`, `<`, `>`, `"`, and `'`, so it's safe in both element-text and attribute contexts.
- Route the remaining raw interpolations through `escapeHtml()`.

Verified the exact repro from the issue no longer breaks out of the attribute, and that escaping is transparent for normal data (browsers decode the entities back to the same display text, so there's no visible change).

Out of scope (per the issue): the embed path (`generate_review.py` → inline `<script>`, issue #1075) and the xlsx preview (relies on SheetJS's own escaping).

## Test plan
- [x] Reproduced the reported XSS locally against the old `escapeHtml`, confirmed the new version neutralizes it (double quote → `&quot;`, no attribute break-out)
- [x] Confirmed benign strings render identically before/after (entities decode back to the same visible text)
- [ ] No existing test harness for this standalone HTML viewer — happy to add one if maintainers want a specific format