### PR TITLE
Fix quick_validate UTF-8 decoding crash on Windows

### DIFF
--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -19,7 +19,9 @@ def validate_skill(skill_path):
         return False, "SKILL.md not found"
 
     # Read and validate frontmatter
-    content = skill_md.read_text()
+    # Explicit UTF-8: read_text() uses the locale default encoding, which is
+    # cp1252 on Windows and crashes on UTF-8 SKILL.md files (e.g. emoji).
+    content = skill_md.read_text(encoding='utf-8')
     if not content.startswith('---'):
         return False, "No YAML frontmatter found"
 

--- a/skills/skill-creator/tests/test_quick_validate.py
+++ b/skills/skill-creator/tests/test_quick_validate.py
@@ -1,0 +1,60 @@
+"""Regression tests for quick_validate.py.
+
+Covers the UTF-8 decoding fix: read_text() without an explicit encoding uses
+the locale default (cp1252 on Windows) and crashes on UTF-8 SKILL.md files
+whose bytes are undefined in that codec. Also guards the frontmatter parsing
+behavior (LF and CRLF line endings - read_text normalizes CRLF - and missing
+frontmatter rejection).
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SKILL_CREATOR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SKILL_CREATOR))
+
+from scripts.quick_validate import validate_skill  # noqa: E402
+
+
+FRONTMATTER = """\
+---
+name: test-skill
+description: A test skill for validation.
+---
+"""
+
+
+def _write_skill(skill_dir: Path, content: str, newline: str) -> None:
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_bytes(content.replace("\n", newline).encode("utf-8"))
+
+
+def test_lf_skill_is_valid(tmp_path: Path) -> None:
+    _write_skill(tmp_path / "test-skill", FRONTMATTER, "\n")
+    valid, message = validate_skill(tmp_path / "test-skill")
+    assert valid, message
+
+
+def test_crlf_skill_is_valid(tmp_path: Path) -> None:
+    _write_skill(tmp_path / "test-skill", FRONTMATTER, "\r\n")
+    valid, message = validate_skill(tmp_path / "test-skill")
+    assert valid, message
+
+
+def test_crlf_skill_with_utf8_content_is_valid(tmp_path: Path) -> None:
+    # The warning sign's UTF-8 bytes include 0x9A, which is undefined in the
+    # cp1252 locale default encoding on Windows - a bare read_text() crashes.
+    content = FRONTMATTER.replace("test skill", "test skill \u26a0\ufe0f")
+    _write_skill(tmp_path / "test-skill", content, "\r\n")
+    valid, message = validate_skill(tmp_path / "test-skill")
+    assert valid, message
+
+
+def test_missing_frontmatter_is_invalid(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "test-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("no frontmatter here", encoding="utf-8")
+    valid, message = validate_skill(skill_dir)
+    assert not valid


### PR DESCRIPTION
## What

One-line fix for a Windows-only crash in the skill validator: `skill_md.read_text()` uses the locale default encoding, which is **cp1252 on Windows** and crashes with `UnicodeDecodeError` on UTF-8 `SKILL.md` files (e.g. the ⚠️ emoji in `claude-api/SKILL.md`).

```python
# before
content = skill_md.read_text()
# after
content = skill_md.read_text(encoding='utf-8')
```

Plus a comment explaining why the encoding must be explicit.

## Why it matters

Running `quick_validate.py` on Windows currently crashes on any skill with non-cp1252 bytes — which is **16 of the 17 bundled skills** (the claude-api one fails on the crash before its real issue can even be reported). The fix is conservative: explicit UTF-8 per the agentskills spec, zero behavior change on Linux/macOS.

## Verification

Reproduced live on Windows (cp1252 default):

```
$ python quick_validate.py skills/claude-api
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position ...: character maps to <undefined>
```

After the fix, the validator runs on all skills. It still flags `claude-api` — but for a real, previously-masked spec violation (its description is 1068 chars, over the 1024 limit) — and the other 16 pass.

## Tests

Added `tests/test_quick_validate.py` (4 tests). The UTF-8 regression test **fails on the pre-fix code** with the exact crash above and passes with the fix; the remaining tests lock in frontmatter parsing behavior (LF, CRLF, missing frontmatter). All pass on this branch.
