### PR TITLE
Add mars-review: holistic multi-perspective paper review skill

### DIFF
--- a/skills/mars-review/LICENSE.txt
+++ b/skills/mars-review/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Kunal Pai.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/mars-review/README.md
+++ b/skills/mars-review/README.md
@@ -1,0 +1,63 @@
+# mars-review
+
+`/mars-review` — a Claude skill that runs a holistic, panel-style peer review of a research
+paper. It distills the methodology of **[MARS: Multi-Agent Review System for Academic
+Papers](https://www.kunpai.space/assets/papers/MARS.pdf)** (Pai & Shetty, UC Davis) into a
+protocol a single Claude session can execute: independent persona reviewers, grounded
+specialist checks, deliberation, and a meta-review — with explicit coverage accounting so
+nothing in the paper gets skimmed.
+
+## What it does
+
+Given a paper (PDF, LaTeX project, or Markdown) and optionally a venue/CFP URL, the skill runs:
+
+1. **Desk check** — scope fit against the actual CFP topics (gates the review, as in MARS's desk reviewer)
+2. **Holistic map** — section inventory plus a claims–evidence table, including an internal-consistency audit (numbers reported differently in two places, abstract overclaiming vs. body)
+3. **Independent panel** — three fixed, function-matched reviewer personas (domain expert, methodologist, informed outsider) reviewing the *whole* paper, each producing a decision plus quality/novelty/soundness/clarity scores
+4. **Grounded specialist passes** — novelty checked against retrieved related work (arXiv + Semantic Scholar), load-bearing citations resolved and verified via Crossref, clarity notes kept advisory (non-voting)
+5. **Socratic Q&A probe** — open-ended questions answered strictly from the paper's own text; the unanswerable residue becomes findings (MARS's questioner, repurposed as a completeness instrument)
+6. **Board-room deliberation** — reviews meet, revisions are recorded, meeting-style minutes are written, and the panel decision is computed by explicit arithmetic
+7. **Coverage audit** — a final self-check table proving every section was addressed
+
+## Contents
+
+```
+SKILL.md                  the review protocol (Claude skill definition)
+scripts/paper_search.py   arXiv + Semantic Scholar retrieval (stdlib only, no API keys)
+scripts/bib_resolve.py    BibTeX parsing + Crossref citation verification (stdlib only)
+```
+
+The bundled scripts run with the Python standard library only:
+
+```bash
+python scripts/paper_search.py "your related-work query" --max 5
+python scripts/bib_resolve.py parse refs.bib somekey2024
+python scripts/bib_resolve.py verify "Some Paper Title" --author "Surname"
+```
+
+## Relation to MARS
+
+MARS orchestrates multiple local LLMs (Mistral, Llama 3.2, Qwen2.5, DeepSeek-R1) as
+sequential reviewers with specialist agents for desk review, novelty, grammar, Socratic
+questioning, and insight fetching. This skill keeps that methodology — persona-driven
+multi-perspective review, CFP-grounded desk checking, retrieval-grounded novelty, Socratic
+questioning, and meta-review summarization — while adapting it for a single-model setting:
+whole-paper (rather than section-wise) judgment, deterministic decision aggregation, and a
+coverage audit as the success criterion.
+
+## Citation
+
+If you use this skill or build on the methodology, please cite the MARS paper:
+
+```bibtex
+@article{pai2025mars,
+  title   = {{MARS}: Multi-Agent Review System for Academic Papers},
+  author  = {Pai, Kunal and Shetty, Saisha},
+  year    = {2025},
+  note    = {Equal contribution},
+  url     = {https://www.kunpai.space/assets/papers/MARS.pdf}
+}
+```
+
+Original MARS implementation: [github.com/kunpai/MARS](https://github.com/kunpai/MARS)
+Original standalone skill: [github.com/kunpai/MARS-Claude](https://github.com/kunpai/MARS-Claude)

--- a/skills/mars-review/SKILL.md
+++ b/skills/mars-review/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: mars-review
+description: >
+  Run a multi-perspective peer review of a research paper using a structured panel protocol
+  (independent persona reviewers → grounded specialist checks → deliberation → meta-review),
+  distilled from the MARS multi-agent review system. The success criterion is HOLISM: every
+  section, every claim, and every review dimension gets covered, and claims are traced to
+  evidence across sections. Use this whenever the user asks to review a paper or draft, act
+  as a peer reviewer or reviewer panel, do a pre-submission check, predict "what reviewers
+  would say", assess a paper against a venue or CFP, or critique a manuscript — even if they
+  just say "look over my paper" or attach a PDF/LaTeX project and ask what's weak.
+---
+
+# Holistic Paper Review (MARS-style panel protocol)
+
+Simulate a review panel the way MARS does — independent persona reviewers, grounded
+specialist agents, and a meta-reviewer — but organized so nothing escapes review. The
+protocol exists because single-pass LLM reviews anchor on whatever they notice first and
+skim the rest. Independence-then-deliberation, plus explicit coverage accounting, is what
+buys holism.
+
+Non-negotiable principle: **the unit of review is the whole paper.** Sections get attention
+individually, but every judgment (novelty, soundness, decision) is made with the full paper
+in view. A methods section cannot be judged sound without seeing the results it produces.
+
+## Phase 0 — Intake and desk check (gate)
+
+Read the entire paper before writing anything. Accept PDF, LaTeX project, Markdown, or
+plain text; for LaTeX, read every `.tex` and `.bib` file.
+
+If the user names a target venue or gives a CFP URL, fetch the CFP and extract its topics.
+Then make a desk decision: is the paper plausibly in scope? Report it as
+`{decision: in-scope | out-of-scope, reasoning}`. If out-of-scope, say so, explain, ask
+whether to continue anyway — and stop unless told otherwise. (A desk check that gates
+nothing is theater.) If no venue is given, skip the scope question but still record the
+paper's apparent audience and contribution type.
+
+## Phase 1 — Holistic map (the backbone)
+
+Before any opinions, build two artifacts. Everything downstream refers back to them.
+
+**Section inventory:** every section, with a one-line summary and its role
+(motivation / method / evidence / discussion / boilerplate).
+
+**Claims–evidence table:** every substantive claim the paper makes (contributions,
+performance numbers, comparisons, generality statements), formatted as:
+
+| # | Claim | Stated in | Evidence in | Status |
+|---|-------|-----------|-------------|--------|
+| 1 | "2.3× speedup over baseline X" | Abstract, §1 | §5.2, Table 3 | supported / partial / unsupported / contradicted |
+
+This table is the holism instrument: abstract promises that no section cashes out, results
+that no claim references, and cross-section contradictions all become visible here. Flag
+every claim whose status is not "supported."
+
+**Internal-consistency audit.** While building the table, actively hunt for the paper
+contradicting *itself* — this catches problems no external search can: the same quantity
+reported with different values in two places (an n, a percentage, a table cell vs. prose),
+the abstract claiming more than the body demonstrates ("at any volume" when only one
+volume was tested), scope or mechanism claims that a later section explicitly walks back,
+and conditions defined in the setup that never appear in the results. Record each mismatch
+in the table with both locations and status `contradicted`. These are the findings human
+reviewers use to reject papers, so err toward checking every number that appears twice.
+
+## Phase 2 — Independent panel (three reviewers)
+
+Three reviewers with **fixed, function-matched personas** — not random attributes. Each
+persona exists to catch a different class of problem:
+
+- **R1 — Domain expert** (deep knowledge of the paper's subfield; critical tone).
+  Focus: technical soundness, novelty relative to the state of the art, whether the
+  approach is well-motivated.
+- **R2 — Methodologist** (statistics/experimental-design skeptic; neutral tone).
+  Focus: evaluation validity, baselines, ablations, statistical rigor, reproducibility,
+  threats to validity.
+- **R3 — Informed outsider** (adjacent-field reader; supportive tone).
+  Focus: clarity, positioning, significance beyond the subfield, whether the paper is
+  understandable and its impact case convincing.
+
+Write the three reviews **independently**: draft each as if the others do not exist, and do
+not reuse phrasing or observations across them — if the same weakness occurs to you for two
+reviewers, that is fine (convergence is signal), but each must arrive at it through its own
+persona's lens and cite its own evidence. Each reviewer reads the whole paper and the
+Phase 1 map.
+
+Each review uses exactly this structure:
+
+```json
+{
+  "decision": "Accept | WeakAccept | WeakReject | Reject",
+  "scores": {"quality": 1-10, "novelty": 1-10, "soundness": 1-10, "clarity": 1-10},
+  "summary": "2-3 sentences on what the paper does and claims",
+  "strengths": ["..."],
+  "weaknesses": ["... — each must cite specific sections/tables/lines"],
+  "questions_for_authors": ["..."]
+}
+```
+
+Weaknesses without a location reference are not allowed; vague criticism is how reviews
+lose holism.
+
+## Phase 3 — Grounded specialist passes
+
+These run alongside the panel and feed the deliberation. Ground them in real retrieval —
+ungrounded novelty opinions are worthless.
+
+**Novelty scout.** Formulate 2–3 search queries from the paper's actual contribution
+statements (not term frequency — write the queries the way a knowledgeable reviewer would).
+Retrieve related work with the bundled script (arXiv + Semantic Scholar, no API keys,
+returns JSON with citation counts):
+
+```bash
+python scripts/paper_search.py "your query" --max 5
+```
+
+If the script hits a network restriction (403/timeout), fall back to WebSearch — the goal
+is grounding, not a particular tool. Compare the paper against the closest 3–5 works found:
+for each, one line on what it does and how this paper differs. Verdict: `novel |
+incremental | overlapping`, with the retrieved titles cited. If no retrieval works at all,
+say so explicitly and mark the novelty verdict as ungrounded — never fake grounding.
+
+**Citation fact-check.** Identify the *load-bearing* cited claims — the ones the argument
+depends on (typically 3–8, not every citation). For LaTeX input, resolve `\cite` keys to
+titles/authors with the bundled parser (brace-counting, so titles containing commas
+survive); then confirm each cited work exists via Crossref:
+
+```bash
+python scripts/bib_resolve.py parse refs.bib key1 key2   # keys → {title, author, year}
+python scripts/bib_resolve.py verify "Resolved Title" --author "Surname"
+```
+
+For non-LaTeX input, work from the reference list; if the network blocks Crossref, fall
+back to WebSearch. Spot-check each claim: does the cited work plausibly say what the paper
+says it says? Report per claim: `verified | plausible | questionable | misattributed`.
+Claims that carry weight but have *no* citation belong in the claims–evidence table as
+unsupported — do not skip them just because there is nothing to look up.
+
+**Clarity and writing pass.** Note grammar, structure, and presentation issues as
+**revision notes only**. Writing quality never contributes to the accept/reject decision —
+prose problems mean revisions, not rejection. (This corrects a MARS miscalibration where a
+grammar agent voted on acceptance.)
+
+## Phase 4 — Question–answer probe
+
+This is the sharpest holism instrument, adapted from MARS's questioner/RAG-answer loop:
+
+1. Generate 6–10 open-ended, non-leading questions a careful reviewer would ask, spread
+   across dimensions (motivation, method, evidence, limitations, generality).
+2. Attempt to answer **every question strictly from the paper's own text**, quoting or
+   citing the section that answers it.
+3. Any question the paper cannot answer is a finding: attach it to the relevant reviewer's
+   weaknesses or questions_for_authors.
+
+A paper that answers all fair questions from its own pages is complete; the residue is
+exactly what the authors need to fix.
+
+## Phase 5 — Board room deliberation
+
+Now, and only now, the reviews meet.
+
+1. Present all three reviews plus the specialist findings and the Q&A residue.
+2. Give each reviewer one revision opportunity: in light of the others' points and the
+   grounded evidence, does R1/R2/R3 change any score or the decision? Record changes with
+   reasons ("R2 lowered soundness 6→4 after the novelty scout surfaced [paper X]").
+   No change is a valid outcome.
+3. Meta-reviewer writes **minutes**: points of agreement, points of disagreement and how
+   they resolve, and the key takeaways — in prose, as if recording a real PC discussion.
+4. Compute the panel decision **explicitly** (never "majority vote" by vibes):
+   map Accept=3, WeakAccept=2, WeakReject=1, Reject=0; average the three post-deliberation
+   decisions; ≥2.5 → Accept, ≥1.5 → WeakAccept, ≥0.75 → WeakReject, else Reject. Report
+   the arithmetic. Specialist passes inform reviewers but do not get votes: the desk check
+   gates, novelty and fact-check are evidence, clarity is advisory.
+
+## Phase 6 — Final report with coverage audit
+
+Deliver a single document in exactly this order:
+
+```
+# Review: [paper title]
+## Panel decision        (decision + score arithmetic + one-paragraph rationale)
+## Summary of the paper  (neutral, 1 paragraph)
+## Meta-review minutes   (from Phase 5)
+## Individual reviews    (R1, R2, R3 — post-deliberation, with changes noted)
+## Grounded findings     (novelty scout table, citation fact-check table)
+## Claims–evidence table (from Phase 1, final statuses)
+## Unanswered questions  (Phase 4 residue — framed as questions for the authors)
+## Revision notes        (clarity/writing, prioritized, non-blocking)
+## Coverage audit
+```
+
+The **coverage audit** is the skill's self-check and must be honest:
+
+| Section | R1 | R2 | R3 | Claims traced | Q&A touched |
+|---------|----|----|----|---------------|-------------|
+
+Every content section must be addressed by at least one reviewer and appear in at least one
+claim trace or Q&A answer. If the audit reveals a gap, go back and close it before
+delivering — an empty cell in this table means the review is not done, because the whole
+point of this protocol is that nothing gets skimmed.
+
+Length calibration: a full paper warrants roughly 1,500–3,000 words of report. For a short
+draft or single chapter, keep the same structure but compress; never drop the claims table,
+the Q&A probe, or the coverage audit — those three are the holism guarantee.

--- a/skills/mars-review/scripts/bib_resolve.py
+++ b/skills/mars-review/scripts/bib_resolve.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Citation resolution + verification for the fact-check pass. Stdlib only, no API keys.
+
+Two subcommands:
+
+  parse  <file.bib> [key ...]
+      Parse a BibTeX file (brace-counting — titles with commas/braces survive).
+      With keys: only those entries. Output: JSON {key: {title, author, year}}.
+
+  verify "<title>" [--author "surname"]
+      Look the title up on Crossref and report the best match, so you can check
+      that a cited work exists and is what the paper says it is.
+      Output: JSON {query, matched_title, authors, year, venue, doi, score_hint}.
+
+Usage examples:
+  python bib_resolve.py parse refs.bib smith2024attention
+  python bib_resolve.py verify "Attention is all you need"
+"""
+import argparse
+import json
+import re
+import sys
+import urllib.parse
+import urllib.request
+
+UA = {"User-Agent": "holistic-paper-review-skill/1.0 (mailto:reviewer@example.org)"}
+
+
+def parse_bib(text):
+    """Brace-counting BibTeX parser. Returns {key: {field: value}}."""
+    entries = {}
+    for m in re.finditer(r'@(\w+)\s*\{\s*([^,\s]+)\s*,', text):
+        if m.group(1).lower() in ("comment", "preamble", "string"):
+            continue
+        key = m.group(2)
+        depth, i = 1, m.end()
+        start = i
+        while i < len(text) and depth > 0:
+            if text[i] == "{":
+                depth += 1
+            elif text[i] == "}":
+                depth -= 1
+            i += 1
+        body = text[start:i - 1]
+        fields = {}
+        for fm in re.finditer(r'(\w+)\s*=\s*', body):
+            fname = fm.group(1).lower()
+            j = fm.end()
+            if j < len(body) and body[j] == "{":
+                d, j2 = 1, j + 1
+                while j2 < len(body) and d > 0:
+                    if body[j2] == "{":
+                        d += 1
+                    elif body[j2] == "}":
+                        d -= 1
+                    j2 += 1
+                val = body[j + 1:j2 - 1]
+            elif j < len(body) and body[j] == '"':
+                j2 = body.find('"', j + 1)
+                val = body[j + 1:j2] if j2 != -1 else body[j + 1:]
+            else:
+                j2 = body.find(",", j)
+                val = body[j:j2] if j2 != -1 else body[j:]
+            fields[fname] = " ".join(val.replace("{", "").replace("}", "").split())
+        entries[key] = {k: v for k, v in fields.items()
+                        if k in ("title", "author", "year", "booktitle", "journal")}
+    return entries
+
+
+def verify(title, author=None):
+    q = urllib.parse.quote(title)
+    url = f"https://api.crossref.org/works?query.bibliographic={q}&rows=3"
+    if author:
+        url += f"&query.author={urllib.parse.quote(author)}"
+    req = urllib.request.Request(url, headers=UA)
+    with urllib.request.urlopen(req, timeout=20) as r:
+        data = json.loads(r.read().decode())
+    items = data.get("message", {}).get("items", [])
+    if not items:
+        return {"query": title, "matched_title": None,
+                "note": "no Crossref match — try arXiv via paper_search.py"}
+    best = items[0]
+    return {
+        "query": title,
+        "matched_title": (best.get("title") or [None])[0],
+        "authors": [f"{a.get('given','')} {a.get('family','')}".strip()
+                    for a in best.get("author", [])][:6],
+        "year": (best.get("issued", {}).get("date-parts") or [[None]])[0][0],
+        "venue": best.get("container-title", [None])[0] if best.get("container-title") else None,
+        "doi": best.get("DOI"),
+        "note": "compare matched_title with query yourself — Crossref returns best-effort matches",
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    p1 = sub.add_parser("parse")
+    p1.add_argument("bibfile")
+    p1.add_argument("keys", nargs="*")
+    p2 = sub.add_parser("verify")
+    p2.add_argument("title")
+    p2.add_argument("--author")
+    args = ap.parse_args()
+
+    if args.cmd == "parse":
+        with open(args.bibfile, encoding="utf-8", errors="replace") as f:
+            entries = parse_bib(f.read())
+        if args.keys:
+            entries = {k: v for k, v in entries.items() if k in args.keys}
+        print(json.dumps(entries, indent=2, ensure_ascii=False))
+    else:
+        try:
+            print(json.dumps(verify(args.title, args.author), indent=2, ensure_ascii=False))
+        except Exception as ex:
+            print(json.dumps({"query": args.title, "error": str(ex)}), file=sys.stdout)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/mars-review/scripts/paper_search.py
+++ b/skills/mars-review/scripts/paper_search.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Related-work retrieval for the novelty scout. Stdlib only, no API keys.
+
+Sources:
+  - arXiv API (export.arxiv.org)   — preprints, abstracts
+  - Semantic Scholar Graph API     — published work, citation counts
+
+Usage:
+  python paper_search.py "query written like a knowledgeable reviewer" [--max 5] [--source arxiv|s2|both]
+
+Output: JSON list of {title, authors, year, venue, abstract, url, citations, source}.
+Rate limits: S2 unauthenticated ~1 req/s; arXiv asks for 3s between requests.
+The script sleeps accordingly — call it once per query, not in tight loops.
+"""
+import argparse
+import json
+import sys
+import time
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
+
+UA = {"User-Agent": "holistic-paper-review-skill/1.0 (research reviewing tool)"}
+
+
+def _get(url, timeout=20):
+    req = urllib.request.Request(url, headers=UA)
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        return r.read().decode("utf-8", errors="replace")
+
+
+def search_arxiv(query, max_results=5):
+    q = urllib.parse.quote(query)
+    url = (f"http://export.arxiv.org/api/query?search_query=all:{q}"
+           f"&max_results={max_results}&sortBy=relevance")
+    ns = {"a": "http://www.w3.org/2005/Atom"}
+    out = []
+    try:
+        root = ET.fromstring(_get(url))
+        for e in root.findall("a:entry", ns):
+            title = " ".join((e.findtext("a:title", "", ns) or "").split())
+            out.append({
+                "title": title,
+                "authors": [a.findtext("a:name", "", ns) for a in e.findall("a:author", ns)][:6],
+                "year": (e.findtext("a:published", "", ns) or "")[:4],
+                "venue": "arXiv",
+                "abstract": " ".join((e.findtext("a:summary", "", ns) or "").split())[:600],
+                "url": e.findtext("a:id", "", ns),
+                "citations": None,
+                "source": "arxiv",
+            })
+    except Exception as ex:
+        print(f"arxiv error: {ex}", file=sys.stderr)
+    return out
+
+
+def search_s2(query, max_results=5):
+    q = urllib.parse.quote(query)
+    fields = "title,authors,year,venue,abstract,url,citationCount"
+    url = (f"https://api.semanticscholar.org/graph/v1/paper/search"
+           f"?query={q}&limit={max_results}&fields={fields}")
+    out = []
+    try:
+        data = json.loads(_get(url))
+        for p in data.get("data", []):
+            out.append({
+                "title": p.get("title"),
+                "authors": [a.get("name") for a in (p.get("authors") or [])][:6],
+                "year": p.get("year"),
+                "venue": p.get("venue") or "n/a",
+                "abstract": (p.get("abstract") or "")[:600],
+                "url": p.get("url"),
+                "citations": p.get("citationCount"),
+                "source": "s2",
+            })
+    except Exception as ex:
+        print(f"s2 error: {ex}", file=sys.stderr)
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("query")
+    ap.add_argument("--max", type=int, default=5)
+    ap.add_argument("--source", choices=["arxiv", "s2", "both"], default="both")
+    args = ap.parse_args()
+
+    results = []
+    if args.source in ("s2", "both"):
+        results += search_s2(args.query, args.max)
+    if args.source in ("arxiv", "both"):
+        if args.source == "both":
+            time.sleep(1)
+        results += search_arxiv(args.query, args.max)
+
+    # De-duplicate by normalized title
+    seen, deduped = set(), []
+    for r in results:
+        key = "".join(c for c in (r["title"] or "").lower() if c.isalnum())
+        if key and key not in seen:
+            seen.add(key)
+            deduped.append(r)
+    print(json.dumps(deduped, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I'd like to propose adding a skill for holistic academic paper review, distilled from a multi-agent review system I built.

**What it does:** Given a paper (PDF, LaTeX, or Markdown) and optionally a venue/CFP, it runs a structured review protocol — desk check against CFP scope, a claims-evidence coverage map with an internal-consistency audit, three independent reviewer personas (domain expert, methodologist, informed outsider), retrieval-grounded novelty and citation checks (arXiv, Semantic Scholar, Crossref — stdlib-only Python, no API keys), a Socratic completeness probe, and a final deliberation with explicit score aggregation and a coverage audit. It's built to avoid the common failure mode of LLM reviewers skimming a paper and only engaging with the abstract.

It's adapted from the methodology in [MARS: Multi-Agent Review System for Academic Papers](https://www.kunpai.space/assets/papers/MARS.pdf) (Pai & Shetty, UC Davis), which orchestrated multiple local LLMs as sequential reviewers; this version reworks that into a single-session protocol for Claude.

Original standalone version: https://github.com/kunpai/MARS-Claude

**Contents:**
- `skills/mars-review/SKILL.md` — the review protocol
- `skills/mars-review/README.md`
- `skills/mars-review/LICENSE.txt` (Apache 2.0)
- `skills/mars-review/scripts/paper_search.py` — arXiv + Semantic Scholar retrieval
- `skills/mars-review/scripts/bib_resolve.py` — BibTeX parsing + Crossref verification

Happy to adjust formatting or structure to match repo conventions — let me know if there's a preferred review process for community skill submissions.