### PR TITLE
Fix duplicated word in theme-factory SKILL.md

### DIFF
--- a/skills/theme-factory/SKILL.md
+++ b/skills/theme-factory/SKILL.md
@@ -7,7 +7,7 @@ license: Complete terms in LICENSE.txt
 
 # Theme Factory Skill
 
-This skill provides a curated collection of professional font and color themes themes, each with carefully selected color palettes and font pairings. Once a theme is chosen, it can be applied to any artifact.
+This skill provides a curated collection of professional font and color themes, each with carefully selected color palettes and font pairings. Once a theme is chosen, it can be applied to any artifact.
 
 ## Purpose
 


### PR DESCRIPTION
Small doc fix: removes an accidentally duplicated word ("themes themes") in the theme-factory skill description.