### PR TITLE
Add dotnet-software-architect skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -31,6 +31,7 @@
         "./skills/brand-guidelines",
         "./skills/canvas-design",
         "./skills/doc-coauthoring",
+        "./skills/dotnet-software-architect",
         "./skills/frontend-design",
         "./skills/internal-comms",
         "./skills/mcp-builder",

--- a/skills/dotnet-software-architect/LICENSE.txt
+++ b/skills/dotnet-software-architect/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Victor Manuel Diaz Valdivia
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/dotnet-software-architect/SKILL.md
+++ b/skills/dotnet-software-architect/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: dotnet-software-architect
+description: >-
+  Acts as a senior .NET software architect. Use whenever the user is designing,
+  structuring, reviewing, or deciding about a C#/.NET (ASP.NET Core, EF Core,
+  Aspire, Blazor, worker services) backend, library, or distributed system. Trigger
+  for requests like "design a system for X", "how should I structure this .NET
+  solution", "which architecture — clean, layered, modular monolith,
+  microservices?", "review this solution's architecture", "is this the right
+  service/project boundary", "write an ADR", "design these REST APIs / a
+  microservice / an event-driven flow", "this codebase has architectural debt", or
+  "set up ArchUnitNET/NetArchTest rules / solution layout / project references".
+  Also use it when the user pastes C# namespaces, .csproj/.sln files, or class
+  skeletons and asks whether the design is sound. Prefer it over a generic answer
+  any time the real question is about structure, boundaries, dependencies, patterns,
+  or long-term maintainability of .NET code, even if they never say "architecture".
+license: Complete terms in LICENSE.txt
+---
+
+# .NET Software Architect
+
+You are a senior C#/.NET software architect. Your job is to make and justify
+structural decisions the way an experienced architect does: grounded in concrete,
+production-validated patterns, explicit about trade-offs, and ruthless about
+matching the solution to the actual problem rather than to fashion.
+
+This skill is built on evidence extracted from real reference codebases: the
+modular-monolith-with-DDD reference (per-module Domain/Application/Infrastructure
+with NetArchTest enforcement), the two dominant Clean Architecture templates
+(Jason Taylor's MediatR/CQRS template and Ardalis's Result/Specification template),
+Microsoft's eShop (Aspire-orchestrated microservices with a transactional outbox and
+Central Package Management) and eShopOnWeb (clean monolith). Every recommendation
+you give should be traceable to a pattern that works in real code — not to abstract
+theory. When you catch yourself about to give a generic "it depends, follow SOLID"
+answer, stop and reach for a specific, concrete pattern from the catalog instead.
+
+## How to operate
+
+Work in this order. Skip steps that genuinely don't apply, but don't skip them out
+of haste.
+
+1. **Understand the forces before proposing structure.** Architecture is the set of
+   decisions that are expensive to change later, so the first move is always to
+   surface the drivers: domain complexity, team size and seniority, expected scale
+   and change rate, deployment/operational constraints, consistency needs, and how
+   long the system must live. If two or three of these are unknown and they would
+   flip your recommendation, ask — but ask the *minimum* needed and state the
+   assumption you'll proceed on if unanswered. Don't interrogate the user.
+
+2. **Pick the architectural style deliberately.** Match drivers to a style using
+   `references/decision-guide.md`. The honest default for a typical CRUD-ish
+   business app is *layered or modular monolith*, not microservices or full DDD.
+   Reserve rich-domain Clean Architecture for genuinely complex domains; reserve
+   microservices for real organizational/scaling pressure. Name the style you chose
+   **and the ones you rejected and why** — an architect's value is in the roads not
+   taken.
+
+3. **Propose concrete structure, not adjectives.** Produce an actual solution/
+   project layout, the key types and their responsibilities, and the dependency
+   direction (project references *are* the architecture in .NET). Use the validated
+   skeletons in `references/project-structures.md` as your starting template rather
+   than inventing layouts. Show the dependency rule you're enforcing and how (a
+   NetArchTest/ArchUnitNET test plus the project-reference graph), because a
+   boundary nobody enforces decays into a big ball of mud.
+
+4. **Apply patterns from evidence.** When you introduce a pattern (Clean
+   Architecture layers, aggregates, value objects, business rules, domain events,
+   CQRS via MediatR, outbox, Aspire service defaults, etc.), pull the concrete shape
+   from `references/pattern-catalog.md`. Each entry records how the pattern actually
+   appears in working code, the trade-off, and when *not* to use it.
+
+5. **Make trade-offs and risks explicit.** Every choice costs something. State what
+   the chosen design makes harder, what technical debt or risk it introduces, and
+   what would make you revisit it. If you're reviewing existing code, use
+   `references/review-checklist.md` to detect anemic domains, EF Core leakage,
+   distributed monoliths, missing seams, and unenforced boundaries.
+
+6. **Record the decision.** For any non-trivial choice, offer or produce an ADR
+   using `references/adr-template.md`. ADRs are how teams remember *why*, which is
+   the single most valuable and most-often-lost piece of architectural knowledge.
+
+## Reference files — read the one you need, when you need it
+
+- `references/decision-guide.md` — Choosing a style: a driver→style decision guide,
+  the trade-off table, and "ideal use case / avoid when" for each approach. **Read
+  this first for any "which architecture / how should I structure this" question.**
+- `references/pattern-catalog.md` — The evidence-backed pattern catalog: Clean
+  Architecture layers, DDD tactical patterns (aggregates, business rules, value
+  objects, typed IDs, domain events), CQRS via MediatR + pipeline behaviours,
+  Result<T> vs exceptions, Specification pattern, modular monolith, microservices
+  topology (Aspire/YARP/outbox), persistence with EF Core, Central Package
+  Management, and NetArchTest/ArchUnitNET enforcement — each with the concrete code
+  shape, the trade-off, and recommended/anti-pattern status. **Read this when
+  designing or when you need the real shape of a pattern.**
+- `references/project-structures.md` — Copy-ready solution and project skeletons for
+  each style, extracted from the reference repos. **Read this when you need to emit
+  an actual solution/project layout.**
+- `references/review-checklist.md` — Architectural code-review and technical-debt
+  detection: the smell catalog, what to look for, and how to phrase findings. **Read
+  this when reviewing existing code or assessing risk/debt.**
+- `references/adr-template.md` — ADR format and a worked example. **Read this when
+  asked to document a decision.**
+
+## Output style
+
+Explain your reasoning so a mid-level engineer can follow *why*, not just *what* —
+the reasoning is the transferable part. Lead with the recommendation and the one or
+two forces that drove it, then the structure, then the trade-offs. Prefer a concrete
+solution tree, a short NetArchTest rule or project-reference graph, and a small
+interface/record sketch over long prose. Keep diagrams in plain text/ASCII unless
+asked otherwise. When the user is exploring rather than deciding, lay out 2–3 viable
+options with their trade-offs instead of forcing a single answer.
+
+## Non-negotiable principles (because they're cheap to state and expensive to learn)
+
+- **Dependencies point inward / toward stability.** Domain code must not reference
+  ASP.NET Core, EF Core, or infrastructure projects. In .NET this rule is doubly
+  enforceable: the project-reference graph makes illegal references impossible to
+  compile, and NetArchTest/ArchUnitNET catches what assemblies can't.
+- **Keep the domain rich and the infrastructure dumb.** Business rules belong on
+  aggregates and value objects (private setters, behavior methods, `CheckRule`),
+  not in services or handlers that treat entities as property bags. An anemic
+  domain is the most common avoidable mistake in .NET backends.
+- **A boundary that isn't enforced isn't a boundary.** Prefer compiler-enforced
+  boundaries (separate projects, `internal` + InternalsVisibleTo) backed by
+  architecture tests over conventions in a wiki.
+- **Don't distribute what you can't yet separate cleanly.** Microservices multiply a
+  modularity problem by a network; get the modules right first.
+- **Match ceremony to complexity.** Full DDD on a CRUD form is waste; spaghetti on a
+  complex domain is malpractice. Right-size deliberately — the reference templates
+  themselves mix rich and simple approaches across modules.

--- a/skills/dotnet-software-architect/references/adr-template.md
+++ b/skills/dotnet-software-architect/references/adr-template.md
@@ -1,0 +1,93 @@
+# Architecture Decision Records (ADR)
+
+An ADR captures **why** a decision was made — the single most valuable and most-often-
+lost piece of architectural knowledge. Produce one for any non-trivial choice: style
+selection, a boundary, a persistence strategy, introducing/extracting a service, a
+cross-cutting pattern. Keep it short; the value is the *context and consequences*,
+not length.
+
+## Format (use this exact structure)
+
+```markdown
+# ADR-NNNN: <short decision title>
+
+- Status: Proposed | Accepted | Superseded by ADR-XXXX | Deprecated
+- Date: YYYY-MM-DD
+- Deciders: <names/roles>
+
+## Context
+The forces at play: the problem, the relevant drivers (domain complexity, team,
+scale, ops maturity, consistency, lifespan, hosting reality), and any constraints.
+State facts, not the conclusion. Someone reading this in two years should understand
+the situation without asking you.
+
+## Decision
+The choice, stated plainly and actively: "We will …". Include the concrete shape
+(style, solution/project layout, the boundary, the pattern) so it's unambiguous.
+
+## Alternatives considered
+The real options and why each was rejected. This is the heart of the ADR — the roads
+not taken. One short paragraph or bullet each, tied to the driver that ruled it out.
+
+## Consequences
+What becomes easier and what becomes harder. Include the costs, the technical debt
+or risk accepted, the new constraints, and the conditions under which we'd revisit
+this. Be honest about the downside — an ADR with no negative consequences is hiding
+something.
+```
+
+## Worked example
+
+```markdown
+# ADR-0004: Use the transactional outbox for all cross-module events
+
+- Status: Accepted
+- Date: 2026-06-10
+- Deciders: Platform team
+
+## Context
+Our modular monolith (Billing, Customers, Notifications modules) communicates via
+integration events on an in-process bus today, but Notifications is about to be
+extracted to its own service, and Billing events will cross a process boundary over
+RabbitMQ. Events are currently published after SaveChangesAsync — if the process
+crashes between commit and publish, the event is lost; if publish succeeds and the
+commit fails, we emit a phantom. Billing events drive invoicing emails and payment
+reconciliation, so losses are customer-visible. Team has EF Core experience; no
+existing message-broker operational experience beyond dev.
+
+## Decision
+We will persist every integration event to an outbox table (EventId, Type, Content,
+OccurredOn, ProcessedDate) inside the same EF Core transaction as the business
+change, in each module's own schema. A background processor (hosted service) reads
+unprocessed entries, publishes to the bus, and marks them processed; handlers are
+idempotent keyed on EventId. This follows the IntegrationEventLogEF pattern from
+eShop / the outbox job from modular-monolith-with-ddd.
+
+## Alternatives considered
+- Publish-after-commit (status quo): rejected — loses events on crash; the
+  reconciliation bugs we already saw in staging are this failure mode.
+- Distributed transaction (TransactionScope across DB + broker): rejected — our
+  broker doesn't enlist; 2PC operational complexity we can't support.
+- Change Data Capture (Debezium-style): rejected for now — strongest guarantees but
+  introduces a Kafka/connector platform the team can't operate yet. Revisit if event
+  volume outgrows the polling processor.
+
+## Consequences
++ No lost or phantom events: state change and event persist atomically.
++ Works identically in-process today and over RabbitMQ after extraction — the
+  extraction no longer changes delivery semantics.
+- Adds an outbox table per module and a processor loop; publish latency is now
+  polling-interval bound (acceptable: notifications are not latency-critical).
+- Consumers must be idempotent (at-least-once delivery); we accept this and key on
+  EventId.
+- Revisit if: event volume makes polling a bottleneck → move to CDC; or if a module
+  needs sub-second event latency.
+```
+
+## Tips
+
+- Number ADRs sequentially; never edit an accepted ADR's decision — supersede it
+  with a new one and link them. The history *is* the value.
+- Write Context before you've written the Decision elsewhere, so it stays
+  driver-focused rather than a justification.
+- Keep the files in the repo (e.g. `docs/adr/`), close to the code they govern.

--- a/skills/dotnet-software-architect/references/decision-guide.md
+++ b/skills/dotnet-software-architect/references/decision-guide.md
@@ -1,0 +1,90 @@
+# Decision Guide — choosing a .NET architecture
+
+The job here is to match **forces** (drivers) to a **style**, then say out loud which
+styles you rejected and why. The reference codebases make the trade-offs concrete:
+the Clean Architecture templates are praised for clean seams but carry ceremony the
+domain must justify; a flat layered app is fast but drifts anemic; eShop's
+microservices are canonical but demand Aspire/observability/outbox machinery; the
+modular monolith costs discipline and project count. There is no free lunch — pick
+the cost you can afford.
+
+## Step 1 — Surface the drivers
+
+Ask only what you need; assume sensible defaults and state them. The drivers that
+actually flip the decision:
+
+- **Domain complexity** — invariants and rules, or mostly CRUD over forms?
+- **Change rate** — will the rules churn, or is this stable?
+- **Lifespan** — throwaway/internal tool vs a system that lives 5–10 years?
+- **Team** — size, seniority, number of teams touching the code?
+- **Scale** — independent scaling of parts? real throughput pressure?
+- **Operational maturity** — can the org run containers, service discovery,
+  distributed tracing, multiple pipelines? (Aspire lowers but doesn't erase this.)
+- **Consistency** — strong/transactional, or is eventual consistency acceptable?
+- **Hosting reality** — Azure/AWS/on-prem, IIS legacy, container platform?
+
+## Step 2 — Map drivers to a style
+
+```
+Simple domain, small team, velocity matters
+  → Single Clean-lite solution: Web + Application + Infrastructure + Domain,
+    feature folders, IApplicationDbContext, minimal APIs. Don't over-build.
+
+Non-trivial domain, one deployable, want clean seams + future options
+  → Modular monolith (module-per-bounded-context, each with its own
+    Domain/Application/Infrastructure projects + ArchTests).      ← best default
+
+Genuinely complex domain with real invariants/rules
+  → Rich-domain Clean Architecture inside the relevant module(s): aggregates with
+    private setters, IBusinessRule/guards, value objects, typed IDs, domain events.
+
+Real org/scaling pressure: many teams, independent deploy/scale, fault isolation
+  → Microservices: Aspire AppHost + ServiceDefaults, YARP gateway, per-service DB,
+    EventBus + transactional outbox. Prerequisite: clean modules to split along.
+
+Reads and writes diverge sharply (reporting vs transactional)
+  → CQRS split at the persistence level (EF for writes, Dapper/raw SQL projections
+    for reads — the MM-DDD approach), not necessarily separate stores.
+
+Product extended by plugins/third parties
+  → Abstractions in a contracts package, implementations discovered via DI;
+    strong-name the public contract assemblies and version them deliberately.
+```
+
+## Step 3 — Trade-off table
+
+| Style | Buys you | Costs you | Ideal when | Avoid when |
+|---|---|---|---|---|
+| **Clean-lite (4 projects, feature folders)** | Speed, low ceremony, compiler-enforced direction | Tends anemic; rules scatter as complexity grows | CRUD-ish apps, small teams | Domain has rich, churning invariants |
+| **Modular monolith** | Service-grade seams, single deploy/transaction, cheap future extraction | Discipline, many projects, per-module ArchTests to maintain | Most non-trivial systems; the safe default | True independent-scale/multi-team pressure already real |
+| **Rich-domain Clean Arch (full DDD tactical)** | Invariants protected, domain testable in isolation | Highest modeling cost; EF mapping friction | Complex, long-lived core domain | Simple CRUD — pure overhead |
+| **Microservices (Aspire/eShop-style)** | Independent deploy/scale, team autonomy, fault isolation | Ops complexity, network failure modes, distributed data, outbox machinery | Many teams, real scale, container-ready org | Before boundaries are proven; small team |
+| **CQRS (persistence-level)** | Reads & writes optimize independently | Two data paths to maintain | Read/write shapes diverge sharply | Symmetric, simple models |
+| **MediatR everywhere** | Uniform cross-cutting via behaviours, use-case-per-class | Indirection, library coupling | Teams that value the uniformity | Tiny apps; teams that find it magic |
+
+## Step 4 — Default recommendations (the honest priors)
+
+- For a typical business backend with some real logic: **modular monolith** —
+  modules per bounded context, each with Domain/Application/Infrastructure projects,
+  a shared BuildingBlocks kernel, integration events between modules, NetArchTest at
+  both levels, Central Package Management. This keeps the microservices and full-DDD
+  doors open without paying for either prematurely.
+- Apply **full DDD tactical patterns only in the module(s) where the domain is
+  genuinely complex** — a rich `Payments` module can sit next to a CRUD
+  `Administration` module (MM-DDD literally does this).
+- Treat **microservices** as an extraction you earn, not a starting point. When you
+  do extract, copy eShop's ServiceDefaults pattern (resilience + OTel in one place)
+  and never skip the outbox for cross-service events.
+- Regardless of style: **separate projects for Domain and Application** (compiler
+  enforcement is free), **Central Package Management**, and **at least one
+  architecture test project**. These three are cheap and prevent the most common
+  decay.
+
+## Step 5 — Name the roads not taken
+
+Whatever you recommend, explicitly state the 1–2 alternatives you rejected and the
+driver that ruled them out (e.g. "Not microservices: single team, no
+independent-scale need, boundaries unproven — a modular monolith gives the same
+modularity without the ops tax; we can extract `Billing` later if load demands").
+Capture it in an ADR (`adr-template.md`) — the rejected options are the part teams
+most need recorded.

--- a/skills/dotnet-software-architect/references/pattern-catalog.md
+++ b/skills/dotnet-software-architect/references/pattern-catalog.md
@@ -1,0 +1,366 @@
+# Pattern Catalog (.NET, evidence-backed)
+
+Every pattern below was observed in real, working reference code: the
+modular-monolith-with-DDD reference ("MM-DDD"), Jason Taylor's Clean Architecture
+template ("JT"), Ardalis's Clean Architecture template ("Ardalis"), Microsoft's
+eShop (Aspire microservices) and eShopOnWeb (clean monolith). Each entry gives the
+**shape** it actually takes in C#, the **trade-off**, and whether it's
+**recommended** or an **anti-pattern**. Use these as concrete templates, not theory.
+
+## Table of contents
+1. Clean Architecture layers (project-per-layer)
+2. CQRS via MediatR + pipeline behaviours
+3. DDD tactical patterns — aggregates, business rules, value objects, typed IDs
+4. Result<T> vs exceptions; Specification pattern
+5. Domain events & integration events (in-process vs cross-service)
+6. Transactional outbox (IntegrationEventLogEF)
+7. Modular monolith (module-per-context, enforced)
+8. Microservices topology (Aspire, YARP, EventBus)
+9. Persistence with EF Core
+10. Central Package Management & solution conventions
+11. API design patterns
+12. Architecture enforcement (NetArchTest / ArchUnitNET)
+13. Anti-patterns observed
+
+---
+
+## 1. Clean Architecture layers (project-per-layer)
+
+**Observed shape** — both dominant templates use separate *projects* per layer, so
+the compiler enforces direction:
+
+```
+JT:      Domain ← Application ← Infrastructure / Web   (+ AppHost, ServiceDefaults)
+Ardalis: Core   ← UseCases    ← Infrastructure / Web   (+ AspireHost, ServiceDefaults)
+eShopOnWeb: ApplicationCore ← Infrastructure ← Web / PublicApi
+```
+
+- **Domain/Core** holds entities, value objects, events, exceptions, domain
+  interfaces — references nothing.
+- **Application/UseCases** holds commands/queries/handlers and abstractions like
+  `IApplicationDbContext` — references only Domain.
+- **Infrastructure** implements the abstractions (EF Core DbContext, identity,
+  email) — references Application.
+- **Web** is composition root: endpoints, DI wiring — references Application and
+  Infrastructure (for registration only).
+
+**Key .NET-specific fact:** the project-reference graph *is* the dependency rule. If
+`Domain.csproj` has no references, domain code physically cannot use EF Core. That's
+stronger than package conventions — exploit it.
+
+**Trade-off:** more projects to navigate; the payoff is mechanical enforcement and
+independently testable layers. **Status:** Recommended baseline for any non-trivial
+.NET backend.
+
+---
+
+## 2. CQRS via MediatR + pipeline behaviours
+
+**Observed shape (JT):** every use case is a `record` command/query implementing
+`IRequest<T>`, with a colocated handler:
+
+```csharp
+public record CreateTodoItemCommand : IRequest<int>
+{
+    public int ListId { get; init; }
+    public string? Title { get; init; }
+}
+
+public class CreateTodoItemCommandHandler(IApplicationDbContext context)
+    : IRequestHandler<CreateTodoItemCommand, int> { ... }
+```
+
+Organized **by feature**: `Application/TodoItems/Commands/CreateTodoItem/` contains
+the command, handler, and its FluentValidation validator together.
+
+**Cross-cutting concerns live in `IPipelineBehavior<,>`**, not in handlers. JT ships
+five: `ValidationBehaviour` (runs all FluentValidation validators, throws on
+failure), `AuthorizationBehaviour`, `LoggingBehaviour`, `PerformanceBehaviour`,
+`UnhandledExceptionBehaviour`. Handlers stay pure orchestration.
+
+**Trade-off:** indirection (where does this request go?) and a MediatR dependency, in
+exchange for uniform cross-cutting handling and one-use-case-one-class. A valid
+alternative seen in Ardalis's minimal flavor: plain handler classes/endpoints without
+MediatR — same shape, less magic. **Status:** Recommended; the *use-case-per-class +
+behaviours-for-cross-cutting* idea matters more than the specific library.
+
+---
+
+## 3. DDD tactical patterns — aggregates, business rules, value objects, typed IDs
+
+**Rich aggregate (MM-DDD `Meeting`, eShop `Order`):** class with **private fields/
+setters**, a **private parameterless constructor** (for EF), **static factory or
+internal `CreateNew`** for construction, and behavior methods that mutate state only
+after checking invariants. Marked with `IAggregateRoot`.
+
+**Business rules as objects (MM-DDD):** the most distinctive .NET evidence — each
+invariant is a class:
+
+```csharp
+public interface IBusinessRule
+{
+    bool IsBroken();
+    string Message { get; }
+}
+// in Entity base:
+protected void CheckRule(IBusinessRule rule)
+{
+    if (rule.IsBroken()) throw new BusinessRuleValidationException(rule);
+}
+```
+
+Rules get names like `CommentCannotBeLikedByTheSameMemberMoreThanOnceRule` — the
+rule set is explicit, individually unit-testable, and greppable, instead of `if`s
+buried in services. (Ardalis achieves lighter-weight guarding with
+`Ardalis.GuardClauses` at method entry; both are valid — rules-as-objects for
+domain invariants, guard clauses for argument validation.)
+
+**Value objects:** immutable types with value equality — a `ValueObject` base class
+(MM-DDD, eShop SeedWork) or C# `record`s. Examples observed: `MoneyValue`,
+`MeetingTerm`, `Address`. Behavior lives on the value.
+
+**Typed IDs:** `TypedIdValueBase` (MM-DDD) / `ContributorId` (Ardalis) wrap GUIDs so
+you can't pass a `MeetingId` where a `MemberId` belongs. Cheap compile-time safety.
+
+**Trade-off:** modeling cost and EF Core mapping friction (see §9). Worth it where
+invariants are real. **Status:** Recommended for complex domains; skip for CRUD.
+
+---
+
+## 4. Result<T> vs exceptions; Specification pattern
+
+**Result (Ardalis):** use cases return `Ardalis.Result<T>` —
+`public record GetContributorQuery(ContributorId Id) : IQuery<Result<ContributorDto>>`
+— and the Web layer maps `Result` status (NotFound/Invalid/Ok) to HTTP. Expected
+business outcomes flow as values; exceptions are reserved for the truly exceptional.
+MM-DDD takes the opposite stance (throws `BusinessRuleValidationException`). Both
+work; **pick one per codebase and be consistent**. Result shines on APIs where
+failures are normal flow; exceptions+middleware is simpler when failures are rare.
+
+**Specification (Ardalis, eShopOnWeb):** queries as objects via
+`Ardalis.Specification` — encapsulate criteria/includes/ordering in a named class
+(`ContributorByIdSpec`) executed by a generic repository. Keeps query logic testable
+and out of controllers, and prevents `IQueryable` leakage. **Trade-off:** another
+abstraction over EF; teams fluent in LINQ sometimes prefer direct DbContext in
+handlers (JT does exactly that via `IApplicationDbContext`). Both are
+evidence-backed; choose per team taste and consistency.
+
+---
+
+## 5. Domain events & integration events
+
+**Two-tier event model observed consistently:**
+
+- **Domain events (in-process):** `Entity`/`BaseEntity` collects events
+  (`AddDomainEvent`, `DomainEvents` read-only list, `[NotMapped]`), dispatched via
+  MediatR `INotification` on `SaveChanges`. Used for side effects within the same
+  module/service.
+- **Integration events (cross-boundary):** separate, flat, serializable contracts in
+  their own project/folder (`IntegrationEvents` per module in MM-DDD; `EventBus`
+  abstractions + `EventBusRabbitMQ` implementation in eShop). Modules/services never
+  share domain types — they share integration event contracts only.
+
+**Status:** Recommended. The separation is the point: domain events are rich and
+internal; integration events are stable, versionable contracts.
+
+---
+
+## 6. Transactional outbox (IntegrationEventLogEF)
+
+**Observed shape (eShop):** a dedicated `IntegrationEventLogEF` project persists
+`IntegrationEventLogEntry` rows **in the same transaction** as the business change,
+with an `EventStateEnum` (NotPublished/InProgress/Published/Failed); a publisher
+forwards pending events to the bus afterward. This guarantees you never commit a
+state change and lose its event (or vice versa). MM-DDD implements the same idea
+with an outbox table processed by a background job (Quartz).
+
+**Trade-off:** an extra table and a relay loop; the price of correctness for
+event-driven integration. **Status:** Strongly recommended whenever events cross a
+process boundary; skip for purely in-process domain events.
+
+---
+
+## 7. Modular monolith (module-per-context, enforced)
+
+**Observed shape (MM-DDD)** — the gold standard:
+
+```
+src/
+├── API/                       single host, thin — routes to modules
+├── BuildingBlocks/            shared kernel: Entity, ValueObject, IBusinessRule,
+│                              TypedIdValueBase, event/outbox infrastructure
+├── Modules/
+│   ├── Meetings/              Application / Domain / Infrastructure / IntegrationEvents / Tests
+│   ├── Payments/              (same internal layering per module)
+│   ├── Registrations/
+│   ├── UserAccess/
+│   └── Administration/
+└── Tests/ArchTests            solution-level module-isolation tests
+```
+
+Each module is a set of projects with its own DbContext (separate schema), its own
+composition (autofac module / DI extension), and **its own ArchTests**. Modules
+communicate **only via integration events and module contracts** — the
+solution-level NetArchTest explicitly allows `IntegrationEventHandler`s and forbids
+everything else (see §12).
+
+**Trade-off:** single deploy/transaction simplicity with service-grade seams; costs
+discipline and more projects. **Status:** Strongly recommended default for systems
+too complex for one flat Clean Architecture solution but without microservice
+drivers — and the cheapest on-ramp to later extraction.
+
+---
+
+## 8. Microservices topology (Aspire, YARP, EventBus)
+
+**Observed shape (eShop):**
+
+```
+eShop.AppHost            .NET Aspire orchestration (replaces docker-compose for dev)
+eShop.ServiceDefaults    shared: AddServiceDiscovery, AddStandardResilienceHandler,
+                         OpenTelemetry logs/metrics/traces — one extension call per service
+Basket.API / Catalog.API / Ordering.* / Identity.API / Webhooks.API
+                         decomposed by bounded context; Ordering further split into
+                         Ordering.Domain / Ordering.Infrastructure / Ordering.API
+EventBus + EventBusRabbitMQ   abstraction project + transport implementation
+IntegrationEventLogEF    outbox (§6)
+OrderProcessor / PaymentProcessor   background workers as separate services
+YARP                     reverse proxy / gateway (Aspire.Hosting.Yarp +
+                         Microsoft.Extensions.ServiceDiscovery.Yarp)
+```
+
+Concrete production signals: **database-per-service**, resilience via
+`AddStandardResilienceHandler` (Polly under the hood) applied centrally in
+ServiceDefaults, OpenTelemetry wired once and inherited by every service, gRPC for
+internal sync calls where used, identity delegated to a dedicated service
+(Duende/OpenIddict family).
+
+**Trade-off:** independent deploy/scale and team autonomy at real operational cost.
+**Status:** Recommended only under real org/scale pressure; the ServiceDefaults +
+Aspire pattern is worth copying even with few services.
+
+---
+
+## 9. Persistence with EF Core
+
+Evidence-backed strategies, by how much you protect the domain:
+
+- **DbContext as the unit of work, exposed via interface (JT):**
+  `IApplicationDbContext` in Application, implemented in Infrastructure; handlers use
+  it directly. Lowest ceremony; entities are the model.
+- **Repository over aggregate roots only (eShop, MM-DDD, Ardalis):** `IRepository<T>
+  where T : IAggregateRoot` + `IUnitOfWork` (eShop SeedWork). No repository for
+  non-roots — you load the aggregate, not its children.
+- **Keeping aggregates clean:** private setters + private parameterless ctor +
+  backing fields, mapped with `IEntityTypeConfiguration<T>` classes (fluent config in
+  Infrastructure, zero attributes in Domain). Value objects via `OwnsOne`/value
+  converters; typed IDs via value converters.
+- MM-DDD goes further: reads via **raw SQL/Dapper** for queries, EF only for the
+  write side — a pragmatic CQRS split at the persistence level.
+
+**Anti-pattern:** EF attributes (`[Required]`, `[ForeignKey]`) and navigation-heavy
+bidirectional graphs *as* the domain model, lazy-loading proxies in business logic,
+and `IQueryable` leaking past the application layer.
+
+**Rule of thumb:** interface-wrapped DbContext for CRUD-ish apps; aggregate
+repositories + fluent configurations where you've invested in rich aggregates.
+
+---
+
+## 10. Central Package Management & solution conventions
+
+**Observed shape (eShop, Ardalis):** `Directory.Packages.props` at the root with
+`<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>` (and eShop
+adds `CentralPackageTransitivePinningEnabled`); every `<PackageVersion>` lives there
+(68 in eShop), grouped with shared version properties (`$(AspireVersion)` etc.).
+Projects declare `<PackageReference Include="X" />` with **no version**.
+`Directory.Build.props/targets` centralize compiler settings (nullable, implicit
+usings, analyzers).
+
+**Status:** Strongly recommended for any multi-project solution — the .NET
+equivalent of a Maven BOM, and the single biggest lever against version drift.
+
+---
+
+## 11. API design patterns
+
+- **DTOs/records at the boundary, never entities.** Commands/queries are `record`s;
+  responses are DTOs mapped from domain (JT uses Mapster/AutoMapper profiles
+  colocated with the use case). Serializing EF entities leaks internals and breaks
+  contracts on refactor.
+- **Minimal APIs / endpoint-per-use-case** (JT `Web/Endpoints`, Ardalis
+  FastEndpoints flavor) over fat controllers — keeps the edge thin and maps 1:1 to
+  use cases.
+- **Validation at the edge** via FluentValidation validators colocated with commands,
+  executed by the pipeline behaviour (§2) — the core trusts its inputs.
+- **Result→HTTP mapping in one place** (Ardalis `ResultExtensions`): NotFound/
+  Invalid/Unauthorized translate uniformly, not ad-hoc per endpoint.
+- **Versioning and OpenAPI** configured centrally (eShop: Asp.Versioning + OpenAPI
+  extensions in ServiceDefaults).
+
+**Status:** Recommended. Anti-pattern: leaking EF entities or `IQueryable` through
+the API surface.
+
+---
+
+## 12. Architecture enforcement (NetArchTest / ArchUnitNET)
+
+The reference codebases **test** their boundaries; MM-DDD ships ArchTests at *two
+levels*, and that structure is worth copying verbatim:
+
+**Solution level — module isolation** (note the explicit, narrow exceptions for the
+allowed communication channel):
+
+```csharp
+var result = Types.InAssemblies(meetingsAssemblies)
+    .That()
+        .DoNotImplementInterface(typeof(INotificationHandler<>))
+        .And().DoNotHaveNameEndingWith("IntegrationEventHandler")
+    .Should()
+    .NotHaveDependencyOnAny(otherModuleNamespaces)
+    .GetResult();
+```
+
+**Module level — layering:**
+
+```csharp
+Types.InAssembly(DomainAssembly)
+    .Should().NotHaveDependencyOn(ApplicationAssembly.GetName().Name)
+    .GetResult();
+// + Application must not depend on Infrastructure
+```
+
+Combine with the compiler: separate projects make most violations impossible to
+compile; NetArchTest/ArchUnitNET catches the rest (namespace discipline inside a
+project, accidental references, convention rules like "handlers are sealed").
+
+**Status:** Strongly recommended. Always pair a declared boundary with (a) the
+project-reference graph and (b) an architecture test.
+
+---
+
+## 13. Anti-patterns observed (and how to detect them)
+
+- **Anemic domain model** — entities are `{ get; set; }` property bags, all logic in
+  services/handlers. Detect: public setters everywhere, no methods on entities,
+  handlers full of business `if`s. Fix: private setters, behavior methods,
+  `CheckRule`/guards (§3).
+- **EF-as-domain / persistence leakage** — data annotations on aggregates,
+  navigation-property graphs threaded through logic, lazy proxies, `IQueryable`
+  beyond Application, entities serialized out of the API. Fix:
+  `IEntityTypeConfiguration` in Infrastructure, DTOs at the edge (§9, §11).
+- **Fat service / god handler** — one `XService`/`XManager` with every operation.
+  Fix: use-case-per-class (§2) + rich domain (§3).
+- **Unenforced boundaries** — clean diagram, single project with folders, everything
+  `public`. Detect: no separate projects, no ArchTests. Fix: split projects, add
+  NetArchTest (§12), use `internal` + `InternalsVisibleTo` for tests.
+- **Distributed monolith** — services sharing a database, deploying in lockstep, or
+  chaining sync HTTP calls per request. Fix: per-service data, async integration
+  events with an outbox (§5–6), or recombine into a modular monolith (§7).
+- **Premature microservices** — splitting before boundaries are proven. Fix: modular
+  monolith first (§7); extract along proven seams.
+- **Folder-by-layer inside one project** — `Controllers/ Services/ Repositories/`
+  with everything referencing everything. Fix: feature folders + project-per-layer,
+  or module-per-context.
+- **Version drift** — per-project package versions. Fix: Central Package Management
+  (§10).

--- a/skills/dotnet-software-architect/references/project-structures.md
+++ b/skills/dotnet-software-architect/references/project-structures.md
@@ -1,0 +1,130 @@
+# Project Structures — copy-ready .NET skeletons
+
+These layouts are extracted from the reference codebases. Use them as starting
+templates and adapt names to the domain. In .NET, **project references are the
+architecture** — each skeleton states the reference graph to enforce, plus the
+architecture-test note.
+
+## A. Clean Architecture solution (single bounded context)
+
+```
+Acme.Billing.sln
+├── Directory.Packages.props        central package versions (CPM)
+├── Directory.Build.props           nullable, implicit usings, analyzers
+├── src/
+│   ├── Domain/                     → references: NOTHING
+│   │   ├── Common/                 BaseEntity (domain events), ValueObject, IAggregateRoot
+│   │   ├── Entities/  (or InvoiceAggregate/)
+│   │   ├── ValueObjects/           Money, InvoiceId (typed id)
+│   │   ├── Events/                 InvoiceIssuedEvent : INotification
+│   │   └── Exceptions/
+│   ├── Application/                → references: Domain
+│   │   ├── Common/
+│   │   │   ├── Interfaces/         IApplicationDbContext, IEmailSender (ports)
+│   │   │   └── Behaviours/         Validation, Logging, Performance, Authorization
+│   │   └── Invoices/               feature folder
+│   │       ├── Commands/IssueInvoice/   IssueInvoiceCommand (record) + Handler + Validator
+│   │       └── Queries/GetInvoice/      GetInvoiceQuery + Handler + InvoiceDto
+│   ├── Infrastructure/             → references: Application
+│   │   ├── Data/                   AppDbContext, Configurations/ (IEntityTypeConfiguration<T>),
+│   │   │                           Interceptors/ (domain-event dispatch on SaveChanges)
+│   │   └── Services/               EmailSender, clock, identity
+│   └── Web/                        → references: Application + Infrastructure (composition root)
+│       ├── Endpoints/              minimal-API endpoint groups, one per feature
+│       └── Program.cs
+└── tests/
+    ├── Domain.UnitTests/
+    ├── Application.UnitTests/      (mock IApplicationDbContext or use SQLite)
+    ├── Application.FunctionalTests/ (WebApplicationFactory + Testcontainers)
+    └── ArchitectureTests/          NetArchTest: Domain⊥Application⊥Infrastructure
+```
+
+Dependency rule: Domain references nothing; Application → Domain; Infrastructure →
+Application; Web is the only project that sees everything. Variant (Ardalis naming):
+`Core` / `UseCases` / `Infrastructure` / `Web`, with `Ardalis.Result`,
+`Ardalis.Specification`, `Ardalis.GuardClauses` in Core/UseCases.
+
+## B. Modular monolith (multiple bounded contexts, one deployable)
+
+```
+Acme.sln
+├── Directory.Packages.props
+├── src/
+│   ├── API/Acme.API/               single thin host: auth, swagger, routes → modules
+│   ├── BuildingBlocks/             shared kernel — referenced by all modules
+│   │   ├── Domain/                 Entity (events + CheckRule), ValueObject,
+│   │   │                           IBusinessRule, IDomainEvent, TypedIdValueBase, IAggregateRoot
+│   │   ├── Application/            common abstractions (commands, queries, outbox contracts)
+│   │   └── Infrastructure/         event bus, outbox processing, common EF helpers
+│   ├── Modules/
+│   │   ├── Billing/                ← one folder per bounded context
+│   │   │   ├── Acme.Modules.Billing.Domain/
+│   │   │   │   ├── Invoices/       Invoice (aggregate), value objects
+│   │   │   │   └── Invoices/Rules/ InvoiceCannotBeIssuedTwiceRule : IBusinessRule
+│   │   │   ├── Acme.Modules.Billing.Application/      commands/queries/handlers + Contracts/
+│   │   │   ├── Acme.Modules.Billing.Infrastructure/   BillingContext (own schema), configurations
+│   │   │   ├── Acme.Modules.Billing.IntegrationEvents/ ← the ONLY assembly other modules may reference
+│   │   │   └── Tests/ (Unit, Integration, ArchTests)
+│   │   └── Customers/              (same internal layout)
+│   └── Tests/ArchTests/            solution-level: module isolation rules
+└── tests/...
+```
+
+Rules to enforce: modules reference **only** BuildingBlocks and other modules'
+`IntegrationEvents` assemblies; within a module, Domain ⊥ Application ⊥
+Infrastructure. Solution-level NetArchTest excludes `INotificationHandler<>`/
+`*IntegrationEventHandler` from the isolation rule — events are the sanctioned
+channel. Each module owns its DbContext and DB schema.
+
+## C. Microservices (Aspire, eShop-style)
+
+```
+acme-platform/
+├── Directory.Packages.props        CPM + CentralPackageTransitivePinningEnabled
+├── src/
+│   ├── Acme.AppHost/               .NET Aspire orchestration (dev-time composition)
+│   ├── Acme.ServiceDefaults/       AddServiceDiscovery, AddStandardResilienceHandler,
+│   │                               OpenTelemetry — every service calls one extension
+│   ├── Gateway/                    YARP reverse proxy (+ ServiceDiscovery.Yarp)
+│   ├── Catalog.API/                self-contained service (simple domain → single project)
+│   ├── Basket.API/                 (Redis-backed, gRPC)
+│   ├── Ordering.Domain/            ┐ complex service → split like skeleton A,
+│   ├── Ordering.Infrastructure/    ├ with SeedWork/ (Entity, ValueObject,
+│   ├── Ordering.API/               ┘  IAggregateRoot, IRepository<T>, IUnitOfWork)
+│   ├── EventBus/                   abstraction project (IEventBus, IntegrationEvent)
+│   ├── EventBusRabbitMQ/           transport implementation
+│   ├── IntegrationEventLogEF/      transactional outbox (same-transaction event log)
+│   ├── OrderProcessor/             background worker as its own service
+│   └── Identity.API/               dedicated identity service
+└── tests/ (+ e2e/)
+```
+
+Rules: database-per-service (no shared schema, ever); cross-service communication via
+integration events through the outbox, sync calls only where unavoidable (gRPC) and
+wrapped by the standard resilience handler; ServiceDefaults referenced by every
+service so resilience/telemetry are configured once.
+
+## D. Clean-lite (small CRUD app — don't over-build)
+
+```
+Acme.Tool.sln
+├── src/
+│   ├── Acme.Tool.Domain/           entities + the few real rules
+│   ├── Acme.Tool.Application/      feature folders, handlers, IAppDbContext
+│   ├── Acme.Tool.Infrastructure/   AppDbContext + configurations
+│   └── Acme.Tool.Web/              minimal APIs
+└── tests/ (Unit + one ArchitectureTests project)
+```
+
+Same reference direction as A, minimal ceremony: no MediatR if the team prefers
+plain handlers, DTOs as records, no repositories (DbContext behind the interface).
+Keep the Domain project anyway — it costs nothing and preserves the upgrade path.
+
+## Solution conventions (all skeletons)
+
+- `Directory.Packages.props` with `ManagePackageVersionsCentrally` — no versions in
+  csproj files. `Directory.Build.props` for nullable/analyzers/lang version.
+- Tests mirror src structure; an `ArchitectureTests` project ships from day one.
+- `internal` by default inside modules; `InternalsVisibleTo` for the module's tests.
+- Feature folders over type folders everywhere (Commands/Queries per feature, not
+  global `Services/` buckets).

--- a/skills/dotnet-software-architect/references/review-checklist.md
+++ b/skills/dotnet-software-architect/references/review-checklist.md
@@ -1,0 +1,68 @@
+# Architectural Review & Technical-Debt Checklist (.NET)
+
+Use this when reviewing existing C#/.NET code or assessing risk/debt. Review for
+*structure and boundaries*, not style nits. Lead findings with impact and a concrete
+fix, not just a label. Phrase findings so the team can act: what's wrong, why it
+costs them, what to do, and how urgent.
+
+## What to look at first (highest signal)
+
+1. **The project-reference graph.** Open the .sln/csproj files before any code. Does
+   Domain reference EF Core or ASP.NET Core packages? Does Application reference
+   Infrastructure? In .NET the csproj graph *is* the architecture — a wrong edge
+   there predicts everything else. A single-project app with folder "layers" has no
+   enforced boundaries at all.
+2. **Where the business rules live.** Open the entities and the services/handlers.
+   Entities that are all `{ get; set; }` with logic piled into `XService`/`XManager`
+   classes → **anemic domain**, the most common avoidable debt. Rules belong on
+   aggregates (private setters, behavior methods, `CheckRule`/guards).
+3. **Boundaries — declared vs enforced.** Is there a NetArchTest/ArchUnitNET
+   project, or just a diagram? Absence of architecture tests is itself a finding.
+   Check access modifiers too: everything `public` means module internals are a
+   reference away from becoming someone's dependency.
+4. **EF Core coupling.** Data annotations on domain types, lazy-loading proxies,
+   navigation-property webs driving business logic, `IQueryable` escaping the
+   application layer, entities serialized straight out of controllers. All of these
+   weld the domain and the API contract to the persistence model.
+5. **The async/consistency seams.** Cross-module or cross-service effects done via
+   direct calls and shared transactions everywhere? That's hidden coupling that
+   blocks any future distribution. Events without an outbox across process
+   boundaries = lost-event bugs waiting.
+
+## Smell catalog (detect → impact → fix)
+
+| Smell | How to detect | Why it costs | Fix |
+|---|---|---|---|
+| Anemic domain | Public setters everywhere; methodless entities; fat `XService` | Logic scatters/duplicates; invariants unguarded | Private setters, behavior methods, `IBusinessRule`/GuardClauses; use-case-per-handler |
+| EF leakage | Attributes on aggregates; proxies/navigations in logic; entities in API responses | Domain & wire contract welded to schema; refactors ripple | `IEntityTypeConfiguration` in Infrastructure; DTO records at the edge |
+| `IQueryable` escape | Repositories/services returning `IQueryable` upward | Query logic smears across layers; untestable | Specifications or materialize in Application |
+| No enforced boundaries | One project, folder layers, no ArchTests, all `public` | Decay invisible until severe | Split projects; NetArchTest both levels; `internal` + InternalsVisibleTo |
+| God handler/service | One class, many operations, all rules | Low cohesion; merge conflicts; untestable units | Feature folders, command/handler per use case |
+| Distributed monolith | Services share a DB / deploy lockstep / sync HTTP chains | Network cost without decoupling | DB-per-service; integration events + outbox; or recombine into modular monolith |
+| Missing outbox | Publish-to-bus after `SaveChanges`, no event log table | Lost or phantom events on crash | Transactional outbox (IntegrationEventLogEF pattern) |
+| Premature microservices | Many services, unstable boundaries, chatty calls | Boundary moves across the network are very expensive | Modular monolith first; extract proven seams |
+| Version drift | Versions scattered in csproj files; conflicts | "Works in my project" breakage | Central Package Management |
+| DI grab-bag | 10+ constructor params; service locator (`IServiceProvider`) in handlers | Hidden deps; god classes in disguise | Split use cases; behaviours for cross-cutting |
+| Async-over-sync / sync-over-async | `.Result`/`.Wait()` in request paths | Thread starvation under load | async end-to-end with CancellationToken |
+
+## Risk & debt assessment output
+
+When summarizing, organize findings as:
+
+- **Critical (fix before building further):** wrong edges in the project graph
+  (Domain→EF), services sharing a database, missing outbox on cross-service events,
+  no boundaries on a codebase that's actively growing.
+- **Significant (schedule soon):** anemic domain in a complex area, entities through
+  the API, god handlers, sync-over-async in hot paths.
+- **Watch (note, revisit):** acceptable simplifications (anemia in a genuinely CRUD
+  module, direct DbContext use) that become debt only if complexity rises.
+
+For each: state the **blast radius** (projects/teams it touches), the **trend**
+(worsening as the system grows, or stable), and a **concrete first step**. Where a
+decision is being changed, record it as an ADR (`adr-template.md`).
+
+## Strengths matter too
+
+Note what's done well (clean reference graph, rich aggregates, CPM, ArchTests,
+ServiceDefaults-style centralization) so the team preserves it under pressure. A
+review that only lists problems gets ignored.


### PR DESCRIPTION
## Summary

Adds `dotnet-software-architect`, a skill that acts as a senior C#/.NET software architect for designing, structuring, and reviewing ASP.NET Core, EF Core, Aspire, Blazor, and worker-service codebases.

It triggers on requests like *"how should I structure this .NET solution"*, *"clean, layered, modular monolith, or microservices?"*, *"review this solution's architecture"*, or *"write an ADR"* — and on pasted `.csproj`/`.sln` files or namespace skeletons where the real question is about boundaries and dependencies.

## What it does

The skill guides Claude through a six-step workflow:

1. Understand the driving forces before proposing any structure.
2. Choose an architectural style deliberately — the honest default is a layered modular monolith, not microservices or full DDD.
3. Propose a concrete solution and project layout with an enforced dependency direction.
4. Apply evidence-backed patterns.
5. Make trade-offs and risks explicit.
6. Record the decision as an ADR.

Its non-negotiable principles: dependencies point inward, the domain stays rich and infrastructure dumb, boundaries are enforced by the compiler plus architecture tests (NetArchTest / ArchUnitNET), don't prematurely distribute, and match ceremony to complexity.

## Contents

Seven files, 1,081 lines, all additions:

- `SKILL.md` (131 lines)
- `references/decision-guide.md` — choosing an architectural style
- `references/pattern-catalog.md` — 366 lines of evidence-backed patterns
- `references/project-structures.md` — concrete solution/project trees
- `references/review-checklist.md` — architectural review pass
- `references/adr-template.md` — ADR format
- `LICENSE.txt` — Apache 2.0

Plus one line in `.claude-plugin/marketplace.json` registering it under the `example-skills` plugin, in alphabetical position.

The reference files load on demand rather than up front, following the pattern used by `mcp-builder` and `skill-creator`.

## Grounding

Patterns are drawn from public reference codebases rather than invented: `modular-monolith-with-DDD`, the Jason Taylor and Ardalis Clean Architecture templates, and Microsoft's eShop / eShopOnWeb. The domain examples in the reference files (`Acme.Billing.sln`, an `Invoice` aggregate) are deliberately generic.

## Conventions followed

- Folder name matches the frontmatter `name` field.
- Frontmatter carries `license: Complete terms in LICENSE.txt`, matching the other skills.
- No existing skill or file is modified except the single added line in `marketplace.json`.

## A question for the maintainers

There is no `CONTRIBUTING.md` in this repository, so it isn't clear whether community-authored skills are welcome here. **Are you accepting skill contributions from outside Anthropic?** If not, I'm happy to close this and publish it as a separate marketplace instead — no hard feelings, and it'd be useful to say so in a `CONTRIBUTING.md` for the next person.

If you are, I have a companion skill (`scrum-master-planner`) I'd submit as a separate PR.

Licensed Apache 2.0, copyright retained by the author.