### PR TITLE
Normalize .xsd line endings via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# The OOXML schemas are vendored verbatim from ECMA/ISO and are never edited by
+# hand. Upstream ships them CRLF, and the tooling that copies them in preserves
+# that, so without this every sync rewrites all 42 files end-to-end: ~82k diff
+# lines, zero content change, burying the actual edits.
+*.xsd text eol=lf


### PR DESCRIPTION
## Summary

The vendored OOXML schema files (`.xsd`) are copied verbatim from ECMA/ISO and ship with CRLF line endings, while the rest of the tree is LF. Because nothing normalized them, every sync of the schemas re-wrote all 42 files end to end — roughly 82k diff lines with zero content change — burying the actual edits in any PR that happened to touch the skills. This adds a `.gitattributes` rule (`*.xsd text eol=lf`) so git stores and compares them as LF, making that churn disappear now and on every future sync.

## Test plan

With the rule in place, `git status` reports 0 modified `.xsd` files (previously 42), `git diff` on a schema file is empty even though the working-tree copy is still physically CRLF, and `git check-attr text eol` on a schema reports `text: set`, `eol: lf`. No code paths are affected.