### PR TITLE
claude-api: clarify batch prompt-cache warmups

### DIFF
--- a/skills/claude-api/python/claude-api/batches.md
+++ b/skills/claude-api/python/claude-api/batches.md
@@ -115,6 +115,13 @@ For manual control, use `first_page.has_next_page()` / `first_page.get_next_page
 
 ## Batch with Prompt Caching
 
+Batch prompt-cache entries are separate from regular Messages API entries. For
+batch workloads, warm the cache with a **single-request Message Batch** that
+uses the same stable prefix and `cache_control` breakpoint as the production
+batch; a preceding `client.messages.create(...)` request is not a reliable
+warm-up. The Batches API does not accept `max_tokens: 0`, so use the smallest
+useful output budget for the warm-up item and then submit the remaining items.
+
 ```python
 shared_system = [
     {"type": "text", "text": "You are a literary analyst."},

--- a/skills/claude-api/shared/prompt-caching.md
+++ b/skills/claude-api/shared/prompt-caching.md
@@ -204,6 +204,15 @@ For fan-out patterns: send 1 request, await the first streamed token (not the fu
 
 To eliminate the cache-miss latency on the *first* real request, send a **`max_tokens: 0`** request at startup (or on an interval). The API runs prefill — writing the cache at your `cache_control` breakpoint — and returns immediately with `content: []`, `stop_reason: "max_tokens"`, and a populated `usage` block (zero output tokens billed; normal cache-write charge on `cache_creation_input_tokens`).
 
+**Message Batches use a separate cache path.** If the workload will be sent to
+`/v1/messages/batches`, pre-warm with a single-request Message Batch rather
+than a regular `messages.create` call. Do not rely on a cache entry written by
+the Messages API being readable by a later batch submission (or vice versa);
+the batch's first request should carry the same stable prefix and
+`cache_control` breakpoint as the requests you will process. The batch API does
+not accept `max_tokens: 0`, so use a minimal-output batch item and account for
+the normal cache-write charge.
+
 **When to pre-warm** — pre-warming trades a cache-write charge *now* for lower TTFT on the *next* real request. It's worth it when all three hold: (a) first-request latency is user-visible (chat/voice/interactive — not background jobs), (b) the shared prefix is large enough that a cold write is noticeably slow, and (c) there's a moment *before* traffic to fire it — app startup, worker boot, post-deploy, start of a scheduled window.
 
 | Skip pre-warming when… | Because |


### PR DESCRIPTION
## Summary\n- document that Message Batches and regular Messages use separate cache paths\n- explain that batch workloads should warm via a single-request batch\n- add the guidance to the Python Batches reference\n\nFixes #1475\n\nValidation: git diff --check\n\n