### PR TITLE
plan-file-hygiene: add post-edit verification (follow-up to #1479)

### DIFF
--- a/skills/plan-file-hygiene/LICENSE.txt
+++ b/skills/plan-file-hygiene/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Palo Alto AI Research Lab
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/plan-file-hygiene/SKILL.md
+++ b/skills/plan-file-hygiene/SKILL.md
@@ -75,6 +75,8 @@ Rule 2 guards against clobbering before you edit; this rule catches what slipped
 
 This is one cheap diff read, and it's the only check that happens after the write has actually landed — treat a shrinking or unexpected diff here with the same suspicion as the pre-write red flags in Rule 2.
 
+**Example**: You edit `PLAN.md` to check off item 3. Before writing, the file was 40 lines. After writing, `git diff` shows the expected one-line checkbox flip — plus a 12-line section under `## Research notes` removed, one you never touched. That's not your edit: a parallel session added that section after your read and your whole-file write overwrote it. Stop, re-read the current file (now including the research notes), and reapply just the checkbox change against that current version, so the notes survive.
+
 ## Report the hygiene pass
 
 After applying these rules, state briefly:
@@ -105,3 +107,4 @@ Actions: fold the still-relevant findings from `NOTES.md` into `PLAN.md` as a ta
 - **Concurrent writers on one plan**: give each writer its own `##` section and append-only discipline within it; always re-read immediately before writing.
 - **Several active tasks in one directory**: one `plan-<task-slug>.md` per task; a plan index file is optional and only worth it above three or four active plans.
 - **Ephemeral scratch that must exist mid-task**: name it so discovery finds it (`scratch-<task-slug>.md`) and delete it in the same session that finishes the task — scratch that outlives its session becomes someone else's mystery.
+- **No git, or the file is untracked**: keep a copy of the pre-edit content (in memory for this turn, or a quick shell copy) before writing, and diff against that copy after — the check in Rule 5 doesn't require version control, only a before-snapshot.

--- a/skills/plan-file-hygiene/SKILL.md
+++ b/skills/plan-file-hygiene/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: plan-file-hygiene
+description: Keeps working plans and scratch notes from multiplying and going stale. Before creating any PLAN.md, NOTES.md, TODO.md, or scratch markdown file, discover what already exists and update it instead of spawning a duplicate; never regenerate a shared plan file from memory; supersede old plans explicitly and archive them when their task completes. Use when starting or resuming multi-step work that tracks state in markdown files, or when a working directory has accumulated stray plan, notes, or scratch files that need consolidation.
+license: Apache-2.0. Complete terms in LICENSE.txt
+---
+
+# Plan File Hygiene
+
+Long-running agentic work tends to leave a trail: each planning or research step spawns its own `PLAN.md`, `NOTES.md`, or scratch file, and nothing ever merges, prunes, or supersedes them. Returning to the project, neither the agent nor the human can tell which plan is current.
+
+There is a second, quieter failure mode that makes this worse: "refreshing" a plan by rewriting the whole file from what the current session remembers. When more than one writer touches a plan — a parallel session, an earlier run, a human — a whole-file rewrite silently deletes every section the current session did not know about. The file still looks healthy afterward, so the loss goes unnoticed until someone needs the missing sections.
+
+These rules come from a production multi-writer setup where repeated plan-file losses were traced, via file version history, not to sync races but to exactly that whole-file-rewrite habit — and were eliminated by the discipline below.
+
+## Rule 1: Discover before you create
+
+Before creating any plan, notes, or scratch markdown file:
+
+1. **Search for existing candidates** in the working directory (and `docs/` if present):
+   - `PLAN*.md`, `*-plan.md`, `plan-*.md`
+   - `NOTES*.md`, `TODO*.md`, `SCRATCH*.md`, `scratch-*.md`
+   - Any markdown file at the repo root modified in the last few days
+2. **Read what you find** and classify each file: *current* (this task, still accurate), *superseded* (an older plan for the same work), *stale* (task finished or abandoned), or *unrelated* (different task, leave alone).
+3. **Decide**: exactly one file should be current for a given task.
+   - A matching plan exists → update it in place (Rule 2). Do not create a sibling.
+   - Scratch findings for a task that already has a plan file belong **in the plan file** — fold them in rather than growing a parallel notes file. Keep a separate notes file only while it serves a genuinely distinct purpose; once it overlaps the plan, merge it in and remove it.
+   - No match → create one file with a predictable name: `PLAN.md` for single-task repos, or `plan-<task-slug>.md` when several tasks share the directory.
+
+Never skip discovery because "this is just a quick scratch file" — quick scratch files are precisely what accumulates.
+
+## Rule 2: Merge, don't spawn; append, don't regenerate
+
+When a plan file already exists:
+
+- **Update means: re-read, then edit.** Read the file immediately before modifying it, then make a targeted edit — add your section, update your items, correct what changed. Base the edit on what is *in the file now*, not on what you remember being there.
+- **Never write the whole file from memory.** A regenerated plan contains only what the current session knows and deletes everyone else's sections. If your tooling only supports whole-file writes, do read → minimal diff → write back as one short operation, and if the file changed under you meanwhile, re-read and redo. Note that read-then-rewrite is still not race-safe: two writers can both read, then the later write erases the earlier one. When concurrent writers are a real possibility, use per-writer append-only sections (see Edge cases) — or, for a robust fix, route all writes through a single lock-protected append script.
+- **Do not create version-suffixed siblings** (`PLAN-v2.md`, `PLAN-final.md`, `PLAN-new.md`). A restructured plan replaces the old one explicitly (Rule 3); anything less is an edit to the existing file.
+
+Warning signs that you are about to clobber:
+
+- You are writing to a plan file you have not read in this turn.
+- You are "cleaning up" or "consolidating" by rewriting the file wholesale.
+- Your output is noticeably **smaller** than the existing file. Plans grow until they are archived; a plan file shrinking *in place* is a red flag, not a cleanup. (Deleting a scratch file whose content you just merged elsewhere is not a shrink — the content demonstrably moved.)
+
+## Rule 3: One current plan; supersede explicitly
+
+Adding or updating sections in place is a targeted edit (Rule 2). A restructure — the case for this rule — is when the successor would discard or reorder most of the existing content. Supersede only plans for **your own task**: another writer's plan is theirs to restructure — propose the supersede in your report instead of doing it. If your plan genuinely needs it:
+
+1. Mark the old file at the very top, naming the successor:
+   ```markdown
+   > **Superseded** by [plan-checkout-rewrite.md](plan-checkout-rewrite.md) on 2026-07-25. Kept for history.
+   ```
+2. Create the successor file.
+3. Move the superseded file out of the current location (see Rule 4) in the same working session.
+
+The marker goes on first deliberately: if the work is interrupted midway, a marker pointing at a successor still being written is recoverable, while two files both claiming to be the current plan is the original problem, restated.
+
+## Rule 4: Close the lifecycle when the task ends
+
+Plans need an explicit end of life:
+
+- **On task completion**: mark the plan done at the top (`> Done 2026-07-25`), then either archive it (move to `archive/` or `plans/archive/`, keeping the name) or delete it if it is pure scratch with no decisions worth keeping.
+- **Staleness sweep** when entering a cluttered directory: a plan or scratch file untouched for roughly two weeks (adjust to the project's cadence) whose task appears finished or abandoned is a candidate. Files belonging to *your own* task that are clearly finished → archive directly and say so in the report. Files whose ownership or state is uncertain → flag and propose, don't act.
+- **Delete only what is yours and absorbed.** Deleting is reserved for files you created (this session or a prior run of your own task) whose useful content is either nil or demonstrably merged elsewhere. Archive rather than delete whenever the file records decisions, constraints, or context.
+- **Respect other writers — and untracked always wins.** Never silently delete or archive a file you did not create. In a git repository, check `git status` first — an untracked plan or notes file may be someone's uncommitted work in progress. Untracked-and-not-yours overrides every other rule here, including staleness: flag it in the report, touch nothing.
+
+## Report the hygiene pass
+
+After applying these rules, state briefly:
+
+- which file is the current plan;
+- what was merged into it, and from where;
+- what was archived, superseded, or flagged as stale;
+- what was left untouched and why (unrelated, uncommitted, uncertain).
+
+This report is what lets the next session — or the human — trust the directory again.
+
+## Worked example
+
+A working directory contains:
+
+| File | Observation |
+|---|---|
+| `PLAN.md` | current task, updated 3 days ago, has open checkboxes |
+| `NOTES.md` | your own scratch findings from the same task, overlaps PLAN.md |
+| `plan-old-refactor.md` | task shipped a month ago, untouched since |
+| `TODO-ideas.md` | untracked in git, not yours |
+
+Actions: fold the still-relevant findings from `NOTES.md` into `PLAN.md` as a targeted edit (re-read first), then delete `NOTES.md` — it is yours and its content now lives in the plan; mark `plan-old-refactor.md` done and move it to `archive/` (tracked, clearly finished, so act directly); leave `TODO-ideas.md` in place but flag it in the report as someone else's uncommitted file. Result: one current plan, one archived plan, one flagged file — and a report saying exactly that.
+
+## Edge cases
+
+- **Concurrent writers on one plan**: give each writer its own `##` section and append-only discipline within it; always re-read immediately before writing.
+- **Several active tasks in one directory**: one `plan-<task-slug>.md` per task; a plan index file is optional and only worth it above three or four active plans.
+- **Ephemeral scratch that must exist mid-task**: name it so discovery finds it (`scratch-<task-slug>.md`) and delete it in the same session that finishes the task — scratch that outlives its session becomes someone else's mystery.

--- a/skills/plan-file-hygiene/SKILL.md
+++ b/skills/plan-file-hygiene/SKILL.md
@@ -64,6 +64,17 @@ Plans need an explicit end of life:
 - **Delete only what is yours and absorbed.** Deleting is reserved for files you created (this session or a prior run of your own task) whose useful content is either nil or demonstrably merged elsewhere. Archive rather than delete whenever the file records decisions, constraints, or context.
 - **Respect other writers — and untracked always wins.** Never silently delete or archive a file you did not create. In a git repository, check `git status` first — an untracked plan or notes file may be someone's uncommitted work in progress. Untracked-and-not-yours overrides every other rule here, including staleness: flag it in the report, touch nothing.
 
+## Rule 5: Verify after you write
+
+Rule 2 guards against clobbering before you edit; this rule catches what slipped through anyway. After every write to a shared plan file:
+
+1. **Diff old vs. new.** Compare the file's content immediately before your edit against what's on disk now — `git diff` in a repo, or a copy of the pre-edit content otherwise. Read the diff; don't just trust that the edit tool call succeeded.
+2. **Confirm only your change is there.** The diff should show the lines you intended to add, remove, or change, and nothing else. A section you didn't touch showing up as removed-then-re-added is a red flag even if its final content looks right — a full rewrite that happens to reproduce old text still risks losing a concurrent writer's edit that landed between your read and your write.
+3. **On an unexpected deletion, stop and re-read** — don't patch the gap from memory. The file changed under you; redo the edit as a fresh targeted diff against its current content. Papering over a missing section from what you remember it said is the same regenerate-from-memory failure Rule 2 warns about, one step later.
+4. **Note the check in your report**: which lines changed, and that nothing else did.
+
+This is one cheap diff read, and it's the only check that happens after the write has actually landed — treat a shrinking or unexpected diff here with the same suspicion as the pre-write red flags in Rule 2.
+
 ## Report the hygiene pass
 
 After applying these rules, state briefly:
@@ -71,7 +82,8 @@ After applying these rules, state briefly:
 - which file is the current plan;
 - what was merged into it, and from where;
 - what was archived, superseded, or flagged as stale;
-- what was left untouched and why (unrelated, uncommitted, uncertain).
+- what was left untouched and why (unrelated, uncommitted, uncertain);
+- confirmation that the post-write diff (Rule 5) showed only the intended change.
 
 This report is what lets the next session — or the human — trust the directory again.
 


### PR DESCRIPTION
Follow-up to #1479 (plan-file-hygiene skill, addresses #1417) — picks up the thread where @tonydzi and I discussed adding a check that runs after an edit lands, not just before it.

Rule 2 guards against clobbering before a write. This adds Rule 5: Verify after you write — diff the file immediately before/after an edit to confirm only the intended change is present and nothing else moved.
Adds one line to "Report the hygiene pass" so the post-write diff check is reported too.

Stacked on [#1479](https://github.com/halilxibrahim/skills/issues/1479)'s commit since plan-file-hygiene doesn't exist on main yet — only the last commit is new. Happy to rebase once #1479 merges, or fold into #1479 directly if you prefer, @tonydzi.