### PR TITLE
fix(skill-creator): fail loudly on degenerate train split in run_loop

### DIFF
--- a/skills/skill-creator/scripts/run_loop.py
+++ b/skills/skill-creator/scripts/run_loop.py
@@ -41,6 +41,25 @@ def split_eval_set(eval_set: list[dict], holdout: float, seed: int = 42) -> tupl
     test_set = trigger[:n_trigger_test] + no_trigger[:n_no_trigger_test]
     train_set = trigger[n_trigger_test:] + no_trigger[n_no_trigger_test:]
 
+    # A single-member class always lands entirely in the test split, and an
+    # empty train split would make the loop report "all passed" on iteration 1
+    # without testing anything. Fail loudly rather than silently producing a
+    # degenerate run.
+    if not eval_set:
+        raise ValueError("Eval set is empty; nothing to split.")
+    if len(trigger) > 0 and not trigger[n_trigger_test:]:
+        raise ValueError(
+            f"Cannot split eval set with holdout={holdout}: only {len(trigger)} "
+            "trigger query(ies), leaving none for the train split. Add at least "
+            "2 queries per polarity class or run with --holdout 0."
+        )
+    if len(no_trigger) > 0 and not no_trigger[n_no_trigger_test:]:
+        raise ValueError(
+            f"Cannot split eval set with holdout={holdout}: only {len(no_trigger)} "
+            "non-trigger query(ies), leaving none for the train split. Add at "
+            "least 2 queries per polarity class or run with --holdout 0."
+        )
+
     return train_set, test_set
 
 

--- a/skills/skill-creator/tests/test_run_loop.py
+++ b/skills/skill-creator/tests/test_run_loop.py
@@ -1,0 +1,56 @@
+"""Regression tests for run_loop.split_eval_set.
+
+Covers the degenerate-split bug: with a small eval set and holdout > 0, the
+train split could come back empty (or missing a polarity class), which made
+the optimization loop exit with "all_passed" on iteration 1 without testing
+anything.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SKILL_CREATOR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SKILL_CREATOR))
+
+from scripts.run_loop import split_eval_set  # noqa: E402
+
+
+def _eval_set(n_trigger: int, n_no_trigger: int) -> list[dict]:
+    return [
+        {"query": f"trigger-{i}", "should_trigger": True} for i in range(n_trigger)
+    ] + [
+        {"query": f"no-trigger-{i}", "should_trigger": False}
+        for i in range(n_no_trigger)
+    ]
+
+
+def test_balanced_set_splits_both_classes() -> None:
+    train, test = split_eval_set(_eval_set(3, 3), holdout=0.4)
+    assert train and test
+    assert any(e["should_trigger"] for e in train)
+    assert any(not e["should_trigger"] for e in train)
+    assert len(train) + len(test) == 6
+
+
+def test_single_trigger_query_fails_loudly() -> None:
+    with pytest.raises(ValueError, match="train split"):
+        split_eval_set(_eval_set(1, 3), holdout=0.4)
+
+
+def test_single_no_trigger_query_fails_loudly() -> None:
+    with pytest.raises(ValueError, match="train split"):
+        split_eval_set(_eval_set(3, 1), holdout=0.4)
+
+
+def test_two_query_eval_set_fails_loudly() -> None:
+    # 1 trigger + 1 no-trigger with the default holdout leaves an empty train
+    # split — the loop used to report "all_passed" instead of failing.
+    with pytest.raises(ValueError, match="train split"):
+        split_eval_set(_eval_set(1, 1), holdout=0.4)
+
+
+def test_empty_eval_set_fails_loudly() -> None:
+    with pytest.raises(ValueError, match="empty"):
+        split_eval_set([], holdout=0.4)


### PR DESCRIPTION
## What

`run_loop.py`'s train/test split could silently hand the optimization loop an **empty train split** (or one missing a polarity class), causing it to exit iteration 1 with `all_passed` — reporting success without testing a single query.

### Root cause

`split_eval_set()` takes `n_test = max(1, int(len(class) * holdout))` per polarity class. A class with **one member** always sends that member to the test split, leaving nothing in train. With the default `--holdout 0.4`:

- a 2-query eval set (1 trigger + 1 non-trigger) → **empty train split** → `train_summary["failed"] == 0` → `exit_reason = "all_passed (iteration 1)"`
- a 1-trigger + N-non-trigger set → train contains only non-trigger queries → the loop "optimizes" against a single polarity

Either way the tool claims a result it never measured, and the "best" description it returns is whatever it started with.

### Fix

`split_eval_set()` now **fails loudly** instead of returning a degenerate split:

- raises on an empty eval set
- raises when the trigger or non-trigger class has no members left for the train split, with a message telling the user to add more queries per class or run with `--holdout 0`

A class needs ≥2 members for a non-empty train split, so valid eval sets are unaffected.

## Verification

Added `tests/test_run_loop.py` (5 tests). On the unmodified code the four degenerate-split tests **fail** (the old code returns without raising); with the fix all 5 pass, and the balanced-split test pins the valid path so it can't regress. Full run: `pytest skills/skill-creator/tests/` green.
