### PR TITLE
Add Modellix to Partner Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,4 @@ The markdown content below contains the instructions, examples, and guidelines t
 Skills are a great way to teach Claude how to get better at using specific pieces of software. As we see awesome example skills from partners, we may highlight some of them here:
 
 - **Notion** - [Notion Skills for Claude](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0)
+- **Modellix** - [Modellix Skill for AI image and video generation](https://github.com/Modellix/modellix-skill/tree/main/modellix-skill)

--- a/README.md
+++ b/README.md
@@ -94,4 +94,4 @@ The markdown content below contains the instructions, examples, and guidelines t
 Skills are a great way to teach Claude how to get better at using specific pieces of software. As we see awesome example skills from partners, we may highlight some of them here:
 
 - **Notion** - [Notion Skills for Claude](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0)
-- **Modellix** - [Modellix Skill for AI image and video generation](https://github.com/Modellix/modellix-skill/tree/main/modellix-skill)
+- **Modellix** - [Modellix Skill for AI image and video generation](https://github.com/Modellix/modellix-plugin/tree/main/skills/modellix)


### PR DESCRIPTION
## Summary
Request to highlight Modellix under Partner Skills.

Modellix provides a unified Model-as-a-Service API/CLI for AI image and video generation, with an Agent Skills-compatible package:

https://github.com/Modellix/modellix-skill/tree/main/modellix-skill

This PR only adds a Partner Skills link (similar to Notion), without adding files under `./skills`.

Happy to adjust format if you prefer a different partner listing style.

Made with [Cursor](https://cursor.com)