### PR TITLE
skill-creator: make the description optimizer run on Windows (select() on pipes, UTF-8 IO)

### DIFF
--- a/skills/skill-creator/scripts/generate_report.py
+++ b/skills/skill-creator/scripts/generate_report.py
@@ -311,12 +311,12 @@ def main():
     if args.input == "-":
         data = json.load(sys.stdin)
     else:
-        data = json.loads(Path(args.input).read_text())
+        data = json.loads(Path(args.input).read_text(encoding="utf-8"))
 
     html_output = generate_html(data, skill_name=args.skill_name)
 
     if args.output:
-        Path(args.output).write_text(html_output)
+        Path(args.output).write_text(html_output, encoding="utf-8")
         print(f"Report written to {args.output}", file=sys.stderr)
     else:
         print(html_output)

--- a/skills/skill-creator/scripts/improve_description.py
+++ b/skills/skill-creator/scripts/improve_description.py
@@ -186,7 +186,7 @@ Please respond with only the new description text in <new_description> tags, not
     if log_dir:
         log_dir.mkdir(parents=True, exist_ok=True)
         log_file = log_dir / f"improve_iter_{iteration or 'unknown'}.json"
-        log_file.write_text(json.dumps(transcript, indent=2))
+        log_file.write_text(json.dumps(transcript, indent=2), encoding="utf-8")
 
     return description
 
@@ -205,10 +205,10 @@ def main():
         print(f"Error: No SKILL.md found at {skill_path}", file=sys.stderr)
         sys.exit(1)
 
-    eval_results = json.loads(Path(args.eval_results).read_text())
+    eval_results = json.loads(Path(args.eval_results).read_text(encoding="utf-8"))
     history = []
     if args.history:
-        history = json.loads(Path(args.history).read_text())
+        history = json.loads(Path(args.history).read_text(encoding="utf-8"))
 
     name, _, content = parse_skill_md(skill_path)
     current_description = eval_results["description"]

--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -19,7 +19,7 @@ def validate_skill(skill_path):
         return False, "SKILL.md not found"
 
     # Read and validate frontmatter
-    content = skill_md.read_text()
+    content = skill_md.read_text(encoding="utf-8")
     if not content.startswith('---'):
         return False, "No YAML frontmatter found"
 

--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -8,9 +8,10 @@ for a set of queries. Outputs results as JSON.
 import argparse
 import json
 import os
-import select
+import queue
 import subprocess
 import sys
+import threading
 import time
 import uuid
 from concurrent.futures import ProcessPoolExecutor, as_completed
@@ -30,6 +31,25 @@ def find_project_root() -> Path:
         if (parent / ".claude").is_dir():
             return parent
     return current
+
+
+def _drain_pipe(stream, chunks: "queue.Queue[bytes]") -> None:
+    """Forward a subprocess pipe into a queue, ending with a b"" sentinel.
+
+    Runs on a daemon thread. Exists because select.select() cannot watch pipes
+    on Windows -- select there accepts sockets only, so every call raised
+    OSError (WinError 10038), each probe was caught as "query failed", and the
+    whole eval scored as a non-trigger. Blocking reads on a thread behave
+    identically on POSIX and Windows.
+    """
+    try:
+        while True:
+            chunk = os.read(stream.fileno(), 8192)
+            chunks.put(chunk)
+            if not chunk:
+                break
+    except OSError:
+        chunks.put(b"")
 
 
 def run_single_query(
@@ -65,7 +85,7 @@ def run_single_query(
             f"# {skill_name}\n\n"
             f"This skill handles: {skill_description}\n"
         )
-        command_file.write_text(command_content)
+        command_file.write_text(command_content, encoding="utf-8")
 
         cmd = [
             "claude",
@@ -97,21 +117,26 @@ def run_single_query(
         pending_tool_name = None
         accumulated_json = ""
 
+        # Reader thread + queue rather than select(): same 1-second poll
+        # cadence and the same timeout semantics, but portable. EOF arrives as
+        # a b"" sentinel, so process exit is observed through the queue only
+        # after any buffered output has been consumed -- the previous
+        # poll()-then-break path could drop tail output on a fast exit.
+        chunks: "queue.Queue[bytes]" = queue.Queue()
+        threading.Thread(
+            target=_drain_pipe, args=(process.stdout, chunks), daemon=True
+        ).start()
+
         try:
             while time.time() - start_time < timeout:
-                if process.poll() is not None:
-                    remaining = process.stdout.read()
-                    if remaining:
-                        buffer += remaining.decode("utf-8", errors="replace")
-                    break
-
-                ready, _, _ = select.select([process.stdout], [], [], 1.0)
-                if not ready:
+                try:
+                    chunk = chunks.get(timeout=1.0)
+                except queue.Empty:
+                    if process.poll() is not None and chunks.empty():
+                        break
                     continue
-
-                chunk = os.read(process.stdout.fileno(), 8192)
                 if not chunk:
-                    break
+                    break  # EOF sentinel -- process closed stdout
                 buffer += chunk.decode("utf-8", errors="replace")
 
                 while "\n" in buffer:
@@ -269,7 +294,7 @@ def main():
     parser.add_argument("--verbose", action="store_true", help="Print progress to stderr")
     args = parser.parse_args()
 
-    eval_set = json.loads(Path(args.eval_set).read_text())
+    eval_set = json.loads(Path(args.eval_set).read_text(encoding="utf-8"))
     skill_path = Path(args.skill_path)
 
     if not (skill_path / "SKILL.md").exists():

--- a/skills/skill-creator/scripts/run_loop.py
+++ b/skills/skill-creator/scripts/run_loop.py
@@ -148,7 +148,7 @@ def run_loop(
                 "test_size": len(test_set),
                 "history": history,
             }
-            live_report_path.write_text(generate_html(partial_output, auto_refresh=True, skill_name=name))
+            live_report_path.write_text(generate_html(partial_output, auto_refresh=True, skill_name=name), encoding="utf-8")
 
         if verbose:
             def print_eval_stats(label, results, elapsed):
@@ -258,7 +258,7 @@ def main():
     parser.add_argument("--results-dir", default=None, help="Save all outputs (results.json, report.html, log.txt) to a timestamped subdirectory here")
     args = parser.parse_args()
 
-    eval_set = json.loads(Path(args.eval_set).read_text())
+    eval_set = json.loads(Path(args.eval_set).read_text(encoding="utf-8"))
     skill_path = Path(args.skill_path)
 
     if not (skill_path / "SKILL.md").exists():
@@ -275,7 +275,7 @@ def main():
         else:
             live_report_path = Path(args.report)
         # Open the report immediately so the user can watch
-        live_report_path.write_text("<html><body><h1>Starting optimization loop...</h1><meta http-equiv='refresh' content='5'></body></html>")
+        live_report_path.write_text("<html><body><h1>Starting optimization loop...</h1><meta http-equiv='refresh' content='5'></body></html>", encoding="utf-8")
         webbrowser.open(str(live_report_path))
     else:
         live_report_path = None
@@ -310,15 +310,15 @@ def main():
     json_output = json.dumps(output, indent=2)
     print(json_output)
     if results_dir:
-        (results_dir / "results.json").write_text(json_output)
+        (results_dir / "results.json").write_text(json_output, encoding="utf-8")
 
     # Write final HTML report (without auto-refresh)
     if live_report_path:
-        live_report_path.write_text(generate_html(output, auto_refresh=False, skill_name=name))
+        live_report_path.write_text(generate_html(output, auto_refresh=False, skill_name=name), encoding="utf-8")
         print(f"\nReport: {live_report_path}", file=sys.stderr)
 
     if results_dir and live_report_path:
-        (results_dir / "report.html").write_text(generate_html(output, auto_refresh=False, skill_name=name))
+        (results_dir / "report.html").write_text(generate_html(output, auto_refresh=False, skill_name=name), encoding="utf-8")
 
     if results_dir:
         print(f"Results saved to: {results_dir}", file=sys.stderr)

--- a/skills/skill-creator/scripts/utils.py
+++ b/skills/skill-creator/scripts/utils.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 def parse_skill_md(skill_path: Path) -> tuple[str, str, str]:
     """Parse a SKILL.md file, returning (name, description, full_content)."""
-    content = (skill_path / "SKILL.md").read_text()
+    content = (skill_path / "SKILL.md").read_text(encoding="utf-8")
     lines = content.split("\n")
 
     if lines[0].strip() != "---":


### PR DESCRIPTION
Two independent breakages stop skill-creator's trigger-eval loop from working on Windows. Neither fails cleanly — both produce confident output that measures nothing, which is why they're worth fixing rather than documenting.

## 1. `select.select()` cannot watch pipes on Windows

On Windows, `select` accepts sockets only. Every poll in `run_eval.run_single_query` raised `OSError (WinError 10038)`, which the caller caught as `"query failed"` and recorded as a **non-trigger**.

So the loop didn't crash — it scored **zero for every query**, then passed those zeros to `improve_description` as evidence and rewrote the description to fix misses that never happened. A 20-query set produced 60 identical warnings and a 0% trigger rate for a description that was never actually exercised.

Replaced with a daemon reader thread feeding a `queue.Queue`. Same 1-second poll cadence, same timeout semantics, **no behavioural change on POSIX**.

It also closes a latent race in the old loop: EOF now arrives as a `b""` sentinel *through the queue*, so process exit is observed only after buffered output has been consumed. The previous `poll()`-then-`break` path could drop tail output when the process exited quickly.

## 2. Fourteen IO calls inherit the platform default encoding

Across six scripts, `read_text()`/`write_text()` use the platform default — cp1252 on most Windows installs — while the content is UTF-8 throughout: SKILL.md bodies, JSON eval sets, generated HTML.

**The write side is loud.** The progress report contains `U+2717`; cp1252 can't encode it, so the run dies with `UnicodeEncodeError` partway through — while writing its own report about how the optimization is going.

**The read side is quieter and worse.** `parse_skill_md` decoding a UTF-8 SKILL.md as cp1252 doesn't raise. It mojibakes em-dashes and arrows, then feeds that corrupted text to the loop *as the description being optimized*. The optimizer then scores and rewrites a description the author never wrote — with no visible symptom.

## Verification

Windows 11, Python 3.13. Before: 60 × `WinError 10038` and a crash writing the HTML report. After: **0 warnings, 1.0 trigger rate** on a positive query.

Run single-worker on purpose, so the result isolates these two fixes from unrelated concurrency behaviour.

## Notes for review

- **POSIX behaviour is unchanged.** The thread/queue swap is a portability fix, not a redesign, and `encoding="utf-8"` is a no-op where the platform default is already UTF-8.
- **`quick_validate.py:22` is included for consistency** — it reads SKILL.md the same way and would mojibake identically, though it isn't on the optimizer's path. Happy to drop it if you'd prefer the diff strictly minimal.
- **Small overlap with [#1457](https://github.com/anthropics/skills/pull/1457).** Both touch `run_eval.py`'s import block; that PR adds `shutil`/`tempfile`, this one swaps `select` for `queue`/`threading`. Whichever merges second needs a one-line rebase — the substantive hunks don't overlap. They're separate PRs because they serve different audiences: #1457 fixes a measurement bug affecting **every** platform, this one is Windows-only.

`python -m py_compile` clean across all six files.
