### PR TITLE
fix: refactor subprocess command construction for LibreOffice

### DIFF
--- a/skills/xlsx/scripts/recalc.py
+++ b/skills/xlsx/scripts/recalc.py
@@ -171,26 +171,31 @@ def _recalc_with_profile(filename, abs_path, timeout, profile_dir: Path):
 
     before = _stamp(abs_path)
 
-    cmd = [
-        "soffice",
+    args = [
         "--headless",
         "--norestore",
         f"-env:UserInstallation={profile_url}",
-        "vnd.sun.star.script:Standard.Module1.RecalculateAndSave?language=Basic&location=application",
         abs_path,
+        "vnd.sun.star.script:Standard.Module1.RecalculateAndSave?language=Basic&location=application",
     ]
 
+    wrapped_cmd = None
     if platform.system() == "Linux" and shutil.which("timeout"):
-        cmd = ["timeout", str(timeout)] + cmd
+        wrapped_cmd = ["timeout", str(timeout), "soffice"] + args
     elif platform.system() == "Darwin" and has_gtimeout():
-        cmd = ["gtimeout", str(timeout)] + cmd
+        wrapped_cmd = ["gtimeout", str(timeout), "soffice"] + args
 
     timed_out = f"LibreOffice timed out after {timeout}s; formulas were NOT recalculated. Re-run with a longer timeout."
 
     try:
-        result = subprocess.run(
-            cmd, capture_output=True, text=True, env=get_soffice_env(), timeout=timeout + 15
-        )
+        if wrapped_cmd is not None:
+            result = subprocess.run(
+                wrapped_cmd, capture_output=True, text=True, env=get_soffice_env(), timeout=timeout + 15
+            )
+        else:
+            result = run_soffice(
+                args, capture_output=True, text=True, env=get_soffice_env(), timeout=timeout + 15
+            )
     except subprocess.TimeoutExpired:
         return {"error": timed_out}
     except FileNotFoundError:


### PR DESCRIPTION
The `cmd` list hard-codes `"soffice"` as the executable, bypassing `run_soffice` and the shim logic in `soffice.py`. On systems where AF_UNIX sockets are blocked, the shim is applied via `get_soffice_env()` through the `env=` argument at line 192, but there is no guarantee that `"soffice"` resolves correctly without the wrapper. More importantly, `run_soffice` prepends `-env:UserInstallation` automatically when not present, and `profile_url` is already being passed here — but the pattern diverges from the established abstraction. The direct concern is that the `SOFFICE_MISSING` error at line 197 raises `FileNotFoundError` only if `soffice` is not on PATH, but `run_soffice` from `soffice.py` always calls `subprocess.run(["soffice"] + args, ...)`, so this is consistent. However, the macro invocation argument ordering places the macro URI before `abs_path`, while LibreOffice expects the file to open first and then the macro to run — this may cause the macro to execute against no document. The correct invocation order for LibreOffice macro execution is: open the file, then specify the macro via `--headless ... file.xlsx --infilter=... vnd.sun.star.script:...`, but LibreOffice's `--headless` with a bare script URI and a file argument may not reliably open the file first. Verify that LibreOffice actually opens `abs_path` before executing the macro, or use a dispatch-style invocation.