### PR TITLE
fix(skill-creator): load flat benchmark grading files

### DIFF
--- a/skills/skill-creator/scripts/aggregate_benchmark.py
+++ b/skills/skill-creator/scripts/aggregate_benchmark.py
@@ -82,6 +82,7 @@ def load_run_results(benchmark_dir: Path) -> dict:
         return {}
 
     results: dict[str, list] = {}
+    loaded_count = 0
 
     for eval_idx, eval_dir in enumerate(sorted(search_dir.glob("eval-*"))):
         metadata_path = eval_dir / "eval_metadata.json"
@@ -101,15 +102,26 @@ def load_run_results(benchmark_dir: Path) -> dict:
         for config_dir in sorted(eval_dir.iterdir()):
             if not config_dir.is_dir():
                 continue
-            # Skip non-config directories (inputs, outputs, etc.)
-            if not list(config_dir.glob("run-*")):
+            # Skip non-config directories (inputs, outputs, etc.). A config
+            # may contain run-N/grading.json files or one flat grading.json.
+            run_dirs = sorted(config_dir.glob("run-*"))
+            if not run_dirs and not (config_dir / "grading.json").is_file():
                 continue
             config = config_dir.name
             if config not in results:
                 results[config] = []
 
-            for run_dir in sorted(config_dir.glob("run-*")):
-                run_number = int(run_dir.name.split("-")[1])
+            if run_dirs:
+                run_entries = [
+                    (int(run_dir.name.split("-")[1]), run_dir)
+                    for run_dir in run_dirs
+                ]
+            else:
+                # Treat the config directory itself as run 1 for the
+                # documented single-run layout.
+                run_entries = [(1, config_dir)]
+
+            for run_number, run_dir in run_entries:
                 grading_file = run_dir / "grading.json"
 
                 if not grading_file.exists():
@@ -122,6 +134,8 @@ def load_run_results(benchmark_dir: Path) -> dict:
                 except json.JSONDecodeError as e:
                     print(f"Warning: Invalid JSON in {grading_file}: {e}")
                     continue
+
+                loaded_count += 1
 
                 # Extract metrics
                 result = {
@@ -169,6 +183,9 @@ def load_run_results(benchmark_dir: Path) -> dict:
                 result["notes"] = notes
 
                 results[config].append(result)
+
+    if loaded_count == 0:
+        print(f"Warning: no grading.json files found in {benchmark_dir}")
 
     return results
 

--- a/skills/skill-creator/scripts/test_aggregate_benchmark.py
+++ b/skills/skill-creator/scripts/test_aggregate_benchmark.py
@@ -1,0 +1,58 @@
+import contextlib
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from aggregate_benchmark import load_run_results
+
+
+def write_grading(path: Path, pass_rate: float) -> None:
+    path.write_text(
+        json.dumps({"summary": {
+            "pass_rate": pass_rate,
+            "passed": int(pass_rate * 10),
+            "failed": int((1 - pass_rate) * 10),
+            "total": 10,
+        }}),
+        encoding="utf-8",
+    )
+
+
+class AggregateBenchmarkTests(unittest.TestCase):
+    def test_flat_single_run_layout_is_loaded_as_run_one(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config = Path(temp_dir) / "eval-0" / "with_skill"
+            config.mkdir(parents=True)
+            write_grading(config / "grading.json", 0.8)
+
+            results = load_run_results(Path(temp_dir))
+
+            self.assertEqual(results["with_skill"][0]["run_number"], 1)
+            self.assertEqual(results["with_skill"][0]["pass_rate"], 0.8)
+
+    def test_nested_run_layout_remains_supported(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            run = Path(temp_dir) / "eval-0" / "without_skill" / "run-2"
+            run.mkdir(parents=True)
+            write_grading(run / "grading.json", 0.4)
+
+            results = load_run_results(Path(temp_dir))
+
+            self.assertEqual(results["without_skill"][0]["run_number"], 2)
+            self.assertEqual(results["without_skill"][0]["pass_rate"], 0.4)
+
+    def test_empty_configs_emit_a_visible_warning(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            (Path(temp_dir) / "eval-0" / "with_skill").mkdir(parents=True)
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                results = load_run_results(Path(temp_dir))
+
+            self.assertEqual(results, {})
+            self.assertIn("no grading.json files found", output.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- load the documented flat `<eval-N>/<config>/grading.json` layout as run 1
- preserve the existing `run-N/grading.json` and legacy `runs/` layouts
- emit a visible warning when no grading files are found instead of silently producing an all-zero benchmark
- add standard-library regression tests for flat, nested, and empty layouts

Fixes #1425. The single-run layout documented by `skill-creator` now reaches `benchmark.json` and `benchmark.md` aggregation instead of being skipped.

## Verification

- `python -m unittest discover -s skills/skill-creator/scripts -p 'test_*.py' -v` (3 tests)
- `python -m py_compile skills/skill-creator/scripts/aggregate_benchmark.py skills/skill-creator/scripts/test_aggregate_benchmark.py`
- `python skills/skill-creator/scripts/aggregate_benchmark.py --help`
- `git diff --check`