### PR TITLE
fix(webapp-testing): kill the server's process group so servers aren't orphaned

### DIFF
--- a/skills/webapp-testing/scripts/with_server.py
+++ b/skills/webapp-testing/scripts/with_server.py
@@ -18,6 +18,8 @@ import subprocess
 import socket
 import time
 import sys
+import os
+import signal
 import argparse
 
 def is_server_ready(port, timeout=30):
@@ -66,11 +68,15 @@ def main():
             print(f"Starting server {i+1}/{len(servers)}: {server['cmd']}")
 
             # Use shell=True to support commands with cd and &&
+            # start_new_session puts the shell and everything it spawns into one process
+            # group, so cleanup can signal the whole group. Without it, terminate() reaches
+            # only the shell and the real server is orphaned, still holding its port.
             process = subprocess.Popen(
                 server['cmd'],
                 shell=True,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE
+                stderr=subprocess.PIPE,
+                start_new_session=True
             )
             server_processes.append(process)
 
@@ -92,11 +98,25 @@ def main():
         # Clean up all servers
         print(f"\nStopping {len(server_processes)} server(s)...")
         for i, process in enumerate(server_processes):
+            # Signal the whole process group, not just the shell.
             try:
-                process.terminate()
+                pgid = os.getpgid(process.pid)
+            except ProcessLookupError:
+                pgid = None
+            try:
+                if pgid is not None:
+                    os.killpg(pgid, signal.SIGTERM)
+                else:
+                    process.terminate()
                 process.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                process.kill()
+            except (subprocess.TimeoutExpired, ProcessLookupError):
+                try:
+                    if pgid is not None:
+                        os.killpg(pgid, signal.SIGKILL)
+                    else:
+                        process.kill()
+                except ProcessLookupError:
+                    pass
                 process.wait()
             print(f"Server {i+1} stopped")
         print("All servers stopped")


### PR DESCRIPTION
## Problem

`scripts/with_server.py` launches each server with `shell=True` and stops it with `process.terminate()`. That signals the **shell**, not the server the shell spawned. For any command of the documented multi-server form:

```bash
python scripts/with_server.py \
  --server "cd backend && python server.py" --port 3000 \
  --server "cd frontend && npm run dev" --port 5173 \
  -- python test.py
```

the shell dies and the real server is orphaned, still bound to its port. The script prints `All servers stopped` while the process is very much alive, and the next run fails with `EADDRINUSE` / `Address already in use`.

## Reproduction

```bash
python scripts/with_server.py --server "cd site && python3 -m http.server 8917" --port 8917 -- true
ss -ltn | grep 8917   # still listening after "All servers stopped"
```

## Fix

- `start_new_session=True` puts the shell and everything it spawns into one process group.
- Cleanup signals that group with `os.killpg` — `SIGTERM` first, `SIGKILL` after the existing 5s timeout.
- `ProcessLookupError` is tolerated on both paths, for a server that already exited on its own.

Behaviour is unchanged when the server is a direct child; this only extends the reach of the existing terminate/kill escalation.

## Verification

Reproduced the orphan on Linux (Ubuntu 24.04, Python 3.12), confirmed the port stays bound after cleanup, applied the patch, and confirmed the port is released. Checked with a page whose content is set by JS, so the run also exercises the documented `networkidle` path via Playwright before teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
