### PR TITLE
fix(webapp-testing): declare allowed-tools for shell and file access

### DIFF
--- a/skills/webapp-testing/SKILL.md
+++ b/skills/webapp-testing/SKILL.md
@@ -2,6 +2,7 @@
 name: webapp-testing
 description: Toolkit for interacting with and testing local web applications using Playwright. Supports verifying frontend functionality, debugging UI behavior, capturing browser screenshots, and viewing browser logs.
 license: Complete terms in LICENSE.txt
+allowed-tools: Bash(python:*) Read Write
 ---
 
 # Web Application Testing


### PR DESCRIPTION
## Summary

Add `allowed-tools` frontmatter to the `webapp-testing` skill declaring the capabilities its bundled scripts and examples use.

## Motivation

Fixes #1468. The skill shells out via `scripts/with_server.py` and its Playwright examples read HTML and write screenshots/logs, but the frontmatter gave agents no pre-approval signal for those capabilities. This is the only vendored skill flagged by capability scanners for a missing permission declaration.

## Changes

- Add `allowed-tools: Bash(python:*) Read Write` to `skills/webapp-testing/SKILL.md`
  - `Bash(python:*)` — running `with_server.py` and Playwright automation scripts (documented entry points all use `python …`)
  - `Read` — reading local HTML and example files per the decision tree
  - `Write` — writing Playwright automation scripts agents produce

## Tests

- `python3 skills/skill-creator/scripts/quick_validate.py skills/webapp-testing` → **Skill is valid!**
- Composer 2.5 review: **APPROVE** (accurate, minimal, matches agentskills.io spec format)

## Notes

- `npm`/`node` dev-server commands are passed as arguments to `with_server.py`; the agent only invokes `python`, so separate `Bash(npm:*)` is not needed.
- Runtime file writes inside Python (screenshots to `/tmp`, logs to `/mnt/user-data/outputs`) are not agent `Write` tool calls.

Fixes #1468