### PR TITLE
skill-creator: isolate nested eval stdin

### DIFF
--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -84,6 +84,7 @@ def run_single_query(
 
         process = subprocess.Popen(
             cmd,
+            stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             cwd=project_root,

--- a/skills/skill-creator/scripts/test_run_eval_stdin.py
+++ b/skills/skill-creator/scripts/test_run_eval_stdin.py
@@ -1,0 +1,26 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import run_eval
+
+
+class RunEvalProcessTests(unittest.TestCase):
+    def test_nested_claude_process_does_not_inherit_stdin(self):
+        process = unittest.mock.Mock()
+        process.poll.return_value = 0
+        process.stdout.read.return_value = b""
+
+        with tempfile.TemporaryDirectory() as root, patch.object(
+            run_eval.subprocess, "Popen", return_value=process
+        ) as popen:
+            run_eval.run_single_query(
+                "query", "demo", "description", 1, Path(root)
+            )
+
+        self.assertIs(popen.call_args.kwargs["stdin"], run_eval.subprocess.DEVNULL)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary\n- connect nested claude -p evaluations to subprocess.DEVNULL for stdin\n- prevent inherited session input from adding stalls or consuming parent input\n- add a regression test for the Popen configuration\n\nFixes #1414\n\nValidation: python -m unittest discover -s scripts -p 'test_*.py' -v, python -m py_compile scripts/run_eval.py scripts/test_run_eval_stdin.py, python scripts/quick_validate.py ., git diff --check\n\nAssisted-by: Codex