### PR TITLE
skill-creator: validate user-invocable metadata

### DIFF
--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -39,7 +39,10 @@ def validate_skill(skill_path):
         return False, f"Invalid YAML in frontmatter: {e}"
 
     # Define allowed properties
-    ALLOWED_PROPERTIES = {'name', 'description', 'license', 'allowed-tools', 'metadata', 'compatibility'}
+    ALLOWED_PROPERTIES = {
+        'name', 'description', 'license', 'allowed-tools', 'metadata',
+        'compatibility', 'user-invocable'
+    }
 
     # Check for unexpected properties (excluding nested keys under metadata)
     unexpected_keys = set(frontmatter.keys()) - ALLOWED_PROPERTIES
@@ -90,6 +93,10 @@ def validate_skill(skill_path):
             return False, f"Compatibility must be a string, got {type(compatibility).__name__}"
         if len(compatibility) > 500:
             return False, f"Compatibility is too long ({len(compatibility)} characters). Maximum is 500 characters."
+
+    user_invocable = frontmatter.get('user-invocable')
+    if user_invocable is not None and not isinstance(user_invocable, bool):
+        return False, f"user-invocable must be a boolean, got {type(user_invocable).__name__}"
 
     return True, "Skill is valid!"
 

--- a/skills/skill-creator/scripts/test_quick_validate.py
+++ b/skills/skill-creator/scripts/test_quick_validate.py
@@ -1,0 +1,32 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from quick_validate import validate_skill
+
+
+class UserInvocableValidationTests(unittest.TestCase):
+    def _validate(self, frontmatter):
+        with tempfile.TemporaryDirectory() as directory:
+            skill = Path(directory)
+            (skill / "SKILL.md").write_text(
+                f"---\n{frontmatter}\n---\n\n# Test\n"
+            )
+            return validate_skill(skill)
+
+    def test_user_invocable_boolean_is_accepted(self):
+        self.assertEqual(
+            self._validate("name: test\ndescription: A test skill\nuser-invocable: true"),
+            (True, "Skill is valid!"),
+        )
+
+    def test_user_invocable_must_be_boolean(self):
+        valid, message = self._validate(
+            "name: test\ndescription: A test skill\nuser-invocable: 1"
+        )
+        self.assertFalse(valid)
+        self.assertIn("user-invocable must be a boolean", message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary\n- accept the supported user-invocable frontmatter property\n- validate that its value is boolean\n- add regression tests for valid and invalid metadata\n\nFixes #1431\n\nValidation: python -m unittest discover -s scripts -p 'test_*.py' -v, python -m py_compile scripts/quick_validate.py scripts/test_quick_validate.py, python scripts/quick_validate.py ., git diff --check\n\n