### PR TITLE
Accept documented Claude Code frontmatter fields in the skill validator

### DIFF
--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -39,11 +39,12 @@ def validate_skill(skill_path):
         return False, f"Invalid YAML in frontmatter: {e}"
 
     # Agent Skills spec fields (agentskills.io/specification)
-    # + documented Claude Code extensions (code.claude.com/docs/en/skills#skill-md-frontmatter)
+    # + documented Claude Code extensions (code.claude.com/docs/en/skills#frontmatter-reference)
     SPEC_PROPERTIES = {'name', 'description', 'license', 'allowed-tools', 'metadata', 'compatibility'}
     CLAUDE_CODE_PROPERTIES = {
         'agent', 'argument-hint', 'arguments', 'context', 'disable-model-invocation',
-        'disallowed-tools', 'effort', 'hooks', 'model', 'paths', 'shell', 'user-invocable',
+        'disallowed-tools', 'effort', 'hooks', 'model', 'paths', 'shell',
+        'user-invocable', 'when_to_use',
     }
     ALLOWED_PROPERTIES = SPEC_PROPERTIES | CLAUDE_CODE_PROPERTIES
 

--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -38,8 +38,14 @@ def validate_skill(skill_path):
     except yaml.YAMLError as e:
         return False, f"Invalid YAML in frontmatter: {e}"
 
-    # Define allowed properties
-    ALLOWED_PROPERTIES = {'name', 'description', 'license', 'allowed-tools', 'metadata', 'compatibility'}
+    # Agent Skills spec fields (agentskills.io/specification)
+    # + documented Claude Code extensions (code.claude.com/docs/en/skills#skill-md-frontmatter)
+    SPEC_PROPERTIES = {'name', 'description', 'license', 'allowed-tools', 'metadata', 'compatibility'}
+    CLAUDE_CODE_PROPERTIES = {
+        'agent', 'argument-hint', 'arguments', 'context', 'disable-model-invocation',
+        'disallowed-tools', 'effort', 'hooks', 'model', 'paths', 'shell', 'user-invocable',
+    }
+    ALLOWED_PROPERTIES = SPEC_PROPERTIES | CLAUDE_CODE_PROPERTIES
 
     # Check for unexpected properties (excluding nested keys under metadata)
     unexpected_keys = set(frontmatter.keys()) - ALLOWED_PROPERTIES


### PR DESCRIPTION
Fixes #1431

## Problem

`skills/skill-creator/scripts/quick_validate.py` rejects `SKILL.md` files that use documented Claude Code frontmatter fields such as `user-invocable: true`, because its allowlist only contains the six base Agent Skills spec fields (https://agentskills.io/specification). The same check also rejects `disable-model-invocation`, `argument-hint`, `model`, `hooks`, and the other extension fields documented at https://code.claude.com/docs/en/skills#skill-md-frontmatter — so a skill written exactly per the Claude Code docs fails validation.

## Change

The allowlist is now the union of two named sets: the Agent Skills spec fields and the documented Claude Code extensions, each with a source link. Unknown keys (e.g. typos like `descriptoin`) are still rejected, so the typo-catching value of the check is preserved. `package_skill.py` imports the same `validate_skill`, so packaging picks up the fix automatically.

## Verification

- A skill with `user-invocable: true`, `disable-model-invocation: true`, and `argument-hint` previously failed with `Unexpected key(s) in SKILL.md frontmatter`; now it validates.
- A skill with a misspelled key (`descriptoin`) is still rejected.
- All 17 skills in this repo validate with no regressions (the one pre-existing failure, `claude-api`'s over-long description, fails identically on `main`).