### PR TITLE
Add git-commit-writer skill

### DIFF
--- a/skills/git-commit-writer/LICENSE.txt
+++ b/skills/git-commit-writer/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Anthropic, PBC.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/git-commit-writer/SKILL.md
+++ b/skills/git-commit-writer/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: git-commit-writer
+description: Write clear, conventional git commit messages from staged changes, unstaged diffs, or a described set of edits. Use whenever the user asks to "write a commit message", "commit these changes", "help me commit", generate a Conventional Commits message, split a large diff into logical commits, or draft a PR title/body from recent commits — even if they don't explicitly mention Conventional Commits or a style guide.
+---
+
+# Git Commit Writer
+
+Turn a diff into a well-structured git commit message. The default style is [Conventional Commits](https://www.conventionalcommits.org/) because it plays well with automated changelogs and semantic-release, but the skill adapts to whatever convention the target repository already uses.
+
+## When to use this skill
+
+Trigger for any of these signals:
+
+- User says "write a commit message", "commit this", "help me commit", "generate a commit", or "what should I put as the commit message".
+- User pastes a diff, describes code changes, or asks for a PR title/description.
+- User has staged files and wants a summary of them.
+- User asks to split a large change into multiple logical commits.
+
+## Workflow
+
+Follow these steps in order. Skip steps only when the user has already provided the information (e.g., they pasted the diff directly).
+
+### 1. Detect repository conventions
+
+Before writing anything, quickly check the repo for an existing convention so the new message blends in:
+
+```bash
+# Look at the last ~20 commits for prevailing style
+git log -20 --pretty=format:'%s'
+# Check for a commit lint config or contributor guide
+ls CONTRIBUTING.md commitlint.config.* .commitlintrc* .gitmessage 2>/dev/null
+```
+
+Rules of thumb:
+- If most subject lines look like `feat(scope): ...` / `fix: ...` → use **Conventional Commits**.
+- If they look like `[JIRA-123] Do the thing` → mirror the ticket-prefix style.
+- If they're free-form imperative sentences → match that.
+- If in doubt, default to Conventional Commits.
+
+### 2. Read the actual changes
+
+Never guess from filenames alone. Read the diff:
+
+```bash
+git diff --staged           # what's about to be committed
+git diff                    # unstaged changes
+git diff HEAD~1             # last commit's changes (for rewording)
+```
+
+For large diffs, focus on:
+- Which files changed and their roles (source, test, config, docs).
+- The public API surface (added/removed/renamed exports, function signatures).
+- Behavior changes vs. pure refactors.
+- Anything that looks like a breaking change.
+
+### 3. Classify the change
+
+Pick exactly one Conventional Commit type per commit:
+
+| Type       | Use when                                                              |
+|------------|-----------------------------------------------------------------------|
+| `feat`     | A user-visible feature or capability is added.                        |
+| `fix`      | A bug is fixed.                                                       |
+| `docs`     | Docs-only change (README, comments, guides).                          |
+| `refactor` | Internal restructure with no behavior change.                         |
+| `perf`     | Performance improvement without changing behavior.                    |
+| `test`     | Adding or fixing tests only.                                          |
+| `build`    | Build system, package manager, or dependency changes.                 |
+| `ci`       | CI configuration (GitHub Actions, CircleCI, etc.).                    |
+| `chore`    | Housekeeping that doesn't fit above (formatting, renames, cleanup).   |
+| `revert`   | Reverts a previous commit.                                            |
+
+Optional scope in parentheses (`feat(auth): ...`) — use the top-level module, package, or directory name that changed.
+
+### 4. Write the message
+
+Format:
+
+```
+<type>(<optional scope>): <imperative subject, ≤ 72 chars, no trailing period>
+
+<optional body: what changed and why, wrapped at ~72 chars, blank line after subject>
+
+<optional footers>
+```
+
+**Subject line rules:**
+- Imperative mood: "add", "fix", "remove" — not "added", "fixes", "removing".
+- Lowercase first word after the colon (unless it's a proper noun).
+- No trailing period.
+- ≤ 72 characters. Aim for 50 if you can.
+
+**Body rules (include when the change isn't self-explanatory):**
+- Explain **what** and **why**, not **how** — the diff shows how.
+- Wrap at ~72 chars.
+- Reference issues/tickets in footers, not the subject.
+
+**Footers:**
+- `BREAKING CHANGE: <description>` — for breaking API changes. Also allowed as `!` after the type: `feat(api)!: drop v1 endpoints`.
+- `Refs: #123`, `Closes: #456`, `Co-authored-by: Name <email>`.
+
+### 5. Splitting a large diff into multiple commits
+
+If the staged diff mixes unrelated concerns, propose a split before writing messages. Group hunks by:
+1. Bug fixes vs. features vs. refactors — never combine.
+2. Public API changes vs. internal.
+3. Source vs. test vs. docs vs. build config (small doc/test bumps that accompany a code change can stay together).
+
+Present the proposed split as a numbered list and let the user confirm, then produce one message per group. Suggest the `git add -p` workflow to stage each group.
+
+### 6. Present the result
+
+Always show the final message in a fenced code block so the user can copy it verbatim:
+
+````
+```
+feat(auth): support passkey login
+
+Add WebAuthn registration and assertion endpoints behind the
+`AUTH_PASSKEYS` feature flag. Falls back to password login when
+the flag is off.
+
+Refs: #4821
+```
+````
+
+If you produced multiple commits, show each in its own code block with a one-line description above it.
+
+## Examples
+
+### Example 1 — small fix
+
+**Diff:** one-line change in `src/utils/date.ts` fixing an off-by-one in `daysBetween`.
+
+```
+fix(utils): correct off-by-one in daysBetween
+
+The end date was excluded from the range, causing all durations
+to be reported one day short. Include it and update the tests.
+
+Closes: #312
+```
+
+### Example 2 — feature with breaking change
+
+**Diff:** removes the old `/v1/users` endpoint and adds `/v2/users`.
+
+```
+feat(api)!: replace /v1/users with /v2/users
+
+The v2 endpoint returns paginated results and uses cursor-based
+navigation. Clients pinned to v1 must migrate before deploy.
+
+BREAKING CHANGE: /v1/users has been removed. Use /v2/users with
+the `cursor` query parameter.
+```
+
+### Example 3 — pure refactor
+
+**Diff:** extracts `formatCurrency` into its own module; no behavior change.
+
+```
+refactor(billing): extract formatCurrency into shared module
+
+No behavior change. Prepares for reuse in the upcoming invoice
+export feature.
+```
+
+### Example 4 — docs-only
+
+```
+docs(readme): clarify local setup for Windows users
+```
+
+## Anti-patterns to avoid
+
+- `update` / `fix stuff` / `wip` — meaningless subjects.
+- Ending the subject with a period.
+- Past tense (`added feature X`).
+- Mentioning file names in the subject when a scope would do (`fix(auth)` beats `fix login.ts`).
+- Combining unrelated changes in one commit.
+- Restating the diff in the body — say **why**, not **what line changed**.
+
+## Handoff
+
+If the user wants you to actually create the commit, run:
+
+```bash
+git commit -m "<subject>" -m "<body>"
+```
+
+Otherwise just output the message and let them run it themselves. For messages with complex bodies, suggest:
+
+```bash
+git commit -F- <<'MSG'
+<paste the full message here>
+MSG
+```
+
+## Further reading
+
+- [`references/conventional-commits.md`](references/conventional-commits.md) — quick reference for the Conventional Commits spec.

--- a/skills/git-commit-writer/references/conventional-commits.md
+++ b/skills/git-commit-writer/references/conventional-commits.md
@@ -1,0 +1,79 @@
+# Conventional Commits — Quick Reference
+
+Adapted from <https://www.conventionalcommits.org/en/v1.0.0/>.
+
+## Structure
+
+```
+<type>[optional scope][!]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+The `!` before the colon (or a `BREAKING CHANGE:` footer) signals a breaking change and, under semantic-release, bumps the major version.
+
+## Types and their SemVer effect
+
+| Type       | SemVer bump         | Notes                                             |
+|------------|---------------------|---------------------------------------------------|
+| `feat`     | MINOR               | New user-visible capability.                      |
+| `fix`      | PATCH               | Bug fix.                                          |
+| `perf`     | PATCH               | Performance improvement.                          |
+| `refactor` | none                | Internal restructure, no behavior change.         |
+| `docs`     | none                | Documentation only.                               |
+| `test`     | none                | Tests only.                                       |
+| `build`    | none                | Build system or external dependencies.            |
+| `ci`       | none                | CI configuration.                                 |
+| `chore`    | none                | Housekeeping that doesn't fit elsewhere.          |
+| `revert`   | matches reverted    | Reverts an earlier commit.                        |
+| any `!`    | MAJOR               | Breaking change on top of the base type.          |
+
+## Scope
+
+Optional single token in parentheses identifying the affected area:
+
+```
+feat(parser): add ability to parse arrays
+fix(auth): reject expired refresh tokens
+```
+
+Prefer scopes that match top-level package/module names in the repo. Keep them short (one word if possible).
+
+## Footers
+
+Follow the [git trailer format](https://git-scm.com/docs/git-interpret-trailers) — one per line, `Token: value`.
+
+Common footers:
+
+- `BREAKING CHANGE: <description>` — full description of the break.
+- `Refs: #123` — related issue, no auto-close.
+- `Closes: #123` / `Fixes: #123` — auto-close on merge (GitHub/GitLab).
+- `Co-authored-by: Name <email@example.com>` — credit collaborators.
+- `Reviewed-by:`, `Signed-off-by:` — code-review / DCO trailers.
+
+## Full example
+
+```
+feat(shopping-cart)!: switch to server-side cart persistence
+
+Move cart storage from localStorage to the /carts service so that
+carts survive across devices and browser reinstalls. Anonymous
+users get a cookie-scoped cart that is merged into their account
+cart on login.
+
+BREAKING CHANGE: The client-side `Cart` API is removed. Consumers
+must call `useCart()` which now returns a promise.
+
+Closes: #1841
+Refs: RFC-0007
+```
+
+## Common mistakes
+
+- Writing `Fix: bug` — the type is `fix`, lowercase, no colon before the scope.
+- Adding the ticket ID to the subject (`fix: JIRA-123 fix login`) — put it in a footer.
+- Squashing unrelated changes under a single `chore:` — split them by concern.
+- Using past tense (`fixed`, `added`) — Conventional Commits uses imperative mood.
+- Ending the subject with a period.


### PR DESCRIPTION
Introduces a new skill that generates Conventional Commits-style messages from staged or unstaged diffs, adapts to the target repo's existing convention, and can split large diffs into logical commits. Includes a references/conventional-commits.md quick reference.