### PR TITLE
Fix skill-creator run_eval.py cross-matching skill UUIDs across parallel workers

### DIFF
--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -9,8 +9,10 @@ import argparse
 import json
 import os
 import select
+import shutil
 import subprocess
 import sys
+import tempfile
 import time
 import uuid
 from concurrent.futures import ProcessPoolExecutor, as_completed
@@ -19,25 +21,11 @@ from pathlib import Path
 from scripts.utils import parse_skill_md
 
 
-def find_project_root() -> Path:
-    """Find the project root by walking up from cwd looking for .claude/.
-
-    Mimics how Claude Code discovers its project root, so the command file
-    we create ends up where claude -p will look for it.
-    """
-    current = Path.cwd()
-    for parent in [current, *current.parents]:
-        if (parent / ".claude").is_dir():
-            return parent
-    return current
-
-
 def run_single_query(
     query: str,
     skill_name: str,
     skill_description: str,
     timeout: int,
-    project_root: str,
     model: str | None = None,
 ) -> bool:
     """Run a single query and return whether the skill was triggered.
@@ -50,7 +38,14 @@ def run_single_query(
     """
     unique_id = uuid.uuid4().hex[:8]
     clean_name = f"{skill_name}-skill-{unique_id}"
-    project_commands_dir = Path(project_root) / ".claude" / "commands"
+    # Isolate each query in its own project dir so the `claude -p` subprocess
+    # only ever sees THIS query's command file. Previously every parallel worker
+    # shared one .claude/commands/ dir, so each subprocess saw all siblings'
+    # command files (identical descriptions, different UUIDs). The model would
+    # trigger a sibling's skill name while this query only matches its own UUID,
+    # collapsing trigger rates to ~0 whenever num_workers > 1.
+    iso_root = Path(tempfile.mkdtemp(prefix="trigeval-"))
+    project_commands_dir = iso_root / ".claude" / "commands"
     command_file = project_commands_dir / f"{clean_name}.md"
 
     try:
@@ -86,7 +81,7 @@ def run_single_query(
             cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
-            cwd=project_root,
+            cwd=str(iso_root),
             env=env,
         )
 
@@ -177,8 +172,7 @@ def run_single_query(
 
         return triggered
     finally:
-        if command_file.exists():
-            command_file.unlink()
+        shutil.rmtree(iso_root, ignore_errors=True)
 
 
 def run_eval(
@@ -187,7 +181,6 @@ def run_eval(
     description: str,
     num_workers: int,
     timeout: int,
-    project_root: Path,
     runs_per_query: int = 1,
     trigger_threshold: float = 0.5,
     model: str | None = None,
@@ -205,7 +198,6 @@ def run_eval(
                     skill_name,
                     description,
                     timeout,
-                    str(project_root),
                     model,
                 )
                 future_to_info[future] = (item, run_idx)
@@ -278,7 +270,6 @@ def main():
 
     name, original_description, content = parse_skill_md(skill_path)
     description = args.description or original_description
-    project_root = find_project_root()
 
     if args.verbose:
         print(f"Evaluating: {description}", file=sys.stderr)
@@ -289,7 +280,6 @@ def main():
         description=description,
         num_workers=args.num_workers,
         timeout=args.timeout,
-        project_root=project_root,
         runs_per_query=args.runs_per_query,
         trigger_threshold=args.trigger_threshold,
         model=args.model,

--- a/skills/skill-creator/scripts/run_loop.py
+++ b/skills/skill-creator/scripts/run_loop.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 from scripts.generate_report import generate_html
 from scripts.improve_description import improve_description
-from scripts.run_eval import find_project_root, run_eval
+from scripts.run_eval import run_eval
 from scripts.utils import parse_skill_md
 
 
@@ -60,7 +60,6 @@ def run_loop(
     log_dir: Path | None = None,
 ) -> dict:
     """Run the eval + improvement loop."""
-    project_root = find_project_root()
     name, original_description, content = parse_skill_md(skill_path)
     current_description = description_override or original_description
 
@@ -92,7 +91,6 @@ def run_loop(
             description=current_description,
             num_workers=num_workers,
             timeout=timeout,
-            project_root=project_root,
             runs_per_query=runs_per_query,
             trigger_threshold=trigger_threshold,
             model=model,


### PR DESCRIPTION
## Summary

`skills/skill-creator/scripts/run_eval.py` produces systematically wrong (near-zero) trigger rates whenever `--num-workers > 1` (the default is 10), silently making every `should_trigger: true` case fail and every `should_trigger: false` case "pass" trivially. Fixes #1352.

## Root cause

`run_single_query()` wrote each query's temp command file into a **shared** project `.claude/commands/` dir and ran every `claude -p` in that **same** project (`cwd=project_root`):

```python
clean_name = f"{skill_name}-skill-{unique_id}"            # per-query UUID
project_commands_dir = Path(project_root) / ".claude" / "commands"   # SHARED
```

With `ProcessPoolExecutor(max_workers=N)`, up to N command files — **identical descriptions, different UUIDs** — coexist in that one dir, so each `claude -p` sees *every* sibling's file. The model invokes one instance of the skill, but each query only counts a trigger when the invoked name contains **its own** UUID:

```python
return clean_name in accumulated_json
```

so it almost always matches a sibling's UUID instead → false negative on nearly every query → trigger rate collapses to ~0. Serial runs (`--num-workers 1`) measure correctly, which is what makes the bug so easy to miss: the aggregate looks like a bad skill description when in fact the *measurement* is broken.

## Fix

Isolate each query in its own `tempfile.mkdtemp()` project dir, so a given `claude -p` only ever sees that query's command file. This removes the cross-matching entirely while keeping parallelism, and the temp dir is cleaned up in a `finally`.

Because queries no longer need to run inside the real project, project-root discovery becomes dead code — so this also drops `find_project_root()` and the `project_root` plumbing threaded through `run_eval()` and `run_loop.py`. Net **−12 lines**.

## Verification

Ran the same 6-query trigger set (3 positive, 3 negative) against the `mcp-builder` skill at `--num-workers 1` (trusted serial baseline) and `--num-workers 6` (the fixed parallel path), 3 runs per query:

| expected | serial | parallel |
|---|---|---|
| trigger | 2/3 (0.67) | 2/3 (0.67) |
| trigger | 1/3 (0.33) | 0/3 (0.00) |
| trigger | 3/3 (1.00) | 3/3 (1.00) |
| no trigger | 0/3 | 0/3 |
| no trigger | 0/3 | 0/3 |
| no trigger | 0/3 | 0/3 |

Per-query pass/fail **matches across both modes** (5/6 in each), every serial-confirmed positive **also fires in parallel**, and all negatives correctly stay at 0. The parallel path now measures identically to the serial baseline instead of collapsing to ~0. (The middle row is a deliberately weak query that the serial baseline also only triggers 1/3 of the time — it behaves the same in both modes and is unrelated to parallelism.)

## Note on behavior

Queries now run in an isolated temp project, so `claude -p` no longer inherits the *real project's* `.claude/settings.json` (the global `~/.claude` still applies). That is intended — the shared project state was the source of the cross-matching — and the verification above confirms triggering still works correctly in the isolated dir.
