### PR TITLE
fix(docx): make validator encoding-safe on Windows

### DIFF
--- a/skills/docx/scripts/office/validators/base.py
+++ b/skills/docx/scripts/office/validators/base.py
@@ -783,7 +783,7 @@ class BaseSchemaValidator:
         try:
             schema = _load_schema(str(schema_path))
 
-            with open(xml_file, "r") as f:
+            with open(xml_file, "rb") as f:
                 xml_doc = lxml.etree.parse(f)
 
             xml_doc, _ = self._remove_template_tags_from_text_nodes(xml_doc)

--- a/skills/docx/scripts/office/validators/docx.py
+++ b/skills/docx/scripts/office/validators/docx.py
@@ -252,7 +252,7 @@ class DOCXSchemaValidator(BaseSchemaValidator):
         original_count = self.count_paragraphs_in_original()
         diff = new_count - original_count
         diff_str = f"+{diff}" if diff > 0 else str(diff)
-        print(f"\nParagraphs: {original_count} → {new_count} ({diff_str})")
+        print(f"\nParagraphs: {original_count} -> {new_count} ({diff_str})")
 
     def _parse_id_value(self, val: str, base: int = 16) -> int:
         return int(val, base)
@@ -446,7 +446,7 @@ class DOCXSchemaValidator(BaseSchemaValidator):
 
                             elem.setAttribute(attr_name, new_id)
                             pending.append(
-                                f"  Repaired: {xml_file.name}: durableId {durable_id} → {new_id}"
+                                f"  Repaired: {xml_file.name}: durableId {durable_id} -> {new_id}"
                             )
                             modified = True
 


### PR DESCRIPTION
## Summary

Makes DOCX validation encoding-safe on Windows by letting the XML parser handle encoding from the XML declaration and keeping validator console output ASCII-safe.

This prevents locale-dependent `UnicodeDecodeError` and `UnicodeEncodeError` failures, particularly on Windows systems using cp1252.

Fixes #712