### PR TITLE
fix(skill-creator): fix false-negative early returns + add cost guardrail

### DIFF
--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -382,12 +382,12 @@ Save the eval set to the workspace, then run in the background:
 python -m scripts.run_loop \
   --eval-set <path-to-trigger-eval.json> \
   --skill-path <path-to-skill> \
-  --model <model-id-powering-this-session> \
+  --model claude-haiku-4-5 \
   --max-iterations 5 \
   --verbose
 ```
 
-Use the model ID from your system prompt (the one powering the current session) so the triggering test matches what the user actually experiences.
+Use `claude-haiku-4-5` for the eval model — it matches real triggering behaviour while keeping invocation costs low. Large reasoning models consume far more tokens per call and will exhaust a subscription quota in minutes given the default parallelism. If you need to test triggering on a specific model, substitute it, but warn the user of the cost first.
 
 While it runs, periodically tail the output to give the user updates on which iteration it's on and what the scores look like.
 

--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -137,8 +137,6 @@ def run_single_query(
                                 if tool_name in ("Skill", "Read"):
                                     pending_tool_name = tool_name
                                     accumulated_json = ""
-                                else:
-                                    return False
 
                         elif se_type == "content_block_delta" and pending_tool_name:
                             delta = se.get("delta", {})
@@ -149,9 +147,10 @@ def run_single_query(
 
                         elif se_type in ("content_block_stop", "message_stop"):
                             if pending_tool_name:
-                                return clean_name in accumulated_json
-                            if se_type == "message_stop":
-                                return False
+                                if clean_name in accumulated_json:
+                                    return True
+                                pending_tool_name = None
+                                accumulated_json = ""
 
                     # Fallback: full assistant message
                     elif event.get("type") == "assistant":
@@ -165,7 +164,8 @@ def run_single_query(
                                 triggered = True
                             elif tool_name == "Read" and clean_name in tool_input.get("file_path", ""):
                                 triggered = True
-                            return triggered
+                        if triggered:
+                            return True
 
                     elif event.get("type") == "result":
                         return triggered

--- a/skills/skill-creator/scripts/run_loop.py
+++ b/skills/skill-creator/scripts/run_loop.py
@@ -267,6 +267,18 @@ def main():
 
     name, _, _ = parse_skill_md(skill_path)
 
+    est = len(eval_set) * args.runs_per_query * args.max_iterations
+    print(
+        f"Estimated claude invocations: ~{est} "
+        f"({len(eval_set)} queries × {args.runs_per_query} runs × {args.max_iterations} iterations, "
+        f"{args.num_workers} parallel workers, model: {args.model})",
+        file=sys.stderr,
+    )
+    if sys.stdin.isatty():
+        resp = input("Continue? [y/N] ").strip().lower()
+        if resp not in ("y", "yes"):
+            sys.exit(0)
+
     # Set up live report path
     if args.report != "none":
         if args.report == "auto":


### PR DESCRIPTION
## What

Three early-return bugs in `run_eval.py` and a missing cost guardrail in `run_loop.py` that together caused the description-optimization loop to burn a Max subscription quota in ~3 minutes (reported in #1412).

### Bug 1 — `else: return False` on non-Skill/Read tool

If the model runs `Grep`, `Glob`, `TodoWrite`, or any other tool before loading the skill, `run_single_query` hit `else: return False` on the first `content_block_start` and scored the run as a miss — before the skill had a chance to trigger. Models frequently do a quick search or write a todo before invoking a skill.

**Fix:** remove the `else: return False` branch entirely.

### Bug 2 — `message_stop` returns False when no Skill/Read pending

A multi-turn session can invoke the skill in a second or later assistant message. The `if se_type == "message_stop": return False` guard fired at the end of every message where no Skill/Read was the last pending block, ending the run prematurely.

**Fix:** on `content_block_stop`/`message_stop`, if the pending Skill/Read didn't match, clear the pending state and continue — only the `result` event ends the run with False.

### Bug 3 — fallback branch returns after the first `tool_use` block

The full-assistant-message fallback exited the loop after inspecting only the first `tool_use` block. If the skill appeared second or later in the message content list, it was missed.

**Fix:** move `return True` outside the for loop, after all blocks are scanned.

### Bug 4 — no cost guardrail

Defaults multiply to ~300 claude invocations per run (`20 queries × 3 runs × 5 iterations`). With 10 parallel workers on a reasoning-class model, this exhausted subscription quota in minutes with no warning.

**Fix:** print an estimated invocation count before starting. Prompt for confirmation in interactive mode (skipped in CI/piped usage via `sys.stdin.isatty()`).

### Bug 5 — SKILL.md instructs using the session model

The skill instructed agents to pass `--model <model-id-powering-this-session>`, which on a Max subscription means every eval call uses a large reasoning model.

**Fix:** default to `claude-haiku-4-5` in the documented command with an explanation. Haiku matches real triggering behaviour at a fraction of the token cost.

## Files changed

- `skills/skill-creator/scripts/run_eval.py` — bugs 1–3 (3 targeted edits)
- `skills/skill-creator/scripts/run_loop.py` — bug 4 (cost guardrail)
- `skills/skill-creator/SKILL.md` — bug 5 (model recommendation)

## Note on related PR

PR #1586 (Fixes #1419) fixes two additional `run_eval.py` bugs on different lines (installed-skill shadowing + parallel worker hash matching). The changes do not conflict at the line level.

## Test plan

- [ ] A run where the model executes Grep before the skill no longer scores as a miss
- [ ] A multi-turn session where the skill triggers in turn 2 is detected correctly
- [ ] Non-interactive call (`echo '' | python -m scripts.run_loop ...`) skips the confirmation prompt
- [ ] Interactive call shows invocation estimate before starting

Fixes #1412