### PR TITLE
fix(web-artifacts-builder): avoid stray backup file from sed on macOS

### DIFF
--- a/skills/web-artifacts-builder/scripts/init-artifact.sh
+++ b/skills/web-artifacts-builder/scripts/init-artifact.sh
@@ -25,9 +25,9 @@ fi
 
 # Detect OS and set sed syntax
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  SED_INPLACE="sed -i ''"
+  sed_inplace() { sed -i '' "$@"; }
 else
-  SED_INPLACE="sed -i"
+  sed_inplace() { sed -i "$@"; }
 fi
 
 # Check if pnpm is installed
@@ -62,8 +62,8 @@ pnpm create vite "$PROJECT_NAME" --template react-ts
 cd "$PROJECT_NAME"
 
 echo "🧹 Cleaning up Vite template..."
-$SED_INPLACE '/<link rel="icon".*vite\.svg/d' index.html
-$SED_INPLACE 's/<title>.*<\/title>/<title>'"$PROJECT_NAME"'<\/title>/' index.html
+sed_inplace '/<link rel="icon".*vite\.svg/d' index.html
+sed_inplace 's/<title>.*<\/title>/<title>'"$PROJECT_NAME"'<\/title>/' index.html
 
 echo "📦 Installing base dependencies..."
 pnpm install


### PR DESCRIPTION
## Problem

`skills/web-artifacts-builder/scripts/init-artifact.sh` stores the in-place `sed` invocation in a string and expands it unquoted:

```bash
if [[ "$OSTYPE" == "darwin"* ]]; then
  SED_INPLACE="sed -i ''"
else
  SED_INPLACE="sed -i"
fi
...
$SED_INPLACE '/<link rel="icon".*vite\.svg/d' index.html
```

Quote removal does **not** apply to the result of a variable expansion, so on macOS `$SED_INPLACE` word-splits into `sed`, `-i`, `''` where the last token is two **literal** single-quote characters. BSD `sed -i <suffix>` then treats `''` as a backup-file suffix and writes a junk file literally named `index.html''` into the new project.

## Reproduce (macOS / bash)

```bash
SED_INPLACE="sed -i ''"
$SED_INPLACE 's/old/new/' index.html
ls   # -> index.html   index.html''   <- stray file
```

## Fix

Use a function so the empty backup suffix is passed as its own argument:

```bash
if [[ "$OSTYPE" == "darwin"* ]]; then
  sed_inplace() { sed -i '' "$@"; }
else
  sed_inplace() { sed -i "$@"; }
fi
```

and call `sed_inplace ...` at the two call sites. After the fix, running the script on macOS edits `index.html` in place with no stray `index.html''` left behind. Verified with `bash -n` and by running the two cleanup `sed` calls on a sample `index.html`.

Scope note: this only affects macOS (the Linux branch `sed -i` word-splits cleanly), so it bites developers running the script locally on a Mac rather than the Linux hosted path.
