### PR TITLE
docs(xlsx): note banner-merge and header/footer ampersand gotchas

### DIFF
--- a/skills/xlsx/SKILL.md
+++ b/skills/xlsx/SKILL.md
@@ -74,6 +74,8 @@ literal `#NAME?` baked into the file you deliver.
 - **`data_only=True` is destructive if you save.** That workbook has no formulas left, so saving replaces every one with a literal — permanently.
 - **`data_only=True` on a file openpyxl just wrote returns `None` everywhere** — run `recalc.py` first. (A formula whose result is `""` also reads back as `None`.)
 - **Merged cells: write the top-left anchor only.** Every other cell in the range is a `MergedCell` whose `.value` is read-only.
+- **A fill and long text do not overflow a cell reliably.** A colored title/banner in `A1` only fills `A1`, and the overflow text clips at the cell edge in many renderers (worst when the first column is narrow). Merge the row across the table so both span: `ws.merge_cells(f"A1:{get_column_letter(ws.max_column)}1")`.
+- **A literal `&` in a header or footer must be doubled.** openpyxl writes `oddHeader`/`oddFooter` text straight into Excel's field-code language, where `&` introduces a field (`&C` center, `&P` page number, …), so `"Revenue & Costs"` loses everything after the `&`. Write `"Revenue && Costs"` for a literal ampersand.
 - **`.xlsm` loses its macros unless you pass `keep_vba=True`** to `load_workbook`.
 - **A sheet name containing a space must be quoted** in a cross-sheet reference: `='Assumptions Inputs'!$B$5`. Unquoted, it evaluates to `#VALUE!`.
 


### PR DESCRIPTION
Refs #1440.

Two openpyxl **presentation** gotchas that silently produce visually broken output, both within the xlsx skill's existing scope. Added as two bullets to the "openpyxl gotchas" section.

## 1. A fill + long text does not overflow a cell reliably

A colored title/banner in `A1` whose text is wider than column A relies on overflow into empty neighbors. But the fill covers only `A1`, and the overflow text clips at the cell edge in many renderers/exports (worst when the first column is narrow, e.g. a `#` column). Merging the row across the table makes both the fill and the text span:

```python
from openpyxl.utils import get_column_letter
ws.merge_cells(f"A1:{get_column_letter(ws.max_column)}1")
```

## 2. A literal `&` in a header/footer must be doubled

openpyxl writes `oddHeader`/`oddFooter` text straight into Excel's field-code language, where `&` introduces a field (`&C` center, `&P` page number, ...). So `"Revenue & Costs"` loses everything after the `&`; write `"Revenue && Costs"`.

## Verified (openpyxl 3.1.5)

- **Banner:** a `PatternFill` on `A1` leaves `B1` unfilled (`fgColor 00000000`), so the banner does not span; `merge_cells("A1:E1")` yields a single merged range across the row.
- **Header/footer:** saving `left.text = "Revenue & Costs"` serializes to `<oddFooter>&LRevenue & Costs</oddFooter>` — the lone `&` enters the code stream — while `"Q1 && Q2"` serializes with `&&` and renders a literal `&`. openpyxl does not auto-escape it.

Scoped to a two-bullet note; happy to expand into an example if the maintainers prefer.
