### PR TITLE
fix(skill-creator): aggregate the flat single-run grading.json layout

### DIFF
--- a/skills/skill-creator/scripts/aggregate_benchmark.py
+++ b/skills/skill-creator/scripts/aggregate_benchmark.py
@@ -32,6 +32,13 @@ The script supports two directory layouts:
             │   └── run-1/grading.json
             └── without_skill/
                 └── run-1/grading.json
+
+    Single-run (flat) layout — grading.json directly in the config dir, as
+    written by SKILL.md Step 4 and read by the eval-viewer:
+    <benchmark_dir>/
+    └── eval-N/
+        ├── with_skill/grading.json
+        └── without_skill/grading.json
 """
 
 import argparse
@@ -62,6 +69,74 @@ def calculate_stats(values: list[float]) -> dict:
         "min": round(min(values), 4),
         "max": round(max(values), 4)
     }
+
+
+def _build_run_result(grading_file: Path, run_dir: Path, eval_id, run_number: int) -> dict:
+    """
+    Load a single ``grading.json`` into a run-result dict.
+
+    ``run_dir`` is the directory holding sibling artifacts such as
+    ``timing.json``; for the flat single-run layout it is the config dir
+    itself. Returns an empty dict (after printing a warning) when the grading
+    file is missing or unreadable.
+    """
+    if not grading_file.exists():
+        print(f"Warning: grading.json not found in {run_dir}")
+        return {}
+
+    try:
+        with open(grading_file) as f:
+            grading = json.load(f)
+    except json.JSONDecodeError as e:
+        print(f"Warning: Invalid JSON in {grading_file}: {e}")
+        return {}
+
+    # Extract metrics
+    result = {
+        "eval_id": eval_id,
+        "run_number": run_number,
+        "pass_rate": grading.get("summary", {}).get("pass_rate", 0.0),
+        "passed": grading.get("summary", {}).get("passed", 0),
+        "failed": grading.get("summary", {}).get("failed", 0),
+        "total": grading.get("summary", {}).get("total", 0),
+    }
+
+    # Extract timing — check grading.json first, then sibling timing.json
+    timing = grading.get("timing", {})
+    result["time_seconds"] = timing.get("total_duration_seconds", 0.0)
+    timing_file = run_dir / "timing.json"
+    if result["time_seconds"] == 0.0 and timing_file.exists():
+        try:
+            with open(timing_file) as tf:
+                timing_data = json.load(tf)
+            result["time_seconds"] = timing_data.get("total_duration_seconds", 0.0)
+            result["tokens"] = timing_data.get("total_tokens", 0)
+        except json.JSONDecodeError:
+            pass
+
+    # Extract metrics if available
+    metrics = grading.get("execution_metrics", {})
+    result["tool_calls"] = metrics.get("total_tool_calls", 0)
+    if not result.get("tokens"):
+        result["tokens"] = metrics.get("output_chars", 0)
+    result["errors"] = metrics.get("errors_encountered", 0)
+
+    # Extract expectations — viewer requires fields: text, passed, evidence
+    raw_expectations = grading.get("expectations", [])
+    for exp in raw_expectations:
+        if "text" not in exp or "passed" not in exp:
+            print(f"Warning: expectation in {grading_file} missing required fields (text, passed, evidence): {exp}")
+    result["expectations"] = raw_expectations
+
+    # Extract notes from user_notes_summary
+    notes_summary = grading.get("user_notes_summary", {})
+    notes = []
+    notes.extend(notes_summary.get("uncertainties", []))
+    notes.extend(notes_summary.get("needs_review", []))
+    notes.extend(notes_summary.get("workarounds", []))
+    result["notes"] = notes
+
+    return result
 
 
 def load_run_results(benchmark_dir: Path) -> dict:
@@ -101,74 +176,35 @@ def load_run_results(benchmark_dir: Path) -> dict:
         for config_dir in sorted(eval_dir.iterdir()):
             if not config_dir.is_dir():
                 continue
-            # Skip non-config directories (inputs, outputs, etc.)
-            if not list(config_dir.glob("run-*")):
+
+            run_dirs = sorted(config_dir.glob("run-*"))
+            flat_grading = config_dir / "grading.json"
+
+            # Skip non-config directories (inputs, outputs, etc.). A real config
+            # has either run-* subdirs or, for the documented single-run layout,
+            # a grading.json sitting directly inside it (the same flat layout the
+            # eval-viewer's generate_review.py accepts).
+            if not run_dirs and not flat_grading.exists():
                 continue
+
             config = config_dir.name
             if config not in results:
                 results[config] = []
 
-            for run_dir in sorted(config_dir.glob("run-*")):
-                run_number = int(run_dir.name.split("-")[1])
-                grading_file = run_dir / "grading.json"
-
-                if not grading_file.exists():
-                    print(f"Warning: grading.json not found in {run_dir}")
-                    continue
-
-                try:
-                    with open(grading_file) as f:
-                        grading = json.load(f)
-                except json.JSONDecodeError as e:
-                    print(f"Warning: Invalid JSON in {grading_file}: {e}")
-                    continue
-
-                # Extract metrics
-                result = {
-                    "eval_id": eval_id,
-                    "run_number": run_number,
-                    "pass_rate": grading.get("summary", {}).get("pass_rate", 0.0),
-                    "passed": grading.get("summary", {}).get("passed", 0),
-                    "failed": grading.get("summary", {}).get("failed", 0),
-                    "total": grading.get("summary", {}).get("total", 0),
-                }
-
-                # Extract timing — check grading.json first, then sibling timing.json
-                timing = grading.get("timing", {})
-                result["time_seconds"] = timing.get("total_duration_seconds", 0.0)
-                timing_file = run_dir / "timing.json"
-                if result["time_seconds"] == 0.0 and timing_file.exists():
-                    try:
-                        with open(timing_file) as tf:
-                            timing_data = json.load(tf)
-                        result["time_seconds"] = timing_data.get("total_duration_seconds", 0.0)
-                        result["tokens"] = timing_data.get("total_tokens", 0)
-                    except json.JSONDecodeError:
-                        pass
-
-                # Extract metrics if available
-                metrics = grading.get("execution_metrics", {})
-                result["tool_calls"] = metrics.get("total_tool_calls", 0)
-                if not result.get("tokens"):
-                    result["tokens"] = metrics.get("output_chars", 0)
-                result["errors"] = metrics.get("errors_encountered", 0)
-
-                # Extract expectations — viewer requires fields: text, passed, evidence
-                raw_expectations = grading.get("expectations", [])
-                for exp in raw_expectations:
-                    if "text" not in exp or "passed" not in exp:
-                        print(f"Warning: expectation in {grading_file} missing required fields (text, passed, evidence): {exp}")
-                result["expectations"] = raw_expectations
-
-                # Extract notes from user_notes_summary
-                notes_summary = grading.get("user_notes_summary", {})
-                notes = []
-                notes.extend(notes_summary.get("uncertainties", []))
-                notes.extend(notes_summary.get("needs_review", []))
-                notes.extend(notes_summary.get("workarounds", []))
-                result["notes"] = notes
-
-                results[config].append(result)
+            if run_dirs:
+                for run_dir in run_dirs:
+                    run_number = int(run_dir.name.split("-")[1])
+                    result = _build_run_result(
+                        run_dir / "grading.json", run_dir, eval_id, run_number
+                    )
+                    if result:
+                        results[config].append(result)
+            else:
+                # Flat single-run layout: grading.json lives directly in the
+                # config dir (see SKILL.md Step 4). Treat the config dir as run 0.
+                result = _build_run_result(flat_grading, config_dir, eval_id, 0)
+                if result:
+                    results[config].append(result)
 
     return results
 


### PR DESCRIPTION
Closes #1425.

## Problem

`aggregate_benchmark.py`'s `load_run_results()` only treats a directory as a config when it contains `run-*` subdirectories:

```python
# Skip non-config directories (inputs, outputs, etc.)
if not list(config_dir.glob("run-*")):
    continue
```

So when `grading.json` sits directly in `<config>/` (the flat single-run layout), the whole config is skipped and every statistic comes back `0%`. It is also silent: the `Warning: grading.json not found` line lives inside the `run-*` loop, which never runs for the flat layout, so nothing prints. The result reads as "the skill scored zero" rather than "no data was found."

The eval-viewer already accepts this layout. `generate_review.py:131` looks for grading at either location:

```python
for candidate in [run_dir / "grading.json", run_dir.parent / "grading.json"]:
```

So the aggregator and the viewer disagreed on where `grading.json` may live.

## Fix

When a config dir has no `run-*` subdirs but does have a `grading.json`, treat the config dir itself as a single run (run 0). The per-run grading read is factored into a `_build_run_result()` helper shared by both layouts, and the non-config skip now keeps genuine `inputs`/`outputs` dirs out while letting the flat layout through. The module docstring gains the flat layout for completeness.

## Verification

Two-config fixture (`with_skill` pass_rate 1.0, `without_skill` 0.5) in the flat layout:

Before (original code):

```
Delta:         +0.00
```

(no per-config pass rate printed, and no warning — the silent 0% from the issue)

After:

```
With Skill: 100.0% pass rate
Without Skill: 50.0% pass rate
Delta:         +0.50
```

The existing `run-*` (workspace) and `runs/` (legacy) layouts produce identical output before and after, so there is no regression.
