### PR TITLE
Add flops-compute-prices skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -38,7 +38,8 @@
         "./skills/slack-gif-creator",
         "./skills/theme-factory",
         "./skills/web-artifacts-builder",
-        "./skills/webapp-testing"
+        "./skills/webapp-testing",
+        "./skills/flops-compute-prices"
       ]
     }
     ,

--- a/skills/flops-compute-prices/LICENSE.txt
+++ b/skills/flops-compute-prices/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Support. While redistributing the Work or
+      Derivative Works thereof, You may choose to offer, and charge a
+      fee for, acceptance of support, warranty, indemnity, or other
+      liability obligations and/or rights consistent with this License.
+      However, in accepting such obligations, You may act only on Your
+      own behalf and on Your sole responsibility, not on behalf of any
+      other Contributor, and only if You agree to indemnify, defend,
+      and hold each Contributor harmless for any liability incurred by,
+      or claims asserted against, such Contributor by reason of your
+      accepting any such warranty or support.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 FLOPS Index
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License.

--- a/skills/flops-compute-prices/README.md
+++ b/skills/flops-compute-prices/README.md
@@ -1,0 +1,33 @@
+# flops-compute-prices — a Claude Skill
+
+A self-contained [Agent Skill](https://docs.claude.com/en/docs/agents-and-tools/agent-skills) that teaches an AI agent to look up **GPU / compute rental reference prices** and cite them with a **verifiable source**, using the public [FLOPS Index](https://flopsindex.com) API. **No API key required.**
+
+## What it does
+When a user asks what an accelerator costs to rent — "what's an H100 going for?", "cheapest A100 right now?", "is $1.50/hr for an H100 spot right?" — the skill drives the **price → verify → cite** flow against the public FLOPS API:
+
+- **Price** — `GET /v1/price/{slug}` returns the public envelope (value, unit, `as_of`, confidence, verify/citation URLs).
+- **Cheapest** — lowest rate across a chip's markets (spot / on-demand / DePIN).
+- **Verify** — fact-check a claimed value against the published reference.
+- **Cite** — present the value with its timestamp, the delayed-reference caveat, and a link the reader can independently check.
+
+## Contents
+- `SKILL.md` — the skill definition (instructions + when-to-use).
+- `scripts/flops.py` — a zero-dependency (stdlib `urllib`) helper: `price`, `catalog`, `search`, `verify`, `cheapest`.
+
+## Requirements
+Python 3.8+ — standard library only, no third-party packages. On macOS/Linux use `python3` in place of `python` below.
+
+## Try it
+```bash
+python scripts/flops.py cheapest h100        # cheapest across a chip's markets (flags decentralized/DePIN rates)
+python scripts/flops.py price FLOPS-H100-SPOT
+python scripts/flops.py verify FLOPS-H100-SPOT 1.50
+python scripts/flops.py catalog              # every index + its value
+python scripts/flops.py search h100          # find slugs by keyword
+```
+The helper mirrors the public API. Note `data_tier: "LIVE"` is a *coverage* tier, **not** a freshness claim — public values are always delayed to the most recent 6-hour UTC mark.
+
+## Note
+FLOPS publishes **indicative, delayed, source-opaque reference levels** — not live provider quotes, settlement marks, or investment advice. The skill carries that caveat on every citation. Same data is also available as [MCP tools](https://app.flopsindex.com/mcp) and SDKs (`pip install flopsindex`, `npm i @flopsindex/sdk`).
+
+Apache-2.0.

--- a/skills/flops-compute-prices/SKILL.md
+++ b/skills/flops-compute-prices/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: flops-compute-prices
+description: Look up and cite verifiable GPU/compute rental reference prices (H100, A100, H200, and more; spot, on-demand, or DePIN markets) from the public FLOPS Index — no API key required. Use when the user asks what a GPU or accelerator costs to rent, wants the cheapest option for a given chip, wants to compare spot vs on-demand vs decentralized compute rates, or wants to fact-check / cite a compute price with a source they can independently verify. Keywords: GPU price, H100 cost, A100 rental, compute pricing, spot price, on-demand, DePIN, GPU-hour, accelerator rental, FLOPS index.
+---
+
+# FLOPS Compute Prices
+
+Look up **GPU / compute rental reference rates** and cite them with a **verifiable source**, using the public FLOPS Index API. Everything here is key-free.
+
+## When to use this skill
+- The user asks what an accelerator costs to rent — "what's an H100 going for?", "cheapest A100 right now?", "on-demand H200 price?".
+- The user wants to compare rates across GPUs or across market types (spot / on-demand / DePIN).
+- The user states a compute price and wants it fact-checked, or wants a citable price with a link a reader can verify.
+
+## What FLOPS is (and is NOT)
+FLOPS publishes **indicative reference levels** for GPU compute, snapped to the most recent 6-hour UTC mark and refreshed every 6 hours. Values are **source-opaque** (no provider identities) and **delayed** on the public surface. A value is **not** a live provider quote, **not** a settlement mark, and **not** investment advice. Always carry that caveat when you cite one. **Never fabricate a number** — if a call fails or returns null, say so.
+
+## Index slugs
+`FLOPS-<ACCELERATOR>-<MARKET>` where `<MARKET>` ∈ `SPOT`, `OD` (on-demand), `DEPIN` (decentralized). E.g. `FLOPS-H100-SPOT`, `FLOPS-A100-OD`, `FLOPS-A100-DEPIN`. Don't guess the accelerator list — use the catalog.
+
+## Which endpoint returns what
+- **`/v1/price/{slug}`** — the **authoritative** single-index record: full envelope + citation/verify URLs. Use this for any value you will cite.
+- **`/v2/catalog/public`** — every index **with its value** in one call; best for scanning/comparing a family. ⚠️ For a given slug, `catalog` may report a slightly different `confidence` / `change_24h` than `/v1/price` (a known backend inconsistency). **When they disagree, `/v1/price` wins** — always confirm a citable value with `/v1/price`.
+- **`/v1/search?q=`** — returns matching **slugs + citation URLs only, NO value**. Use it to discover slugs, then call `price`.
+
+## How to use it — price → verify → cite
+
+### 1. Get a price (authoritative)
+`GET https://app.flopsindex.com/v1/price/{slug}` — helper: `python scripts/flops.py price FLOPS-H100-SPOT`
+Envelope: `value`, `unit` ("USD/GPU-hr"), `as_of`, `delayed`, `confidence` ("HIGH" | "MED" | "LOW" — an ordinal label, never a number), `change_24h` ("UP" | "FLAT" | "DOWN" | null), `data_tier` (e.g. "LIVE" = coverage tier, **not** a freshness claim — the value is still delayed), `verify_url`, `citation_url`, `methodology_url`, `disclaimer`. (Other fields like `permalink`, `upgrade` may appear; list is not exhaustive.)
+
+**`as_of` is a 6-hour UTC bucket label** (00/06/12/18 UTC). The current bucket can read slightly ahead of your wall clock — that's normal bucketing, not stale/future data. Present it as UTC.
+
+### 2. Cheapest for a given chip
+Fastest path: `python scripts/flops.py cheapest a100` — fetches `/v1/price` for each of that chip's SPOT/OD/DEPIN slugs and returns the lowest (authoritative), with `market`, an `all_markets` breakdown, and the verify link. Or read `/v2/catalog/public`, filter `FLOPS-<CHIP>-*`, take the min `value`, then confirm the winner with `/v1/price`.
+
+**Two things to get right when reporting the cheapest:**
+- **Flag the market class.** The family-min is very often a **DEPIN** (decentralized) rate — a different reliability/risk class than on-demand or spot. Do not present a DePIN number as an apples-to-apples cloud rate; say it's decentralized, and offer the cheapest *conventional* (SPOT/OD) rate alongside. (`cheapest` emits a `market_class_note` when the winner is DePIN.)
+- **Cite from a fresh `/v1/price`.** The 6-hour `as_of` bucket can roll between calls, so the envelope inside `cheapest` may carry an older bucket than a `/v1/price` you make seconds later. Re-pull `/v1/price/{winner}` at cite time for the timestamp you print.
+
+### 3. Verify / fact-check a claimed value
+`GET https://app.flopsindex.com/v1/verify?index_id={slug}&value={n}` — helper: `python scripts/flops.py verify FLOPS-H100-SPOT 1.50`
+Returns `verified`, `actual_value`, `delta_pct`, `tolerance_pct`, `tolerance_abs`.
+
+**Interpreting the result — read this before you narrate a verdict:**
+- `delta_pct = (submitted − actual) / actual × 100`. Negative ⇒ the user's number is **below** the reference; positive ⇒ **above**. State the direction explicitly.
+- `tolerance_pct` is tiny (±0.5%). Verify is an **exact-match check against the published mark**, NOT a plausibility/fairness test. So `verified:false` means "doesn't match the reference to ~2 decimals," **not** "the user is wrong." Never tell a user their estimate is "wrong" — say it "differs from the FLOPS reference by X% (below/above)".
+- If a value fails for the market the user named, **check the sibling markets** (SPOT/OD/DEPIN) before concluding — the gap is often a market mismatch (e.g. a DePIN listing vs a spot rate), and saying so is the fair answer.
+
+### 4. Cite it
+Always present the value WITH its `as_of`, the delayed-reference caveat, and the verify + citation URLs. The API's raw `verify_url` has **no** value attached — append `&value={value}` to make it checkable (the `price` and `cheapest` helpers already emit a ready `verify_url_checkable`). Canonical one-liner:
+
+> **$2.33/GPU-hr** — H100 spot reference (`FLOPS-H100-SPOT`) as of 2026-07-16 12:00 UTC; delayed indicative level, not a live quote. Verify: https://app.flopsindex.com/v1/verify?index_id=FLOPS-H100-SPOT&value=2.33 · Source: https://app.flopsindex.com/i/FLOPS-H100-SPOT
+
+## Notes
+- **Key-free.** A `FLOPS_API_KEY` (header `X-FLOPS-Api-Key`) upgrades the same calls to real-time full precision, but is never required.
+- `change_24h` is often `null` — handle it; not an error.
+- Same data is available as MCP tools (`https://app.flopsindex.com/mcp`) and SDKs: `pip install flopsindex`, `npm i @flopsindex/sdk`.

--- a/skills/flops-compute-prices/scripts/flops.py
+++ b/skills/flops-compute-prices/scripts/flops.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Minimal helper for the FLOPS public compute-price API.
+
+Standard library only (urllib), zero dependencies, key-free. Mirrors the public
+REST surface used by the flops-compute-prices skill.
+
+Usage:
+    python flops.py price   <slug>          e.g. price FLOPS-H100-SPOT
+    python flops.py catalog                 list every public index slug
+    python flops.py search  <query>         e.g. search h100
+    python flops.py verify  <slug> <value>  fact-check a claimed value
+    python flops.py cheapest <accelerator>  lowest rate across a chip's markets, e.g. cheapest a100
+
+An optional FLOPS_API_KEY env var upgrades responses to full precision; never
+required.
+"""
+import json
+import os
+import sys
+import urllib.parse
+import urllib.request
+
+BASE = "https://app.flopsindex.com"
+
+
+def _get(path):
+    req = urllib.request.Request(BASE + path, headers={"Accept": "application/json"})
+    key = os.environ.get("FLOPS_API_KEY")
+    if key:
+        req.add_header("X-FLOPS-Api-Key", key)
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        return json.load(resp)
+
+
+def price(slug):
+    rec = _get(f"/v1/price/{urllib.parse.quote(slug, safe='')}")
+    # Convenience: the API's verify_url carries no value; add a checkable variant so
+    # an agent can cite a link that actually resolves to a pass/fail check.
+    vurl, val = rec.get("verify_url"), rec.get("value")
+    if vurl and val is not None:
+        rec["verify_url_checkable"] = vurl + ("&" if "?" in vurl else "?") + f"value={val}"
+    return rec
+
+
+def catalog():
+    return _get("/v2/catalog/public")
+
+
+def search(query):
+    return _get("/v1/search?" + urllib.parse.urlencode({"q": query}))
+
+
+def verify(slug, value):
+    return _get("/v1/verify?" + urllib.parse.urlencode({"index_id": slug, "value": value}))
+
+
+def cheapest(accel):
+    """Lowest reference level across a chip's markets (SPOT/OD/DEPIN).
+
+    Finds the chip's slugs from the catalog, then confirms each with the
+    authoritative /v1/price call and returns the minimum. accel is the middle
+    slug segment, e.g. 'a100' -> FLOPS-A100-*.
+    """
+    cat = catalog()
+    items = cat.get("indices", cat.get("items", cat if isinstance(cat, list) else []))
+    want = accel.upper()
+    slugs = []
+    for i in items:
+        s = i.get("index_id") or i.get("slug")
+        parts = (s or "").split("-")
+        if len(parts) >= 3 and parts[0] == "FLOPS" and parts[1] == want:
+            slugs.append(s)
+    priced = []
+    for s in slugs:
+        rec = price(s)
+        if rec.get("value") is not None:
+            priced.append((rec["value"], s, rec))
+    if not priced:
+        return {"error": f"no priced FLOPS-{want}-* indices found", "candidates": slugs}
+    priced.sort(key=lambda r: r[0])
+    val, slug, rec = priced[0]
+    market = slug.split("-")[-1]  # SPOT | OD | DEPIN
+    vurl = rec.get("verify_url", "")
+    out = {
+        "cheapest_slug": slug,
+        "market": market,
+        "value": val,
+        "unit": rec.get("unit"),
+        "as_of": rec.get("as_of"),
+        "citation_url": rec.get("citation_url"),
+        "verify_url": (vurl + ("&" if "?" in vurl else "?") + f"value={val}") if vurl else None,
+        "all_markets": [{"slug": s, "market": s.split("-")[-1], "value": v} for v, s, _ in priced],
+    }
+    if market == "DEPIN":
+        out["market_class_note"] = (
+            "Cheapest is a DEPIN (decentralized) rate — a different reliability/risk class "
+            "than on-demand. Caveat this; do not present it as an apples-to-apples cloud rate."
+        )
+    out["cite_note"] = "Re-pull /v1/price/<cheapest_slug> at cite time for the freshest as_of bucket."
+    return out
+
+
+def main(argv):
+    if not argv:
+        print(__doc__)
+        return 1
+    cmd, rest = argv[0], argv[1:]
+    try:
+        if cmd == "price" and rest:
+            out = price(rest[0])
+        elif cmd == "catalog":
+            out = catalog()
+        elif cmd == "search" and rest:
+            out = search(rest[0])
+        elif cmd == "verify" and len(rest) >= 2:
+            out = verify(rest[0], rest[1])
+        elif cmd == "cheapest" and rest:
+            out = cheapest(rest[0])
+        else:
+            print("usage: flops.py {price <slug> | catalog | search <q> | "
+                  "verify <slug> <value> | cheapest <accelerator>}")
+            return 1
+    except Exception as exc:  # noqa: BLE001 - surface any transport/HTTP error plainly
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(out, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## What this adds

A new self-contained example skill: **`flops-compute-prices`** (`skills/flops-compute-prices/`).

It teaches Claude to look up and **cite verifiable GPU / compute rental reference prices** — H100, A100, H200, and more, across **spot**, **on-demand**, and **DePIN** markets — from the public [FLOPS Index](https://flopsindex.com) API, following a **price -> verify -> cite** flow. **No API key required.**

## Contents
- `SKILL.md` — instructions + when-to-use (frontmatter is `name` + `description` only, per the repo template).
- `scripts/flops.py` — a stdlib-only (`urllib`) helper with `price` / `catalog` / `search` / `verify` / `cheapest` subcommands. **Zero third-party dependencies**, key-free.
- `README.md`, `LICENSE.txt` (Apache-2.0).

Also registers the skill in the `example-skills` plugin in `.claude-plugin/marketplace.json`, matching the pattern used by other example skills.

## Notes
- Everything works against the **public, key-free** API surface. Values are **indicative, delayed (6-hour UTC buckets), source-opaque reference levels** — not live provider quotes, settlement marks, or investment advice. The skill carries that caveat on every citation and never fabricates a number.
- `python skills/flops-compute-prices/scripts/flops.py cheapest h100` is a quick way to see it in action.

Offered as a demonstration/example skill in the spirit of this repo. Happy to adjust placement, naming, or drop the `marketplace.json` change if you'd prefer folder-only.