### PR TITLE
Add wechat-mp-backup skill: export all articles from your own WeChat Official Account

### DIFF
--- a/skills/wechat-mp-backup/LICENSE.txt
+++ b/skills/wechat-mp-backup/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 特里斯丹 (Tristan)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/wechat-mp-backup/SKILL.md
+++ b/skills/wechat-mp-backup/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: wechat-mp-backup
+description: Export and back up every article from the user's own WeChat Official Account (微信公众号) as Markdown + images + raw HTML + metadata, with a single QR-code login and resumable downloads. Use when the user wants to export, back up, migrate or download the full article history of a WeChat Official Account they administer (公众号文章导出/备份/迁移/历史文章下载).
+license: Complete terms in LICENSE.txt
+---
+
+# 微信公众号历史文章备份
+
+脚本位于本 skill 的 `scripts/` 目录：`step1_list_articles.py`、`step2_download_articles.py`、`step3_wayback.py`、`make_index.py`
+（找不到时可 `git clone https://github.com/pixel-ju/wechat-mp-backup` 从仓库根目录取）。
+项目主页与完整说明：https://github.com/pixel-ju/wechat-mp-backup
+
+## 何时使用
+用户是公众号管理员，想把自己账号里的历史文章（含图片）全部导出到本地或迁移到其他平台。
+**只用于用户自己有管理权限的账号**；如果用户想抓别人的公众号，说明本工具不适用。
+
+## 前置条件
+- Python 3.9+：`pip install playwright requests beautifulsoup4 markdownify`
+- 本机安装 Google Chrome（Playwright 自带 Chromium 在微信文章页会崩溃/被拦，纯 `curl` 只能拿到"环境异常"验证页）
+- 用户能用管理员微信扫码
+
+## 步骤
+1. 在用户指定的工作目录（没有就新建 `wechat_export/`）里，把本 skill `scripts/` 下的 4 个 `.py` 脚本复制过去。
+2. 后台运行 `nohup python3 -u step1_list_articles.py > step1.log 2>&1 &`（`-u` 必须，否则日志不刷新），告诉用户浏览器已弹出、请扫码。脚本检测到 URL 里的 `token=` 即登录成功，并**立刻**把 cookie 存到 `mp_login_state.json`；之后所有步骤自动复用，**不要再让用户扫码**。
+3. 等 `step1.log` 出现 `>>> 完成`，读取 `articles.json`：按年份统计篇数、`is_deleted` 数量；日志里的"空 publish_info, 跳过"是纯文字/图片群发（非图文），属正常。
+4. `python3 step2_download_articles.py --limit 3` 试跑，检查 `output/` 里的 `article.md` 与 `images/`；没问题后后台全量运行 `nohup python3 -u step2_download_articles.py > step2.log 2>&1 &`，用 `until grep -qE ">>> 完成|Traceback" step2.log; do sleep 15; done` 等待（约 10 秒/篇）。
+5. `python3 make_index.py` 生成 `INDEX.md`。向用户汇报：成功篇数、图片总数、体积、失败原因分布，并说明失败类型均为微信侧不可恢复：
+   - `已删除(后台标记 is_deleted)`：作者自己删过，公开页显示"该内容已被发布者删除"，后台 `get_appmsg` 也返回 not found；
+   - `此内容发送失败无法查看` / `该内容暂时无法查看`：当年群发被拒或被平台屏蔽。
+6. 可选：`python3 step3_wayback.py` 去 Wayback Machine 找失败文章的存档（archive.org 限流很严，命中率也不高，如实告知用户）。
+
+## 输出结构
+`output/YYYY-MM-DD_标题/`：`article.md`（front-matter + 本地图片路径）、`article.html`、`page_raw.html`（原页备份）、`images/`、`meta.json`；另有 `articles.json/csv`、`download_log.json`、`INDEX.md`。
+
+## 坑
+- 老账号"发表记录"里会有 `publish_info` 为空的条目，必须跳过而不是崩溃（脚本已处理）。
+- 素材库（`appmsg?action=list_ex`）通常是已发表文章的子集，不用指望从中找回已删文章。
+- 每篇之间随机等待 3–6 秒；触发验证页时脚本会等 90 秒重试，不要把间隔调短。
+- 用户如果说"从 2012 年就开始发"，但清单最早只到某年，请如实告知后台记录起点，可能是另一个账号或早期已清理。
+- `mp_login_state.json` 含登录 cookie，绝不能提交到 git 或发给他人。

--- a/skills/wechat-mp-backup/scripts/make_index.py
+++ b/skills/wechat-mp-backup/scripts/make_index.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""生成 INDEX.md：全部文章清单 + 下载状态。用法: python3 make_index.py"""
+import json
+from pathlib import Path
+BASE = Path(__file__).parent
+a = json.loads((BASE / "articles.json").read_text("utf-8"))
+log = json.loads((BASE / "download_log.json").read_text("utf-8")) if (BASE / "download_log.json").exists() else {}
+ok = sum(1 for v in log.values() if v.get("ok"))
+lines = ["# 公众号文章总索引\n", f"共 {len(a)} 篇文章记录；已下载 {ok} 篇。\n",
+         "| 日期 | 标题 | 状态 | 本地目录 / 原链接 |", "|---|---|---|---|"]
+for x in a:
+    v = log.get(x["link"], {})
+    if v.get("ok"):
+        st, loc = "✅ 已下载", f"[{v['dir']}](output/{v['dir']}/article.md)"
+    else:
+        st, loc = "❌ " + v.get("reason", "未处理"), x["link"]
+    lines.append(f"| {x['date']} | {x['title'].replace('|', '｜')} | {st} | {loc} |")
+(BASE / "INDEX.md").write_text("\n".join(lines) + "\n", "utf-8")
+print(f"INDEX.md 已生成：{len(a)} 篇，已下载 {ok} 篇")

--- a/skills/wechat-mp-backup/scripts/step1_list_articles.py
+++ b/skills/wechat-mp-backup/scripts/step1_list_articles.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+步骤一：列出公众号后台的全部历史文章（发表记录）。
+用法:  python3 step1_list_articles.py
+  1. 会弹出浏览器窗口打开 mp.weixin.qq.com，请用管理员微信扫码登录。
+  2. 登录成功后脚本自动翻页拉取全部文章清单，保存到 articles.json / articles.csv。
+"""
+import csv, json, re, sys, time
+from pathlib import Path
+from playwright.sync_api import sync_playwright
+
+OUT_DIR = Path(__file__).parent
+STATE_FILE = OUT_DIR / "mp_login_state.json"   # 保存 cookie，下次不用重复扫码
+PAGE_SIZE = 10
+SLEEP = 2.5   # 每页之间的间隔，别太快
+
+def wait_login(page):
+    print(">>> 请在弹出的浏览器里扫码登录公众号后台 ...")
+    page.goto("https://mp.weixin.qq.com/")
+    last = ""
+    for i in range(1800):  # 最多等 30 分钟
+        for pg in page.context.pages:
+            m = re.search(r"token=(\d+)", pg.url)
+            if m:
+                print(">>> 登录成功, token =", m.group(1), "  url:", pg.url[:80])
+                return m.group(1)
+        # 兜底：已登录但 URL 里没 token 时，请求首页从正文里找 token
+        if i % 5 == 0:
+            try:
+                body = page.evaluate("async () => { const r = await fetch('https://mp.weixin.qq.com/cgi-bin/home?t=home/index&lang=zh_CN', {credentials:'include'}); return (await r.text()).slice(0, 200000); }")
+                m = re.search(r'token["\'=:\s]+(\d{6,})', body)
+                if m and "登录" not in body[:3000]:
+                    print(">>> 登录成功(从首页解析), token =", m.group(1))
+                    return m.group(1)
+            except Exception:
+                pass
+        if page.url != last:
+            print("    当前页面:", page.url[:100]); last = page.url
+        time.sleep(1)
+    sys.exit("登录超时")
+
+def api(page, url):
+    """在页面上下文里发请求，自动带 cookie"""
+    return page.evaluate("""async (u) => {
+        const r = await fetch(u, {credentials: 'include'});
+        return await r.json();
+    }""", url)
+
+def fetch_publish_list(page, token):
+    """接口一：发表记录 appmsgpublish（包含群发+发布的所有文章）"""
+    items, begin, total = [], 0, None
+    while True:
+        url = ("https://mp.weixin.qq.com/cgi-bin/appmsgpublish?sub=list&search_field=null"
+               f"&begin={begin}&count={PAGE_SIZE}&query=&fakeid=&type=101_1&free_publish_type=1"
+               f"&sub_action=list_ex&token={token}&lang=zh_CN&f=json&ajax=1")
+        data = api(page, url)
+        if data.get("base_resp", {}).get("ret") != 0:
+            print("!!! 接口返回异常:", data.get("base_resp"))
+            if data.get("base_resp", {}).get("ret") == 200013:
+                print("    被限频了，休息 60 秒后重试 ..."); time.sleep(60); continue
+            break
+        pp = json.loads(data["publish_page"])
+        if total is None:
+            total = pp.get("total_count", 0)
+            print(f">>> 发表记录总数(条群发/发布): {total}")
+        plist = pp.get("publish_list", [])
+        if not plist:
+            break
+        (OUT_DIR / "raw_pages").mkdir(exist_ok=True)
+        (OUT_DIR / "raw_pages" / f"publish_{begin:04d}.json").write_text(json.dumps(pp, ensure_ascii=False), "utf-8")
+        for p in plist:
+            try:
+                info = json.loads(p["publish_info"]) if p.get("publish_info") else {}
+            except Exception as e:
+                print("    !! publish_info 解析失败, 跳过:", str(p)[:200]); continue
+            if not info:
+                print("    !! 空 publish_info, 跳过 (publish_type=%s)" % p.get("publish_type")); continue
+            sent = info.get("sent_info", {})
+            for a in info.get("appmsgex", []):
+                items.append({
+                    "title": a.get("title"),
+                    "link": a.get("link"),
+                    "digest": a.get("digest"),
+                    "author": a.get("author_name"),
+                    "cover": a.get("cover"),
+                    "create_time": a.get("create_time"),
+                    "date": time.strftime("%Y-%m-%d", time.localtime(a.get("create_time", 0))),
+                    "aid": a.get("aid"),
+                    "is_deleted": a.get("is_deleted", False),
+                    "publish_type": p.get("publish_type"),
+                    "sent_time": sent.get("time"),
+                })
+        begin += PAGE_SIZE
+        print(f"    已获取 {len(items)} 篇文章 (begin={begin}/{total})")
+        (OUT_DIR / "articles_partial.json").write_text(json.dumps(items, ensure_ascii=False, indent=2), "utf-8")
+        if begin >= total:
+            break
+        time.sleep(SLEEP)
+    return items
+
+def fetch_appmsg_list(page, token):
+    """接口二(兜底)：素材/图文消息列表 appmsg list_ex"""
+    items, begin, total = [], 0, None
+    while True:
+        url = ("https://mp.weixin.qq.com/cgi-bin/appmsg?action=list_ex"
+               f"&begin={begin}&count={PAGE_SIZE}&fakeid=&type=9&query=&token={token}&lang=zh_CN&f=json&ajax=1")
+        data = api(page, url)
+        if data.get("base_resp", {}).get("ret") != 0:
+            print("!!! 接口二返回异常:", data.get("base_resp")); break
+        if total is None:
+            total = data.get("app_msg_cnt", 0)
+            print(f">>> 接口二 图文总数: {total}")
+        lst = data.get("app_msg_list", [])
+        if not lst: break
+        for a in lst:
+            items.append({
+                "title": a.get("title"), "link": a.get("link"), "digest": a.get("digest"),
+                "author": a.get("author_name"), "cover": a.get("cover"),
+                "create_time": a.get("create_time"),
+                "date": time.strftime("%Y-%m-%d", time.localtime(a.get("create_time", 0))),
+                "aid": a.get("aid"), "is_deleted": a.get("is_deleted", False),
+                "publish_type": "appmsg", "sent_time": a.get("update_time"),
+            })
+        begin += PAGE_SIZE
+        print(f"    已获取 {len(items)} 篇 (begin={begin}/{total})")
+        if begin >= total: break
+        time.sleep(SLEEP)
+    return items
+
+def launch_browser(p, headless):
+    """优先用系统 Chrome（微信页面在 Playwright 自带 Chromium 上会崩溃/被拦），没有再退回自带 Chromium"""
+    for ch in ("chrome", "msedge", None):
+        try:
+            return p.chromium.launch(headless=headless, channel=ch) if ch else p.chromium.launch(headless=headless)
+        except Exception:
+            continue
+    raise SystemExit("找不到可用浏览器，请安装 Google Chrome 或运行: playwright install chromium")
+
+def main():
+    with sync_playwright() as p:
+        browser = launch_browser(p, headless=False)
+        ctx = browser.new_context(storage_state=str(STATE_FILE) if STATE_FILE.exists() else None)
+        page = ctx.new_page()
+        token = wait_login(page)
+        ctx.storage_state(path=str(STATE_FILE))
+
+        items = fetch_publish_list(page, token)
+        if not items:
+            print(">>> 接口一没拿到数据，改用接口二 ...")
+            items = fetch_appmsg_list(page, token)
+
+        # 去重（同一 link 可能在群发和发布里各出现一次）
+        seen, uniq = set(), []
+        for it in items:
+            key = it["link"] or (it["title"], it["create_time"])
+            if key in seen: continue
+            seen.add(key); uniq.append(it)
+        uniq.sort(key=lambda x: x["create_time"] or 0)
+
+        (OUT_DIR / "articles.json").write_text(json.dumps(uniq, ensure_ascii=False, indent=2), "utf-8")
+        with open(OUT_DIR / "articles.csv", "w", newline="", encoding="utf-8-sig") as f:
+            w = csv.DictWriter(f, fieldnames=list(uniq[0].keys()) if uniq else ["title"])
+            w.writeheader(); w.writerows(uniq)
+        print(f"\n>>> 完成：共 {len(uniq)} 篇文章，已保存到 articles.json / articles.csv")
+        if uniq:
+            print("    最早:", uniq[0]["date"], uniq[0]["title"])
+            print("    最晚:", uniq[-1]["date"], uniq[-1]["title"])
+        browser.close()
+
+if __name__ == "__main__":
+    main()

--- a/skills/wechat-mp-backup/scripts/step2_download_articles.py
+++ b/skills/wechat-mp-backup/scripts/step2_download_articles.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""
+步骤二：按 articles.json 清单逐篇下载文章（正文 HTML + 图片 + Markdown + 元数据）。
+用法:
+  python3 step2_download_articles.py                 # 下载 articles.json 里的全部文章（可中断、可续跑）
+  python3 step2_download_articles.py --url <链接>    # 单篇测试
+  python3 step2_download_articles.py --limit 5       # 只下前 5 篇（试跑）
+输出目录: output/YYYY-MM-DD_标题/
+    article.md        Markdown（图片已改成本地相对路径）
+    article.html      清理过的正文 HTML（图片本地路径）
+    page_raw.html     微信原始整页 HTML（备份，图片仍指向微信 CDN）
+    meta.json         标题/作者/时间/原链接/图片清单
+    images/           所有图片
+"""
+import argparse, json, random, re, sys, time
+from pathlib import Path
+from urllib.parse import urlparse, parse_qs
+from bs4 import BeautifulSoup
+from markdownify import markdownify as md
+from playwright.sync_api import sync_playwright
+
+BASE = Path(__file__).parent
+OUT = BASE / "output"
+STATE_FILE = BASE / "mp_login_state.json"
+UA = ("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+      "(KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36")
+
+def safe_name(s, n=60):
+    s = re.sub(r'[\\/:*?"<>|\r\n\t]+', "_", s or "").strip(" ._")
+    return (s[:n] or "untitled")
+
+def img_ext(url, content_type=""):
+    q = parse_qs(urlparse(url).query)
+    fmt = (q.get("wx_fmt") or [""])[0].lower()
+    if fmt in ("jpeg", "jpg"): return "jpg"
+    if fmt in ("png", "gif", "webp", "bmp", "svg"): return fmt
+    if "png" in content_type: return "png"
+    if "gif" in content_type: return "gif"
+    if "webp" in content_type: return "webp"
+    return "jpg"
+
+def get_var(html, name):
+    m = re.search(r'var\s+' + name + r'\s*=\s*(?:htmlDecode\()?["\']([^"\']*)["\']', html)
+    return m.group(1) if m else ""
+
+def fetch_one(ctx, url, out_dir_hint=None, retries=3):
+    page = ctx.new_page()
+    try:
+        for attempt in range(retries):
+            page.goto(url, wait_until="domcontentloaded", timeout=60000)
+            page.wait_for_timeout(2500)
+            html = page.content()
+            if "环境异常" in html and "js_content" not in html:
+                print("    !! 触发验证页，等待 90 秒后重试 ...")
+                time.sleep(90); continue
+            break
+        soup = BeautifulSoup(html, "html.parser")
+        content = soup.select_one("#js_content")
+        if content is None:
+            # 已删除 / 违规 / 不存在
+            tip = soup.select_one(".weui-msg__title, .global_error_msg, #js_top_ad_area, .text_area")
+            reason = tip.get_text(strip=True) if tip else "未找到正文(#js_content)"
+            return {"ok": False, "reason": reason[:100], "raw": html}
+
+        title = (soup.select_one("#activity-name") or soup.select_one("h1"))
+        title = title.get_text(strip=True) if title else get_var(html, "msg_title")
+        author = (soup.select_one("#js_author_name") or soup.select_one("#meta_content .rich_media_meta_text"))
+        author = author.get_text(strip=True) if author else get_var(html, "author")
+        nickname = soup.select_one("#js_name")
+        nickname = nickname.get_text(strip=True) if nickname else get_var(html, "nickname")
+        create_time = get_var(html, "createTime")
+        if not create_time:
+            pt = soup.select_one("#publish_time")
+            create_time = pt.get_text(strip=True) if pt else ""
+        ct = get_var(html, "ct")
+        date = create_time[:10] if create_time else (time.strftime("%Y-%m-%d", time.localtime(int(ct))) if ct.isdigit() else "0000-00-00")
+        digest = get_var(html, "msg_desc")
+        cover = get_var(html, "msg_cdn_url")
+
+        # 目录
+        d = OUT / f"{date}_{safe_name(title)}"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "images").mkdir(exist_ok=True)
+        (d / "page_raw.html").write_text(html, "utf-8")
+
+        # 图片：收集 + 下载 + 改写
+        images = []
+        def download(src, idx, tag="img"):
+            if not src or src.startswith("data:"): return None
+            if src.startswith("//"): src = "https:" + src
+            try:
+                r = ctx.request.get(src, headers={"Referer": "https://mp.weixin.qq.com/"}, timeout=60000)
+                if r.status != 200 or len(r.body()) < 100: 
+                    print(f"    !! 图片下载失败 {r.status}: {src[:80]}"); return None
+                ext = img_ext(src, r.headers.get("content-type", ""))
+                fn = f"{tag}_{idx:03d}.{ext}"
+                (d / "images" / fn).write_bytes(r.body())
+                images.append({"file": f"images/{fn}", "src": src})
+                return f"images/{fn}"
+            except Exception as e:
+                print(f"    !! 图片异常: {e} {src[:80]}"); return None
+
+        for i, img in enumerate(content.find_all("img"), 1):
+            src = img.get("data-src") or img.get("src")
+            local = download(src, i)
+            for a in ["data-src", "data-w", "data-ratio", "data-type", "data-s", "data-backh", "data-backw",
+                      "data-croporisrc", "data-cropx1", "data-cropx2", "data-cropy1", "data-cropy2", "data-fail", "data-imgfileid", "crossorigin"]:
+                img.attrs.pop(a, None)
+            img.attrs.pop("style", None) if img.get("style") and "visibility" in img.get("style") else None
+            if local: img["src"] = local
+            elif src: img["src"] = src
+            time.sleep(random.uniform(0.2, 0.6))
+
+        # 背景图（section style="background-image:url(...)"）也尽量抓下来
+        bg_i = 0
+        for el in content.find_all(style=re.compile(r"background-image")):
+            m = re.search(r'url\((["\']?)(https?://mmbiz[^"\')]+)\1\)', el["style"])
+            if m:
+                bg_i += 1
+                local = download(m.group(2), bg_i, "bg")
+                if local: el["style"] = el["style"].replace(m.group(2), local)
+
+        if cover:
+            download(cover, 0, "cover")
+
+        # 去掉隐藏样式，导出正文 HTML
+        if content.get("style"):
+            content["style"] = re.sub(r"visibility\s*:\s*hidden;?|opacity\s*:\s*0;?", "", content["style"])
+        content_html = str(content)
+        page_html = f"""<!DOCTYPE html><html><head><meta charset="utf-8"><title>{title}</title>
+<style>body{{max-width:680px;margin:20px auto;padding:0 16px;font:16px/1.75 -apple-system,Helvetica,Arial,sans-serif;color:#333}} img{{max-width:100%;height:auto}}</style></head>
+<body><h1>{title}</h1><p style="color:#888">{nickname} · {author} · {create_time}<br><a href="{url}">{url}</a></p>
+{content_html}</body></html>"""
+        (d / "article.html").write_text(page_html, "utf-8")
+
+        body_md = md(content_html, heading_style="ATX", strip=["script", "style"])
+        body_md = re.sub(r"\n{3,}", "\n\n", body_md).strip()
+        front = f"---\ntitle: \"{title}\"\naccount: \"{nickname}\"\nauthor: \"{author}\"\ndate: \"{create_time}\"\nsource: \"{url}\"\ndigest: \"{digest}\"\n---\n\n# {title}\n\n"
+        (d / "article.md").write_text(front + body_md + "\n", "utf-8")
+
+        meta = {"title": title, "account": nickname, "author": author, "create_time": create_time,
+                "date": date, "url": url, "digest": digest, "cover": cover, "images": images, "dir": str(d.relative_to(BASE))}
+        (d / "meta.json").write_text(json.dumps(meta, ensure_ascii=False, indent=2), "utf-8")
+        return {"ok": True, "dir": d, "title": title, "n_img": len(images)}
+    finally:
+        page.close()
+
+def launch_browser(p, headless):
+    for ch in ("chrome", "msedge", None):
+        try:
+            return p.chromium.launch(headless=headless, channel=ch) if ch else p.chromium.launch(headless=headless)
+        except Exception:
+            continue
+    raise SystemExit("找不到可用浏览器，请安装 Google Chrome 或运行: playwright install chromium")
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--url"); ap.add_argument("--limit", type=int); ap.add_argument("--headed", action="store_true"); ap.add_argument("--include-deleted", action="store_true")
+    a = ap.parse_args()
+    OUT.mkdir(exist_ok=True)
+
+    if a.url:
+        items = [{"title": "", "link": a.url}]
+    else:
+        items = json.loads((BASE / "articles.json").read_text("utf-8"))
+        if a.limit: items = items[:a.limit]
+
+    done_file = BASE / "download_log.json"
+    log = json.loads(done_file.read_text("utf-8")) if done_file.exists() else {}
+
+    with sync_playwright() as p:
+        b = launch_browser(p, headless=not a.headed)
+        ctx = b.new_context(user_agent=UA, storage_state=str(STATE_FILE) if STATE_FILE.exists() else None)
+        total = len(items)
+        for i, it in enumerate(items, 1):
+            url = it["link"]
+            if not url:
+                continue
+            if url in log and log[url].get("ok"):
+                continue
+            if it.get("is_deleted") and not a.include_deleted:
+                log[url] = {"ok": False, "reason": "已删除(后台标记 is_deleted, 跳过)", "title": it.get("title"), "date": it.get("date")}
+                continue
+            print(f"[{i}/{total}] {it.get('date','')} {it.get('title','')[:40]}")
+            try:
+                r = fetch_one(ctx, url)
+            except Exception as e:
+                r = {"ok": False, "reason": f"exception: {e}"[:200]}
+            if r["ok"]:
+                print(f"    ✓ {r['n_img']} 张图 -> {r['dir'].name}")
+                log[url] = {"ok": True, "dir": r["dir"].name, "title": r["title"]}
+            else:
+                print(f"    ✗ 失败: {r['reason']}")
+                log[url] = {"ok": False, "reason": r["reason"], "title": it.get("title")}
+                if r.get("raw"):
+                    fd = OUT / "_failed"; fd.mkdir(exist_ok=True)
+                    (fd / f"{safe_name(it.get('title') or url[-20:])}.html").write_text(r["raw"], "utf-8")
+            done_file.write_text(json.dumps(log, ensure_ascii=False, indent=2), "utf-8")
+            time.sleep(random.uniform(3, 6))
+        b.close()
+
+    ok = sum(1 for v in log.values() if v.get("ok")); bad = [k for k, v in log.items() if not v.get("ok")]
+    print(f"\n>>> 完成: 成功 {ok} 篇, 失败 {len(bad)} 篇。日志: download_log.json")
+    for k in bad[:20]: print("   失败:", log[k].get("title"), log[k].get("reason"), k)
+
+if __name__ == "__main__":
+    main()

--- a/skills/wechat-mp-backup/scripts/step3_wayback.py
+++ b/skills/wechat-mp-backup/scripts/step3_wayback.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""
+步骤三（可选）：对微信侧已删除/无法查看的文章，去 Wayback Machine (web.archive.org) 找存档。
+用法: python3 step3_wayback.py        # 读取 download_log.json 中失败的文章，逐个查询，有存档就下载到 output_wayback/
+注意: archive.org 限流很严，每次查询间隔 6 秒；被 429 时会自动等待 2 分钟再试。
+"""
+import json, re, time, urllib.parse
+from pathlib import Path
+import requests
+from bs4 import BeautifulSoup
+from markdownify import markdownify as md
+
+BASE = Path(__file__).parent
+OUT = BASE / "output_wayback"; OUT.mkdir(exist_ok=True)
+log = json.loads((BASE / "download_log.json").read_text("utf-8"))
+targets = [(u, v) for u, v in log.items() if not v.get("ok")]
+print(f"待查询 {len(targets)} 篇")
+res_file = BASE / "wayback_log.json"
+res = json.loads(res_file.read_text("utf-8")) if res_file.exists() else {}
+S = requests.Session(); S.headers["User-Agent"] = "Mozilla/5.0"
+
+def get(url, **kw):
+    for _ in range(5):
+        r = S.get(url, timeout=60, **kw)
+        if r.status_code == 429:
+            print("   429 限流，等 120 秒 ..."); time.sleep(120); continue
+        return r
+    return r
+
+for i, (url, v) in enumerate(targets, 1):
+    if url in res: continue
+    print(f"[{i}/{len(targets)}] {v.get('title')}")
+    r = get("https://archive.org/wayback/available?url=" + urllib.parse.quote(url, safe=""))
+    try:
+        snap = r.json().get("archived_snapshots", {}).get("closest")
+    except Exception:
+        snap = None
+    if not snap:
+        res[url] = {"found": False, "title": v.get("title")}; print("   无存档")
+    else:
+        snap_url = snap["url"]
+        page = get(snap_url)
+        soup = BeautifulSoup(page.text, "html.parser")
+        content = soup.select_one("#js_content")
+        if content is None or "该内容已被发布者删除" in page.text:
+            res[url] = {"found": True, "usable": False, "snapshot": snap_url, "title": v.get("title")}
+            print("   有存档但无正文:", snap_url)
+        else:
+            title = (soup.select_one("#activity-name") or soup.title).get_text(strip=True)
+            d = OUT / re.sub(r'[\\/:*?"<>|]+', "_", f"{snap['timestamp'][:8]}_{title}")[:70]; d.mkdir(exist_ok=True)
+            (d / "page_raw.html").write_text(page.text, "utf-8")
+            (d / "article.md").write_text(f"# {title}\n\n来源: {url}\n存档: {snap_url}\n\n" + md(str(content), heading_style="ATX"), "utf-8")
+            res[url] = {"found": True, "usable": True, "snapshot": snap_url, "dir": d.name, "title": title}
+            print("   ✓ 找回:", d.name)
+    res_file.write_text(json.dumps(res, ensure_ascii=False, indent=2), "utf-8")
+    time.sleep(6)
+print("完成，结果见 wayback_log.json")


### PR DESCRIPTION
## Summary

Adds **wechat-mp-backup**, a skill that lets Claude export and back up every article from the user's *own* WeChat Official Account (微信公众号) — the largest Chinese-language publishing platform, with millions of accounts and no official bulk-export feature.

- One QR-code login to mp.weixin.qq.com (the account owner's own backend), then fully automatic: list every published article via the publish-history API, download each one as **Markdown + all images + raw HTML + metadata**, build an index, report what WeChat itself no longer serves.
- Resumable, rate-limit aware, cross-platform (Playwright + system Chrome; no Windows WeChat client / packet capture required).
- Only touches accounts the user administers — no scraping of third-party accounts.

## Why it's useful

Existing tools target other people's accounts, need the Windows WeChat client, or depend on a backend search API WeChat shut down in 2026. Owners who get their account restricted or want to migrate platforms had no lightweight, working option. Tested end-to-end on a real account with 400+ articles (148 recoverable articles, 1,129 images, ~730 MB exported).

## Layout

```
skills/wechat-mp-backup/
├── SKILL.md          # instructions (zh-CN body, bilingual description) — workflow, output structure, known pitfalls
├── LICENSE.txt       # MIT
└── scripts/          # step1_list_articles.py, step2_download_articles.py, step3_wayback.py, make_index.py
```

Source / issue tracker: https://github.com/pixel-ju/wechat-mp-backup (also installable as a Claude Code plugin marketplace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)