### PR TITLE
docs: deduplicate pptx, algorithmic-art, canvas-design SKILL.md (13 verified edits)

### DIFF
--- a/skills/algorithmic-art/SKILL.md
+++ b/skills/algorithmic-art/SKILL.md
@@ -81,7 +81,6 @@ Algorithmic expression: Randomized circle packing or Voronoi tessellation. Start
 - **PARAMETRIC EXPRESSION**: Ideas communicate through mathematical relationships, forces, behaviors - not static composition
 - **ARTISTIC FREEDOM**: The next Claude interprets the philosophy algorithmically - provide creative implementation room
 - **PURE GENERATIVE ART**: This is about making LIVING ALGORITHMS, not static images with randomness
-- **EXPERT CRAFTSMANSHIP**: Repeatedly emphasize the final algorithm must feel meticulously crafted, refined through countless iterations, the product of deep expertise by someone at the absolute top of their field in computational aesthetics
 
 **The algorithmic philosophy should be 4-6 paragraphs long.** Fill it with poetic computational philosophy that brings together the intended vision. Avoid repeating the same points. Output this algorithmic philosophy as a .md file.
 
@@ -109,14 +108,7 @@ With the philosophy AND conceptual framework established, express it through cod
 1. **Read** `templates/viewer.html` using the Read tool
 2. **Study** the exact structure, styling, and Anthropic branding
 3. **Use that file as the LITERAL STARTING POINT** - not just inspiration
-4. **Keep all FIXED sections exactly as shown** (header, sidebar structure, Anthropic colors/fonts, seed controls, action buttons)
-5. **Replace only the VARIABLE sections** marked in the file's comments (algorithm, parameters, UI controls for parameters)
-
-**Avoid:**
-- ❌ Creating HTML from scratch
-- ❌ Inventing custom styling or color schemes
-- ❌ Using system fonts or dark themes
-- ❌ Changing the sidebar structure
+4. **Keep FIXED sections, replace VARIABLE sections** - see WHAT'S FIXED VS VARIABLE below
 
 **Follow these practices:**
 - ✅ Copy the template's exact HTML structure
@@ -327,12 +319,11 @@ Add as many control-group divs as there are parameters.
 **4. Actions (FIXED)** - Always include exactly as shown:
 - Regenerate button
 - Reset button
-- Download PNG button
 
 **Requirements**:
 - Seed controls must work (prev/next/random/jump/display)
 - All parameters must have UI controls
-- Regenerate, Reset, Download buttons must work
+- Regenerate and Reset buttons must work
 - Keep Anthropic branding (UI styling, not art colors)
 
 ### USING THE ARTIFACT
@@ -389,8 +380,7 @@ This skill includes helpful templates and documentation:
 
 - **templates/viewer.html**: REQUIRED STARTING POINT for all HTML artifacts.
   - This is the foundation - contains the exact structure and Anthropic branding
-  - **Keep unchanged**: Layout structure, sidebar organization, Anthropic colors/fonts, seed controls, action buttons
-  - **Replace**: The p5.js algorithm, parameter definitions, and UI controls in Parameters section
+  - See WHAT'S FIXED VS VARIABLE above for what to keep vs replace
   - The extensive comments in the file mark exactly what to keep vs replace
 
 - **templates/generator_template.js**: Reference for p5.js best practices and code structure principles.

--- a/skills/canvas-design/SKILL.md
+++ b/skills/canvas-design/SKILL.md
@@ -80,9 +80,9 @@ Visual expression: Grid-based precision, bold photography or stark graphics, dra
 - **SPATIAL EXPRESSION**: Ideas communicate through space, form, color, composition - not paragraphs
 - **ARTISTIC FREEDOM**: The next Claude interprets the philosophy visually - provide creative room
 - **PURE DESIGN**: This is about making ART OBJECTS, not documents with decoration
-- **EXPERT CRAFTSMANSHIP**: Repeatedly emphasize the final work must look meticulously crafted, labored over with care, the product of countless hours by someone at the top of their field
+- **EXPERT CRAFTSMANSHIP**: See the craftsmanship framing under CRITICAL GUIDELINES above
 
-**The design philosophy should be 4-6 paragraphs long.** Fill it with poetic design philosophy that brings together the core vision. Avoid repeating the same points. Keep the design philosophy generic without mentioning the intention of the art, as if it can be used wherever. Output the design philosophy as a .md file.
+Fill it with poetic design philosophy that brings together the core vision. Avoid repeating the same points. Keep the design philosophy generic without mentioning the intention of the art, as if it can be used wherever. Output the design philosophy as a .md file.
 
 ---
 
@@ -101,11 +101,11 @@ This is **VERY IMPORTANT**: The reference must be refined so it enhances the wor
 
 With both the philosophy and the conceptual framework established, express it on a canvas. Take a moment to gather thoughts and clear the mind. Use the design philosophy created and the instructions below to craft a masterpiece, embodying all aspects of the philosophy with expert craftsmanship.
 
-**IMPORTANT**: For any type of content, even if the user requests something for a movie/game/book, the approach should still be sophisticated. Never lose sight of the idea that this should be art, not something that's cartoony or amateur.
+**IMPORTANT**: For any type of content, even if the user requests something for a movie/game/book, the approach should still be sophisticated.
 
 To create museum or magazine quality work, use the design philosophy as the foundation. Create one single page, highly visual, design-forward PDF or PNG output (unless asked for more pages). Generally use repeating patterns and perfect shapes. Treat the abstract philosophical design as if it were a scientific bible, borrowing the visual language of systematic observation—dense accumulation of marks, repeated elements, or layered patterns that build meaning through patient repetition and reward sustained viewing. Add sparse, clinical typography and systematic reference markers that suggest this could be a diagram from an imaginary discipline, treating the invisible subject with the same reverence typically reserved for documenting observable phenomena. Anchor the piece with simple phrase(s) or details positioned subtly, using a limited color palette that feels intentional and cohesive. Embrace the paradox of using analytical visual language to express ideas about human experience: the result should feel like an artifact that proves something ephemeral can be studied, mapped, and understood through careful attention. This is true art. 
 
-**Text as a contextual element**: Text is always minimal and visual-first, but let context guide whether that means whisper-quiet labels or bold typographic gestures. A punk venue poster might have larger, more aggressive type than a minimalist ceramics studio identity. Most of the time, font should be thin. All use of fonts must be design-forward and prioritize visual communication. Regardless of text scale, nothing falls off the page and nothing overlaps. Every element must be contained within the canvas boundaries with proper margins. Check carefully that all text, graphics, and visual elements have breathing room and clear separation. This is non-negotiable for professional execution. **IMPORTANT: Use different fonts if writing text. Search the `./canvas-fonts` directory. Regardless of approach, sophistication is non-negotiable.**
+**Text as a contextual element**: Text is always minimal and visual-first, but let context guide whether that means whisper-quiet labels or bold typographic gestures. A punk venue poster might have larger, more aggressive type than a minimalist ceramics studio identity. Most of the time, font should be thin. All use of fonts must be design-forward and prioritize visual communication. Every element must stay fully within the canvas boundaries with clear margins, breathing room, and no overlaps, regardless of text scale. This is non-negotiable for professional execution. **IMPORTANT: Use different fonts if writing text. Search the `./canvas-fonts` directory. Regardless of approach, sophistication is non-negotiable.**
 
 Download and use whatever fonts are needed to make this a reality. Get creative by making the typography actually part of the art itself -- if the art is abstract, bring the font onto the canvas, not typeset digitally.
 

--- a/skills/pptx/SKILL.md
+++ b/skills/pptx/SKILL.md
@@ -51,7 +51,7 @@ Paths are relative to this skill's directory. Everything else is plain Python, `
 
 ## Editing existing decks and templates
 
-Pick layouts first: `python scripts/thumbnail.py template.pptx template-thumbs` writes a labeled grid of every slide and prints the file(s) it created — `template-thumbs.jpg`, split into `template-thumbs-N.jpg` past 12 slides. **Always pass that second argument, named after the deck.** It defaults to `thumbnails`, so two decks thumbnailed in one directory silently overwrite each other's grids — the first deck's are simply gone (template analysis only — visual QA needs the full-resolution renders from [Converting to Images](#converting-to-images); it only accepts `.pptx`, so copy a `.potx` to a `.pptx` name first). Use it with `markitdown` to map each content section onto a template slide, and vary the layouts — don't put every section on the same title-and-bullets slide.
+Pick layouts first: `python scripts/thumbnail.py template.pptx template-thumbs` writes a labeled grid of every slide and prints the file(s) it created — `template-thumbs.jpg`, split into `template-thumbs-N.jpg` past 12 slides. **Always pass that second argument, named after the deck** — see the thumbnail.py note above for why (template analysis only — visual QA needs the full-resolution renders from [Converting to Images](#converting-to-images); it only accepts `.pptx`, so copy a `.potx` to a `.pptx` name first). Use it with `markitdown` to map each content section onto a template slide, and vary the layouts — don't put every section on the same title-and-bullets slide.
 
 ```bash
 python3 -c "import sys,zipfile; zipfile.ZipFile(sys.argv[1]).extractall('unpacked')" deck.pptx
@@ -149,14 +149,10 @@ Choose colors that match your topic — don't default to generic blue. Use these
 
 ### Avoid (Common Mistakes)
 
-- **Don't repeat the same layout** — vary columns, cards, and callouts across slides
 - **Don't center body text** — left-align paragraphs and lists; center only titles
 - **Don't skimp on size contrast** — titles need 36pt+ to stand out from 14-16pt body
-- **Don't default to blue** — pick colors that reflect the specific topic
 - **Don't mix spacing randomly** — choose 0.3" or 0.5" gaps and use consistently
 - **Don't style one slide and leave the rest plain** — commit fully or keep it simple throughout
-- **Don't create text-only slides** — add images, icons, charts, or visual elements; avoid plain title + bullets
-- **Don't forget text box padding** — when aligning lines or shapes with text edges, set `margin: 0` on the text box or offset the shape to account for padding
 - **Don't use low-contrast elements** — icons AND text need strong contrast against the background; avoid light text on light backgrounds or dark text on dark backgrounds
 - **NEVER use accent lines under titles** — these are a hallmark of AI-generated slides; use whitespace or background color instead
 - **NEVER add decorative color bars or accent stripes** — this includes: header/footer bars spanning the slide width, vertical sidebar stripes down one edge of the slide, thin accent stripes along one edge of a card or content block, and "single-side borders" on rectangles. These read as AI-generated filler. If you want to set a card apart, use a subtle background tint, a drop shadow, or an icon — not an edge stripe.


### PR DESCRIPTION
Hi — we ran an eval-driven doc-hygiene pass over a sample of these skills and this PR carries the 13 edits that survived verification. Each edit descends from a finding confirmed by a 3-skeptic adversarial pass (each skeptic independently tries to refute the finding against the document; only unanimous survivors ship), and the edited files were re-probed under the same instrument afterward: confirmed findings on these three skills drop from 14 to 6.

The dominant defect class, in all three files: an "Avoid" list entry that restates, negated, a rule the document already gives positively elsewhere — the same meaning maintained in two places, which costs tokens on every invocation and creates two spots to keep in sync. Representative examples:

- **pptx**: "Don't default to blue" (Avoid list) duplicated "Choose colors that match your topic — don't default to generic blue" (Color Palettes); the thumbnail-overwrite warning appeared in full twice. The positive statements stay; the restatements point back or go.
- **algorithmic-art**: the four-item "❌ Avoid" list under STEP 0 restated the adjacent "✅ Follow these practices" list; STEP 0 also restated material RESOURCES already carries.
- **canvas-design**: same pattern, plus one verbatim-duplicated craftsmanship principle.

No behavioral instructions were changed and no frontmatter descriptions were touched (one candidate description edit was deliberately excluded because we couldn't verify routing parity for it — we only ship description changes we've measured).

For what it's worth: `skill-creator` was probed in the same pass and came back clean — zero confirmed findings.

Method and receipts are public at https://github.com/StartupBros-com/skill-tuner (`reports/external-anthropic-001` before, `reports/external-fixed-001` after). Happy to split per-skill or adjust to your conventions.
