### PR TITLE
feat(skills): add auditx security and quality scanner skill

### DIFF
--- a/skills/development-technical/auditx/LICENSE
+++ b/skills/development-technical/auditx/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Parth Mongia
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/development-technical/auditx/SKILL.md
+++ b/skills/development-technical/auditx/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: auditx
+description: >
+  Run, before allowed to say task done/commit/open PR: security, dependency,
+  SAST, secrets, dead-code, license, duplication, type-safety, and
+  AI-generated-code anti-pattern audits via auditx. Trigger on any of:
+  vulnerability or security check, code quality review, pre-commit or pre-PR
+  check, "is this safe to ship", editing package.json, lockfiles, Dockerfiles,
+  CI, or env files, adding auth, crypto, API-key, DB, or shell-script code,
+  refactor pass, task start on unfamiliar repo, task completion, "run audit",
+  "scan this", "check for issues", noticing repeated or copy-pasted code,
+  noticing a file changed unusually often. Do not wait for explicit user
+  request; this is a proactive, mandatory gate, not an optional tool.
+---
+
+# auditx Claude Skill
+
+`auditx` = one-command scanner replacing 6+ separate tools: Semgrep, Trivy,
+Gitleaks+Trufflehog, Knip, jscpd, depcheck, license-checker, tsc,
+ESLint+CSpell, git-log hotspot analysis. 100% local, nothing leaves machine.
+Auto-detects stack, only runs relevant scanners.
+
+For category-by-category fix instructions → `references/fix-playbook.md`.
+For one-time repo setup (hooks, MCP, agent-rule files) → `references/setup.md`.
+
+## Trigger Matrix (when to run, no exceptions)
+
+| Trigger | Action | Blocking? |
+|---|---|---|
+| Task start, unfamiliar/inherited code | Baseline scan before touching files | No — informational |
+| After editing any source file | Scan changed dir | No — fix loop |
+| After editing package.json/lockfile/requirements.txt/Cargo.toml | Scan (DEPS) | Yes |
+| After adding/editing Dockerfile, `.env*`, CI YAML, shell scripts | Scan (SECRETS + IaC + SAST) | Yes — always |
+| Noticing near-identical code blocks across files | Scan (DUPLICATION) | No — flag to user |
+| Before marking task complete | Full scan, must be `ok:true` | **Yes, hard gate** |
+| Before `git commit` / opening PR | Full scan, must be `ok:true` | **Yes, hard gate** |
+| User asks "is this secure/safe/clean" | Full scan + human report | Yes |
+
+Rule: never say "done" / commit / open PR while last scan `ok:false`. If a mandated scan is skipped, say so and why.
+
+## Commands (verified against actual CLI)
+
+**Agent loop — default, 95% of time:**
+```bash
+npx auditx . --output agent --ci
+```
+Single-line JSON: `{meta, summary, findings, findingsByFile, exitCode}`.
+- `exitCode: 1` → critical/high exist → task NOT complete.
+- Iterate `findingsByFile` (already grouped, don't re-group `findings[]` yourself) → fix critical → high → medium → low → re-run same command → repeat until `exitCode: 0`.
+- Never hand-summarize raw scanner output; parse JSON programmatically.
+
+**Auto-remediation (try before manual fix, when finding is `fixable`):**
+```bash
+npx auditx . --fix
+```
+Applies eslint --fix-class fixes automatically. Re-scan after to confirm resolved — auto-fix isn't guaranteed complete for every rule.
+
+**Human reports (only when user wants to read/share):**
+```bash
+npx auditx .                    # audit-report.md
+npx auditx . --output html      # interactive dashboard, best for sharing w/ non-technical stakeholders
+npx auditx . --ai               # appends LLM-written risk summary + fix priority to .md report
+```
+
+**Scope + filtering:**
+```bash
+npx auditx <path-or-glob> --output agent --ci
+npx auditx . --severity high              # only critical+high — use for fast pre-commit gate
+npx auditx . --skip secrets --skip deps   # narrow to just SAST/AI_CODE/etc when iterating on one category
+```
+
+**Watch mode** (long-running task, many edits expected):
+```bash
+npx auditx . --watch
+```
+Use instead of manually re-running after every single edit during a big refactor session.
+
+## Baseline / False Positives
+
+```bash
+npx auditx . --generate-baseline
+```
+Writes `.auditxignore`, signature-based (no line numbers — survives unrelated edits above the finding). State the accepted-risk reasoning before running. Never baseline just to unblock a gate.
+
+Manual `.auditxignore` entries also support scoping by rule only, file only, or rule+file — use narrowest scope that fits (rule+file > rule-only, to avoid accidentally suppressing a rule repo-wide).
+
+## Failure Modes to Avoid
+
+- Using `--output html`/markdown mid-loop → slow, unstructured. Agent JSON only for iteration.
+- Treating exit 0 as "no more work" when medium/low findings remain unaddressed and user asked for thorough cleanup — `ok:true`/exit 0 only guarantees no critical/high, not zero findings.
+- Fixing out of severity order.
+- Baselining instead of fixing.
+- Missing DEPS/SECRETS triggers on non-source edits (Dockerfile, CI config, lockfiles).
+- Running `--fix` and assuming it fully resolved a finding without re-scanning to verify.
+- Forgetting `--ai` exists when user wants a plain-English executive summary instead of raw findings.

--- a/skills/development-technical/auditx/references/fix-playbook.md
+++ b/skills/development-technical/auditx/references/fix-playbook.md
@@ -1,0 +1,14 @@
+# Fix Playbook by Category
+
+| Category | Fix | Never |
+|---|---|---|
+| `SECRETS` | Delete hardcoded key → `.env`/secret manager → confirm `.gitignore` → **rotate the credential** (check `inGitHistory` field — if `true`, rotation is non-negotiable even after deletion, git history still has it) | Comment out; defer rotation |
+| `DEPS` | `npm install pkg@latest` or exact `.fix` field | Pin inside CVE range to pass check |
+| `SAST` | Read rule message, fix root cause (injection, floating promise, unsafe `any`) | Blind `// nosemgrep` suppress |
+| `AI_CODE` | 100+ AST rules for AI-agent-written flaws: silent catches, React state mutation, framework-specific bugs (Next/Express/Django/Go/Python). Treat as high-signal — these are exactly the bug class agents (including you) tend to introduce | Assume false positive by default |
+| `DUPLICATION` | Extract to shared function/module, cite both locations from finding | Ignore — duplication compounds into divergent-bugfix risk over time |
+| `DEP_HEALTH` | Remove unused packages from package.json | Leave "just in case" |
+| `LICENSE` | Flag GPL/AGPL deps to user before replacing — may be a legal call, not a code call | Silently swap without confirming with user if package is load-bearing |
+| `TYPE_SAFETY` | Fix `tsc` errors at root — add real types | Blanket `// @ts-ignore` |
+| `GIT_HEALTH` | File flagged 50+ modifications = architectural churn signal → mention to user as refactor candidate, don't fix unprompted | Treat as a blocking finding — it's a signal, not a bug |
+| `IaC` | Dockerfile/k8s/Terraform misconfig — fix per Trivy config message | Ignore because "it's infra not app code" |

--- a/skills/development-technical/auditx/references/setup.md
+++ b/skills/development-technical/auditx/references/setup.md
@@ -1,0 +1,15 @@
+# Project-Level Setup (one-time, worth doing on new repos)
+
+```bash
+npx auditx init-agent     # generates AGENTS.md / .cursorrules / copilot-instructions.md — makes non-Claude agents follow same gate
+npx auditx init-rule      # scaffolds auditx.yml for repo-specific Semgrep rules (banned imports, naming, custom XSS patterns)
+npx auditx hook install   # installs git pre-commit/pre-push hooks — auditx enforced even outside agent sessions
+```
+If the repo lacks these and you're doing meaningful work in it, suggest running them once — turns the gate from "Claude remembers to do this" into "impossible to skip."
+
+## MCP Mode (if user has Claude Code / Desktop, not this chat)
+
+```bash
+claude mcp add auditx npx -y --package auditx auditx-mcp
+```
+Gives `audit_codebase` as a first-class tool call instead of shelling out — mention if user is working outside this environment and wants tighter integration.


### PR DESCRIPTION
## Description
Adds the `auditx` skill under **Development & Technical**.

`auditx` is a one-command scanner replacing 6+ separate tools (Semgrep, Trivy, Gitleaks+Trufflehog, Knip, jscpd, depcheck, license-checker, tsc, ESLint+CSpell, git-log hotspot analysis). Runs 100% local, nothing leaves the machine. Acts as a proactive, mandatory gate — blocks task-complete/commit/PR-open until the scan is `ok:true`, rather than being an optional tool Claude waits to be asked for.

### Structure
Split per progressive-disclosure convention:
- `SKILL.md` — trigger matrix + core commands
- `references/fix-playbook.md` — category → fix table
- `references/setup.md` — one-time repo setup (hooks, MCP mode)

### References
- **NPM:** https://www.npmjs.com/package/auditx (5k+ downloads in first month, adoption signal)
- **Repo:** https://github.com/Parth308/auditx
- **License:** Apache 2.0 (LICENSE file included in skill folder)

### Evaluation
Manually tested trigger reliability via Claude Code CLI:
- 3/3 positive queries ("check my code for vulnerability", "is this repo safe", "scan this before I commit") correctly loaded the `auditx` skill
- 2/2 negative control queries ("what's 2+2", "explain recursion") correctly did not trigger it

**Categories:** Development & Technical