### PR TITLE
fix(pdf): handle bare-string /Opt entries in choice fields

### DIFF
--- a/skills/pdf/scripts/extract_form_field_info.py
+++ b/skills/pdf/scripts/extract_form_field_info.py
@@ -35,10 +35,12 @@ def make_field_dict(field, field_id):
     elif ft == "/Ch":
         field_dict["type"] = "choice"
         states = field.get("/_States_", [])
-        field_dict["choice_options"] = [{
-            "value": state[0],
-            "text": state[1],
-        } for state in states]
+        # Per ISO 32000-1 §12.7.4.4, each /Opt entry is either a bare string
+        # (used as both export value and display text) or a [value, text] pair.
+        field_dict["choice_options"] = [
+            {"value": s, "text": s} if isinstance(s, str) else {"value": s[0], "text": s[1]}
+            for s in states
+        ]
     else:
         field_dict["type"] = f"unknown ({ft})"
     return field_dict


### PR DESCRIPTION
## Summary

`extract_form_field_info.py` assumed every choice-field `/Opt` entry is a `[export_value, display_text]` pair. Per ISO 32000-1 §12.7.4.4, an `/Opt` entry may instead be a single text string, used as both the export value and display text. On bare-string entries, `state[0]`/`state[1]` indexed into the string itself instead of a pair — silently corrupting output character-by-character (`"Red"` → `value="R", text="e"`), and hard-crashing with `IndexError` on any single-character option.

## Fix

Normalize each `/Opt` entry: a bare string maps to `{value: s, text: s}`; a pair keeps the existing `[value, text]` handling.

## Testing

Reproduced the exact repro from the issue and verified the fix against 5 cases, pulling the actual committed file from the branch (not just the local diff) each time:

| Case | Before fix | After fix |
|---|---|---|
| Bare strings (`"Red","Green","Blue"`) | Corrupted: `value="R", text="e"` etc. | Correct: `{value:"Red", text:"Red"}` etc. |
| Single-char bare strings (`"A","B"`) | Hard crash: `IndexError: string index out of range` | Correct: `{value:"A", text:"A"}` etc. |
| Paired form (`["US","United States"]`, existing/correct case) | Correct | Unchanged — still correct |
| Mixed bare + paired in one array | N/A (untested edge case) | Correct for both entry types |
| Empty `/Opt` array | Correct (no crash) | Unchanged — still correct |

No regressions in the already-correct paired-form path.

Closes #1469