### PR TITLE
skill-creator: load flat benchmark grading files

### DIFF
--- a/skills/skill-creator/scripts/aggregate_benchmark.py
+++ b/skills/skill-creator/scripts/aggregate_benchmark.py
@@ -102,14 +102,23 @@ def load_run_results(benchmark_dir: Path) -> dict:
             if not config_dir.is_dir():
                 continue
             # Skip non-config directories (inputs, outputs, etc.)
-            if not list(config_dir.glob("run-*")):
+            run_dirs = sorted(config_dir.glob("run-*"))
+            if not run_dirs and (config_dir / "grading.json").exists():
+                # The documented single-run layout stores grading.json directly
+                # in the config directory, which the eval viewer also accepts.
+                run_dirs = [config_dir]
+            if not run_dirs:
                 continue
             config = config_dir.name
             if config not in results:
                 results[config] = []
 
-            for run_dir in sorted(config_dir.glob("run-*")):
-                run_number = int(run_dir.name.split("-")[1])
+            for run_dir in run_dirs:
+                run_number = (
+                    int(run_dir.name.split("-")[1])
+                    if run_dir is not config_dir
+                    else 1
+                )
                 grading_file = run_dir / "grading.json"
 
                 if not grading_file.exists():

--- a/skills/skill-creator/scripts/test_aggregate_benchmark.py
+++ b/skills/skill-creator/scripts/test_aggregate_benchmark.py
@@ -1,0 +1,48 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from aggregate_benchmark import load_run_results
+
+
+def _write_grading(path: Path, pass_rate: float):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "summary": {
+                    "pass_rate": pass_rate,
+                    "passed": 1,
+                    "failed": 0,
+                    "total": 1,
+                }
+            }
+        )
+    )
+
+
+class GradingLayoutTests(unittest.TestCase):
+    def test_flat_single_run_layout_is_loaded(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            _write_grading(root / "eval-0" / "with_skill" / "grading.json", 1.0)
+
+            results = load_run_results(root)
+
+        self.assertEqual(results["with_skill"][0]["run_number"], 1)
+        self.assertEqual(results["with_skill"][0]["pass_rate"], 1.0)
+
+    def test_nested_runs_keep_their_run_numbers(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            _write_grading(root / "eval-0" / "with_skill" / "run-2" / "grading.json", 0.5)
+
+            results = load_run_results(root)
+
+        self.assertEqual(results["with_skill"][0]["run_number"], 2)
+        self.assertEqual(results["with_skill"][0]["pass_rate"], 0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary\n- support the documented single-run config/grading.json layout\n- preserve existing un-N/grading.json handling\n- add regression tests for flat and nested layouts\n\nFixes #1425\n\nValidation: python -m unittest discover -s scripts -p 'test_*.py' -v, python -m py_compile scripts/aggregate_benchmark.py scripts/test_aggregate_benchmark.py, git diff --check\n\n