### PR TITLE
Add vscode-extension-builder skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -37,6 +37,7 @@
         "./skills/skill-creator",
         "./skills/slack-gif-creator",
         "./skills/theme-factory",
+        "./skills/vscode-extension-builder",
         "./skills/web-artifacts-builder",
         "./skills/webapp-testing"
       ]

--- a/skills/vscode-extension-builder/LICENSE.txt
+++ b/skills/vscode-extension-builder/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Surya Prakash Pandurangi.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/vscode-extension-builder/SKILL.md
+++ b/skills/vscode-extension-builder/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: vscode-extension-builder
+description: Use this skill whenever the user asks to create, scaffold, build, or generate a VS Code extension or Visual Studio Code extension — e.g. "Create a VSCode extension", "Create a Visual Studio Code extension", "build me a vscode extension that does X", "make a VS Code plugin/theme/snippet extension". Fully automates scaffolding, npm dependency installation, TypeScript compiling, packaging with vsce, and local installation into the user's VS Code — the user never installs any package or tool by hand. Also covers publishing an already-built extension to the VS Code Marketplace when explicitly asked.
+license: Complete terms in LICENSE.txt
+---
+
+# VS Code Extension Builder
+
+Builds a working, installed VS Code extension end-to-end from a single user
+request. The user should never be told to run `npm install`, install `yo`,
+`generator-code`, or `vsce` themselves — you do all of it.
+
+## Workflow
+
+### 1. Understand what to build
+
+If the user only said "create a VS Code extension" with no detail, ask ONE
+concise question about what the extension should actually do (e.g. a command
+it runs, a theme, a snippet pack, a webview panel). Don't ask about
+scaffolding mechanics (TypeScript vs JS, folder structure, etc.) — you decide
+those. Infer sensible defaults for name/publisher if the user doesn't care:
+- `name`: kebab-case slug derived from what it does
+- `displayName`: Title Case of the name
+- `publisher`: `local-dev` (fine for local install; real publisher id only
+  matters if they later want to publish to the Marketplace)
+
+Pick an extension `type` for scaffolding purposes:
+- `command` (default) — contributes one or more commands, runs TS logic.
+  Use this for anything behavioral (formatting, automation, panels, status
+  bar items, etc.) — see `reference/contribution-points.md` for how to wire
+  up webviews, menus, keybindings, status bar items, workspace/file watchers,
+  etc. inside the same scaffold.
+- `theme` — a color theme.
+- `snippets` — a snippet pack for one or more languages.
+
+### 2. Check prerequisites (don't skip)
+
+Run these checks yourself; don't ask the user to run them:
+
+```bash
+node --version
+npm --version
+```
+
+If either is missing, Node.js itself is a system-level install — tell the
+user and ask before installing it system-wide (e.g. via `winget install
+OpenJS.NodeJS.LTS`, `brew install node`, or `apt install nodejs npm`
+depending on OS). Everything downstream of this (npm installs inside the new
+project folder, `npx vsce`, etc.) is project-local and reversible, so do NOT
+ask permission for those — just run them.
+
+Also check for the `code` CLI, needed later to auto-install the built
+extension:
+
+```bash
+code --version
+```
+
+If it's missing, don't block — note it and fall back to giving the user the
+`.vsix` path at the end (see step 7).
+
+### 3. Scaffold the project
+
+Pick an output directory (default: a new folder named `<name>` in the
+current workspace/working directory, unless the user specified one). Run the
+bundled generator — it writes all boilerplate deterministically so you don't
+hand-author it from scratch each time:
+
+```bash
+node scripts/create-extension.js \
+  --name "<kebab-case-name>" \
+  --displayName "<Title Case Name>" \
+  --description "<one-line description>" \
+  --publisher "<publisher-id-or-local-dev>" \
+  --type "command|theme|snippets" \
+  --dir "<absolute-output-dir>"
+```
+
+This generates `package.json`, `tsconfig.json` (for `command` type),
+`.vscodeignore`, `.gitignore`, `.vscode/launch.json`, `.vscode/tasks.json`,
+`README.md`, `CHANGELOG.md`, `LICENSE`, and a starter source file
+(`src/extension.ts` for `command`, a theme JSON for `theme`, a snippets JSON
+for `snippets`).
+
+### 4. Implement the actual feature
+
+The generator only produces a minimal skeleton (for `command` type: one
+`helloWorld` command). Now edit the generated files to implement what the
+user actually asked for:
+- `command` type: edit `src/extension.ts` and the `contributes` /
+  `activationEvents` sections of `package.json`. Consult
+  `reference/contribution-points.md` for the right contribution point
+  (commands, menus, keybindings, webviews, status bar, tree views,
+  configuration settings, file watchers, etc.) and wire it up properly —
+  don't leave the placeholder `helloWorld` command unless the user actually
+  wanted a hello-world extension.
+- `theme` type: edit the generated theme JSON's `colors`/`tokenColors` to
+  match what was requested.
+- `snippets` type: edit the generated snippets JSON with the actual
+  snippets, and set `contributes.snippets[].language` correctly in
+  `package.json`.
+
+### 5. Install dependencies and compile
+
+From inside the generated project directory:
+
+```bash
+npm install
+```
+
+For `command` type only, compile to catch errors early:
+
+```bash
+npm run compile
+```
+
+Fix any TypeScript errors before moving on.
+
+### 6. Package with vsce (no global install)
+
+Use `npx` so nothing is installed globally on the user's machine:
+
+```bash
+npx --yes @vscode/vsce package --allow-missing-repository
+```
+
+This produces `<name>-<version>.vsix` in the project root. If it fails
+because of missing `publisher`/`engines.vscode` fields, fix `package.json`
+(the generator already sets these, so this should only happen if you edited
+them incorrectly).
+
+### 7. Install the extension into the user's VS Code automatically
+
+```bash
+code --install-extension "<name>-<version>.vsix"
+```
+
+If `code` wasn't on PATH in step 2, try common install locations before
+giving up:
+- Windows: `%LOCALAPPDATA%\Programs\Microsoft VS Code\bin\code.cmd`, or
+  `C:\Program Files\Microsoft VS Code\bin\code.cmd`
+- macOS: `/usr/local/bin/code`, or
+  `/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code`
+- Linux: `/usr/bin/code`, or `/usr/share/code/bin/code`
+
+If none of those work, tell the user the exact `.vsix` path and that they
+can install it via VS Code's Extensions view → "…" menu → "Install from
+VSIX…", or run `code --install-extension <path>` themselves once `code` is
+on PATH (Command Palette → "Shell Command: Install 'code' command in PATH").
+
+### 8. Wrap up
+
+Tell the user:
+- The extension is installed; they should reload VS Code
+  (Command Palette → "Developer: Reload Window") to activate it.
+- For active development/debugging, open the generated folder in VS Code and
+  press F5 to launch an Extension Development Host — this is already wired
+  up via `.vscode/launch.json` and `.vscode/tasks.json`.
+- Where the project lives on disk, and the command/feature entry point they
+  asked for.
+
+## Publishing to the Marketplace (only if explicitly requested)
+
+Do NOT attempt this as part of a normal "create an extension" request — it
+requires the user's own Azure DevOps account and Personal Access Token,
+which you cannot create or obtain on their behalf. Only walk through
+`reference/publishing.md` if the user explicitly asks to publish to the
+Marketplace, and always have them provide/paste their own PAT interactively
+rather than storing it anywhere.

--- a/skills/vscode-extension-builder/reference/contribution-points.md
+++ b/skills/vscode-extension-builder/reference/contribution-points.md
@@ -1,0 +1,126 @@
+# Common contribution points (command-type extensions)
+
+Quick reference for wiring up `package.json` `contributes` + `src/extension.ts`
+for the most common things a user asks a VS Code extension to do. Only add
+what's needed for the request — don't include unused contribution points.
+
+## Command (already scaffolded)
+
+`package.json`:
+```json
+"contributes": {
+  "commands": [{ "command": "<name>.doThing", "title": "Do Thing" }]
+}
+```
+`extension.ts`:
+```ts
+context.subscriptions.push(
+  vscode.commands.registerCommand('<name>.doThing', () => { /* ... */ })
+);
+```
+
+## Keybinding
+
+```json
+"contributes": {
+  "keybindings": [
+    { "command": "<name>.doThing", "key": "ctrl+alt+d", "mac": "cmd+alt+d", "when": "editorTextFocus" }
+  ]
+}
+```
+
+## Menu item (editor context menu, command palette, etc.)
+
+```json
+"contributes": {
+  "menus": {
+    "editor/context": [{ "command": "<name>.doThing", "when": "editorTextFocus", "group": "navigation" }]
+  }
+}
+```
+
+## Status bar item
+
+```ts
+const item = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
+item.text = '$(rocket) My Status';
+item.command = '<name>.doThing';
+item.show();
+context.subscriptions.push(item);
+```
+
+## Configuration setting
+
+```json
+"contributes": {
+  "configuration": {
+    "title": "<Display Name>",
+    "properties": {
+      "<name>.someSetting": {
+        "type": "boolean",
+        "default": true,
+        "description": "What this setting controls."
+      }
+    }
+  }
+}
+```
+```ts
+const value = vscode.workspace.getConfiguration('<name>').get<boolean>('someSetting');
+```
+
+## Webview panel
+
+```ts
+const panel = vscode.window.createWebviewPanel(
+  '<name>.panel',
+  'Panel Title',
+  vscode.ViewColumn.One,
+  { enableScripts: true }
+);
+panel.webview.html = `<!DOCTYPE html><html><body><h1>Hello</h1></body></html>`;
+```
+
+## Tree view (sidebar panel)
+
+```json
+"contributes": {
+  "views": {
+    "explorer": [{ "id": "<name>.view", "name": "<Display Name>" }]
+  }
+}
+```
+```ts
+class MyProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
+  getTreeItem(el: vscode.TreeItem) { return el; }
+  getChildren() { return [new vscode.TreeItem('Example')]; }
+}
+vscode.window.registerTreeDataProvider('<name>.view', new MyProvider());
+```
+
+## React to file/workspace changes
+
+```ts
+const watcher = vscode.workspace.createFileSystemWatcher('**/*.ext');
+watcher.onDidChange(uri => { /* ... */ });
+context.subscriptions.push(watcher);
+
+vscode.workspace.onDidSaveTextDocument(doc => { /* run on save */ });
+```
+
+## Format-on-save / document formatter
+
+```ts
+vscode.languages.registerDocumentFormattingEditProvider('<languageId>', {
+  provideDocumentFormattingEdits(document) {
+    // return vscode.TextEdit[]
+  }
+});
+```
+
+## Activation events
+
+Since VS Code 1.74+, `onCommand`, `onLanguage`, and most other activation
+events are inferred automatically from `contributes` — leave
+`activationEvents: []` unless activation needs to happen on something that
+can't be inferred (e.g. `onStartupFinished`, `onFileSystem:<scheme>`).

--- a/skills/vscode-extension-builder/reference/publishing.md
+++ b/skills/vscode-extension-builder/reference/publishing.md
@@ -1,0 +1,156 @@
+# Publishing to the VS Code Marketplace
+
+Only follow this when the user explicitly asks to publish. Never fabricate,
+store, or ask to persist a Personal Access Token (PAT) or Entra ID
+credential — the user provides/pastes it themselves when prompted.
+
+## 1. Ensure package.json is publish-ready
+
+Required fields: `name`, `version` (semver), `publisher`, `engines.vscode`.
+
+Recommended — set these yourself based on what the user described, don't
+leave them for the user to add later:
+- `repository` — enables vsce to auto-adjust relative links in README/CHANGELOG
+- `icon` — 128x128+ PNG only, **SVG is rejected**
+- `keywords` — up to 30 tags; more than that fails publishing outright
+- `galleryBanner.color` — hex color for the Marketplace banner background
+- `pricing` — `"Free"` or `"Trial"` (case-sensitive; defaults to `"Free"` if omitted, requires vsce ≥2.10.0)
+- `sponsor` — `{ "url": "https://..." }` to show a sponsorship link (requires vsce ≥2.9.1)
+
+## 2. Publisher + credential (user does this)
+
+The user must do this part personally — it requires their own authenticated
+browser session and cannot be done on their behalf.
+
+1. User creates a publisher at https://marketplace.visualstudio.com/manage
+   (unique publisher `id` + `name`).
+2. User obtains a credential — two options:
+   - **Personal Access Token (PAT)** — works today, but Azure DevOps is
+     sunsetting global PATs on **December 1, 2026**. Generate at
+     https://go.microsoft.com/fwlink/?LinkId=307137 (Azure DevOps → User
+     settings → Personal access tokens → New Token → Organization: "All
+     accessible organizations", Scope: Marketplace → Manage).
+   - **Microsoft Entra ID with workload identity federation** (recommended
+     going forward, especially for CI/CD) — a managed identity is added as a
+     Marketplace publisher member (Contributor role), then credentials are
+     exchanged via Azure CLI/pipeline rather than a long-lived token. This is
+     org/pipeline setup the user (or their Azure admin) configures; walk them
+     to https://code.visualstudio.com/api/working-with-extensions/publishing-extension#continuous-integration
+     if they want it, don't attempt to configure Azure resources yourself.
+3. Make sure `package.json`'s `"publisher"` field matches their publisher id.
+
+## 3. Login (interactive — let the user paste their credential)
+
+```bash
+npx --yes @vscode/vsce login <publisher-id>
+```
+
+With Entra ID / managed identity already configured in the environment, skip
+login and pass `--azure-credential` directly to `publish` instead (see below).
+
+## 4. Publish
+
+```bash
+npx --yes @vscode/vsce publish
+```
+
+Or bump version while publishing:
+
+```bash
+npx --yes @vscode/vsce publish minor
+npx --yes @vscode/vsce publish patch
+npx --yes @vscode/vsce publish major
+npx --yes @vscode/vsce publish 1.1.0
+```
+
+With Entra ID / managed identity:
+
+```bash
+npx --yes @vscode/vsce publish --azure-credential
+```
+
+### Pre-release versions
+
+Only if the user explicitly asks for a pre-release channel:
+
+```bash
+npx --yes @vscode/vsce publish --pre-release
+```
+
+VS Code doesn't support semver pre-release tags (`1.0.0-beta`) — only plain
+`major.minor.patch`. Convention: use **even** minor versions for regular
+releases (`0.2.x`) and **odd** minor versions for pre-releases (`0.3.x`) so
+the two channels never collide on a version number. Requires
+`engines.vscode` >= `1.63.0`, or the pre-release won't show as installable.
+
+### Platform-specific packaging
+
+Only if the extension bundles native/platform-specific code — most
+extensions this skill generates don't need this:
+
+```bash
+npx --yes @vscode/vsce package --target win32-x64
+npx --yes @vscode/vsce publish --target win32-x64 win32-arm64
+```
+
+Supported targets: `win32-x64`, `win32-arm64`, `linux-x64`, `linux-arm64`,
+`linux-armhf`, `alpine-x64`, `alpine-arm64`, `darwin-x64`, `darwin-arm64`,
+`web`. If you want the extension to also run in the browser, `web` must be
+included as one of the targets.
+
+## Unpublishing / removing a version
+
+```bash
+npx --yes @vscode/vsce unpublish <publisher-id>.<extension-name>
+```
+
+This sets the extension's status to "Unpublished" — it's hidden from VS Code
+and the Marketplace, but statistics are preserved and it remains reachable
+via the API. **This is destructive and irreversible for that identifier** —
+confirm explicitly with the user before running it; never run it
+speculatively or as part of a troubleshooting attempt.
+
+Deleting a single version, or removing an extension entirely (freeing
+nothing — the name is permanently reserved and can never be reused by any
+publisher), can only be done by the user via the
+https://marketplace.visualstudio.com/manage web UI ("More Actions" menu) —
+there's no CLI for those two operations.
+
+## Alternative: manual upload (no credential needed in the terminal)
+
+```bash
+npx --yes @vscode/vsce package
+```
+
+Then the user uploads the generated `.vsix` manually at
+https://marketplace.visualstudio.com/manage.
+
+## Gotchas
+
+- **SVG images are rejected.** Anywhere an image is resolvable in the
+  extension (icon, README, CHANGELOG) — use PNG for the icon and
+  HTTPS-hosted images (PNG/SVG-from-a-trusted-badge-provider only) elsewhere.
+- **Publishing from Windows can lose POSIX file attributes** in the packaged
+  `.vsix` (executable bits on bundled scripts, etc.). If the extension ships
+  any file that needs an executable bit, publish from Linux or macOS (e.g. a
+  CI runner) instead of a Windows dev machine.
+- **`engines.vscode` semver matters.** No caret (`"1.8.0"`) pins to exactly
+  that version; `"^1.8.0"` (the generator's default) allows that version and
+  all later ones — almost always what you want.
+
+## Troubleshooting
+
+- **"You exceeded the number of allowed tags of 30"** — trim the `keywords`
+  array in `package.json` to 30 or fewer.
+- **403 Forbidden / 401 Unauthorized on login or publish** — the PAT's scope
+  or organization is wrong. It must be scoped to "All accessible
+  organizations" with "Marketplace (Manage)" access.
+- **"Extension 'name' already exists"** — the `name` (or `displayName`) isn't
+  unique on the Marketplace; pick a different one. Marketplace name
+  uniqueness is separate from local scaffold naming, so this can surface
+  only at publish time even though scaffolding succeeded.
+- **`vsce unpublish` doesn't work** — this happens if the extension or
+  publisher ID was changed after a prior publish. Fall back to the
+  marketplace.visualstudio.com/manage web UI.
+- **Pre-release not showing as installable** — `engines.vscode` is below
+  `1.63.0`; bump it.

--- a/skills/vscode-extension-builder/scripts/create-extension.js
+++ b/skills/vscode-extension-builder/scripts/create-extension.js
@@ -1,0 +1,339 @@
+#!/usr/bin/env node
+/**
+ * Deterministic scaffolder for a new VS Code extension.
+ * Usage:
+ *   node create-extension.js --name my-ext --displayName "My Ext" \
+ *     --description "Does a thing" --publisher local-dev \
+ *     --type command --dir /abs/path/to/output
+ */
+const fs = require('fs');
+const path = require('path');
+
+function parseArgs(argv) {
+	const out = {};
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		if (arg.startsWith('--')) {
+			const key = arg.slice(2);
+			const next = argv[i + 1];
+			if (next === undefined || next.startsWith('--')) {
+				out[key] = true;
+			} else {
+				out[key] = next;
+				i++;
+			}
+		}
+	}
+	return out;
+}
+
+const args = parseArgs(process.argv.slice(2));
+
+const name = args.name;
+if (!name || !/^[a-z0-9][a-z0-9-]*$/.test(name)) {
+	console.error('Error: --name is required and must be a kebab-case identifier (e.g. "my-extension").');
+	process.exit(1);
+}
+
+const displayName = args.displayName || name.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+const description = args.description || `${displayName} for VS Code.`;
+const publisher = args.publisher || 'local-dev';
+const type = args.type || 'command';
+const outDir = path.resolve(args.dir || path.join(process.cwd(), name));
+
+if (!['command', 'theme', 'snippets'].includes(type)) {
+	console.error(`Error: --type must be one of command | theme | snippets (got "${type}")`);
+	process.exit(1);
+}
+
+if (fs.existsSync(outDir) && fs.readdirSync(outDir).length > 0) {
+	console.error(`Error: output directory "${outDir}" already exists and is not empty.`);
+	process.exit(1);
+}
+
+function write(relPath, content) {
+	const full = path.join(outDir, relPath);
+	fs.mkdirSync(path.dirname(full), { recursive: true });
+	fs.writeFileSync(full, content, 'utf8');
+}
+
+const year = new Date().getFullYear();
+
+const commonGitignore = `out/\nnode_modules/\n*.vsix\n.vscode-test/\n`;
+
+const readme = `# ${displayName}
+
+${description}
+
+## Features
+
+<!-- Describe the extension's features here. -->
+
+## Requirements
+
+None.
+
+## Extension Settings
+
+This extension does not currently contribute any settings.
+
+## Known Issues
+
+None.
+
+## Release Notes
+
+### 0.0.1
+
+Initial release.
+`;
+
+const changelog = `# Change Log
+
+All notable changes to the "${name}" extension will be documented in this file.
+
+## [0.0.1]
+
+- Initial release
+`;
+
+const license = `MIT License
+
+Copyright (c) ${year} ${publisher}
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+`;
+
+if (type === 'command') {
+	const packageJson = {
+		name,
+		displayName,
+		description,
+		version: '0.0.1',
+		publisher,
+		license: 'MIT',
+		engines: { vscode: '^1.85.0' },
+		categories: ['Other'],
+		activationEvents: [],
+		main: './out/extension.js',
+		contributes: {
+			commands: [
+				{
+					command: `${name}.helloWorld`,
+					title: 'Hello World',
+				},
+			],
+		},
+		scripts: {
+			'vscode:prepublish': 'npm run compile',
+			compile: 'tsc -p ./',
+			watch: 'tsc -watch -p ./',
+		},
+		devDependencies: {
+			'@types/vscode': '^1.85.0',
+			'@types/node': '^20.0.0',
+			typescript: '^5.4.0',
+		},
+	};
+	write('package.json', JSON.stringify(packageJson, null, 2) + '\n');
+
+	write(
+		'tsconfig.json',
+		JSON.stringify(
+			{
+				compilerOptions: {
+					module: 'commonjs',
+					target: 'ES2022',
+					outDir: 'out',
+					lib: ['ES2022'],
+					sourceMap: true,
+					rootDir: 'src',
+					strict: true,
+				},
+				exclude: ['node_modules', '.vscode-test'],
+			},
+			null,
+			2
+		) + '\n'
+	);
+
+	write(
+		'src/extension.ts',
+		`import * as vscode from 'vscode';
+
+export function activate(context: vscode.ExtensionContext) {
+	console.log('${displayName} is now active.');
+
+	const disposable = vscode.commands.registerCommand('${name}.helloWorld', () => {
+		vscode.window.showInformationMessage('Hello World from ${displayName}!');
+	});
+
+	context.subscriptions.push(disposable);
+}
+
+export function deactivate() {}
+`
+	);
+
+	write(
+		'.vscode/launch.json',
+		JSON.stringify(
+			{
+				version: '0.2.0',
+				configurations: [
+					{
+						name: 'Run Extension',
+						type: 'extensionHost',
+						request: 'launch',
+						args: ['--extensionDevelopmentPath=${workspaceFolder}'],
+						outFiles: ['${workspaceFolder}/out/**/*.js'],
+						preLaunchTask: '${defaultBuildTask}',
+					},
+				],
+			},
+			null,
+			2
+		) + '\n'
+	);
+
+	write(
+		'.vscode/tasks.json',
+		JSON.stringify(
+			{
+				version: '2.0.0',
+				tasks: [
+					{
+						type: 'npm',
+						script: 'watch',
+						problemMatcher: '$tsc-watch',
+						isBackground: true,
+						presentation: { reveal: 'never' },
+						group: { kind: 'build', isDefault: true },
+					},
+				],
+			},
+			null,
+			2
+		) + '\n'
+	);
+
+	write(
+		'.vscodeignore',
+		['.vscode/**', '.vscode-test/**', 'src/**', '.gitignore', 'tsconfig.json', '**/*.map', '**/*.ts', 'node_modules/**'].join('\n') + '\n'
+	);
+} else if (type === 'theme') {
+	const themeFileName = `${name}-color-theme.json`;
+	const packageJson = {
+		name,
+		displayName,
+		description,
+		version: '0.0.1',
+		publisher,
+		license: 'MIT',
+		engines: { vscode: '^1.85.0' },
+		categories: ['Themes'],
+		contributes: {
+			themes: [
+				{
+					label: displayName,
+					uiTheme: 'vs-dark',
+					path: `./themes/${themeFileName}`,
+				},
+			],
+		},
+	};
+	write('package.json', JSON.stringify(packageJson, null, 2) + '\n');
+
+	write(
+		`themes/${themeFileName}`,
+		JSON.stringify(
+			{
+				name: displayName,
+				type: 'dark',
+				colors: {
+					'editor.background': '#1e1e1e',
+					'editor.foreground': '#d4d4d4',
+				},
+				tokenColors: [
+					{
+						scope: ['comment'],
+						settings: { foreground: '#6a9955', fontStyle: 'italic' },
+					},
+					{
+						scope: ['keyword'],
+						settings: { foreground: '#569cd6' },
+					},
+					{
+						scope: ['string'],
+						settings: { foreground: '#ce9178' },
+					},
+				],
+			},
+			null,
+			2
+		) + '\n'
+	);
+
+	write('.vscodeignore', ['.vscode/**', '.gitignore'].join('\n') + '\n');
+} else if (type === 'snippets') {
+	const snippetsFileName = `${name}.code-snippets`;
+	const packageJson = {
+		name,
+		displayName,
+		description,
+		version: '0.0.1',
+		publisher,
+		license: 'MIT',
+		engines: { vscode: '^1.85.0' },
+		categories: ['Snippets'],
+		contributes: {
+			snippets: [
+				{
+					language: 'plaintext',
+					path: `./snippets/${snippetsFileName}`,
+				},
+			],
+		},
+	};
+	write('package.json', JSON.stringify(packageJson, null, 2) + '\n');
+
+	write(
+		`snippets/${snippetsFileName}`,
+		JSON.stringify(
+			{
+				'Example Snippet': {
+					prefix: name,
+					body: ['$1'],
+					description: 'Example snippet — replace with real snippets.',
+				},
+			},
+			null,
+			2
+		) + '\n'
+	);
+
+	write('.vscodeignore', ['.vscode/**', '.gitignore'].join('\n') + '\n');
+}
+
+write('.gitignore', commonGitignore);
+write('README.md', readme);
+write('CHANGELOG.md', changelog);
+write('LICENSE', license);
+
+console.log(`Scaffolded "${type}" extension "${name}" at: ${outDir}`);


### PR DESCRIPTION
## Summary
- Adds a new example skill, `vscode-extension-builder`, under the Development & Technical category.
- The skill scaffolds, compiles, packages (via `vsce`), and locally installs a working VS Code extension end-to-end from a single natural-language request - supporting command extensions, color themes, and snippet packs - without the user ever running `npm install`, `yo`, `generator-code`, or `vsce` by hand.
- Includes reference docs for wiring additional contribution points (webviews, menus, keybindings, status bar items, tree views, file watchers, etc.) and for publishing an already-built extension to the VS Code Marketplace when explicitly requested.
- Registered the skill under the `example-skills` plugin entry in `.claude-plugin/marketplace.json`, alongside `webapp-testing`, `mcp-builder`, etc.

## Test plan
- [x] Verified `SKILL.md` frontmatter (`name`, `description`, `license`) matches the format used by other skills in this repo (e.g. `webapp-testing`, `mcp-builder`).
- [x] Verified the bundled `scripts/create-extension.js` generator runs standalone and produces a working `command`/`theme`/`snippets` scaffold (scaffold -> `npm install` -> `npm run compile` -> `vsce package`), exercised via a separate smoke-test harness in the skill's origin repo.
- [x] Confirmed `.claude-plugin/marketplace.json` JSON is valid and the new skill path resolves under `example-skills`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)