### PR TITLE
fix(docx): declare Python 3.10+/defusedxml deps and fix 3.9 import crash

### DIFF
--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -88,4 +88,4 @@ The script writes `comments.xml`, `commentsExtended.xml`, `commentsIds.xml`, `co
 
 ## Dependencies
 
-`docx` (npm, preinstalled — install only if `require('docx')` fails) · `pandoc` · LibreOffice (`soffice`) · `pdftoppm` (Poppler)
+`docx` (npm, preinstalled — install only if `require('docx')` fails) · `pandoc` · LibreOffice (`soffice`) · `pdftoppm` (Poppler) · Python 3.10+ · `defusedxml` (Python package)

--- a/skills/docx/scripts/office/helpers/__init__.py
+++ b/skills/docx/scripts/office/helpers/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import posixpath
 import re


### PR DESCRIPTION
## Summary

The docx skill's Python scripts fail on Python 3.9 (e.g. stock macOS system Python) in two consecutive ways, and neither requirement was declared:

1. `merge_runs.py` imports third-party `defusedxml`, which isn't preinstalled on a stock machine → `ModuleNotFoundError`.
2. After installing defusedxml, `office/helpers/__init__.py`'s `opc_target()` has a `-> str | None` return annotation evaluated eagerly at import time (no `from __future__ import annotations`). PEP 604 union syntax needs Python 3.10+, so this raises `TypeError` at import on 3.9 — breaking the whole `office.helpers` import chain that `merge_runs.py` depends on.

## Fix

1. Add `from __future__ import annotations` to `office/helpers/__init__.py`, matching the sibling `office/helpers/pptx_chart.py`, which already carries this for the same reason. Postpones annotation evaluation to strings, so the union syntax no longer needs 3.10 at import time. Zero behavior change — annotations aren't evaluated at runtime anywhere else in this file.
2. Document `Python 3.10+` and `defusedxml` in `SKILL.md`'s Dependencies line, alongside the existing npm/pandoc/LibreOffice/pdftoppm entries.

## Testing

Reproduced the fix's effect locally: ran `merge_runs.py` against a sample unpacked docx (adjacent runs `"Hello "` + `"world"`) before and after adding the future-annotations import — identical output (`Merged 1 runs`, text correctly coalesced to `"Helloworld"`), and `opc_target()`'s behavior across relative/absolute/external/empty targets is unchanged. This confirms the fix is a no-op for behavior while resolving the import-time crash (PEP 604 `X | Y` syntax requiring `type.__or__`, added in Python 3.10, is well-documented Python behavior — this sandbox only has Python 3.12 available, so the literal 3.9 crash wasn't executed directly, but the same annotation pattern already fixes this for the sibling file).

Closes #1461