### PR TITLE
fix(xlsx): match defined names case-insensitively in external_links_at_risk

### DIFF
--- a/skills/xlsx/scripts/recalc.py
+++ b/skills/xlsx/scripts/recalc.py
@@ -99,7 +99,10 @@ def external_links_at_risk(filename):
             if isinstance(getattr(dn, "value", None), str) and EXTERNAL_REF_RE.search(dn.value)
         ]
         name_re = (
-            re.compile(r"\b(" + "|".join(re.escape(n) for n in external_names) + r")\b")
+            re.compile(
+                r"\b(" + "|".join(re.escape(n) for n in external_names) + r")\b",
+                re.IGNORECASE,
+            )
             if external_names
             else None
         )

--- a/skills/xlsx/scripts/test_recalc_external_links.py
+++ b/skills/xlsx/scripts/test_recalc_external_links.py
@@ -1,0 +1,43 @@
+"""Regression tests for external_links_at_risk() in recalc.py."""
+
+import os
+import tempfile
+import unittest
+import zipfile
+
+from openpyxl import Workbook
+from openpyxl.workbook.defined_name import DefinedName
+
+from recalc import external_links_at_risk
+
+
+def _workbook_with_case_variant_name_reference(path: str) -> None:
+    wb = Workbook()
+    ws = wb.active
+    ws["A1"] = "=mixedcase+1"
+    wb.defined_names.add(
+        DefinedName("MixedCase", attr_text="[1]external.xlsx!$A$1")
+    )
+    wb.save(path)
+
+    with zipfile.ZipFile(path, "a") as archive:
+        archive.writestr(
+            "xl/externalLinks/externalLink1.xml",
+            '<?xml version="1.0"?>'
+            '<externalLink xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"/>',
+        )
+
+
+class ExternalLinksAtRiskTests(unittest.TestCase):
+    def test_matches_defined_names_case_insensitively(self):
+        fd, path = tempfile.mkstemp(suffix=".xlsx")
+        os.close(fd)
+        try:
+            _workbook_with_case_variant_name_reference(path)
+            self.assertEqual(external_links_at_risk(path), ["Sheet!A1"])
+        finally:
+            os.unlink(path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add `re.IGNORECASE` when compiling the defined-name regex in `external_links_at_risk()`, so formulas that reference external-linked names with different casing are correctly flagged as at-risk before recalculation.

## Motivation

Excel defined names are case-insensitive. A workbook may define `MixedCase` pointing to an external workbook, while a formula references it as `mixedcase`. The previous case-sensitive regex missed these cells, so `recalc.py` could proceed and destroy cached external-link values silently.

Fixes #1464

## Changes

- Compile the defined-name pattern with `re.IGNORECASE` in `skills/xlsx/scripts/recalc.py`
- Add `skills/xlsx/scripts/test_recalc_external_links.py` regression test covering a case-variant name reference with an injected `xl/externalLinks/` entry

## Tests

```bash
cd skills/xlsx/scripts
python3 -m unittest test_recalc_external_links.py -v
```

Result: 1 test passed.

## Notes

- composer-2.5 review: APPROVE
- This is intentionally conservative: case-insensitive matching may also match built-in function names that collide case-insensitively with an external defined name (e.g. defined name `Sum` vs formula `=SUM(...)`). That trade-off matches Excel semantics and is safer than missing at-risk cells.