### PR TITLE
fix: parse drained subprocess output tail in skill-creator eval

### DIFF
--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -97,6 +97,61 @@ def run_single_query(
         pending_tool_name = None
         accumulated_json = ""
 
+        def parse_line(line: str) -> bool | None:
+            """Parse one NDJSON line. Returns True=triggered, False=not-triggered, None=continue."""
+            nonlocal pending_tool_name, accumulated_json
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                return None
+
+            # Early detection via stream events
+            if event.get("type") == "stream_event":
+                se = event.get("event", {})
+                se_type = se.get("type", "")
+
+                if se_type == "content_block_start":
+                    cb = se.get("content_block", {})
+                    if cb.get("type") == "tool_use":
+                        tool_name = cb.get("name", "")
+                        if tool_name in ("Skill", "Read"):
+                            pending_tool_name = tool_name
+                            accumulated_json = ""
+                        else:
+                            return False
+
+                elif se_type == "content_block_delta" and pending_tool_name:
+                    delta = se.get("delta", {})
+                    if delta.get("type") == "input_json_delta":
+                        accumulated_json += delta.get("partial_json", "")
+                        if clean_name in accumulated_json:
+                            return True
+
+                elif se_type in ("content_block_stop", "message_stop"):
+                    if pending_tool_name:
+                        return clean_name in accumulated_json
+                    if se_type == "message_stop":
+                        return False
+
+            # Fallback: full assistant message
+            elif event.get("type") == "assistant":
+                message = event.get("message", {})
+                for content_item in message.get("content", []):
+                    if content_item.get("type") != "tool_use":
+                        continue
+                    tool_name = content_item.get("name", "")
+                    tool_input = content_item.get("input", {})
+                    if tool_name == "Skill" and clean_name in tool_input.get("skill", ""):
+                        return True
+                    elif tool_name == "Read" and clean_name in tool_input.get("file_path", ""):
+                        return True
+                return False
+
+            elif event.get("type") == "result":
+                return False
+
+            return None
+
         try:
             while time.time() - start_time < timeout:
                 if process.poll() is not None:
@@ -120,55 +175,15 @@ def run_single_query(
                     if not line:
                         continue
 
-                    try:
-                        event = json.loads(line)
-                    except json.JSONDecodeError:
-                        continue
+                    result = parse_line(line)
+                    if result is not None:
+                        return result
 
-                    # Early detection via stream events
-                    if event.get("type") == "stream_event":
-                        se = event.get("event", {})
-                        se_type = se.get("type", "")
-
-                        if se_type == "content_block_start":
-                            cb = se.get("content_block", {})
-                            if cb.get("type") == "tool_use":
-                                tool_name = cb.get("name", "")
-                                if tool_name in ("Skill", "Read"):
-                                    pending_tool_name = tool_name
-                                    accumulated_json = ""
-                                else:
-                                    return False
-
-                        elif se_type == "content_block_delta" and pending_tool_name:
-                            delta = se.get("delta", {})
-                            if delta.get("type") == "input_json_delta":
-                                accumulated_json += delta.get("partial_json", "")
-                                if clean_name in accumulated_json:
-                                    return True
-
-                        elif se_type in ("content_block_stop", "message_stop"):
-                            if pending_tool_name:
-                                return clean_name in accumulated_json
-                            if se_type == "message_stop":
-                                return False
-
-                    # Fallback: full assistant message
-                    elif event.get("type") == "assistant":
-                        message = event.get("message", {})
-                        for content_item in message.get("content", []):
-                            if content_item.get("type") != "tool_use":
-                                continue
-                            tool_name = content_item.get("name", "")
-                            tool_input = content_item.get("input", {})
-                            if tool_name == "Skill" and clean_name in tool_input.get("skill", ""):
-                                triggered = True
-                            elif tool_name == "Read" and clean_name in tool_input.get("file_path", ""):
-                                triggered = True
-                            return triggered
-
-                    elif event.get("type") == "result":
-                        return triggered
+            # Parse any remaining buffer after process exits
+            if buffer.strip():
+                result = parse_line(buffer.strip())
+                if result is not None:
+                    return result
         finally:
             # Clean up process on any exit path (return, exception, timeout)
             if process.poll() is None:


### PR DESCRIPTION
## Summary

Factor line-parsing into a closure and call it on the remaining buffer after the subprocess exits. This fixes Bug 1 where the last JSON lines arriving after process exit (common with `--include-partial-messages`) were never parsed, causing false negatives.

## Problem

The skill-creator description optimizer reports ~0% recall for skills that actually trigger. In `run_single_query`, when `process.poll()` returns non-None (process exited), the code reads remaining stdout into `buffer` but never parses it. The parsing logic only runs inside the `while` loop on streamed chunks. If the last JSON lines arrive after the process exits (common with `--include-partial-messages` streaming), they sit in `buffer` unparsed - false negative.

## Solution

- Extract the NDJSON line-parsing logic into a `parse_line` closure that captures `pending_tool_name` and `accumulated_json` via `nonlocal`
- Call `parse_line` inside the streaming loop (as before)
- After the loop exits (process exited), call `parse_line` on any remaining content in `buffer`

## Testing

Run existing eval sets with `--num-workers 10 --runs-per-query 3` and verify recall improves for known-good descriptions.