### PR TITLE
skill-creator: redirect nested claude -p stdin to DEVNULL in run_eval.py

### DIFF
--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -84,6 +84,7 @@ def run_single_query(
 
         process = subprocess.Popen(
             cmd,
+            stdin=subprocess.DEVNULL,  # nested claude -p must not wait on/inherit our stdin
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             cwd=project_root,


### PR DESCRIPTION
`run_single_query()` spawns the nested eval `claude -p` without redirecting stdin, so the child inherits the parent's stdin. When the eval runs nested inside a Claude session (a supported use — the code already strips `CLAUDECODE` from env for exactly this), the child stalls ~3s waiting on the inherited stdin, multiplied across `--num-workers`.

One-line fix: pass `stdin=subprocess.DEVNULL` to the Popen call.

Fixes #1414

Note: open PRs #1323 and #1298 rework this same function but don't touch the Popen call — this change is orthogonal and can be folded into either if they land first.