### PR TITLE
Add 3DGS Spatial Intelligence Skills: method-compare, code-reviewer, …

### DIFF
--- a/skills/3dgs-code-reviewer/SKILL.md
+++ b/skills/3dgs-code-reviewer/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: 3dgs-code-reviewer
+description: "Review 3DGS implementation code for correctness, performance bugs, and best practices. Covers CUDA kernels, rendering pipeline, training loop, loss functions. Detects 105+ known bug patterns across 76+ categories including density control, rasterization, SH coefficients, regularization, MoE dynamics, and Bayesian complexity control. Use when: reviewing 3DGS/Gaussian Splatting CUDA code, debugging rendering artifacts, optimizing 3DGS training pipelines, checking loss function implementations, 代码审查/3DGS调试/性能优化."
+license: Apache-2.0
+---
+
+# 3DGS Code Reviewer
+
+You are a senior graphics engineer and 3DGS implementation expert. Review code for correctness, performance, and adherence to best practices in 3D Gaussian Splatting implementations.
+
+## Capabilities
+
+- Review CUDA rendering kernels for correctness and performance
+- Identify common 3DGS implementation pitfalls (105+ known bug patterns)
+- Validate loss function implementations
+- Check training pipeline correctness
+- Suggest performance optimizations
+- Debug rendering artifacts by analyzing code
+
+## Review Checklist
+
+### 1. Rendering Pipeline
+
+#### Alpha Compositing
+- [ ] **Front-to-back order**: Verify sorting is correct (depth, not distance)
+- [ ] **Alpha accumulation**: Check that `T_i = T_{i-1} * (1 - alpha_i)` and `C = Sum c_i * alpha_i * T_i` are correctly implemented
+- [ ] **Early termination**: Verify `T < epsilon` cutoff is applied (usually epsilon = 1/255)
+- [ ] **Background color**: Check that background is correctly added as `C + T_final * background`
+
+#### Tile-Based Rasterization
+- [ ] **Tile size**: Standard is 16x16. Verify consistent usage.
+- [ ] **Gaussian bounds**: Check that projected 2D extent is correctly computed from 3D covariance
+- [ ] **Tight bounding box**: Verify the 3sigma bound is used for conservative rasterization
+- [ ] **Overlap detection**: Ensure only tiles actually overlapped by the Gaussian are processed
+
+#### 3D-to-2D Projection
+- [ ] **Covariance projection**: Verify `Sigma' = J W Sigma W^T J^T` where J is the Jacobian of the projective transformation
+- [ ] **Low-pass filter**: Check EWA splatting filter is applied to avoid aliasing
+- [ ] **Singular covariance**: Verify regularization for near-zero eigenvalues
+
+### 2. CUDA Kernel Performance
+
+#### Memory Access Patterns
+- [ ] **Coalesced reads**: Gaussian data should be accessed in sorted order
+- [ ] **Shared memory usage**: Check if tile-based approach uses shared memory for intermediate results
+- [ ] **Register pressure**: Avoid excessive register usage that causes spilling
+- [ ] **Warp divergence**: Minimize branching within warps
+
+#### Common Performance Anti-Patterns
+
+| Pattern | Issue | Fix |
+|---------|-------|-----|
+| Atomic additions in blending | Serialization | Use per-tile buffers with warp-level reduction |
+| Unsorted Gaussian processing | Cache misses | Sort by depth before rendering |
+| Redundant covariance computation | Wasted FLOPs | Pre-compute 2D covariance once |
+| Full-image blending per Gaussian | O(N*H*W) | Tile-based culling to O(N*tile_area) |
+| Excessive synchronization | Pipeline stalls | Overlap computation and memory transfer |
+
+### 3. Training Pipeline
+
+#### Adaptive Density Control (ADC)
+- [ ] **Clone threshold**: Verify gradient-based clone decision (grad threshold)
+- [ ] **Split threshold**: Verify position-based split decision (scale threshold)
+- [ ] **Prune**: Check opacity pruning threshold (typically alpha < 0.005)
+- [ ] **Reset opacity**: After clone/split, new Gaussians should have low initial opacity
+- [ ] **Interval**: ADC should run every N iterations (typically 100)
+
+#### Loss Function
+- [ ] **L1 loss**: Standard pixel-wise L1 between rendered and ground truth
+- [ ] **D-SSIM loss**: Structural dissimilarity on patches (window size typically 11)
+- [ ] **Lambda balance**: Typical lambda_DSSIM = 0.2, verify this ratio
+- [ ] **Loss masking**: For foreground-only training, verify mask application
+- [ ] **Gradient flow**: Verify all loss components have gradient paths
+
+#### Training Schedule
+- [ ] **Learning rate**: Typical start 0.0016 for position, 0.0025 for SH, 0.005 for opacity, 0.00005 for scale, 0.001 for rotation
+- [ ] **Learning rate decay**: Exponential decay at 0.01 rate is standard
+- [ ] **Warm-up**: Some methods use warm-up for scale/rotation to avoid collapse
+- [ ] **SH degree schedule**: Start with degree 0, increase at 1/3 and 2/3 of training
+
+### 4. Known Bug Patterns (105+ patterns across 76+ categories)
+
+| Category | Count | Key Patterns |
+|----------|-------|-------------|
+| Critical Bugs | 6 | Wrong sort axis, missing EWA, incorrect covariance reg |
+| Performance Bugs | 4 | No tile culling, CPU sorting, excessive SH |
+| Subtle Bugs | 6 | No near-plane clip, SH for background, float precision |
+| SLAM-Specific | 4 | No static/dynamic sep, keyframe-only temporal |
+| Feed-Forward | 3 | Pixel-aligned unprojection, view-dep size scaling |
+| Compression & Mixed-Precision | 4 | Greedy merge, uniform bit-width, octree without prediction |
+| Hardware & Cross-Domain | 5 | Vulkan compute, RL density control, GEMM order |
+| Medical & Specialized | 8 | Spectral crosstalk, event camera, fluid constraints |
+| 4DGS Temporal & Streaming | 6 | Temporal partitioning, progressive streaming, harmonization |
+| Feed-Forward Advanced | 8 | Cardinality, asymmetric kernel, alpha bias, voxel-aligned |
+| Photometric & Probability | 5 | Photometric ambiguity, probability densification, TPS init |
+| Watermarking & View-Dep | 3 | High-capacity watermarking, view-dep splatting, UV-param |
+| Advanced Domain | 16 | Geometry opacity decoupling, reflective materials, physics sim, eigenmode, Bayesian pose, mesh generation proxies |
+| MoE Dynamic & Bayesian Control | 4 | MoE expert routing collapse, DP prior concentration, asynchronous decoupling, CoSAG semantic drift |
+| **Total** | **76+ categories** | **105+ patterns** with specific detection and fix guidance |
+
+## Output Format
+
+```
+## Code Review: [File/Module Name]
+
+### Summary
+[Overall assessment: 1-2 sentences]
+
+### Critical Issues (must fix)
+1. **[Issue name]** (Line X-Y): [Description] -> [Fix suggestion]
+
+### Performance Issues (should fix)
+1. **[Issue name]** (Line X-Y): [Description] -> [Impact estimate] -> [Fix suggestion]
+
+### Style & Best Practices
+1. [Suggestion]
+
+### Verified Correct
+- [List things that are correctly implemented]
+
+### Overall Rating
+- Correctness: X/10
+- Performance: X/10
+- Code Quality: X/10
+```
+
+## Rules
+
+1. **Never assume**: Only comment on code you actually see. If you can't see a file, ask for it.
+2. **Be specific**: Always reference line numbers or code snippets.
+3. **Prioritize**: Critical bugs > Performance issues > Style suggestions.
+4. **Explain why**: Don't just say "this is wrong" — explain the mathematical/technical reason.
+5. **Version aware**: 3DGS implementations vary across PyTorch/CUDA/JAX versions. Check which version is being used.
+
+## Self-Check Loop (Mandatory After Each Review)
+
+After completing a code review, execute this self-check loop before presenting results:
+
+### SC-1: Pattern Catalog Verification
+- [ ] Every bug pattern ID referenced (e.g., #3, #42) actually exists in the bug database above
+- [ ] No bug pattern ID was invented or guessed
+- [ ] Pattern severity matches its category (Critical/Performance/Subtle)
+
+### SC-2: Technical Accuracy Check
+- [ ] All mathematical formulas referenced (e.g., alpha-compositing, covariance projection) are correctly stated
+- [ ] CUDA kernel behavior descriptions match documented behavior (not speculation)
+- [ ] Performance impact estimates are grounded (cite benchmark or note as approximate)
+
+### SC-3: Completeness Check
+- [ ] The reviewed code's domain was identified (e.g., rendering/SLAM/feed-forward/compression) and corresponding domain-specific patterns were checked
+- [ ] If the code involves a method explicitly listed in the bug database, all patterns for that method were checked
+- [ ] No section of the code was skipped without explicit acknowledgment
+
+### SC-4: Recommendation Consistency
+- [ ] Every suggested fix is technically compatible with the detected code version (PyTorch/CUDA/JAX)
+- [ ] No contradictory recommendations (e.g., "add shared memory" and "reduce register pressure" simultaneously without reconciliation)
+- [ ] Fix complexity is proportional to bug severity (no major refactoring suggestions for style issues)
+
+**If any SC check fails**: Do NOT present the review output. Instead, re-examine the failed check, correct the issue, and re-run the self-check from SC-1.
+
+## Red Lines
+
+- **No invented data**: Never fabricate bug patterns, CUDA kernel behaviors, or performance characteristics. If a value is not found, write "data not available" or "N/A".
+- **No hallucinated citations**: Never invent paper titles, authors, DOIs, arXiv IDs, or venue names.
+- **No silent speculation**: If uncertain about a technical detail, explicitly flag it with "[UNCERTAIN]" rather than presenting it as fact.
+- **No method misattribution**: Do not assign features, results, or mechanisms from one method to another.
+- **No oversimplified comparisons**: Do not reduce multi-dimensional trade-offs to a single "better/worse" judgment without context.
+
+## Related Skills
+
+- **3dgs-method-compare** — Method-level comparison (use when code issues stem from architectural decisions)
+- **3dgs-paper-reader** — Paper analysis (use when verifying code against paper claims)
+- **3dgs-engineering-guide** — Deployment guidance (use when code issues affect production readiness)
+- **3dgs-experiment-planner** — Experiment design (use when code bugs affect experimental validity)
+- **cad-mesh-3dgs** — CAD/Mesh integration (use when code involves mesh extraction or conversion)

--- a/skills/3dgs-engineering-guide/SKILL.md
+++ b/skills/3dgs-engineering-guide/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: 3dgs-engineering-guide
+description: "Guide for deploying 3DGS from research to production: 10 industry verticals, engineering stack, GIS toolchain solutions, cross-platform deployment, and common pitfalls. References 760+ methods. Use when: deploying 3DGS to production or industry, selecting tools/pipeline/platform, troubleshooting engineering problems (OOM, artifacts, platform lock-in), integrating 3DGS with GIS/BIM/ROS2/game engines, 3DGS部署/高斯泼溅工程化/3DGS生产环境/工程指南."
+license: Apache-2.0
+---
+
+# 3DGS Engineering Guide
+
+> **Architecture**: Axis-driven static/dynamic router. Do NOT try to apply the engineering guidance from memory. Always load fragments from disk as described below.
+
+## Role
+
+You are a 3DGS engineering deployment specialist. Bridge the gap from academic research to production deployment for 3D Gaussian Splatting.
+
+## Agent Instructions (Always Follow)
+
+1. **Identify use case** — determine application domain and constraints (platform, scale, real-time, budget)
+2. **Recommend pipeline** — select tools and pipeline from tech-stack and industry-landscape fragments
+3. **Reference papers** — point to methods in the knowledge base
+4. **Provide concrete next steps** — actionable items, not generic advice
+5. **Warn about pitfalls** — highlight domain-specific failure modes
+
+## Step 1 — Detect Request Axes
+
+### Axis: domain
+
+| User Intent | domain value |
+|-------------|-------------|
+| Autonomous driving simulation, sensor sim | autonomous-driving |
+| Digital twin, smart city, GIS | digital-twin |
+| Cultural heritage, museum, 3D archiving | culture |
+| Film, game production, virtual production | film-games |
+| E-commerce, 3D product display, WebAR | ecommerce |
+| Industrial inspection, drone survey | industrial |
+| AR/VR/MR headsets, spatial computing | ar-vr |
+| BIM, architecture, as-built verification | bim |
+| Robotics, embodied AI, manipulation | robotics |
+| Military simulation, defense | military |
+| World model, interactive 3D world | world-model |
+| Unspecified or broad engineering question | all |
+
+### Axis: focus
+
+| User Intent | focus value |
+|-------------|-------------|
+| Data acquisition, reconstruction, deployment pipeline | pipeline |
+| Quality assurance, scalability, cross-platform | best-practices |
+| Debugging artifacts, OOM, deployment failures | pitfalls |
+| Choosing tools by use case/platform/scale | decision-tree |
+| Specific technology stack info (formats, compression, engines) | tech-stack |
+| GIS integration, spatial analysis, S3M/Cesium | gis-toolchain |
+| Unspecified or comprehensive engineering guidance | all |
+
+If the user does not specify, defaults are: domain=all, focus=all.
+
+## Step 2 — Load Required Fragments
+
+### Always Load (every invocation)
+- static/core-stance.md — Role, workflow, deployment scale reference, terminology, guardrails
+
+### On-Demand Load (by detected domain)
+All domain values load static/industry-landscape.md (covers all 10 verticals + world models).
+
+### On-Demand Load (by detected focus)
+
+| focus | Fragment(s) to Load |
+|-------|-------------------|
+| pipeline | static/tech-stack.md |
+| best-practices | static/best-practices.md |
+| pitfalls | static/pitfalls.md |
+| decision-tree | static/decision-trees.md |
+| tech-stack | static/tech-stack.md |
+| gis-toolchain | static/gis-toolchain.md |
+| all | All focus fragments |
+
+### Reference Load (when citing specific methods)
+- static/reference-papers.md — Method tables organized by domain
+
+## Step 3 — Execute Engineering Guidance
+
+After loading the required fragments:
+
+1. Identify use case from domain axis — focus on the relevant industry section
+2. Recommend pipeline from tech-stack fragment
+3. Reference specific methods from reference-papers fragment and knowledge base
+4. Provide concrete next steps — actionable items, not generic advice
+5. Warn about pitfalls from pitfalls fragment — highlight domain-specific failure modes
+
+## Deployment Scale Reference
+
+| Scale | Gaussians | Training | GPU |
+|-------|-----------|----------|-----|
+| Object/room | 100K-1M | 10-30 min | RTX 4070 |
+| Building | 1M-10M | 1-3 h | RTX 4090 |
+| City block | 10M-100M | 3-7 h | A100 80GB |
+| City district | 100M-1B | 12-24 h | A100/H100 cluster |
+
+## Industry Landscape (10 Verticals + World Models)
+
+### 1. Autonomous Driving Simulation
+**Maturity**: Engineering | **Players**: aiSim, Li Auto mindVLA, NVIDIA DRIVE Sim
+**Pipeline**: Real-world scan (LiDAR + multi-camera) -> 3DGS reconstruction -> Sensor simulation -> HIL/SIL testing
+**Quality bar**: Sensor sim error < 0.02, LiDAR > 30 FPS, LPIPS < 0.1
+
+### 2. Digital Twin & Smart City
+**Maturity**: Commercial | **Players**: SuperMap, FantoVision, LCC
+**Pipeline**: Aerial + streetview -> Large-scale 3DGS -> S3M conversion -> GIS integration -> IoT fusion
+**Standards**: S3M (Chinese GIS), OGC 3D Tiles, glTF/glb, CityGML
+
+### 3. Cultural Heritage & Museum
+**Maturity**: Commercial
+**Quality**: Sub-mm geometry, delta-E < 2 (CIE76), 2048x2048+ texture, lossless compression
+
+### 4. Film & Game Production
+**Maturity**: Exploration | **Players**: Volcengine, UE team, Tencent
+**Pipeline**: Multi-camera capture -> 3DGS -> Mesh extraction (SuGaR/2DGS) -> UE5 import -> Virtual production
+
+### 5. E-commerce 3D Display
+**Maturity**: Commercial
+**Requirements**: < 50 MB, browser-renderable (WebGPU/WebGL2 via gsplat.js), < 5s load on 4G
+
+### 6. Industrial Inspection
+**Maturity**: Engineering
+**Pipeline**: Drone capture -> 3DGS -> AI defect detection -> Measurement -> Report
+
+### 7. AR/VR/MR
+**Maturity**: Exploration
+**Requirements**: < 20ms motion-to-photon; VkSplat for cross-VR; hybrid 3DGS+mesh for occlusion
+
+### 8. BIM & Architecture
+**Maturity**: Engineering | **Players**: LumenBIM x LCC
+**Pipeline**: TLS + drone -> 3DGS -> IFC alignment -> As-built verification -> LCC delivery
+
+### 9. Robotics & Embodied AI
+**Maturity**: Rapidly Growing
+**Pipeline**: 3DGS environment -> Physics sim (GS-Playground) -> Policy learning (sim-to-real) -> Deployment
+**Key methods**: GaussianGrasper (T-RO'24), GraspSplats (CoRL'24), ManiGaussian (ECCV'24), GSMem, RoboSplat (RSS'25), GS-Playground (RSS'26)
+
+### 10. Military Simulation
+**Maturity**: Early, classified
+**Requirements**: Air-gapped deployment, indigenous tools, > 60 FPS, multi-spectral
+
+### World Model Integration
+
+| Domain | Method | 3DGS Role | Maturity |
+|--------|--------|-----------|----------|
+| AD Simulation | RAD, DLWM, X-World | Twin digital world for RL/IL | Production |
+| Robot Manipulation | GS-World, Spark 2.0 | Differentiable sim engine | Research -> Early Production |
+| Interactive 3D World | GWM, FlashWorld | Dynamics modeling primitive | Research |
+| Web-Native Rendering | Visionary | WebGPU rendering platform | Open Source |
+
+## Common Engineering Pitfalls
+
+| Pitfall | Cause | Fix |
+|---------|-------|-----|
+| Over-fitting to training views | Artifacts at novel viewpoints | More viewpoints at different elevations, depth/opacity regularization |
+| Floating artifacts | Semi-transparent blobs in empty space | Depth regularization, opacity pruning, post-processing depth filter |
+| Memory explosion at scale | GPU OOM > 10M Gaussians | Spatial partitioning from day one, Scaffold-GS anchors, streaming for > 10M |
+| Sensor sim fidelity ignored | High PSNR but inaccurate sensors | Validate sensor outputs vs real data; opaque surface Gaussians for LiDAR |
+| CUDA lock-in | Cannot deploy to AMD/Intel/Mobile | VkSplat/GSeurat (Vulkan), msplat (Metal), brush (Rust/WebGPU, most complete cross-platform) |
+| Sorting bottleneck for semi-transparent | Alpha-compositing requires depth sort | DP-GES (Depth Peeling for sort-free surfel rendering) |
+| No version control for 3DGS | Cannot reproduce/track changes | git LFS or DVC; separate metadata (YAML) from binary |
+| Static lighting assumption | Breaks under different lighting | Plan relighting upfront; GOR-IS/SSD-GS decomposition; F-RNG for feed-forward relighting |
+| Temporal inconsistency | Video flicker, object jumping | 4DGS (GauFRe, DeformGS, ScubeGS); temporal smoothness loss |
+| Under-estimated compression artifacts | Visible holes, color shifts | Rate-distortion benchmarks first; domain-specific metrics |
+| Hierarchical tile/rasterization mismatch | Breaks exact alpha compositing | Use HiGS-style dual-scale architecture with conservative coverage test |
+
+## Terminology Quick Reference
+
+- **Cardinality Gaussian Expert Routing**: Routing mechanism where discrete experts predict different numbers of Gaussians per pixel based on scene complexity (cf. SplatWeaver)
+- **Bottleneck-Aware Multi-View Compression**: Compressing redundant multi-view latent tokens before Gaussian prediction (cf. ZPressor)
+- **Voxel-Aligned Prediction**: Predicting Gaussians in a shared voxel-space reference frame (cf. VolSplat)
+- **Skew-Normal Splatting**: Using Azzalini skew-normal distribution instead of symmetric Gaussian (cf. SNS)
+- **Stochastic Budget Training**: Randomly sampling Gaussian budget each iteration for LoD-compatible representations (cf. MGS)
+
+## Cross-Skill Routing
+
+- **Method comparison** -> 3dgs-method-compare (for selecting methods for deployment)
+- **Code review/bug detection** -> 3dgs-code-reviewer (for detecting deployment-critical bugs)
+- **MCP rendering** -> 3dgs-mcp-renderer (for real-time rendering integration)
+- **Spatial intelligence** -> 3dgs-spatial-agent (for agent-driven deployment scenarios)
+- **CAD/Mesh integration** -> cad-mesh-3dgs (for BIM/CAD workflows)
+
+## Guardrails
+
+- Never recommend tools or methods not present in the knowledge base
+- Always validate scale assumptions against the deployment scale reference
+- If platform is unspecified, ask — GPU family determines backend choice
+- Never assume CUDA availability; always provide cross-platform fallback path
+- Do NOT try to apply the logic, method data, or technical details from memory. Always read SKILL.md and referenced files from disk before producing any output.
+- If you cannot find a method, pattern, or data point in the loaded files, say so explicitly. Never invent metrics, venue acceptances, or technical features not present in the source data.
+
+## Related Skills
+
+- **3dgs-method-compare** — Method comparison (use for selecting methods for deployment)
+- **3dgs-code-reviewer** — Code review (use for detecting deployment-critical bugs)
+- **3dgs-mcp-renderer** — MCP rendering protocol (use for real-time rendering integration)
+- **3dgs-spatial-agent** — Spatial intelligence (use for agent-driven deployment scenarios)
+- **cad-mesh-3dgs** — CAD/Mesh integration (use for BIM/CAD workflows)

--- a/skills/3dgs-method-compare/SKILL.md
+++ b/skills/3dgs-method-compare/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: 3dgs-method-compare
+description: "Compare 3D Gaussian Splatting variants across 11 dimensions. Built-in knowledge of 760+ methods across 25 categories including Foundation, Compression, Dynamic, SLAM, Geometry, Semantic, Avatar, Autonomous Driving, and more. Supports axis-driven fragment loading for efficient context usage. Use when: comparing 3DGS methods or variants, analyzing trade-offs between Gaussian Splatting approaches, generating comparison tables for 3DGS papers, finding the best 3DGS method for a scenario, 检索3DGS方法对比/3D高斯泼溅方法比较."
+license: Apache-2.0
+---
+
+# 3DGS Method Comparison Engine
+
+> **Architecture**: Axis-driven static/dynamic router. Do NOT try to apply the comparison logic from memory. Always load fragments from disk as described below.
+
+## Capabilities
+
+- Compare any combination of 3DGS variants across 11 technical dimensions
+- Generate publication-quality comparison tables
+- Analyze design trade-offs and identify positioning
+- Provide recommendation based on specific use cases
+
+## Step 1 — Detect Request Axes
+
+Analyze the user's request to determine axis values:
+
+### Axis: category
+
+| User Intent | category value |
+|-------------|---------------|
+| Foundation/baseline methods, opacity, compression | core |
+| Surface reconstruction, geometry, text-to-3D generation | geometry |
+| Language features, semantic, feed-forward inference | semantic |
+| SLAM, large-scale scene, urban reconstruction | slam |
+| Dynamic scenes, 4DGS, human/avatar, articulated objects | dynamic |
+| Cross-domain, autonomous driving, spatial intelligence, editing, systems | application |
+| Broad/unspecified comparison across many categories | all |
+
+### Axis: depth
+
+| User Intent | depth value |
+|-------------|-------------|
+| Quick lookup, single method info | quick |
+| Standard comparison (2-5 methods, focused analysis) | standard |
+| Comprehensive survey, full-category scan | comprehensive |
+
+If the user does not specify, defaults are: category=all, depth=standard.
+
+## Step 2 — Load Required Fragments
+
+### Always Load (every invocation)
+Read these files from static/:
+- static/core-stance.md — Role, capabilities, comparison dimensions, rendering comparison table, guardrails
+
+### On-Demand Load (by detected category)
+
+| category | Fragment to Load |
+|----------|-----------------|
+| core | static/methods-core.md |
+| geometry | static/methods-geometry.md |
+| semantic | static/methods-semantic.md |
+| slam | static/methods-slam.md |
+| dynamic | static/methods-dynamic.md |
+| application | static/methods-application.md |
+| all | ALL method fragments (methods-core.md through methods-application.md) |
+
+### Reference Load (when producing structured output)
+- static/output-rules.md — Output format template and comparison rules
+
+**Optimization**: For depth=quick, load only the relevant category fragment + core-stance. For depth=comprehensive, load all fragments plus output-rules.
+
+## Step 3 — Execute Comparison
+
+After loading the required fragments:
+
+1. Apply the comparison dimensions from core-stance.md
+2. Use method data from the loaded category fragment(s)
+3. Follow output format from output-rules.md if producing tables/reports
+4. Observe all guardrails (no fabrication, flag uncertainty, load from disk not memory)
+
+## Comparison Dimensions (11 Axes)
+
+When comparing methods, analyze across these 11 dimensions:
+
+1. **Primitive Representation** — Shape (3D Gaussian / 2D disk / 1D splat / hybrid / SVGS / Spline / Triangle / Token-cluster), Anisotropy, Parameterization
+2. **Opacity / Alpha Mechanism** — Range ([0,1] / [-1,1] / unbounded / sigmoid / tanh), Signed support, Negative mechanism, Representational Abstraction (RAF)
+3. **Color Representation** — SH order, Color space (RGB / HDR / Feature / Albedo-decomposed), Negative color support
+4. **Rendering Formulation** — Rasterization (Tile-based / Forward / Deferred), Blending direction, Anti-aliasing (EWA / Mip-aware / None)
+5. **Frequency & Geometry Modeling** — HF boundary handling, Surface quality, Geometric constraints
+6. **Density Control** — Strategy (Clone+Split+Prune / Progressive / Anchor-based / Variational), Adaptivity, Compression
+7. **Training Strategy** — Resolution schedule, Iterations, Regularization, Acceleration methods
+8. **Performance Characteristics** — FPS tier, VRAM, Model size, Scalability
+9. **Applicable Scenarios** — NVS / Surface reconstruction / 3D editing / Dynamic / Large-scale / Autonomous driving
+10. **Code & Reproducibility** — Implementation availability, Framework, Dependencies
+11. **Spatial Intelligence & World Model** — 3DGS-as-state / dynamics-primitive / differentiable-simulation-engine
+
+### Rendering Formulation Comparison
+
+| Method | Primitive | Compositing | Key Feature |
+|--------|-----------|-------------|-------------|
+| 3DGS | 3D Anisotropic Gaussian | alpha-compositing (front-to-back) | Tile-based rasterization |
+| Softmax-GS | 3D Anisotropic Gaussian | Softmax competition | Replaces alpha-compositing with learnable softmax |
+| Mip-Splatting | 3D Anisotropic Gaussian + Mip | alpha-compositing | 3D smoothing + 2D Mip filter |
+| 3DGEER | 3D Anisotropic Gaussian | Exact ray-Gaussian integral | Replaces splatting with exact rendering |
+| SNS | Azzalini Skew-Normal Distribution | alpha-compositing | Learnable skewness for asymmetric boundaries |
+| DP-GES | Surfel (sort-free) | Depth Peeling transparency | Eliminates sorting via depth peeling |
+| TriSplat | Triangle primitive | Triangle rasterization | Triangle primitives replacing Gaussians |
+
+## Key Method Categories (Summary)
+
+### Foundation Methods
+3DGS (SIGGRAPH'23), Mip-Splatting (CVPR'24), 2DGS (SIGGRAPH'24), Scaffold-GS (ICCV'23), Softmax-GS (CVPR'26), LeGS, CAdam (SIGGRAPH'26)
+
+### Compression Methods
+Compact-3DGS (10-15x), LightGS (15-20x), MobileGS (50-100x), HAC (~100x), NanoGS (training-free), GETA-3DGS (5x, end-to-end pruning+quantization), MGS (Matryoshka continuous LoD), Prune Wisely (90% reduction via DoG), ProGS (45x, octree progressive)
+
+### Geometry / Surface Methods
+SuGaR (CVPR'24), PGSR (TVCG'24, SOTA), 2D-SuGaR (DTU SOTA), 3DSS (differentiable surface splatting), SVGS (Blender SOTA), AmbiSuR (ICML'26), TriSplat (triangle primitives)
+
+### SLAM Methods
+Gaussian Splatting SLAM (CVPR'24), WildGS-SLAM (CVPR'25), S3PO-GS (ICCV'25), E2EGS (CVPR'26, event camera), MAGS-SLAM (multi-agent), Real-Time LiDAR GS-SLAM
+
+### Dynamic / 4DGS Methods
+Multi-solver sub-dimension: Unified Query (D4RT, 200+ FPS) vs Separate Deformation Fields
+
+### Semantic / Feed-Forward Methods
+LangSplat (CVPR'24), Feature 3DGS (CVPR'24), Semantic Foam (CVPR'26), GS-LRM (ECCV'24), AnySplat (SIGGRAPH'25), SplatWeaver (cardinality expert routing), ArtSplat (articulated feed-forward)
+
+### Human / Avatar Methods
+HumanSplatHMR, EmoTaG (CVPR'26), HairGPT (SIGGRAPH'26), D-Rex (decoupled relighting)
+
+### World Models & Spatial Intelligence
+GWM (dynamics primitive), FlashWorld (real-time interactive 3D), GS-World (differentiable sim engine), GSMem (spatial memory), ESI-Bench (embodied spatial intelligence benchmark)
+
+## Output Format
+
+```
+## [Method A] vs [Method B] vs [Method C]
+
+### Overview Table
+| Dimension | Method A | Method B | Method C |
+|-----------|----------|----------|----------|
+| Primitive | ... | ... | ... |
+| Opacity | ... | ... | ... |
+| Rendering | ... | ... | ... |
+
+### Detailed Analysis
+#### Primitive Representation
+[Paragraph comparing the fundamental representational differences]
+
+#### Design Trade-offs
+[Analysis of what each method gains and sacrifices]
+
+#### Recommendation
+- For novel view synthesis: [Best choice] because ...
+- For surface reconstruction: [Best choice] because ...
+- For real-time rendering: [Best choice] because ...
+```
+
+## Rules
+
+1. **Be technically precise**: Never oversimplify differences. If two methods differ in their opacity parameterization, explain exactly how.
+2. **Quote metrics when available**: Use actual numbers from papers, not estimates.
+3. **Avoid bias**: Present each method's strengths and weaknesses fairly.
+4. **Context matters**: A method that's worse on PSNR might be better for real-time. Always mention the use case.
+5. **Flag uncertainty**: If you don't have reliable data for a comparison dimension, say so explicitly.
+
+## Cross-Skill Routing
+
+- **Paper reading/analysis** → 3dgs-paper-reader
+- **Code review/bug detection** → 3dgs-code-reviewer
+- **Experiment design** → 3dgs-experiment-planner
+- **Engineering deployment** → 3dgs-engineering-guide
+- **Visualization/radar charts** → 3dgs-visualizer
+- **CAD/Mesh integration** → cad-mesh-3dgs
+- **Spatial intelligence/agent** → 3dgs-spatial-agent
+
+## Guardrails
+
+- **Do NOT apply comparison logic from memory.** Always load method data from the static/ fragments. The methods database is updated frequently; stale memory may produce outdated or fabricated comparisons.
+- **Do NOT invent metrics, venues, or method features.** If a method is not found in the loaded fragments, say so explicitly.
+- **Flag uncertainty.** If you don't have reliable data for a comparison dimension, say so explicitly rather than guessing.

--- a/skills/cad-mesh-3dgs/SKILL.md
+++ b/skills/cad-mesh-3dgs/SKILL.md
@@ -1,0 +1,280 @@
+---
+name: cad-mesh-3dgs
+description: "Bridge CAD, Mesh, and 3D Gaussian Splatting representations. Covers mesh<->3DGS conversion, surface extraction, CAD reverse engineering, B-rep/parametric reconstruction, NL-driven assembly, TetSphere physics bridge. Analyzes 61+ methods. Use when: converting mesh to/from 3DGS, extracting surfaces from Gaussian splats, reverse engineering CAD from 3DGS, NL-driven CAD assembly, B-rep reconstruction, TetSphere physics simulation, mesh<->3DGS转换/CAD逆向/曲面提取/参数化重建."
+license: Apache-2.0
+---
+
+# CAD & Mesh x 3DGS Bridge
+
+You are a senior researcher at the intersection of CAD/CAM, geometric processing, and neural rendering (3DGS/NeRF). You have deep knowledge of how structured geometric representations (B-rep, mesh, point cloud) relate to and can be converted to/from 3D Gaussian Splatting representations.
+
+## Capabilities
+
+- Analyze mesh<->3DGS conversion methods and recommend the right approach
+- Guide surface extraction from trained 3DGS models
+- Advise on CAD reverse engineering pipelines using 3DGS
+- Compare geometry quality across mesh, surfel, and Gaussian representations
+- Debug common issues in mesh-Gaussian hybrid methods
+- Evaluate B-rep / parametric reconstruction from images via 3DGS
+
+## Representation Spectrum
+
+```
+Structured <-----------------------------------------------------> Unstructured
+  |                                                                  |
+  B-rep --- Mesh --- Point Cloud --- 3DGS --- NeRF/MLP
+  |          |           |              |           |
+  Parametric Topology   Explicit      Explicit   Implicit
+  Curves+   +Vertex    +Attribute   +Density   +Continuous
+  Surfaces   +Faces    (mu,Sigma,a,c) Control
+  |          |           |              |           |
+  CAD/      Graphics/  LiDAR/       Neural      Volume
+  CAM        Gaming    SfM          Rendering   Rendering
+```
+
+### Key Trade-offs Between Representations
+
+| Aspect | Mesh (Triangulated) | 3DGS (Gaussians) | B-rep (CAD) |
+|--------|---------------------|------------------|-------------|
+| Topology | Explicit (V,E,F) | None | Explicit (faces, edges, vertices) |
+| Smoothness | Discrete approx. | Continuous (covariance) | Exact (NURBS/analytic) |
+| Editing | Hard (vertex-level) | Medium (attribute-level) | Easy (parametric) |
+| Rendering | Rasterization/RT | Differentiable splatting | Rendering engines |
+| From images | Multi-View Stereo | 3DGS training | Reverse engineering |
+| Thin structures | Can represent | Bloated artifacts | Exact boundaries |
+| Physical sim | Ready | Needs mesh extraction | Native |
+
+## Section 1: Mesh -> 3DGS Conversion
+
+### Conversion Pipeline
+
+```
+Mesh (OBJ/PLY) -> Sample Points on Surface -> Initialize Gaussians -> Optimize
+                        |                          |
+                        |                          |-- mu: vertex positions
+                        |-- Poisson disk sampling   |-- Sigma: from face normals + area
+                        |-- Vertex sampling         |-- alpha: 1.0 (on surface)
+                        |-- Edge-aware sampling     |-- SH: from mesh vertex colors
+                                                   |-- R, S: from face orientation
+```
+
+### Initialization Strategies
+
+| Strategy | Description | Quality | Speed |
+|----------|-------------|---------|-------|
+| Vertex sampling | One Gaussian per vertex | Low (undersampled) | Fast |
+| Face sampling | Uniform points per face | Medium | Medium |
+| Area-weighted sampling | Density proportional to face area | Good | Medium |
+| Curvature-aware sampling | More points near high curvature | Best | Slow |
+| Poisson disk sampling | Blue-noise distribution | Good | Medium |
+
+### Known Issues in Mesh->3DGS
+
+| Issue | Symptom | Fix |
+|-------|---------|-----|
+| Floating artifacts | Gaussians drift off surface | Add normal consistency loss |
+| Thick surfaces | Scale in normal direction too large | Clamp normal scale to small value |
+| Missing thin parts | Pruned during density control | Reduce prune threshold for mesh-initialized |
+| Color bleeding | SH degree too high on flat surfaces | Start with SH degree 0, increase gradually |
+| Non-watertight mesh | Holes cause rendering gaps | Pre-process: fill holes with Poisson reconstruction |
+
+## Section 2: 3DGS -> Mesh Extraction
+
+### Extraction Methods Comparison
+
+| Method | Venue | Approach | Speed | Quality |
+|--------|-------|----------|-------|---------|
+| **SuGaR** | CVPR'24 | Regularized Gaussians -> TSDF -> Marching Cubes | ~1 min | High |
+| **2DGS** | SIGGRAPH'24 | 2D oriented disks -> Normal-guided extraction | ~30 min | Very High |
+| **NeuS2** | ECCV'22 | SDF + volume rendering -> Marching Cubes | ~2 hrs | High |
+| **TSDF-3DGS** | Various | Per-Gaussian TSDF fusion -> MC | ~2 min | Good |
+| **Poisson 3DGS** | Various | Render depth multi-view -> Poisson reconstruction | ~10 min | Medium |
+
+### SuGaR Pipeline (Recommended)
+
+```
+Trained 3DGS
+    |-- Step 1: Regularize Gaussians (add normal consistency loss, constrain near surface)
+    |-- Step 2: Extract TSDF (rasterize opacity to depth+normal maps, multi-view fusion)
+    |-- Step 3: Marching Cubes (extract triangle mesh, optional simplification/texturing)
+```
+
+### Geometry Quality Evaluation
+
+| Metric | Tool | What It Measures |
+|--------|------|-----------------|
+| Chamfer Distance (CD) | Open3D / PyTorch3D | Average distance to GT mesh |
+| F-Score @ threshold | Custom | Precision-recall of surface points |
+| Normal Consistency | Open3D | Angle between estimated and GT normals |
+| Mesh watertightness | PyMeshLab / Trimesh | Whether mesh is manifold + closed |
+
+## Section 3: Mesh-Adsorbed & Hybrid Representations
+
+### Key Hybrid Methods
+
+#### MaGS (Mesh-adsorbed Gaussian Splatting) — ICCV 2025
+Gaussians "adsorbed" onto mesh vertices. Mesh provides topology + deformation handle; Gaussians provide appearance. Best for animated/deformable objects.
+
+#### UniMGS (Unified Mesh and 3DGS) — AAAI 2026
+Single-pass rasterization for both mesh and Gaussians. Eliminates redundant computation. Best for real-time applications needing both mesh and appearance.
+
+#### 2DGS (2D Gaussian Splatting) — SIGGRAPH 2024
+Replace 3D anisotropic Gaussians with 2D oriented disks. Disks naturally constrain to surface, enabling direct mesh extraction. Best for tasks requiring high-quality mesh output.
+
+### When to Use Hybrid vs Pure
+
+| Use Case | Recommendation | Reason |
+|----------|---------------|--------|
+| Novel view synthesis only | Pure 3DGS | Fastest, highest visual quality |
+| Need mesh for 3D printing | 2DGS or SuGaR | Best geometry extraction |
+| Animated character + real-time render | MaGS | Deformation follows mesh |
+| CAD reverse engineering | BrepGaussian + mesh | Structured output needed |
+| Game asset pipeline | UniMGS | Unified single-pass rendering |
+
+## Section 4: CAD Reverse Engineering with 3DGS
+
+### The CAD RE Pipeline
+
+```
+Physical Object
+    |-- 3D Scanning (LiDAR / Photogrammetry)
+        |-- Images / Point Cloud
+            |-- 3DGS Training -> High-fidelity appearance model
+            |-- Mesh Extraction (SuGaR / 2DGS)
+                |-- Triangle Mesh
+                    |-- Mesh simplification -> segmentation -> primitive fitting
+                    |-- B-rep / Parametric CAD -> STEP / IGES File
+            |-- Direct B-rep extraction (BrepGaussian)
+    |-- CAD Model Ready for Manufacturing
+```
+
+### BrepGaussian (CVPR 2026) — Direct CAD from Images
+Gaussian Splatting + B-rep reconstruction in a unified framework. Gaussians provide dense geometric prior; B-rep extraction constrained by Gaussian geometry. Output: Parametric CAD model (STEP-compatible).
+
+### Mesh -> B-rep Conversion Methods
+
+| Method | Approach | Automation | Quality |
+|--------|----------|------------|---------|
+| Feature-based (CAD software) | Detect features -> fit primitives | Semi-auto | High |
+| Deep learning (BrepNet, CSGNet) | Predict primitives from point cloud/mesh | Auto | Medium |
+| Sketch-based | Extract edge network -> fit curves/surfaces | Semi-auto | High |
+| BrepGaussian | End-to-end from images via 3DGS prior | Auto | Medium-High |
+
+### Primitive Fitting for CAD Reverse Engineering
+
+| Primitive | Parameters | Detection Method |
+|-----------|-----------|-----------------|
+| Plane | (n, d) | RANSAC |
+| Sphere | (c, r) | RANSAC |
+| Cylinder | (axis, radius, extent) | RANSAC + normal clustering |
+| Cone | (apex, axis, angle) | RANSAC |
+| Torus | (center, axis, R, r) | RANSAC |
+| Free-form surface | NURBS control points | Least-squares fitting |
+
+## Section 5: Common Pitfalls & Debugging
+
+### Mesh Extraction Quality Issues
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| Bumpy surface | TSDF resolution too low | Increase to 512^3 |
+| Holes in mesh | Incomplete multi-view coverage | Add viewpoints or interpolate |
+| Thick surfaces | Gaussians not surface-constrained | Add normal consistency loss |
+| Floating fragments | Prune threshold too high | Post-process: remove small components |
+| Wrong topology | Non-manifold geometry | Repair with meshfix |
+
+### Mesh->3DGS Quality Issues
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| Gaussians drift off mesh | No surface constraint | Add mesh attraction loss |
+| Scale explodes in normal direction | No constraint on sigma_n | Clamp or use separate LR for normal scale |
+| Poor appearance on flat surfaces | SH overfitting | Limit SH degree to 1 for planar regions |
+
+### CAD-Specific Issues
+
+| Issue | Context | Fix |
+|-------|---------|-----|
+| B-rep edges don't align with extracted mesh | Mesh smoothing removed sharp edges | Preserve sharp features: edge-aware sampling |
+| Cylindrical surfaces become faceted | Too few Gaussians on curved surfaces | Increase sampling density by curvature |
+| STEP export invalid | Non-manifold geometry | Repair mesh before B-rep extraction |
+
+## New Methods (v1.6.0 — July 2026)
+
+### HoloTetSphere [arXiv:2607.08398] (ECCV 2026)
+- TetSphere mesh representation bridging 3DGS and physics simulation
+- Volumetric TetSphere -> tetrahedral mesh with guaranteed manifold output
+- Enables physics simulation directly from 3DGS representations
+- Bridges the gap between unstructured Gaussians and structured volumetric meshes needed for FEM
+
+### Incremental 3D Gaussian Triangulation
+- Progressive mesh extraction from 3DGS with topological guarantees
+- Builds triangulation incrementally as Gaussians are added/optimized
+
+### PEAR (SIGGRAPH 2026)
+- Single-image 100 FPS human avatar reconstruction
+- Relevant for CAD/Mesh pipeline: fast human body mesh extraction from Gaussians
+
+## Methods Database Summary (61+ methods)
+
+| Category | Count | Key Methods |
+|----------|-------|-------------|
+| Mesh-Gaussian Hybrid | 7 | MaGS, UniMGS, 2DGS, GauMesh |
+| Generation | 8 | SEIG, TRELLIS.2, MeshWeaver, SGS |
+| Articulated Object & Interaction | 3 | FreeArtGS, ArtGS, PARTICULATE |
+| CAD Reconstruction | 6 | BrepGaussian, CADFS, ParamGS |
+| Surface Extraction | 5 | SuGaR, 2DGS, PGSR, MarchingGS, PAGaS |
+| Cross-Domain Applications | 8 | EnerGS, RGS, E2EGS, FieryGS |
+
+## Output Format
+
+### For Conversion Advice:
+```
+## [Mesh/3DGS/CAD] Conversion Recommendation
+### Input: [description]
+### Output Goal: [description]
+### Recommended Pipeline
+1. [Step 1]: [Tool/Method] — [Why]
+### Expected Quality
+- Geometric accuracy: [High/Medium/Low]
+- Rendering fidelity: [High/Medium/Low]
+### Key Parameters
+- [Param]: [Recommended value] — [Reason]
+### Potential Issues & Mitigations
+1. [Issue] -> [Fix]
+```
+
+### For Method Comparison:
+```
+## [Method A] vs [Method B] for [Task]
+| Dimension | Method A | Method B |
+|-----------|----------|----------|
+| Geometry quality | ... | ... |
+| Rendering speed | ... | ... |
+### Recommendation: [Winner] because ...
+```
+
+## Rules
+
+1. **Representation awareness**: Always clarify which representation the user starts from and needs to end with.
+2. **No free lunch**: Every conversion loses information. Be honest about what degrades.
+3. **Practical tools**: Recommend tools that are actually available and maintained (Open3D, Trimesh, PyMeshLab, Open Cascade).
+4. **File format matters**: Mesh quality depends on export format (OBJ vs STL vs PLY). Specify format when relevant.
+5. **GPU-aware**: 3DGS methods require specific GPU resources. Mention VRAM requirements.
+6. **Domain context**: CAD reverse engineering requires sub-mm accuracy. Adjust precision expectations accordingly.
+7. **Cite accurately**: Only cite methods and metrics you are confident about. Mark uncertain information as "[UNCERTAIN]".
+
+## Red Lines
+
+- **No invented data**: Never fabricate mesh quality metrics, conversion efficiency, or surface reconstruction accuracy.
+- **No hallucinated citations**: Never invent paper titles, authors, DOIs, arXiv IDs, or venue names.
+- **No silent speculation**: Explicitly flag uncertainty with "[UNCERTAIN]" rather than presenting as fact.
+- **No method misattribution**: Do not assign features, results, or mechanisms from one method to another.
+- **No oversimplified comparisons**: Do not reduce multi-dimensional trade-offs to a single "better/worse" judgment without context.
+
+## Related Skills
+
+- **3dgs-method-compare** — Method comparison (use for comparing geometry/surface methods)
+- **3dgs-code-reviewer** — Code review (use for detecting mesh/conversion bugs)
+- **3dgs-articulated-reasoner** — Articulated reasoning (use for URDF/skeleton export)
+- **3dgs-engineering-guide** — Deployment guidance (use for production mesh pipelines)


### PR DESCRIPTION
…cad-mesh-3dgs, engineering-guide

Four new skills for 3D Gaussian Splatting research and deployment:

1. 3dgs-method-compare: 760+ methods knowledge base with 11-dimension comparison across 25 categories
2. 3dgs-code-reviewer: 105+ bug patterns for 3DGS implementation code review with Self-Check Loop
3. cad-mesh-3dgs: Bridge CAD/Mesh and 3DGS representations, 61+ methods, TetSphere physics bridge
4. 3dgs-engineering-guide: Deploy 3DGS to production, 10 industry verticals, common pitfalls

These fill the 3D vision / spatial intelligence gap in the skills repository. All skills use Apache-2.0 license and follow the Agent Skills standard format.