### PR TITLE
xlsx: match defined names case-insensitively in external_links_at_risk

### DIFF
--- a/skills/xlsx/scripts/recalc.py
+++ b/skills/xlsx/scripts/recalc.py
@@ -99,7 +99,10 @@ def external_links_at_risk(filename):
             if isinstance(getattr(dn, "value", None), str) and EXTERNAL_REF_RE.search(dn.value)
         ]
         name_re = (
-            re.compile(r"\b(" + "|".join(re.escape(n) for n in external_names) + r")\b")
+            re.compile(
+                r"\b(" + "|".join(re.escape(n) for n in external_names) + r")\b",
+                re.IGNORECASE,
+            )
             if external_names
             else None
         )

--- a/skills/xlsx/scripts/test_external_links_case.py
+++ b/skills/xlsx/scripts/test_external_links_case.py
@@ -1,0 +1,65 @@
+"""
+Regression test for anthropics/skills#1464.
+
+external_links_at_risk() must match defined-name references case-insensitively,
+since Excel treats defined names as case-insensitive.
+"""
+import shutil
+import sys
+import zipfile
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from openpyxl import Workbook
+from openpyxl.workbook.defined_name import DefinedName
+
+from recalc import external_links_at_risk
+
+
+def build_workbook(path):
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Sheet1"
+
+    # Defined name that "points at" an external workbook, matching the
+    # EXTERNAL_REF_RE shape used to seed `external_names`.
+    wb.defined_names["MixedCase"] = DefinedName(
+        name="MixedCase", attr_text="[1]Sheet1!$A$1"
+    )
+
+    # Formula referencing the name in different case, with no cached value
+    # (mirrors a value openpyxl would strip on save).
+    ws["A1"] = "=mixedcase+1"
+
+    wb.save(path)
+
+    # openpyxl can't author a real xl/externalLinks/ part, but
+    # external_links_at_risk() only checks for the path's presence, so
+    # inject a placeholder entry into the zip.
+    with zipfile.ZipFile(path, "a") as z:
+        z.writestr("xl/externalLinks/externalLink1.xml", "<externalLink/>")
+
+
+def main():
+    tmp_dir = Path("/tmp/xlsx-case-test")
+    tmp_dir.mkdir(exist_ok=True)
+    path = tmp_dir / "case_variant.xlsx"
+    if path.exists():
+        path.unlink()
+
+    build_workbook(path)
+
+    at_risk = external_links_at_risk(str(path))
+    assert at_risk == ["Sheet1!A1"], (
+        f"expected 'Sheet1!A1' to be reported as at-risk (case-insensitive "
+        f"defined-name match), got: {at_risk}"
+    )
+    print("PASS: case-variant reference to a defined name is detected as at-risk")
+
+    shutil.rmtree(tmp_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Fixes #1464
- `external_links_at_risk()` in `skills/xlsx/scripts/recalc.py` builds a regex from external-linked defined names but compiles it without `re.IGNORECASE`. Excel defined names are case-insensitive, so a formula referencing a name with different casing than its stored spelling was not matched, causing the safeguard to under-report and `recalc(force=False)` to proceed when it should refuse — potentially destroying cached external-link values silently.
- Added `re.IGNORECASE` at the compile site, as suggested in the issue.

## Test plan
- Added `skills/xlsx/scripts/test_external_links_case.py`: builds a workbook with a defined name `MixedCase` pointing at an external link, referenced in a formula as `mixedcase`, and asserts `external_links_at_risk()` reports that cell.
- Verified the test fails on the pre-fix code (confirms it actually catches the regression) and passes with the fix applied.
- Ran in a local venv with `openpyxl` installed; no other dependencies required since the test only exercises `external_links_at_risk()`, not the LibreOffice recalculation path.