### PR TITLE
Add skill: explore-verify-loop — orchestrator composing novelty-audit + creative-divergence (5 eval iterations)

### DIFF
--- a/skills/explore-verify-loop/LICENSE.txt
+++ b/skills/explore-verify-loop/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Fernando Dougnac
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/explore-verify-loop/SKILL.md
+++ b/skills/explore-verify-loop/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: explore-verify-loop
+description: An orchestrator that composes the novelty-audit and creative-divergence skills into one pipeline for innovation work on a product, strategy, or research direction. Use when the user wants to both understand what already exists AND have new differentiated options generated for them — "what should we build here", "find our angle in this market", "we want to enter/differentiate/innovate in X". Requires web search and both component skills. Do NOT use for a pure existence check — "does this already exist", "has anyone published this", "find prior art" — even when the user plainly has a product or paper in mind: bringing an idea to be checked is not asking for new ones, and that case belongs to novelty-audit alone. Do NOT use for pure ideation on a private or un-indexed problem (creative-divergence alone).
+---
+
+# Explore-Verify Loop
+
+Generation and verification are different machines: one looks forward into the unbuilt, the other backward at the indexed record. Run separately they fail separately — ideation surfaces false novelty (ideas that feel new and are a competitor's tagline), and audits end at "the concept is crowded" with nothing planted in its place. This loop sequences the two skills so each manufactures the other's raw material. It changes NOTHING inside either component skill; it only defines the order and the handoffs.
+
+## Stage 1 — Audit the terrain (novelty-audit)
+
+Run the novelty-audit protocol on the topic's 2–4 strongest implied claims, exactly per its own spec (written priors before search, adversarial queries, regional rule, recall valve, graveyard gate).
+
+**Handoff artifact — the terrain digest:** close Stage 1 by writing a compact digest for Stage 2: (a) the empirically-confirmed modal mechanisms (what the market/literature demonstrably sells or studies, each with its strongest example), (b) named incumbents and where they sit, (c) the open flanks (sharpened edges and untriaged cells). Keep it to mechanisms and names, not prose.
+
+## Stage 2 — Diverge against the evidence (creative-divergence)
+
+Run the creative-divergence protocol per its own spec, with one substitution: the terrain digest REPLACES introspective modal-guessing. Ideas matching digest mechanisms are labeled modal empirically (with the incumbent named); novelty scores anchor to the digest as the world-modal baseline.
+
+**Anchoring guard:** the digest states what is COMMON — it must never bound what is possible. Phase 2's distant-domain, flipped-assumption, and edge quotas apply at full strength, and at least half the generated approaches must come from mechanism families the digest does not contain. If every approach orbits the incumbents' territory, the digest has anchored generation: regenerate the non-modal quota blind (without re-reading the digest) before proceeding.
+
+## Stage 3 — Audit the survivors (novelty-audit, scoped)
+
+Each survivor that appears in the FINAL deliverable implies a claim ("nobody offers X for Y"). Enumerate the audit list from the final survivor table — AFTER fusion and wild-card synthesis — never from the pre-fusion pool: anything presented to the user gets audited, with no exceptions for late-synthesized candidates (fusions and wild cards are where unaudited claims hide, because they are born after the claim list forms). Before any survivor reaches a document, pitch, or plan, run a scoped audit pass on those claims: priors, adversarial sweep with the frame-change valve (artifact words: vendor names, pricing pages, directories), verdicts with citations. A survivor whose claim is KILLED returns to the pool demoted — which is a finding, not a failure: it was false novelty caught before a reviewer caught it. SHARPENED survivors adopt their narrowed, defensible claim as their positioning.
+
+## Deliverable
+
+One composite memo: the terrain (Stage 1 verdicts and salvage), the options (Stage 2 survivor table with pre-mortems and kill conditions), and the verified positioning (Stage 3 verdicts per survivor, each survivor's claim in its defensible form with citations). After Stage 3, re-word EVERY Stage 2 table entry to verdict-consistent language — a pre-verification table left standing contradicts the audit sitting next to it. No universal negatives anywhere in the memo, for any verdict: rewritten and surviving claims carry a "none found in the indexed record" qualifier, never "no one does X" — absence is a search result, not a fact about the world. End with the loop's honest ledger: how many Stage 2 survivors died or narrowed in Stage 3 — that number is the false-novelty rate the loop exists to drive down, and reporting it is what keeps the loop honest.
+
+## Execution rules
+
+- Each stage follows its component skill's own contract fully and in exact form (written priors, tag formats — the component rules apply verbatim inside the loop, not in spirit). Query aims are a visible-artifact requirement written for how agents actually execute: searches fire in parallel batches, so BEFORE any batch of searches, emit one numbered aim list covering every query in the coming batch — aim-line count equals query count within each batch, and no search runs unlisted. The aim list is an EMITTED artifact: a numbered list in your visible output, auditable from the transcript. Aims drafted in private reasoning do not satisfy this rule — an accountability artifact that lives where no audit can see it does not exist. (A per-search "immediately before each" rule is unimplementable under parallel dispatch; the batch list in emitted output is the honorable unit.) Process-exposure rules inherit and extend: no skill names, stage numbers, or protocol narration in the deliverable, and no document structures that mirror the stages ("Part 1/2/3" tracking the pipeline is leakage) — content-descriptive headings only.
+- Scale: for small questions, Stage 1 compresses to 2 claims and Stage 2 runs its quick mode; Stage 3 is never skipped for any survivor that will be claimed in front of a third party.
+- The graveyard gate applies PER STAGE: waiving it as vacuous in one stage never waives it in another. In Stage 3, any claim that survives in any form (full or narrowed) into the final positioning triggers its own failure sweep, regional rule included; and a vacuous waiver is always stated explicitly ("no claims reached survival; no graveyard needed"), never silent.
+- If the domain is index-blind (practice-heavy, unindexed language, private markets), say so, run Stage 2 alone, and mark all survivor claims UNTRIAGED rather than faking Stage 1/3.
+- Pause offer between Stage 1 and 2 for high-stakes uses: present the terrain, let the user redirect the search before generating against it.


### PR DESCRIPTION
## Dependency, stated up front

This skill is an **orchestrator**. It composes two other skills and does nothing on its own:

- `novelty-audit` — submitted separately as #1549
- `creative-divergence` — submitted separately as #1539

Neither is merged yet. The skill's own description says it requires both plus web search, and it declines to fire when only one half of the job is being asked for. **If the maintainers would rather see the components land first, this PR can wait** — I'm submitting it now so the composition evidence sits with them, not to jump the queue.

## What it does

Three stages for the question neither component answers alone — *what should we build here?*

1. **Map the terrain** with the audit's discipline, priors written before any search, so the map can't be back-fitted to whatever the search returned.
2. **Generate against that terrain.** The verified map becomes the empirical modal baseline — the "obvious answers to be surpassed" are now *measured* rather than guessed. An anchoring guard and a blind-regeneration valve exist for when the map crowds out the generation.
3. **Turn the audit on the loop's own output.** The audit list is enumerated from the final deliverable table, *after* fusion and wild-card synthesis, so a late-invented option can't slip past the verification that killed its siblings.

## Why it may be worth including

The composition earns its cost on one measured axis, pre-registered before the first run.

In the first eval round, the unaudited control shipped **8 of 8** claims that die or narrow under verification, every one presented unqualified ("competes with nobody"). The loop shipped **1** — and that single leak came from the fusion hole that stage 3 was then rewritten to close.

Anchoring was pre-registered as the likeliest way for this design to fail: feed a model a map of what exists and it may just recombine the map. It proved real but small, and the guard closed it exactly — **15 mechanism families with the terrain digest, 15 without**.

The runs' own confessions are the clearest evidence the loop works as intended, and they are quoted from the graded outputs:

> "One of our three lead options died under verification (automatic recompilation … already shipped by Skillsoft and Skill Studio), which is exactly why the verification pass exists."

> "This is the loop working as intended: the claim *felt* novel and is a funded category's core pitch — caught here instead of in front of a reviewer."

## Eval history (5 iterations, independent grader, transcript byte-offsets)

| Iteration | Found | Fixed |
|---|---|---|
| 1 (v1) | Metric succeeded, kill condition not met. Two composition defects: late-synthesized survivors escaped stage 3 (a fusion led a recommendation with an unaudited claim the grader killed in one search); universal negatives leaked into the memo | Audit list enumerated post-fusion; absence claims carry indexed-record qualifiers |
| 2 (v2) | Both fixed, 11/12 both runs. Aim-line rule *narrated rather than executed* — 0 aim lines against 17 searches in one run, 3 of 12 in the other | — |
| 3 (v2.1) | The rule wasn't being disobeyed, it was unimplementable: agents dispatch searches in parallel batches, so "immediately before each search" has no moment at which to be obeyed. Separately, the graveyard gate went silent in stage 3 despite three narrowed survivals | Rule rewritten to the batch as the unit; graveyard gate made per-stage, with vacuous waivers stated explicitly rather than skipped |
| 4 (v2.2) | Graveyard gate confirmed, including an *explicit* vacuous waiver — the never-silent behavior the rule asks for. Batch-aim rule still failed both runs (14/18 and 10/20 searches listed): aims were drafted inside extended thinking and surfaced only from stage 3 onward | One sentence: the aim list is an **emitted** artifact, because an accountability artifact that lives where no audit can see it does not exist |
| 5 (v2.3) | Flipped at exact parity from the first batch — **36 aim lines / 36 searches** and **19 / 19**, each list byte-preceding its own batch, verified by parsing thinking blocks and text blocks apart. 10/10 and 9/10 | Shipped |

The generalizable lesson, learned three times over: **a compliance rule must specify where the artifact appears, not only what it contains** — otherwise it drifts into private reasoning and quietly stops being auditable.

## Honest caveats

- **Cost is real**: ~1.6–1.9× the tokens and 3–4× the wall-clock of an unverified answer. The skill scales its own depth down for small questions, but this is not free and shouldn't be used where it isn't earned.
- **One open defect, disclosed rather than hidden.** Iteration 5's single failure is that same "artifact in private reasoning" class surfacing in `creative-divergence`'s tag rule — one run's 19 generated approaches lived only in thinking. A fix for that skill is drafted but deliberately **not** included here: it is untested, and #1539 should be evaluated on the version that was actually validated.
- Two prompts per round, 1–2 runs per cell: directional evidence, not calibrated benchmarks.
- Trigger battery: 18 cases, single run each, simulated skill-roster setting rather than a production harness.

## Triggering

18-case battery scored 17/18. The one miss was an over-trigger: given *"I have an idea for a scheduling assistant — does something like this already exist?"*, this orchestrator fired where `novelty-audit` alone was right — the presence of a product idea read as build intent and outweighed the old exclusion.

Rather than report that and move on, the description was tightened to state the actual discriminator: what matters is whether the user asks for new options to be **generated**, not whether they have something in mind. Bringing an idea to be checked is not asking for new ones. A 10-case retest on the tightened wording: the miss flips to `novelty-audit`; a new paired case ("does it exist — and if it does, what should we build instead?") correctly pulls the orchestrator; all five should-fire market/research cases still fire; the pure-audit and private-ideation cases stay with their components. No suppression.

Only the description changed; the instruction body is byte-identical to the version that was evaluated.

Full eval history, iteration by iteration: https://github.com/fdojose/creative-divergence-skill

## License

The skill folder includes its LICENSE.txt (MIT), following the per-skill licensing convention in this repository.
