### PR TITLE
docs: add UIZZE to partner skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,4 +94,4 @@ The markdown content below contains the instructions, examples, and guidelines t
 Skills are a great way to teach Claude how to get better at using specific pieces of software. As we see awesome example skills from partners, we may highlight some of them here:
 
 - **Notion** - [Notion Skills for Claude](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0)
-- **UIZZE** - [Anti-UI-Slop skill](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop) for grounding web and iOS interface work in 800,000+ real screens, with a free local skill and an optional hosted preview.
+- **UIZZE** - [Anti-UI-Slop skill](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop) for product-specific design direction, required states, and a hard finish gate. The local skill is free; optional authenticated MCP retrieves references from 800,000+ real web and iOS screens.

--- a/README.md
+++ b/README.md
@@ -94,3 +94,4 @@ The markdown content below contains the instructions, examples, and guidelines t
 Skills are a great way to teach Claude how to get better at using specific pieces of software. As we see awesome example skills from partners, we may highlight some of them here:
 
 - **Notion** - [Notion Skills for Claude](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0)
+- **UIZZE** - [Anti-UI-Slop skill](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop) for grounding web and iOS interface work in 800,000+ real screens, with a free local skill and an optional hosted preview.


### PR DESCRIPTION
## Summary

Add UIZZE to the Partner Skills section.

UIZZE provides a free anti-ui-slop Skill for product-specific UI direction, required states, and a hard finish gate. Its optional authenticated MCP retrieves focused references and design materials from 800,000+ real web and iOS screens.

This link-only README entry adds no runtime dependency.

- Canonical repository: https://github.com/uizze/uizze
- Skill: https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop
- Free install: `npx skills add https://uizze.com --skill anti-ui-slop`
- Optional authenticated MCP: https://uizze.com/mcp