### PR TITLE
fix(skill-creator): distinguish eval errors from non-triggers

### DIFF
--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -181,6 +181,49 @@ def run_single_query(
             command_file.unlink()
 
 
+def aggregate_results(
+    query_triggers: dict[str, list[bool]],
+    query_items: dict[str, dict],
+    query_errors: dict[str, int],
+    trigger_threshold: float,
+) -> tuple[list[dict], dict]:
+    """Aggregate completed outcomes without treating errors as non-triggers."""
+    results = []
+
+    for query, item in query_items.items():
+        triggers = query_triggers.get(query, [])
+        errored = query_errors.get(query, 0)
+        trigger_rate = sum(triggers) / len(triggers) if triggers else None
+        should_trigger = item["should_trigger"]
+
+        if trigger_rate is None or errored:
+            did_pass = False
+        elif should_trigger:
+            did_pass = trigger_rate >= trigger_threshold
+        else:
+            did_pass = trigger_rate < trigger_threshold
+
+        results.append({
+            "query": query,
+            "should_trigger": should_trigger,
+            "trigger_rate": trigger_rate,
+            "triggers": sum(triggers),
+            "runs": len(triggers),
+            "errored": errored,
+            "pass": did_pass,
+        })
+
+    passed = sum(1 for result in results if result["pass"])
+    total = len(results)
+    summary = {
+        "total": total,
+        "passed": passed,
+        "failed": total - passed,
+        "errored": sum(query_errors.values()),
+    }
+    return results, summary
+
+
 def run_eval(
     eval_set: list[dict],
     skill_name: str,
@@ -193,8 +236,6 @@ def run_eval(
     model: str | None = None,
 ) -> dict:
     """Run the full eval set and return results."""
-    results = []
-
     with ProcessPoolExecutor(max_workers=num_workers) as executor:
         future_to_info = {}
         for item in eval_set:
@@ -211,48 +252,31 @@ def run_eval(
                 future_to_info[future] = (item, run_idx)
 
         query_triggers: dict[str, list[bool]] = {}
-        query_items: dict[str, dict] = {}
+        query_errors: dict[str, int] = {}
+        query_items = {item["query"]: item for item in eval_set}
         for future in as_completed(future_to_info):
             item, _ = future_to_info[future]
             query = item["query"]
-            query_items[query] = item
             if query not in query_triggers:
                 query_triggers[query] = []
             try:
                 query_triggers[query].append(future.result())
             except Exception as e:
                 print(f"Warning: query failed: {e}", file=sys.stderr)
-                query_triggers[query].append(False)
+                query_errors[query] = query_errors.get(query, 0) + 1
 
-    for query, triggers in query_triggers.items():
-        item = query_items[query]
-        trigger_rate = sum(triggers) / len(triggers)
-        should_trigger = item["should_trigger"]
-        if should_trigger:
-            did_pass = trigger_rate >= trigger_threshold
-        else:
-            did_pass = trigger_rate < trigger_threshold
-        results.append({
-            "query": query,
-            "should_trigger": should_trigger,
-            "trigger_rate": trigger_rate,
-            "triggers": sum(triggers),
-            "runs": len(triggers),
-            "pass": did_pass,
-        })
-
-    passed = sum(1 for r in results if r["pass"])
-    total = len(results)
+    results, summary = aggregate_results(
+        query_triggers=query_triggers,
+        query_items=query_items,
+        query_errors=query_errors,
+        trigger_threshold=trigger_threshold,
+    )
 
     return {
         "skill_name": skill_name,
         "description": description,
         "results": results,
-        "summary": {
-            "total": total,
-            "passed": passed,
-            "failed": total - passed,
-        },
+        "summary": summary,
     }
 
 
@@ -297,10 +321,14 @@ def main():
 
     if args.verbose:
         summary = output["summary"]
-        print(f"Results: {summary['passed']}/{summary['total']} passed", file=sys.stderr)
+        print(
+            f"Results: {summary['passed']}/{summary['total']} passed "
+            f"({summary['errored']} run errors)",
+            file=sys.stderr,
+        )
         for r in output["results"]:
             status = "PASS" if r["pass"] else "FAIL"
-            rate_str = f"{r['triggers']}/{r['runs']}"
+            rate_str = f"{r['triggers']}/{r['runs']} ({r['errored']} errors)"
             print(f"  [{status}] rate={rate_str} expected={r['should_trigger']}: {r['query'][:70]}", file=sys.stderr)
 
     print(json.dumps(output, indent=2))

--- a/skills/skill-creator/tests/test_run_eval.py
+++ b/skills/skill-creator/tests/test_run_eval.py
@@ -1,0 +1,62 @@
+import sys
+import unittest
+from pathlib import Path
+
+
+SKILL_CREATOR_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SKILL_CREATOR_ROOT))
+
+from scripts.run_eval import aggregate_results
+
+
+class AggregateResultsTest(unittest.TestCase):
+    def setUp(self):
+        self.items = {
+            "positive": {"query": "positive", "should_trigger": True},
+            "negative": {"query": "negative", "should_trigger": False},
+        }
+
+    def test_completed_outcomes_are_scored_normally(self):
+        results, summary = aggregate_results(
+            query_triggers={"positive": [True], "negative": [False]},
+            query_items=self.items,
+            query_errors={},
+            trigger_threshold=0.5,
+        )
+
+        self.assertEqual([result["pass"] for result in results], [True, True])
+        self.assertEqual(summary, {"total": 2, "passed": 2, "failed": 0, "errored": 0})
+
+    def test_error_does_not_become_passing_negative_outcome(self):
+        results, summary = aggregate_results(
+            query_triggers={"positive": [True], "negative": []},
+            query_items=self.items,
+            query_errors={"negative": 1},
+            trigger_threshold=0.5,
+        )
+
+        negative = results[1]
+        self.assertIsNone(negative["trigger_rate"])
+        self.assertEqual(negative["runs"], 0)
+        self.assertEqual(negative["errored"], 1)
+        self.assertFalse(negative["pass"])
+        self.assertEqual(summary, {"total": 2, "passed": 1, "failed": 1, "errored": 1})
+
+    def test_partial_error_fails_closed_without_changing_denominator(self):
+        results, summary = aggregate_results(
+            query_triggers={"positive": [True], "negative": [False]},
+            query_items=self.items,
+            query_errors={"negative": 1},
+            trigger_threshold=0.5,
+        )
+
+        negative = results[1]
+        self.assertEqual(negative["trigger_rate"], 0.0)
+        self.assertEqual(negative["runs"], 1)
+        self.assertEqual(negative["errored"], 1)
+        self.assertFalse(negative["pass"])
+        self.assertEqual(summary["errored"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Keep failed eval runs separate from valid non-trigger outcomes. Results now report an `errored` count, use only completed outcomes for the trigger-rate denominator, and fail a query closed when any run errors.

## Why

A crashed negative query was previously appended as `False`, so infrastructure failure could score as a correct non-trigger and steer the description optimizer.

## Tests

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s skills/skill-creator/tests -v`
- `python3 -m compileall -q skills/skill-creator/scripts skills/skill-creator/tests`
- `git diff --check`

Fixes #1478

AI assistance was used during investigation and implementation. I reviewed the final diff and ran the tests listed above.