### PR TITLE
xlsx: match case-insensitive external defined names

### DIFF
--- a/skills/xlsx/scripts/recalc.py
+++ b/skills/xlsx/scripts/recalc.py
@@ -99,7 +99,10 @@ def external_links_at_risk(filename):
             if isinstance(getattr(dn, "value", None), str) and EXTERNAL_REF_RE.search(dn.value)
         ]
         name_re = (
-            re.compile(r"\b(" + "|".join(re.escape(n) for n in external_names) + r")\b")
+            re.compile(
+                r"\b(" + "|".join(re.escape(n) for n in external_names) + r")\b",
+                re.IGNORECASE,
+            )
             if external_names
             else None
         )

--- a/skills/xlsx/scripts/test_recalc.py
+++ b/skills/xlsx/scripts/test_recalc.py
@@ -1,0 +1,56 @@
+import sys
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import recalc
+
+
+class _Sheet:
+    def __init__(self, cell):
+        self._cell = cell
+
+    def iter_rows(self):
+        return [[self._cell]]
+
+    def __getitem__(self, coordinate):
+        return self._cell
+
+
+class _Workbook:
+    sheetnames = ["Sheet1"]
+
+    def __init__(self, cell, defined_name):
+        self.defined_names = {"MixedCase": SimpleNamespace(value=defined_name)}
+        self._sheet = _Sheet(cell)
+
+    def __getitem__(self, sheet):
+        return self._sheet
+
+    def close(self):
+        pass
+
+
+class ExternalDefinedNameTests(unittest.TestCase):
+    def test_case_variant_defined_name_is_at_risk(self):
+        formula_cell = SimpleNamespace(value="=mIxEdCaSe", coordinate="A1")
+        cached_cell = SimpleNamespace(value=None)
+        formulas = _Workbook(formula_cell, "'[1]Data'!$A$1")
+        values = _Workbook(SimpleNamespace(value=cached_cell.value, coordinate="A1"), "")
+
+        with tempfile.TemporaryDirectory() as directory:
+            filename = Path(directory) / "book.xlsx"
+            with zipfile.ZipFile(filename, "w") as archive:
+                archive.writestr("xl/externalLinks/externalLink1.xml", "")
+
+            with patch.object(recalc, "load_workbook", side_effect=[formulas, values]):
+                self.assertEqual(recalc.external_links_at_risk(filename), ["Sheet1!A1"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary\n- compile the external defined-name safeguard regex with e.IGNORECASE\n- add regression coverage for mixed-case formula references\n\nFixes #1464\n\nValidation: python -m unittest discover -s scripts -p 'test_*.py' -v, python -m py_compile scripts/recalc.py scripts/test_recalc.py, git diff --check\n\n