### PR TITLE
pdf: preserve bare string choice options

### DIFF
--- a/skills/pdf/scripts/extract_form_field_info.py
+++ b/skills/pdf/scripts/extract_form_field_info.py
@@ -35,10 +35,12 @@ def make_field_dict(field, field_id):
     elif ft == "/Ch":
         field_dict["type"] = "choice"
         states = field.get("/_States_", [])
-        field_dict["choice_options"] = [{
-            "value": state[0],
-            "text": state[1],
-        } for state in states]
+        field_dict["choice_options"] = [
+            {"value": state, "text": state}
+            if isinstance(state, str)
+            else {"value": state[0], "text": state[1]}
+            for state in states
+        ]
     else:
         field_dict["type"] = f"unknown ({ft})"
     return field_dict

--- a/skills/pdf/scripts/test_extract_form_field_info.py
+++ b/skills/pdf/scripts/test_extract_form_field_info.py
@@ -1,0 +1,28 @@
+import unittest
+
+from extract_form_field_info import make_field_dict
+
+
+class ChoiceOptionTests(unittest.TestCase):
+    def test_bare_string_options_preserve_value_and_label(self):
+        field = {"/FT": "/Ch", "/_States_": ["Red", "B"]}
+
+        self.assertEqual(
+            make_field_dict(field, "colors")["choice_options"],
+            [
+                {"value": "Red", "text": "Red"},
+                {"value": "B", "text": "B"},
+            ],
+        )
+
+    def test_value_label_pairs_remain_supported(self):
+        field = {"/FT": "/Ch", "/_States_": [["r", "Red"]]}
+
+        self.assertEqual(
+            make_field_dict(field, "colors")["choice_options"],
+            [{"value": "r", "text": "Red"}],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary\n- normalize PDF choice-field /Opt entries that are bare strings\n- preserve existing [value, label] pair handling\n- add regression tests for both representations\n\nFixes #1469\n\nValidation: python -m unittest discover -s scripts -p 'test_*.py' -v, python -m py_compile scripts/extract_form_field_info.py scripts/test_extract_form_field_info.py, git diff --check\n\nAssisted-by: Codex