### PR TITLE
Fix casing of reference.md/forms.md links in pdf SKILL.md

### DIFF
--- a/skills/pdf/SKILL.md
+++ b/skills/pdf/SKILL.md
@@ -8,7 +8,7 @@ license: Proprietary. LICENSE.txt has complete terms
 
 ## Overview
 
-This guide covers essential PDF processing operations using Python libraries and command-line tools. For advanced features, JavaScript libraries, and detailed examples, see REFERENCE.md. If you need to fill out a PDF form, read FORMS.md and follow its instructions.
+This guide covers essential PDF processing operations using Python libraries and command-line tools. For advanced features, JavaScript libraries, and detailed examples, see reference.md. If you need to fill out a PDF form, read forms.md and follow its instructions.
 
 ## Quick Start
 
@@ -304,11 +304,11 @@ with open("encrypted.pdf", "wb") as output:
 | Create PDFs | reportlab | Canvas or Platypus |
 | Command line merge | qpdf | `qpdf --empty --pages ...` |
 | OCR scanned PDFs | pytesseract | Convert to image first |
-| Fill PDF forms | pdf-lib or pypdf (see FORMS.md) | See FORMS.md |
+| Fill PDF forms | pdf-lib or pypdf (see forms.md) | See forms.md |
 
 ## Next Steps
 
-- For advanced pypdfium2 usage, see REFERENCE.md
-- For JavaScript libraries (pdf-lib), see REFERENCE.md
-- If you need to fill out a PDF form, follow the instructions in FORMS.md
-- For troubleshooting guides, see REFERENCE.md
+- For advanced pypdfium2 usage, see reference.md
+- For JavaScript libraries (pdf-lib), see reference.md
+- If you need to fill out a PDF form, follow the instructions in forms.md
+- For troubleshooting guides, see reference.md


### PR DESCRIPTION
## Summary
- `skills/pdf/SKILL.md` referenced `REFERENCE.md` and `FORMS.md` in several places, but the actual files are lowercase (`reference.md`, `forms.md`).
- Fixed the casing so the doc links match the real filenames, consistent with how other skills (e.g. `mcp-builder`) reference their docs.

## Test plan
- [x] Confirmed actual filenames on disk are lowercase (`reference.md`, `forms.md`)
- [x] Compared against `mcp-builder/SKILL.md` for naming convention consistency
- Docs-only change, no code/behavior affected