### PR TITLE
Add 4 practical skills: video-to-text, de-ai-writer, doc-ocr, ecommerce-material-studio

### DIFF
--- a/skills/de-ai-writer/SKILL.md
+++ b/skills/de-ai-writer/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: de-ai-writer
+description: "AI 文案去味器。用户提供 AI 生成的文本（公众号/小红书/电商文案等），觉得"太 AI 味"要改得更自然、更像人写的时使用。输出自然有人味的中文。De-AI writer: rewrite AI-generated copy (WeChat articles, Xiaohongshu, e-commerce) into natural, human-sounding Chinese text."
+version: 1.0.0
+author: 涛哥
+license: MIT
+metadata:
+  hermes:
+    tags: [writing, editing, humanize, de-ai, copywriting]
+    category: utilities
+    homepage: https://gitee.com/tao6677/useful-tools
+---
+
+# De-AI Writer AI 文案去味器
+
+把 AI 生成的文字改写成自然、有真人味的中文。专治空洞拔高、排比三连、官方黑话、模板化结尾。
+
+## 触发条件
+
+用户提供一段文字（粘贴或文件），要求：
+- "去AI味""改得像人写的""太官方了改自然点"
+- 润色文案（公众号/小红书/电商标题/产品描述）
+
+## 使用步骤
+
+### 1. 有 API Key（推荐，效果好）
+
+```bash
+export LLM_API_KEY="你的key"
+export LLM_BASE_URL="https://api.deepseek.com/v1"  # 任意 OpenAI 兼容接口
+export LLM_MODEL="deepseek-chat"
+
+python3 ~/.hermes/skills/utilities/de-ai-writer/scripts/deai.py 稿子.txt -o 改好.txt
+```
+
+### 2. 无 API Key（零成本模式）
+
+```bash
+python3 ~/.hermes/skills/utilities/de-ai-writer/scripts/deai.py 稿子.txt --prompt-only
+```
+
+输出内置完整改写规则的提示词，粘贴到任何 AI 助手（ChatGPT/文心/Kimi）即可改写。
+
+## 零依赖
+
+纯 Python 标准库，无需安装任何包。
+
+## 💛 免费使用 · 自愿支持
+
+**本技能完全免费使用。**
+
+觉得好用、帮到你了，可以**自愿扫码支持**（金额随意，一杯咖啡即可）：
+
+![支付宝收款码](assets/alipay_qr.jpg)
+
+> 支持过我的人，后续 Pro 版/批量服务有优惠。
+> 想提需求、反馈问题，欢迎到 Gitee 仓库提 Issue。

--- a/skills/doc-ocr/SKILL.md
+++ b/skills/doc-ocr/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: doc-ocr
+description: "文档文字识别。用户提供 PDF/扫描件/图片（合同、发票、书页、截图），需要提取文字、转成可编辑文本时使用。扫描件自动 OCR（macOS Vision，中英文）。Document OCR: extract editable text from PDFs, scans, and images (contracts, invoices, book pages, screenshots) via macOS Vision."
+version: 1.0.0
+author: 涛哥
+license: MIT
+metadata:
+  hermes:
+    tags: [ocr, pdf, document, text-extraction, scan]
+    category: utilities
+    homepage: https://gitee.com/tao6677/useful-tools
+---
+
+# Doc-OCR 文档文字识别
+
+PDF / 扫描件 / 图片 → 可编辑文字。有文字层的 PDF 直接提取，扫描件自动 OCR（macOS Vision 自带，中英文）。
+
+## 触发条件
+
+用户提供 PDF/图片文件，要求：
+- "提取文字""转文字""OCR"
+- 处理扫描件、合同、发票、书页、截图
+
+## 使用步骤
+
+### 1. 单个文件
+
+```bash
+python3 ~/.hermes/skills/utilities/doc-ocr/scripts/dococr.py 合同.pdf
+python3 ~/.hermes/skills/utilities/doc-ocr/scripts/dococr.py 发票.jpg
+```
+
+输出保存为 `<输入名>_ocr.txt`。
+
+### 2. 批量目录
+
+```bash
+python3 ~/.hermes/skills/utilities/doc-ocr/scripts/dococr.py ./扫描件/ -o 全部.txt
+```
+
+### 3. Markdown 输出
+
+```bash
+python3 ~/.hermes/skills/utilities/doc-ocr/scripts/dococr.py 书.pdf --md
+```
+
+## 依赖（首次使用时安装）
+
+```bash
+pip3 install pymupdf pyobjc-framework-Vision
+```
+
+**注意**：OCR 依赖 macOS Vision（仅 macOS 可用）。Linux 需另装 tesseract 等引擎。
+
+## 已知陷阱
+
+- **扫描件判定**：PDF 文字层 <20 字自动走 OCR，正常 PDF 直接提取。
+- **手写体**：Vision 对印刷体/清晰手写效果好，潦草手写不保证。
+- **隐私卖点**：文件在本机处理，不上传第三方。
+
+## 💛 免费使用 · 自愿支持
+
+**本技能完全免费使用。**
+
+觉得好用、帮到你了，可以**自愿扫码支持**（金额随意，一杯咖啡即可）：
+
+![支付宝收款码](assets/alipay_qr.jpg)
+
+> 支持过我的人，后续 Pro 版/批量服务有优惠。
+> 想提需求、反馈问题，欢迎到 Gitee 仓库提 Issue。

--- a/skills/ecommerce-material-studio/SKILL.md
+++ b/skills/ecommerce-material-studio/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: ecommerce-material-studio
+description: "电商素材工坊（中英双语）。用户需要生成电商主图、详情图、场景图、产品图合成、品牌叠加时使用。自动识别品类→匹配风格→场景感知合成→统一文字→自动质检→多平台适配→标准化交付。E-commerce product image studio: category detection, style matching, scene-aware compositing, text overlay, quality check, multi-platform adaptation, batch delivery."
+version: 1.0.0
+author: 涛哥
+license: MIT
+metadata:
+  hermes:
+    tags: [ecommerce, image-generation, product-photo, 电商, 主图, 素材, 场景图]
+---
+
+# 电商素材工坊 / E-commerce Material Studio
+
+生成电商产品素材（主图/详情图/场景图）的一站式工具链。输入产品图片 → 自动完成品类识别、风格匹配、场景合成、文字叠加、质检、多平台适配、批量交付。
+
+**One-stop pipeline for e-commerce product images: category detection → style matching → scene compositing → text overlay → quality check → platform adaptation → batch delivery.**
+
+## 何时使用 / When to use
+
+- 用户需要生成**电商主图/详情图**（如"帮我做一套剃须刀主图"）
+- 需要**产品图合成到场景**（白底图 → 场景图）
+- 需要**品牌叠加**（Logo/保障条/卖点文字/徽章）
+- 需要**多平台尺寸适配**（淘宝/快手/抖音/拼多多/京东等 7 平台）
+- 需要**批量生成**多个产品素材
+
+## 使用流程 / Workflow
+
+```bash
+# 0. 环境依赖（一次性）
+pip install Pillow numpy scipy
+
+# 1. 品类识别：输入产品图 → 识别品类/风格
+python3 scripts/category_detector.py product.png
+
+# 2. 风格匹配：品类+价位+平台+品牌 → 推荐模板
+python3 scripts/style_matcher.py --category 个护电器 --sub-category 剃须刀 --price 169 --platform kuaishou
+
+# 3. 场景感知合成（核心）：场景图+产品图 → 按参照物尺度自动合成
+python3 scripts/scene_aware_compositor.py --scene scene.jpg --product product.png --scene-type lifestyle_bathroom
+
+# 4. 统一文字叠加（z-index 分层，自动避让）
+python3 scripts/text_engine.py --image result.png --text "Type-C快充" --layout bottom_band
+
+# 5. 自动质检（5 项检查）
+python3 scripts/quality_check.py --dir ./output
+
+# 6. 多平台尺寸适配
+python3 scripts/platform_adapter.py --dir ./output --platform kuaishou
+
+# 7. 标准化交付打包（自动生成使用指南+清单+zip）
+python3 scripts/delivery_packager.py --project-dir ./output --product-name "示例产品"
+
+# 8. 批量处理（多产品，断点续传）
+python3 scripts/batch_processor.py --input products.json --output-dir ./batch --prepare
+```
+
+## 模块清单 / Modules
+
+| 模块 | 功能 | 依赖 |
+|:---|:---|:---|
+| `category_detector.py` | 品类识别（色调/材质→子品类） | Pillow |
+| `style_matcher.py` | 风格匹配（品类+价位+平台+品牌→模板） | 无 |
+| `brand_loader.py` | 品牌配置加载（多品牌/Logo选择） | 无 |
+| `text_engine.py` | 统一文字引擎（z-index/避让/对比度） | Pillow |
+| `quality_check.py` | 自动质检（分辨率/可读性/Logo/完整/重叠） | Pillow |
+| `preference_memory.py` | 偏好记忆（跨项目复用风格） | 无 |
+| `batch_processor.py` | 批量处理（断点续传/重试/报告） | 无 |
+| `platform_adapter.py` | 7 平台尺寸适配（resize/crop/压缩） | Pillow |
+| `delivery_packager.py` | 交付打包（使用指南+清单+zip） | Pillow |
+| `layout_engine.py` | 布局引擎（物理尺寸→像素比例） | 无 |
+| `scene_aware_compositor.py` | 场景感知合成（参照物尺度/透视/景深） | Pillow+numpy+scipy |
+
+## 数据文件 / Data (references/)
+
+- `category_templates.json` — 12 品类场景模板库（推荐场景/prompt/配色/文字风格）
+- `product_profiles.json` — 产品档案库（示例：example_shaver）
+- `brand_profiles/langke.json` — 示例品牌配置（朗科=示例品牌，非真实）
+- `brand_config_template.json` — 新建品牌模板
+- `user_preferences.json` — 偏好记忆库（模板）
+
+## 注意事项 / Notes
+
+- **字体**：`text_engine.py` 需要中文字体（macOS: `/System/Library/Fonts/PingFang.ttc`，Linux: NotoSansCJK，Windows: msyh.ttc）——按需修改 `FONT_PATHS_BOLD`/`FONT_PATHS_REGULAR` 常量
+- **品牌配置**：用 `brand_config_template.json` 新建自己的品牌（含 Logo 路径/色系/保障条）
+- **合成模式**：`scene_aware_compositor.py` 支持场景感知模式（自动算尺度）和兼容模式（固定 scale）
+- 参考数据中的"朗科/LangKe"为**示例品牌**，可直接替换为自己的品牌配置
+
+## 💛 免费使用 · 自愿支持 / Free with optional support
+
+**本技能完全免费使用。** 觉得好用、帮到你了，可以**自愿扫码支持**（金额随意，一杯咖啡即可）：
+
+![支付宝收款码](assets/alipay_qr.jpg)
+
+> 支持过我的人，后续 Pro 版/批量服务有优惠。
+> 想提需求、反馈问题，欢迎到 Gitee 仓库提 Issue：https://gitee.com/tao6677/useful-tools

--- a/skills/video-to-text/SKILL.md
+++ b/skills/video-to-text/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: video-to-text
+description: "视频转文字。用户发抖音/快手等视频分享链接，或本地视频文件，需要标题、点赞数、作者等元数据或语音转写全文时使用。抖音链接用 SSR 解析无需 Cookie。Video to text: extract metadata (title, likes, author) and transcribe speech from Douyin/Kuaishou share links or local video files."
+version: 1.0.0
+author: 涛哥
+license: MIT
+metadata:
+  hermes:
+    tags: [video, transcription, douyin, whisper, speech-to-text]
+    category: utilities
+    homepage: https://gitee.com/tao6677/useful-tools
+---
+
+# Video-to-Text 视频转文字
+
+把视频变成可复制、可搜索的文字。支持抖音分享链接（无需登录）和本地视频文件。
+
+## 触发条件
+
+用户发送以下内容时使用本技能：
+- 抖音/快手分享链接，要求"转文字""提取文案""拆解视频"
+- 本地视频文件（.mp4/.mov），要求"语音转文字""字幕"
+
+## 使用步骤
+
+### 1. 抖音分享链接 → 元数据 + 转写
+
+```bash
+python3 ~/.hermes/skills/utilities/video-to-text/scripts/vtt.py "https://v.douyin.com/xxxx/" --transcribe
+```
+
+- 不加 `--transcribe` 只输出元数据（标题/作者/点赞/标签）
+- 脚本自动下载视频、提取音频、faster-whisper 转写
+- 转写文本保存为 `<输入名>_transcript.txt` 并打印时间戳分段
+
+### 2. 本地视频文件 → 语音转写
+
+```bash
+python3 ~/.hermes/skills/utilities/video-to-text/scripts/vtt.py 本地视频.mp4
+```
+
+## 依赖（首次使用时安装）
+
+```bash
+pip3 install faster-whisper        # 转写需要（首次会下载 tiny 模型 ~75MB）
+# macOS 自带 avconvert；Linux 需 ffmpeg
+# 抖音 SSR 解析零依赖（curl + 标准库）
+```
+
+## 已知陷阱
+
+- **duration_ms=0 假阴性**：SSR 元数据时长可能为 0，但实际是视频。若元数据显示 0 秒且有下载 URL，先下载验证，不要直接判定为图文。
+- **play_addr URL 过期**：SSR 解析出的视频 URL 可能 404，此时需 Cookie 降级或让用户提供文件。
+- **whisper 转写慢**：Intel Mac 上 3 分钟视频约 5 分钟；转写必须加 `language='zh'` 否则自动检测多花 1-2 分钟。
+- **图文内容**：duration=0 且下载文件 <1MB 时是图文（无音频），只输出元数据，不要编造内容。
+
+## 💛 免费使用 · 自愿支持
+
+**本技能完全免费使用。**
+
+觉得好用、帮到你了，可以**自愿扫码支持**（金额随意，一杯咖啡即可）：
+
+![支付宝收款码](assets/alipay_qr.jpg)
+
+> 支持过我的人，后续 Pro 版/批量服务有优惠。
+> 想提需求、反馈问题，欢迎到 Gitee 仓库提 Issue。


### PR DESCRIPTION
## Summary
Add 4 production-tested skills following the Agent Skills standard (SKILL.md with name/description frontmatter):

- **video-to-text**: Extract transcripts from Douyin video links or local video files with auto-download
- **de-ai-writer**: Rewrite AI-generated copy into natural human tone (removes robotic phrasing)
- **doc-ocr**: Fully local OCR for PDFs/scans/images — private, no upload
- **ecommerce-material-studio**: Batch e-commerce product images (main/detail/scene) with auto product scaling and brand overlay

## Details
Each skill is self-contained with SKILL.md (instructions + usage examples) and has been used in production e-commerce/content workflows. Compatible with Claude Code and any Agent Skills-compatible tool.

Apache-2.0 licensed.