### PR TITLE
Add skill: novelty-audit — adversarial verification of novelty and whitespace claims (4 eval iterations)

### DIFF
--- a/skills/novelty-audit/LICENSE.txt
+++ b/skills/novelty-audit/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Fernando Dougnac
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/novelty-audit/SKILL.md
+++ b/skills/novelty-audit/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: novelty-audit
+description: An adversarial verification protocol for novelty and whitespace claims. Use whenever a document, pitch, grant application, paper, or plan asserts that something is new, unexplored, "first", "nobody does this", or a market/research gap — before it is published or submitted. Also use when the user asks to check whether an idea already exists, find prior art, or map the whitespace around a topic. The deliverable is a per-claim verdict with citations, not new ideas. Do NOT use for generating ideas (that is creative-divergence's job), for general fact-checking of non-novelty claims, or for plagiarism and text-similarity checks — the audit adjudicates claims about what exists, not prose against its sources.
+---
+
+# Novelty Audit
+
+Every novelty claim will eventually face an adversary whose entire job is one search: the grant reviewer, the referee, the investor's analyst, the patent examiner. This protocol runs the adversary's move first. Its premise is empirical: in literature-heavy domains, unaided priors misjudge what exists roughly as often as not — confidently seeing whitespace where there are literature reviews. The audit's primary product is prevented embarrassment; discovered whitespace is upside.
+
+## Phase 1 — Extract the claims
+
+List every explicit or implicit novelty claim in the input (a document, a pitch, or a stated idea). Implicit ones count: "we are the only", "unlike existing solutions", "there is no tool that", a gap statement in a paper, a differentiation slide. Number them. If the user supplied a topic rather than a document, ask what is being claimed as new, or derive the 2–4 strongest implied claims and confirm them in one line. State once in the deliverable: the audit verifies claims against the world's indexed record and assumes each claim is true of the user's own product or work — whether the described feature or capability actually exists is the user's side of the ledger, not the audit's.
+
+## Phase 2 — Blind priors (before any search)
+
+For each claim, state your own belief BEFORE searching: FULL (counterexamples exist), EMPTY (genuinely unclaimed), or UNKNOWN — with one line of reasoning and a confidence (low/med/high). **Write the priors into the output before issuing the first search** — priors held in reasoning and transcribed afterward are substantively honest but not mechanically auditable, and auditability is the point. This is the control: the audit's value is measured by how many verdicts differ from these priors. Never skip or backfill this step.
+
+## Phase 3 — Adversarial sweep
+
+For each claim, 1–3 queries designed to FIND the counterexample, not to confirm emptiness — search as the hostile reviewer would. Rules inherited from tested ancestors:
+
+- Validate each query's aim: one numbered line per query, adjacent to that query — never an aggregate paragraph covering several, and the count of aim lines must equal the count of queries run. A query that returned adjacent marketing or a different actor's problem is MISFIRED and excluded.
+- Match on mechanism, not vocabulary: a counterexample described in different words still kills the claim.
+- Include at least one query in the claim's home language/region when the claim is regional.
+- **Recall valve:** if the first round finds nothing against a claim, run one second round before issuing any verdict — mandatory for any claim heading toward SURVIVES or UNTRIAGED. The second round must CHANGE VOCABULARY FRAMES, not merely reword: if round one searched concept words (the mechanism, the category, the outcome), round two searches artifact words — vendor and product names, pricing-page language, "companies that", "platform for". For commercial claims, round two must include at least one software-directory or marketplace query (G2, Capterra, product directories, "site-style" category listings) — some occupants live in directories, not in search-phrase space, and three rounds of phrasing discipline cannot reach a cell that a different index holds. A synonym of a query that found nothing finds nothing; the strongest counterexample usually lives one frame — or one index — away.
+
+## Phase 4 — Verdicts
+
+Each claim gets exactly one verdict, with evidence:
+
+- **KILLED** — a counterexample exists; cite it. Include the strongest one found, not the first.
+- **SHARPENED** — the broad claim dies but a narrower edge survives (region, mechanism, combination, regulatory context). Rewrite the claim to its defensible form; cite what killed the broad version and what the sweep found nothing against.
+- **UNTRIAGED** — nothing found, but absence is not yet evidence: state which of the three empty-cell causes remains unexcluded (unexplored / explored-and-died / invisible to the index: other language, practice-only, paywalled) and the single cheapest step that would triage it (a regional query, an expert to ask, a database to check).
+- A claim only earns **SURVIVES** after a graveyard pass: search for failed attempts ("X failed", "X shut down", "X challenges") — a space can be empty because it is a graveyard, and claiming a graveyard as whitespace is the second-most embarrassing outcome available. The graveyard pass inherits the regional rule: a regional claim's graveyard must be searched in the claim's language and region — a global graveyard sweep cannot support "no failed local attempt".
+
+Never promote absence to proof. "Not found" means "not the consensus of the indexed record", nothing more. Every KILLED and SHARPENED verdict must carry a citation; a verdict without evidence is a prior wearing a costume.
+
+## Phase 5 — Deliverable
+
+A claims table: claim → blind prior → evidence → verdict → rewritten claim (for SHARPENED) or replacement use (for KILLED). Then two short sections:
+
+- **Salvage:** killed claims are not waste — a crowded cell is market/research validation. State how each killed claim converts ("the field is investing heavily in exactly this" beats false uniqueness in front of any reviewer).
+- **Audit score:** how many verdicts differed from the blind priors, stated plainly. This is the honest measure of what the sweep added beyond the model's memory.
+
+## Process exposure
+
+Content-descriptive headings; no naming of this skill or its phases in the deliverable; if the user asks how the audit was done, explain fully and accurately. State the scope boundary when relevant: the audit reads the indexed record — it is strongest in literature-heavy domains and weakest where knowledge lives in practice, paywalls, or unindexed languages.


### PR DESCRIPTION
## What this skill does

`novelty-audit` is an adversarial verification protocol, not a research or document skill. It runs the hostile reviewer's search *before* the reviewer does: extract every explicit and implicit novelty claim from a pitch, paper, grant, or plan; commit blind priors to disk **before any search**; sweep adversarially with a stated aim per query; and issue a per-claim verdict — KILLED / SHARPENED / UNTRIAGED / SURVIVES-after-graveyard — with citations.

Two rules do most of the work:

- **Priors before search.** Predictions are written to a file before the first query, so the audit can't be back-fitted to whatever the search happened to return. This is what makes the score honest rather than retrospective, and it is byte-auditable from the transcript.
- **Absence is never promoted to proof.** "Nothing found" is a search result, not a fact about the world. A claim only reaches SURVIVES after a graveyard pass — an explicit hunt for dead and discontinued attempts, in the region's own language where a regional claim is at stake — because a market with no living competitor and a market with five corpses are very different claims.

## Why it may be worth including

It was born from a failed experiment, and the failure is the reason it exists. A pre-registered search extension for a generation skill missed its own kill condition (+1.5 non-modal survivors against a required ≥2), so it was dropped. But its data showed exactly where search *does* pay: verifying literature-adjacent claims, where an idea that feels novel is often published consensus. The audit is that finding turned into a protocol.

Four eval iterations hardened it, each an A/B against the prior version with an independent grader and transcript byte-offset checks:

| Iteration | Found | Fixed |
|---|---|---|
| 1 | Search happened, but the audit could rationalize whatever it found | Written-before-search priors as a disk artifact — byte-verified in 8/8 runs since |
| 2 | The recall valve reworded queries instead of rethinking them | The valve must change *vocabulary frames*, not paraphrase |
| 3 | Commercial "nobody sells this" claims rested on prose search alone | Mandatory software-directory query for commercial claims |
| 4 | Graveyard pass ran in English only against Spanish-market claims | Graveyard inherits the regional-language rule |

## Honest caveats

- **A documented tool boundary, not a hidden one.** A four-iteration hunt for one known counterexample ended unresolved: web search cannot traverse directory listings, so the product could not be reached. The protocol's response is the point — it refuses SURVIVES and hands the user a triage step rather than inventing a verdict. That behavior is a feature, but it means some claims end as UNTRIAGED work for a human.
- Verdicts are only as good as the index. The skill says so in its own output rather than implying global coverage.
- Trigger battery: 18 cases, single run each, in a simulated skill-roster setting rather than a production harness.

## Triggering

Validated with an 18-case battery: should-fire cases (novelty claims in a grant, "does this already exist", "map the whitespace"), should-not-fire cases, and adversarially-adjacent ones — including a deliberate boundary case where the user brings an idea to be checked, which must route here and not to a generation skill. Result: correct routing in every case, including a case that had previously mis-routed and was fixed by a description tightening before submission.

The description explicitly disclaims idea generation, general fact-checking, and plagiarism/text-similarity checks — the audit adjudicates claims about what exists, not prose against its sources.

## Relationship to other submissions

This is one of two skills submitted separately (one PR per skill, per repo convention). It stands alone and depends on nothing else. A companion generation skill is open as #1539, and an orchestrator that composes the two is submitted separately; neither is required for this skill to work.

Full eval history, iteration by iteration: https://github.com/fdojose/creative-divergence-skill

## License

The skill folder includes its LICENSE.txt (MIT), following the per-skill licensing convention in this repository.
