### PR TITLE
Add Ontoly to Partner Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,4 @@ The markdown content below contains the instructions, examples, and guidelines t
 Skills are a great way to teach Claude how to get better at using specific pieces of software. As we see awesome example skills from partners, we may highlight some of them here:
 
 - **Notion** - [Notion Skills for Claude](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0)
+- **Ontoly** - [Software Graph Agent Skills](https://github.com/0xsarwagya/ontoly/tree/main/skills)


### PR DESCRIPTION
Adds Ontoly to the README Partner Skills section.

Ontoly publishes installable Agent Skills that teach coding agents to use Ontoly Software Graph evidence, MCP, and deterministic graph queries for architecture review, impact analysis, request tracing, dependency analysis, security review, and related software-understanding workflows.

This PR only adds a partner link; it does not copy Ontoly skills into Anthropic example skills.

Validation:
- Verified Ontoly skills are publicly installable/listable with `npx --yes skills add 0xsarwagya/ontoly --list`.