### PR TITLE
Add resume-scorer skill for evaluating resumes against job descriptions

### DIFF
--- a/skills/resume-scorer/LICENSE.txt
+++ b/skills/resume-scorer/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Anthropic, PBC.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/resume-scorer/README.md
+++ b/skills/resume-scorer/README.md
@@ -1,0 +1,86 @@
+# Resume Scorer Skill
+
+Evaluate a resume PDF against a job description to produce a structured assessment with per-criterion scores, strengths, gaps, and actionable improvement suggestions.
+
+## Usage
+
+Provide a resume PDF and a job description:
+
+```
+Score my resume at ~/Documents/resume.pdf against this job description:
+
+Senior Backend Engineer at Acme Corp
+Requirements:
+- 5+ years Python experience
+- PostgreSQL, Redis, Docker
+- Experience with microservices architecture
+...
+```
+
+Or reference a JD file:
+
+```
+Evaluate resume.pdf against the job posting in job-description.txt
+```
+
+## What You Get
+
+- **Overall score** (0-10) with a descriptor (Exceptional / Strong / Moderate / Weak / Poor match)
+- **Per-criterion breakdown** with individual scores, weights, and notes
+- **Strengths**: what the resume does well relative to the role
+- **Gaps**: specific JD requirements the resume does not address
+- **Improvement suggestions**: concrete, actionable steps to strengthen the resume
+- **Keyword analysis**: which JD keywords appear in the resume and which are missing
+
+## Default Scoring Criteria
+
+| Criterion | Weight | Description |
+|-----------|--------|-------------|
+| Technical Skills Match | 30% | Overlap between resume skills and JD required/preferred skills |
+| Experience Relevance | 25% | Years and relevance of past roles to the target position |
+| Education Alignment | 15% | Degree level and field vs. JD education requirements |
+| Keyword Coverage | 15% | Presence of JD-specific terms and phrases in the resume |
+| Certifications & Extras | 10% | Relevant certifications, publications, awards |
+| Presentation Quality | 5% | Structure, clarity, quantified achievements |
+
+## Configuration
+
+### Adjusting Weights
+
+Ask for different weights:
+
+```
+Score my resume but weight technical skills at 40% and reduce education to 10%
+```
+
+### Adding Custom Criteria
+
+```
+Also evaluate leadership experience as a criterion with 15% weight
+```
+
+### Different Output Formats
+
+```
+Give me the evaluation as JSON
+```
+
+```
+Write the evaluation report to evaluation.md
+```
+
+### Comparing Multiple Resumes
+
+```
+Compare these three resumes against the same JD:
+- candidate_a.pdf
+- candidate_b.pdf
+- candidate_c.pdf
+```
+
+## Files
+
+- `SKILL.md` - Skill definition and instructions
+- `criteria.json` - Configurable scoring rubric with weights, scales, and scoring guidance
+- `README.md` - This file
+- `LICENSE.txt` - Apache 2.0 license

--- a/skills/resume-scorer/SKILL.md
+++ b/skills/resume-scorer/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: resume-scorer
+description: Evaluate a resume PDF against a job description. Use this skill whenever the user wants to score, evaluate, review, compare, or assess a resume against a job posting, job description, or role requirements. Also use when the user wants to identify gaps in a resume, get improvement suggestions, check keyword alignment, or understand how well a candidate matches a position. Triggers on mentions of resume review, resume scoring, resume analysis, job fit assessment, ATS optimization, or candidate evaluation.
+license: Complete terms in LICENSE.txt
+---
+
+# Resume Scorer
+
+Evaluate a resume against a job description, producing a structured assessment with per-criterion scores, strengths, gaps, and actionable improvement suggestions.
+
+## Inputs
+
+1. **Resume**: A PDF file path. Extract text using `pdfplumber` (preferred) or `pypdf`.
+2. **Job Description**: Either inline text or a file path (`.txt`, `.md`, `.pdf`, or `.docx`). If the user pastes the JD directly in the conversation, use that.
+
+If the user provides only a resume without a JD, ask for the job description before proceeding. If the user provides only a JD, ask for the resume.
+
+## Workflow
+
+### Step 1: Extract Resume Content
+
+```python
+import pdfplumber
+
+with pdfplumber.open(resume_path) as pdf:
+    text = "\n".join(page.extract_text() or "" for page in pdf.pages)
+```
+
+If `pdfplumber` is unavailable, fall back to `pypdf`:
+
+```python
+from pypdf import PdfReader
+
+reader = PdfReader(resume_path)
+text = "\n".join(page.extract_text() or "" for page in reader.pages)
+```
+
+### Step 2: Parse Structured Data from the Resume
+
+Extract and organize the following sections from the raw text. Not every resume will have all sections; extract what is present and note what is missing.
+
+- **Contact Information**: Name, email, phone, LinkedIn, location
+- **Summary / Objective**: Professional summary or career objective
+- **Experience**: For each role: title, company, dates, duration, bullet points
+- **Education**: Degree, institution, graduation date, GPA (if listed)
+- **Skills**: Technical skills, tools, languages, frameworks
+- **Certifications**: Name, issuing body, date
+- **Projects**: Notable projects with descriptions
+- **Publications / Awards**: If present
+
+### Step 3: Parse the Job Description
+
+Extract key requirements from the JD:
+
+- **Required Skills**: Hard skills, technologies, tools explicitly required
+- **Preferred Skills**: Nice-to-have qualifications
+- **Experience Requirements**: Minimum years, specific domain experience
+- **Education Requirements**: Degree level, field of study
+- **Responsibilities**: Core duties of the role
+- **Keywords**: Domain-specific terms, certifications, methodologies
+
+### Step 4: Score Against Criteria
+
+Read the `criteria.json` file bundled with this skill to load the scoring rubric. Each criterion has a name, weight, max score, and scoring guidance.
+
+The default criteria are:
+
+| Criterion | Weight | What to Evaluate |
+|-----------|--------|------------------|
+| Technical Skills Match | 30% | Overlap between resume skills and JD required/preferred skills |
+| Experience Relevance | 25% | Years of experience, relevance of past roles to the target position |
+| Education Alignment | 15% | Degree level and field match against JD requirements |
+| Keyword Coverage | 15% | Presence of JD-specific terms, tools, methodologies in the resume |
+| Certifications & Extras | 10% | Relevant certifications, publications, awards |
+| Presentation Quality | 5% | Clarity, structure, quantified achievements, action verbs |
+
+For each criterion, assign a score from 0 to 10 based on the guidance in `criteria.json`, then compute the weighted overall score.
+
+### Step 5: Produce the Evaluation Report
+
+Output the evaluation as structured text (or JSON if the user requests it) with these sections:
+
+```
+## Resume Evaluation Report
+
+### Candidate
+[Name] | [Current/Most Recent Title]
+
+### Overall Score: [X.X / 10] ([descriptor])
+
+Score descriptors:
+- 9.0-10.0: Exceptional match
+- 7.5-8.9: Strong match
+- 6.0-7.4: Moderate match
+- 4.0-5.9: Weak match
+- 0.0-3.9: Poor match
+
+### Per-Criterion Breakdown
+| Criterion | Score | Weight | Weighted Score | Notes |
+|-----------|-------|--------|----------------|-------|
+| ...       | X/10  | XX%    | X.XX           | ...   |
+
+### Strengths
+- [Specific strength with evidence from the resume]
+- ...
+
+### Gaps
+- [Specific gap: what the JD requires that the resume lacks]
+- ...
+
+### Improvement Suggestions
+1. [Actionable suggestion to improve the resume for this role]
+2. ...
+
+### Keyword Analysis
+- **Present**: [keywords found in both resume and JD]
+- **Missing**: [JD keywords not found in resume]
+```
+
+## Customization
+
+Users can customize scoring by:
+
+1. **Adjusting weights**: "Weight technical skills at 40% instead of 30%"
+2. **Adding criteria**: "Also score for leadership experience"
+3. **Changing scale**: "Use a 100-point scale"
+4. **Focusing on specific areas**: "Only evaluate the technical skills match"
+
+When the user requests custom criteria, modify the rubric accordingly and note the changes in the report.
+
+## Multiple Resumes
+
+If the user provides multiple resumes to compare against the same JD:
+
+1. Score each independently
+2. Produce a comparison summary table ranking candidates
+3. Highlight differentiators between top candidates
+
+## Output Formats
+
+- **Default**: Structured markdown report in the conversation
+- **JSON**: If requested, output a machine-readable JSON object with all scores and analysis
+- **File**: If requested, write the report to a `.md` or `.txt` file
+
+## Guidelines
+
+- Be objective and evidence-based. Every score should be justified by specific content from the resume and JD.
+- Do not penalize for information not typically found on resumes (age, photo, etc.).
+- Recognize equivalent skills (e.g., "React" matches "React.js", "ReactJS"; "AWS" matches "Amazon Web Services").
+- Account for seniority: a senior role JD should weight experience more heavily; an entry-level JD should weight education and projects more.
+- When skills are listed in the JD as "preferred" vs "required", weight required skills more heavily in the technical match score.
+- Flag potential ATS issues: missing keywords, unusual formatting notes from extraction, etc.
+- Keep suggestions constructive and specific rather than generic.

--- a/skills/resume-scorer/criteria.json
+++ b/skills/resume-scorer/criteria.json
@@ -1,0 +1,130 @@
+{
+  "version": "1.0",
+  "scale": {
+    "min": 0,
+    "max": 10,
+    "descriptors": {
+      "9.0-10.0": "Exceptional match",
+      "7.5-8.9": "Strong match",
+      "6.0-7.4": "Moderate match",
+      "4.0-5.9": "Weak match",
+      "0.0-3.9": "Poor match"
+    }
+  },
+  "criteria": [
+    {
+      "name": "Technical Skills Match",
+      "key": "technical_skills",
+      "weight": 0.30,
+      "description": "How well the candidate's technical skills align with the job requirements.",
+      "scoring": {
+        "9-10": "Meets or exceeds all required technical skills and most preferred skills.",
+        "7-8": "Meets most required technical skills, some preferred skills present.",
+        "5-6": "Meets roughly half of the required technical skills.",
+        "3-4": "Meets a few required skills but has significant gaps.",
+        "0-2": "Very little overlap between candidate skills and job requirements."
+      },
+      "evaluation_notes": [
+        "Match required skills before preferred skills.",
+        "Recognize equivalent names (e.g., 'JS' = 'JavaScript', 'K8s' = 'Kubernetes').",
+        "Consider transferable skills from adjacent technologies.",
+        "Differentiate between listed skills and demonstrated skills (used in projects/roles)."
+      ]
+    },
+    {
+      "name": "Experience Relevance",
+      "key": "experience_relevance",
+      "weight": 0.25,
+      "description": "How closely the candidate's work history matches the role's responsibilities and experience requirements.",
+      "scoring": {
+        "9-10": "Extensive directly relevant experience meeting or exceeding the required years. Prior roles closely mirror the target position.",
+        "7-8": "Solid relevant experience near the required years. Most past responsibilities align with the role.",
+        "5-6": "Some relevant experience but gaps in years or domain relevance. Partial alignment with role responsibilities.",
+        "3-4": "Limited relevant experience. Most past roles are in tangentially related areas.",
+        "0-2": "No relevant experience. Career history is unrelated to the target role."
+      },
+      "evaluation_notes": [
+        "Calculate total years of relevant experience from employment dates.",
+        "Weight recent experience more heavily than older roles.",
+        "Look for progression and increasing responsibility.",
+        "Quantified achievements (revenue, users, performance) strengthen this score."
+      ]
+    },
+    {
+      "name": "Education Alignment",
+      "key": "education_alignment",
+      "weight": 0.15,
+      "description": "How well the candidate's educational background meets the stated requirements.",
+      "scoring": {
+        "9-10": "Exceeds education requirements (e.g., Master's when Bachelor's required) in a directly relevant field.",
+        "7-8": "Meets the stated degree requirement in a relevant or closely related field.",
+        "5-6": "Has the required degree level but in a less relevant field, or is one level below in a relevant field.",
+        "3-4": "Education is partially relevant but does not meet the stated minimum.",
+        "0-2": "Education is unrelated or significantly below requirements."
+      },
+      "evaluation_notes": [
+        "If the JD says 'or equivalent experience', treat strong experience as satisfying this criterion.",
+        "Consider bootcamps, MOOCs, and professional training as supplementary education.",
+        "GPA matters only if explicitly requested in the JD.",
+        "Relevant coursework or thesis work can boost the score even if the degree field is not a direct match."
+      ]
+    },
+    {
+      "name": "Keyword Coverage",
+      "key": "keyword_coverage",
+      "weight": 0.15,
+      "description": "Presence of important terms, tools, and domain-specific language from the job description in the resume.",
+      "scoring": {
+        "9-10": "Nearly all important JD keywords and phrases appear naturally in the resume.",
+        "7-8": "Most critical keywords present. A few niche terms missing.",
+        "5-6": "About half of the important keywords found. Several notable omissions.",
+        "3-4": "Few JD keywords present. Resume uses different terminology for most concepts.",
+        "0-2": "Almost no keyword overlap. Resume appears to be for a different domain."
+      },
+      "evaluation_notes": [
+        "Extract keywords from job title, responsibilities, requirements, and preferred sections.",
+        "Count both exact matches and semantic equivalents.",
+        "Keyword stuffing without context should not boost this score.",
+        "Consider ATS implications: missing keywords may cause automated filtering."
+      ]
+    },
+    {
+      "name": "Certifications & Extras",
+      "key": "certifications_extras",
+      "weight": 0.10,
+      "description": "Relevant certifications, licenses, publications, patents, awards, or other differentiators.",
+      "scoring": {
+        "9-10": "Holds certifications or credentials explicitly required or strongly preferred in the JD, plus additional relevant differentiators.",
+        "7-8": "Has most certifications mentioned in the JD or strong alternative differentiators.",
+        "5-6": "Has some relevant certifications or noteworthy extras, but missing key ones from the JD.",
+        "3-4": "Few relevant extras. Certifications are outdated or only tangentially related.",
+        "0-2": "No relevant certifications or extras. JD lists specific required certifications that are absent."
+      },
+      "evaluation_notes": [
+        "Only penalize for missing certifications if the JD explicitly requires or prefers them.",
+        "Open source contributions, conference talks, and publications count as extras.",
+        "Expired or outdated certifications should be noted but scored lower.",
+        "If the JD does not mention certifications, score based on any differentiators present."
+      ]
+    },
+    {
+      "name": "Presentation Quality",
+      "key": "presentation_quality",
+      "weight": 0.05,
+      "description": "Clarity, structure, and professionalism of the resume itself.",
+      "scoring": {
+        "9-10": "Well-structured with clear sections, quantified achievements, strong action verbs, and concise language. Easy to scan.",
+        "7-8": "Good structure and mostly clear. Some achievements quantified. Minor areas for improvement.",
+        "5-6": "Adequate structure but lacking polish. Few quantified results. Some unclear descriptions.",
+        "3-4": "Poorly organized or hard to follow. Vague descriptions. Missing key sections.",
+        "0-2": "Very poor presentation. Major structural issues, excessive length, or missing critical information."
+      },
+      "evaluation_notes": [
+        "This score is about the resume as a document, not the candidate's qualifications.",
+        "Look for: action verbs, quantified results, consistent formatting, appropriate length.",
+        "Note any extraction artifacts that may indicate formatting issues in the original PDF.",
+        "A well-targeted resume (tailored to the specific role) scores higher than a generic one."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- New skill: `resume-scorer` — evaluates a resume PDF against a job description
- Extracts structured data (experience, education, skills, certifications) from resume PDF
- Scores against 6 weighted criteria: technical skills (30%), experience relevance (25%), education (15%), keyword coverage (15%), certifications (10%), presentation (5%)
- Includes configurable `criteria.json` rubric with scoring bands (0-10 scale)
- Supports multi-resume comparison mode

## Files
- `skills/resume-scorer/SKILL.md` — skill definition with full instructions
- `skills/resume-scorer/criteria.json` — configurable scoring rubric
- `skills/resume-scorer/README.md` — usage examples and configuration
- `skills/resume-scorer/LICENSE.txt` — Apache 2.0

## Test plan
- [x] Skill file follows repo conventions (YAML frontmatter, structured instructions)
- [x] Criteria JSON is valid and well-structured
- [x] README covers basic and advanced usage

Developed with Claude Code as a coding partner