### PR TITLE
skill-creator: fix incorrect usage path in package_skill.py

### DIFF
--- a/skills/skill-creator/scripts/package_skill.py
+++ b/skills/skill-creator/scripts/package_skill.py
@@ -3,11 +3,11 @@
 Skill Packager - Creates a distributable .skill file of a skill folder
 
 Usage:
-    python utils/package_skill.py <path/to/skill-folder> [output-directory]
+    python -m scripts.package_skill <path/to/skill-folder> [output-directory]
 
 Example:
-    python utils/package_skill.py skills/public/my-skill
-    python utils/package_skill.py skills/public/my-skill ./dist
+    python -m scripts.package_skill skills/public/my-skill
+    python -m scripts.package_skill skills/public/my-skill ./dist
 """
 
 import fnmatch
@@ -110,10 +110,10 @@ def package_skill(skill_path, output_dir=None):
 
 def main():
     if len(sys.argv) < 2:
-        print("Usage: python utils/package_skill.py <path/to/skill-folder> [output-directory]")
+        print("Usage: python -m scripts.package_skill <path/to/skill-folder> [output-directory]")
         print("\nExample:")
-        print("  python utils/package_skill.py skills/public/my-skill")
-        print("  python utils/package_skill.py skills/public/my-skill ./dist")
+        print("  python -m scripts.package_skill skills/public/my-skill")
+        print("  python -m scripts.package_skill skills/public/my-skill ./dist")
         sys.exit(1)
 
     skill_path = sys.argv[1]


### PR DESCRIPTION
## Summary
- `skills/skill-creator/scripts/package_skill.py`'s docstring and `main()` usage output referenced `python utils/package_skill.py` — matching neither the file's actual location (`scripts/`) nor how it must be run.
- The script can't be run directly due to the `from scripts.quick_validate import validate_skill` import; it must be invoked as `python -m scripts.package_skill`.
- `SKILL.md` (line 413) already documented the correct command (`python -m scripts.package_skill`), but the script's own help output contradicted it.
- Fixed the docstring and the usage/example lines in `main()` to use `python -m scripts.package_skill`.

Fixes #904