### PR TITLE
docs(docx): document footnote separator repair workaround

### DIFF
--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -29,6 +29,7 @@ A `.docx` is a ZIP archive of XML files. Choose your approach by task:
 - **`PageBreak` must be inside a `Paragraph`.**
 - **Never use `\n`** — use separate `Paragraph` elements.
 - **TOC:** headings must use built-in `HeadingLevel.*`; custom heading styles need `outlineLevel` set or they won't appear.
+- **Footnotes:** if a docx-js document with footnotes opens with Word's repair dialog, inspect `word/footnotes.xml` before delivery. The special separator and continuation-separator footnotes are structural markers, not ordinary content footnotes; remove any `w:footnoteRef` and `FootnoteReference` run style that docx-js emitted inside those special entries while preserving their separator runs, then repack and verify the document again.
 - **Don't use a table as a horizontal rule** — use a paragraph bottom border instead.
 - **Dot-leader / right-aligned-on-same-line:** use `PositionalTab` (`alignment: PositionalTabAlignment.RIGHT`, `leader: PositionalTabLeader.DOT`) inside a `TextRun`, not literal `.` or space padding.
 


### PR DESCRIPTION
## Summary

Documents the footnote-separator repair failure reported for docx-js generated Word files.

When a generated document with footnotes opens with Word's repair dialog, the DOCX skill now tells the workflow to inspect `word/footnotes.xml` and remove content-footnote reference markup (`w:footnoteRef` / `FootnoteReference`) from the special separator and continuation-separator entries while preserving their separator runs, then repack and verify the document.

This intentionally addresses the reproducible footnote-separator path without adopting the issue's broader XML optimization suggestions.

Addresses #570