### PR TITLE
fix(skill-creator): isolate parallel command clone matching

### DIFF
--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -32,6 +32,40 @@ def find_project_root() -> Path:
     return current
 
 
+def command_clone_prefix(skill_name: str) -> str:
+    """Return the prefix shared by command clones for one evaluated skill."""
+    return f"{skill_name}-skill-"
+
+
+def is_command_clone_reference(reference: str, skill_name: str) -> bool:
+    """Whether a tool reference points at any worker clone for this skill."""
+    return command_clone_prefix(skill_name) in reference
+
+
+def remove_stale_command_clones(project_root: Path, skill_name: str) -> int:
+    """Remove command clones left by interrupted evaluations.
+
+    Clones are generated with the skill-specific prefix, so this sweep cannot
+    remove unrelated user commands. It runs once before workers start and
+    prevents old descriptions from competing with the current evaluation.
+    """
+    commands_dir = project_root / ".claude" / "commands"
+    if not commands_dir.is_dir():
+        return 0
+
+    removed = 0
+    prefix = command_clone_prefix(skill_name)
+    for path in commands_dir.glob(f"{prefix}*.md"):
+        if not path.is_file():
+            continue
+        try:
+            path.unlink()
+            removed += 1
+        except OSError as exc:
+            print(f"Warning: could not remove stale command clone {path}: {exc}", file=sys.stderr)
+    return removed
+
+
 def run_single_query(
     query: str,
     skill_name: str,
@@ -144,12 +178,12 @@ def run_single_query(
                             delta = se.get("delta", {})
                             if delta.get("type") == "input_json_delta":
                                 accumulated_json += delta.get("partial_json", "")
-                                if clean_name in accumulated_json:
+                                if is_command_clone_reference(accumulated_json, skill_name):
                                     return True
 
                         elif se_type in ("content_block_stop", "message_stop"):
                             if pending_tool_name:
-                                return clean_name in accumulated_json
+                                return is_command_clone_reference(accumulated_json, skill_name)
                             if se_type == "message_stop":
                                 return False
 
@@ -161,9 +195,9 @@ def run_single_query(
                                 continue
                             tool_name = content_item.get("name", "")
                             tool_input = content_item.get("input", {})
-                            if tool_name == "Skill" and clean_name in tool_input.get("skill", ""):
+                            if tool_name == "Skill" and is_command_clone_reference(tool_input.get("skill", ""), skill_name):
                                 triggered = True
-                            elif tool_name == "Read" and clean_name in tool_input.get("file_path", ""):
+                            elif tool_name == "Read" and is_command_clone_reference(tool_input.get("file_path", ""), skill_name):
                                 triggered = True
                             return triggered
 
@@ -194,6 +228,10 @@ def run_eval(
 ) -> dict:
     """Run the full eval set and return results."""
     results = []
+
+    removed = remove_stale_command_clones(project_root, skill_name)
+    if removed:
+        print(f"Removed {removed} stale command clone(s) for {skill_name}", file=sys.stderr)
 
     with ProcessPoolExecutor(max_workers=num_workers) as executor:
         future_to_info = {}

--- a/skills/skill-creator/scripts/test_run_eval.py
+++ b/skills/skill-creator/scripts/test_run_eval.py
@@ -1,0 +1,34 @@
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.run_eval import command_clone_prefix, is_command_clone_reference, remove_stale_command_clones
+
+
+class CommandCloneTests(unittest.TestCase):
+    def test_prefix_matches_any_worker_clone(self):
+        self.assertTrue(is_command_clone_reference("demo-skill-a1b2c3d4", "demo"))
+        self.assertTrue(is_command_clone_reference("demo-skill-deadbeef", "demo"))
+        self.assertFalse(is_command_clone_reference("other-skill-deadbeef", "demo"))
+
+    def test_stale_sweep_only_removes_generated_clones(self):
+        with tempfile.TemporaryDirectory() as root:
+            commands = Path(root) / ".claude" / "commands"
+            commands.mkdir(parents=True)
+            stale = commands / "demo-skill-deadbeef.md"
+            current = commands / "demo-skill-cafebabe.md"
+            unrelated = commands / "README.md"
+            for path in (stale, current, unrelated):
+                path.write_text("placeholder")
+
+            self.assertEqual(remove_stale_command_clones(Path(root), "demo"), 2)
+            self.assertFalse(stale.exists())
+            self.assertFalse(current.exists())
+            self.assertTrue(unrelated.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- match any generated command clone for the evaluated skill instead of only the worker's random hash
- remove stale generated clones before parallel workers start
- add regression tests for multi-worker matching and safe stale-clone cleanup

Fixes #1427. Parallel workers currently publish identical descriptions under different hashed command names; a model can select another worker's clone and the worker incorrectly records a non-trigger. Prefix matching makes every clone a valid trigger signal, while the startup sweep prevents interrupted runs from contaminating later evaluations.

## Verification

- `python -m unittest discover -s scripts -p "test_*.py" -v` (2 passed)
- `python -m py_compile scripts/run_eval.py scripts/test_run_eval.py`
- `python scripts/quick_validate.py .`
- `git diff --check`

AI assistance was used to prepare this change; the diff was reviewed line-by-line and the tests cover the matching and cleanup invariants.
