### PR TITLE
skill-creator: isolate each trigger-eval probe in its own project root

### DIFF
--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -9,8 +9,10 @@ import argparse
 import json
 import os
 import select
+import shutil
 import subprocess
 import sys
+import tempfile
 import time
 import uuid
 from concurrent.futures import ProcessPoolExecutor, as_completed
@@ -50,7 +52,16 @@ def run_single_query(
     """
     unique_id = uuid.uuid4().hex[:8]
     clean_name = f"{skill_name}-skill-{unique_id}"
-    project_commands_dir = Path(project_root) / ".claude" / "commands"
+
+    # Each probe gets a private project root. Sharing one commands directory
+    # across workers does not just risk collisions -- it silently destroys the
+    # measurement. Every concurrent probe writes a command carrying the same
+    # candidate description under a different uuid into the same
+    # .claude/commands/, so Claude sees N indistinguishable skills and picks
+    # one, while each probe only counts its own uuid. Trigger rate then
+    # converges on 1/num_workers however good the description is.
+    probe_root = Path(tempfile.mkdtemp(prefix="skill-trigger-eval-"))
+    project_commands_dir = probe_root / ".claude" / "commands"
     command_file = project_commands_dir / f"{clean_name}.md"
 
     try:
@@ -86,7 +97,7 @@ def run_single_query(
             cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
-            cwd=project_root,
+            cwd=str(probe_root),
             env=env,
         )
 
@@ -177,8 +188,42 @@ def run_single_query(
 
         return triggered
     finally:
-        if command_file.exists():
-            command_file.unlink()
+        # Remove the whole probe root, not just the command file. A killed run
+        # previously stranded probe commands in the shared .claude/commands/,
+        # where they stayed visible as bogus skills to the next run and to the
+        # operator's own session.
+        #
+        # ignore_errors stays True on every attempt: this runs in a finally, so
+        # a raised cleanup error would mask the trigger result we came for.
+        # The retry is for Windows, which will not unlink a directory that is
+        # still a process's cwd; the killed subprocess releases that handle
+        # asynchronously.
+        for _ in range(4):
+            shutil.rmtree(probe_root, ignore_errors=True)
+            if not probe_root.exists():
+                break
+            time.sleep(0.25)
+
+
+def _sweep_probe_roots() -> None:
+    """Delete spent probe roots left behind by per-probe cleanup.
+
+    Only needed on Windows, which will not unlink a directory that is still a
+    process's cwd; the killed `claude` subprocess releases that handle after
+    wait() returns, and waiting it out inside the run costs more than the empty
+    directories do. The per-probe cleanup removes the contents (the part that
+    matters -- a stranded command file is a bogus skill the next run can see),
+    and this removes the empty shells afterwards.
+
+    Roots still holding a .md are skipped, so a probe in flight -- in this run
+    or a concurrent one -- cannot have its command file deleted underneath it.
+    """
+    for path in Path(tempfile.gettempdir()).glob("skill-trigger-eval-*"):
+        try:
+            if not any(path.rglob("*.md")):
+                shutil.rmtree(path, ignore_errors=True)
+        except OSError:
+            pass
 
 
 def run_eval(
@@ -223,6 +268,10 @@ def run_eval(
             except Exception as e:
                 print(f"Warning: query failed: {e}", file=sys.stderr)
                 query_triggers[query].append(False)
+
+    # The executor context has exited, so every claude subprocess is gone and
+    # the cwd handles it held are released.
+    _sweep_probe_roots()
 
     for query, triggers in query_triggers.items():
         item = query_items[query]


### PR DESCRIPTION
## The bug

`run_eval.py` measures whether a candidate description causes Claude to trigger a skill. Each probe writes a throwaway command into `.claude/commands/` under a unique name, runs `claude -p`, and checks whether *that* name was invoked.

All concurrent probes share one commands directory. So with `num_workers=N`, Claude sees **N indistinguishable skills** — same candidate description, different uuids — picks one, and each probe scores only whether its own uuid won.

Trigger rate therefore converges on **1/num_workers**, regardless of how good the description is.

The failure is silent. Nothing raises, and `run_loop.py` consumes the diluted rates as genuine scores, then asks Claude to rewrite the description to "fix" failures that are purely a contention artifact. The loop can report iteration-over-iteration progress while measuring nothing.

## Evidence

Same skill, same eval set, varying only worker count:

| workers | trigger rate on a positive query |
|---|---|
| 3 | 0.33 |
| 12 | 0.08 |
| 12 (train split) | 0.00 — recall 0%, precision 100% |

The 1/N fingerprint is hard to miss once you look for it. `precision=100%` sitting next to `recall=0%` is the giveaway: no negative query could falsely trigger, because *nothing* triggered.

After the change, same skill and eval set, **6 concurrent workers: 1.00**.

For what it's worth, the run that prompted this then produced a sane result — 100% on the held-out split, and the optimizer correctly kept the original description rather than "improving" it. That outcome was unreachable before.

## The fix

Each probe gets a private `tempfile.mkdtemp()` root containing its own `.claude/commands/`, with `claude -p` run from that cwd. A probe can only ever see its own candidate.

Cleanup now removes the probe root rather than the single command file. That also closes a smaller pre-existing leak: a killed run used to strand probe commands in the shared directory, where they stayed visible as bogus skills to the next run *and* to the operator's own Claude Code session.

## Notes for review

- **The contention bug is not platform-specific.** It's a shared directory, not an OS API — any multi-worker run on any platform is affected. I found it on Windows, but nothing about the mechanism is Windows-only.
- **Two pieces here *are* Windows-only** and I'd understand scepticism about them: the `rmtree` retry and `_sweep_probe_roots()`. Windows won't unlink a directory that is still a process's cwd, and the killed subprocess releases that handle asynchronously. On POSIX the first `rmtree` succeeds and the sweep is a no-op. I kept the sweep conservative — it skips any root still holding a `.md`, so a probe in flight (this run or a concurrent one) can't have its command file deleted underneath it. Happy to drop it to a plain `rmtree` if you'd rather not carry the extra code for a platform you don't target.
- **Deliberately scoped to this one issue.** Two further Windows-only breakages live in the same file — `select.select()` on pipes (sockets-only on Windows, so every probe raises `WinError 10038`, gets caught as "query failed", and scores as a non-trigger) and default-encoding read/write of UTF-8 content. Both are fixed in my local copy and I'm glad to send them separately if useful; they'd have muddied this diff.

`python -m py_compile` clean. No other files touched.
