### PR TITLE
docs(docx): add Word interoperability pitfalls

### DIFF
--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -58,6 +58,12 @@ python scripts/office/validate.py out.docx --original doc.docx   # XSD checks; -
 # redlining? add --author "<the name you redlined under>" to check every edit is tracked
 ```
 
+When editing OOXML manually, preserve Word interoperability:
+
+- **Line breaks in text:** do not put literal newlines inside `<w:t>`. End the text run, add `<w:r><w:br/></w:r>`, then continue in a new run.
+- **Header/footer relationship IDs:** never hardcode `rId1`, `rId2`, etc. Read `word/_rels/document.xml.rels` and use the actual relationship IDs referenced by the document.
+- **Numbering definitions:** when creating `w:abstractNum` manually, preserve the full Word-compatible structure from the template when possible, including `w:nsid`, `w:multiLevelType`, `w:tmpl`, and the appropriate `w:lvl` elements rather than emitting a minimal definition.
+
 Word splits text across many `<w:r>` runs (revision ids, spell-check markers), so a phrase you can see in the document often doesn't exist as a contiguous string in the XML. `merge_runs.py` merges adjacent identically-formatted runs in `word/document.xml` without changing content or rendering; it also accepts a `.docx` directly (`python scripts/merge_runs.py doc.docx -o merged.docx`).
 
 **Tracked changes:** when redlining, validate with `--author "<the name you redlined under>"` (needs `--original`) — it reports any text you changed without a `<w:ins>`/`<w:del>` around it, which is easy to do by accident and invisible in the accepted view. Wrap runs in `<w:ins>`/`<w:del>` with `w:id`, `w:author`, `w:date` attributes. Inside `<w:del>`, the text element is `<w:delText>`, not `<w:t>`. A deleted paragraph mark (`<w:pPr><w:rPr><w:del w:id=".." w:author=".." w:date=".."/></w:rPr></w:pPr>`) means "merge this paragraph into the next" — so deleting a paragraph outright is that plus a `<w:del>` around every run. The `<w:del/>` must come before the rPr's other children; their order is schema-enforced.


### PR DESCRIPTION
## Summary

Documents three OOXML interoperability pitfalls that can cause Microsoft Word to report unreadable content:

- literal newlines inside `<w:t>`
- hard-coded header/footer relationship IDs
- incomplete `w:abstractNum` numbering definitions

Adds the corresponding Word-compatible patterns to the DOCX skill.

Fixes #1060