### PR TITLE
docs(webapp-testing): declare required tool capabilities

### DIFF
--- a/skills/webapp-testing/SKILL.md
+++ b/skills/webapp-testing/SKILL.md
@@ -2,6 +2,7 @@
 name: webapp-testing
 description: Toolkit for interacting with and testing local web applications using Playwright. Supports verifying frontend functionality, debugging UI behavior, capturing browser screenshots, and viewing browser logs.
 license: Complete terms in LICENSE.txt
+allowed-tools: Bash(python:*) Read Write
 ---
 
 # Web Application Testing


### PR DESCRIPTION
## Summary

- declare `Bash(python:*) Read Write` in `webapp-testing` frontmatter

Fixes #1468. The skill already invokes Python helper scripts that launch user-provided servers and writes screenshots/logs, but it provided no capability declaration for hosts that use `allowed-tools` metadata.

## Verification

- `python skills/skill-creator/scripts/quick_validate.py skills/webapp-testing` — passed
- `git diff --check` — passed

The unrelated `skill-creator` validation command could not run in this Windows shell because its existing SKILL.md contains a byte that the default cp1252 reader cannot decode; no skill-creator files are changed here.