### PR TITLE
docx: document Python script dependencies

### DIFF
--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -88,4 +88,4 @@ The script writes `comments.xml`, `commentsExtended.xml`, `commentsIds.xml`, `co
 
 ## Dependencies
 
-`docx` (npm, preinstalled — install only if `require('docx')` fails) · `pandoc` · LibreOffice (`soffice`) · `pdftoppm` (Poppler)
+`docx` (npm, preinstalled — install only if `require('docx')` fails) · `pandoc` · LibreOffice (`soffice`) · `pdftoppm` (Poppler) · Python 3.10+ · `defusedxml` (install with `python -m pip install -r requirements.txt` before running the bundled Python scripts)

--- a/skills/docx/requirements.txt
+++ b/skills/docx/requirements.txt
@@ -1,0 +1,1 @@
+defusedxml>=0.7,<1


### PR DESCRIPTION
## Summary\n- document the Python 3.10+ runtime required by bundled docx scripts\n- declare defusedxml in a requirements file and show the installation command\n\nFixes #1461\n\nValidation: python -m compileall -q scripts, git diff --check\n\n