### PR TITLE
fix(skill-creator): match any parallel eval command clone

### DIFF
--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -32,6 +32,38 @@ def find_project_root() -> Path:
     return current
 
 
+def command_clone_prefix(skill_name: str) -> str:
+    """Shared name prefix for command clones of one skill under eval."""
+    return f"{skill_name}-skill-"
+
+
+def is_command_clone_reference(reference: str, skill_name: str) -> bool:
+    """True if a tool reference names any worker's clone of this skill."""
+    return command_clone_prefix(skill_name) in reference
+
+
+def remove_stale_command_clones(project_root: Path, skill_name: str) -> int:
+    """Delete leftover eval clones for this skill under .claude/commands/.
+
+    Interrupted runs leave orphans that inflate N and may carry outdated
+    descriptions. Only paths matching the generated clone prefix are removed.
+    """
+    commands_dir = project_root / ".claude" / "commands"
+    if not commands_dir.is_dir():
+        return 0
+
+    removed = 0
+    for path in commands_dir.glob(f"{command_clone_prefix(skill_name)}*.md"):
+        if not path.is_file():
+            continue
+        try:
+            path.unlink()
+            removed += 1
+        except OSError as exc:
+            print(f"Warning: could not remove stale command clone {path}: {exc}", file=sys.stderr)
+    return removed
+
+
 def run_single_query(
     query: str,
     skill_name: str,
@@ -144,12 +176,14 @@ def run_single_query(
                             delta = se.get("delta", {})
                             if delta.get("type") == "input_json_delta":
                                 accumulated_json += delta.get("partial_json", "")
-                                if clean_name in accumulated_json:
+                                # Any clone of this skill counts — parallel workers
+                                # publish identical descriptions under different hashes.
+                                if is_command_clone_reference(accumulated_json, skill_name):
                                     return True
 
                         elif se_type in ("content_block_stop", "message_stop"):
                             if pending_tool_name:
-                                return clean_name in accumulated_json
+                                return is_command_clone_reference(accumulated_json, skill_name)
                             if se_type == "message_stop":
                                 return False
 
@@ -161,9 +195,13 @@ def run_single_query(
                                 continue
                             tool_name = content_item.get("name", "")
                             tool_input = content_item.get("input", {})
-                            if tool_name == "Skill" and clean_name in tool_input.get("skill", ""):
+                            if tool_name == "Skill" and is_command_clone_reference(
+                                tool_input.get("skill", ""), skill_name
+                            ):
                                 triggered = True
-                            elif tool_name == "Read" and clean_name in tool_input.get("file_path", ""):
+                            elif tool_name == "Read" and is_command_clone_reference(
+                                tool_input.get("file_path", ""), skill_name
+                            ):
                                 triggered = True
                             return triggered
 
@@ -194,6 +232,13 @@ def run_eval(
 ) -> dict:
     """Run the full eval set and return results."""
     results = []
+
+    removed = remove_stale_command_clones(project_root, skill_name)
+    if removed:
+        print(
+            f"Removed {removed} stale command clone(s) for {skill_name}",
+            file=sys.stderr,
+        )
 
     with ProcessPoolExecutor(max_workers=num_workers) as executor:
         future_to_info = {}

--- a/skills/skill-creator/scripts/test_run_eval.py
+++ b/skills/skill-creator/scripts/test_run_eval.py
@@ -1,0 +1,52 @@
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.run_eval import (
+    command_clone_prefix,
+    is_command_clone_reference,
+    remove_stale_command_clones,
+)
+
+
+class CommandCloneTests(unittest.TestCase):
+    def test_prefix_matches_any_worker_clone(self):
+        # Parallel workers only differ by the trailing hash; any clone is a hit.
+        self.assertEqual(command_clone_prefix("demo"), "demo-skill-")
+        self.assertTrue(is_command_clone_reference("demo-skill-a1b2c3d4", "demo"))
+        self.assertTrue(is_command_clone_reference("demo-skill-deadbeef", "demo"))
+        self.assertTrue(
+            is_command_clone_reference(
+                '/tmp/.claude/commands/demo-skill-cafebabe.md', "demo"
+            )
+        )
+        self.assertFalse(is_command_clone_reference("other-skill-deadbeef", "demo"))
+        self.assertFalse(is_command_clone_reference("demo", "demo"))
+
+    def test_stale_sweep_only_removes_generated_clones(self):
+        with tempfile.TemporaryDirectory() as root:
+            commands = Path(root) / ".claude" / "commands"
+            commands.mkdir(parents=True)
+            stale = commands / "demo-skill-deadbeef.md"
+            current = commands / "demo-skill-cafebabe.md"
+            unrelated = commands / "README.md"
+            user_cmd = commands / "my-helper.md"
+            for path in (stale, current, unrelated, user_cmd):
+                path.write_text("placeholder")
+
+            self.assertEqual(remove_stale_command_clones(Path(root), "demo"), 2)
+            self.assertFalse(stale.exists())
+            self.assertFalse(current.exists())
+            self.assertTrue(unrelated.exists())
+            self.assertTrue(user_cmd.exists())
+
+    def test_stale_sweep_noop_without_commands_dir(self):
+        with tempfile.TemporaryDirectory() as root:
+            self.assertEqual(remove_stale_command_clones(Path(root), "demo"), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Count a trigger when the model invokes **any** generated command clone for the skill under eval (`{skill}-skill-` prefix), not only the current worker's exact hash.
- Remove stale `{skill}-skill-*.md` clones from `.claude/commands/` once before parallel workers start, so interrupted runs do not contaminate later evals.
- Add focused unit tests for multi-worker matching and safe stale-clone cleanup.

Fixes #1427.

### Problem

With the default `--num-workers 10`, each worker writes an identical-description clone named `<skill>-skill-<uuid8>.md` into the shared project `.claude/commands/` directory, then only scores a trigger if the model invokes **its** hashed name. The model sees N identical entries and picks one arbitrarily, so per-worker match rate is ≤1/N and measured recall collapses toward 0. Orphans from killed runs make N worse and can carry outdated descriptions.

### Approach

Within one evaluation, all concurrent clones share the same description, so any clone hit is a valid trigger signal. Prefix matching fixes the false negatives without giving up parallelism or requiring isolated project roots. The startup sweep only touches the generated clone prefix, so user command files are left alone.

## Test plan

- [x] `python3.12 -m py_compile skills/skill-creator/scripts/run_eval.py skills/skill-creator/scripts/test_run_eval.py`
- [x] `cd skills/skill-creator && python3.12 -m unittest discover -s scripts -p "test_*.py" -v` (3 passed)
- [x] `git diff --check`