### PR TITLE
xlsx: add surgical package-editing guidance for complex workbooks

### DIFF
--- a/skills/xlsx/SKILL.md
+++ b/skills/xlsx/SKILL.md
@@ -77,6 +77,35 @@ literal `#NAME?` baked into the file you deliver.
 - **`.xlsm` loses its macros unless you pass `keep_vba=True`** to `load_workbook`.
 - **A sheet name containing a space must be quoted** in a cross-sheet reference: `='Assumptions Inputs'!$B$5`. Unquoted, it evaluates to `#VALUE!`.
 
+## Complex workbooks: surgical package editing
+
+An openpyxl load→save rewrites the entire package. Parts it does not model — native
+charts, drawings, comment VML, slicers, `extLst` extensions — are silently dropped or
+regenerated, and `xl/styles.xml` is rewritten. Desktop Excel opens the result with a
+"repair" dialog whose recovery log is generic and names no specific part.
+
+Check first (`unzip -l file.xlsx`): if the workbook has chart, drawing, or comment
+parts that must survive, do not full-save with a library. Patch surgically instead:
+rewrite only the target worksheet XML members inside the ZIP and copy every other
+member byte-for-byte. Each rule below, violated, produces the same repair prompt:
+
+- **Never round-trip worksheet XML through a generic XML serializer.** ElementTree
+  renames namespace prefixes on write (`mc` becomes `ns1`). Legal in plain XML —
+  fatal in OOXML, because `mc:Ignorable="x14ac xr …"` names prefixes as literal
+  strings and every name listed must be a declared prefix in scope (ISO 29500-3).
+  Edit sheet XML with targeted string surgery or a prefix-preserving serializer
+  (lxml), and diff the changed part's prefix→URI map against the original before
+  delivery.
+- **Keep `xl/styles.xml` byte-identical.** Cells reference the style table by
+  numeric index; merging or reordering it leaves dangling references. Reuse the
+  workbook's existing style ids for new cells.
+- **If cell contents changed, delete `xl/calcChain.xml`** (the ZIP member and its
+  `[Content_Types].xml` override) and set `<calcPr fullCalcOnLoad="1"/>` in
+  `workbook.xml`; Excel rebuilds the chain cleanly on open.
+- **Validate before delivery**: ZIP integrity, every changed part parses, internal
+  relationship targets resolve, untouched members byte-identical to the source.
+  Excel's repair log will not tell you which rule you broke.
+
 ## Financial models
 
 Unless the user says otherwise, or the existing file already does something else.


### PR DESCRIPTION
## What

Adds a `## Complex workbooks: surgical package editing` section to the xlsx skill, covering how to edit chart/drawing-heavy workbooks without desktop Excel rejecting the output with a repair dialog.

## Why

Distilled from a production incident with an agent using this skill's recommended openpyxl workflow on a real-world financial template (native charts, drawings, comment VML, `extLst` parts). Desktop Excel rejected the output **twice**, with only a generic recovery log each time:

1. **First failure**: the load→save round-trip rewrote `xl/styles.xml`. Cells reference the style table by numeric index, so a merged/reordered table leaves dangling references → file-level repair.
2. **Second failure** (subtler): worksheet XML was round-tripped through Python's ElementTree, which renamed the namespace prefixes (`mc` → `ns1`, etc.) while the root attribute `mc:Ignorable="x14ac xr xr2 xr3"` still referenced the original names. Prefix renaming is legal in plain XML, but OOXML's markup-compatibility layer (ISO 29500-3) matches `mc:Ignorable` entries against declared prefixes **as literal strings** — an unresolvable name is an invalid MC state and triggers repair.

Both failure modes were verified by byte-level comparison of the rejected/accepted packages. Neither is currently covered by the skill, which recommends the openpyxl round-trip for all edits; the existing gotchas cover formula/value issues but not package integrity.

## Guidance added

- Inspect the package first; if it has chart/drawing/comment parts that must survive, patch ZIP members surgically instead of full-saving with a library
- Never round-trip sheet XML through a prefix-renaming serializer; verify the changed part's prefix→URI map against the original
- Keep `xl/styles.xml` byte-identical; reuse existing style ids
- Drop `xl/calcChain.xml` + set `fullCalcOnLoad` when cell contents change
- Validate ZIP integrity / parseability / byte-identity of untouched members before delivery, since Excel's repair log never names the broken part

🤖 Generated with [Claude Code](https://claude.com/claude-code)