### PR TITLE
docs(pptx): prevent unsafe Office COM rendering

### DIFF
--- a/skills/pptx/SKILL.md
+++ b/skills/pptx/SKILL.md
@@ -233,6 +233,8 @@ ls -1 "$PWD"/slide-*.jpg
 
 **After fixes, rerun all four commands above** — the PDF must be regenerated from the edited `.pptx` before `pdftoppm` can reflect your changes.
 
+**Never drive a locally installed Office application (PowerPoint, Word, Excel) to render or convert — on Windows or anywhere else.** Office COM automation can attach to an Office instance that the user already has open, so calling `Quit()` can close their entire Office session and `Close()` can close their presentation, potentially losing unsaved work. If LibreOffice is missing on Windows, install it (`winget install TheDocumentFoundation.LibreOffice`) and rerun the commands above. If it can't be installed, skip visual QA and say so — COM automation is not a fallback. Should COM be unavoidable for some other task, operate only on the presentation you opened and never call `Quit()` or `Close()` on a shared instance.
+
 ## Dependencies
 
 `pptxgenjs` (npm, preinstalled — install only if `require('pptxgenjs')` fails) · `markitdown[pptx]`, `Pillow`, `defusedxml`, `lxml` (pip — text dump, thumbnail, clean, validate) · LibreOffice (`soffice`, auto-configured for sandboxed environments via `scripts/office/soffice.py`) · `pdftoppm` (Poppler)


### PR DESCRIPTION
## Summary

This updates the PPTX visual-QA instructions to make the Windows workflow safer.

- Warn against using an existing PowerPoint/Office installation for rendering.
- Explain the risk of COM automation closing open presentations or unsaved work.
- Point Windows users to LibreOffice for rendering instead.
- If LibreOffice isn't available, recommend skipping visual QA rather than using Office COM automation.

Fixes #1523