### PR TITLE
Add skill: agent-dev-standards

### DIFF
--- a/skills/agent-dev-standards/LICENSE.txt
+++ b/skills/agent-dev-standards/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/agent-dev-standards/SKILL.md
+++ b/skills/agent-dev-standards/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: agent-dev-standards
+description: "Agent development quality standards and engineering guardrails. Use when Codex is: (1) Developing or modifying an Agent (code-reviewer, rag-bot, coding-agent, etc.), (2) Designing agent prompts, tool schemas, or function calling logic, (3) Setting up agent evaluation, tracing, or CI pipelines, (4) Reviewing agent code quality or enforcing development standards, (5) Defining agent registry entries, versioning, or deployment configurations. Not for: general AI Coding tool usage (Claude Code/Codex/Cursor), pure RAG pipeline without agent logic, or non-agent LLM applications."
+---
+
+# Agent Development Standards
+
+Enforceable engineering standards for building production-grade Agents. This skill embeds knowledge from the LLM application optimization and Agent engineering series into actionable rules.
+
+## Core Principles
+
+Every Agent must pass a 6-pillar gate before considered production-ready:
+
+| Pillar | Principle | Fail if |
+|--------|-----------|---------|
+| Prompt Management | Every prompt is a versioned file, not inline code | No front-matter or version |
+| Agent Registry | Every agent has a registry entry | No registry or stale dependency |
+| Tool Calling | Every tool has a typed schema + error recovery | Tools without error handling |
+| Evaluation | Every agent has a golden test suite | No evaluation before release |
+| Observability | Every agent emits spans and cost tags | No tracing or cost attribution |
+| Safety | Every agent has injection protection | No input validation or permission model |
+
+## Workflow: Agent Development Lifecycle
+
+### Phase 1: Design
+
+1. **Define intent**: What business problem does this agent solve? Single-responsibility per agent.
+2. **Registry entry**: Create agent entry with metadata (name, version, dependencies, prompt refs).
+3. **Prompt design**: Write system prompt as a .md file with front-matter (see references/prompt-management.md).
+4. **Tool schema**: Define tool schemas with typed parameters and error recovery paths (see references/tool-calling.md).
+
+### Phase 2: Implement
+
+5. **Prompt to code binding**: Use a loader that reads prompts from files, not f-strings.
+6. **Tool implementation**: Each tool must handle: success, partial success, retryable failure, terminal failure.
+7. **Tracing integration**: Agent must emit spans for each LLM call and tool call (see references/agent-observability.md).
+8. **Cost tagging**: Every LLM call tagged with agent_name, prompt_version, tool_name.
+
+### Phase 3: Validate
+
+9. **Golden test suite**: Minimum 10 golden cases covering happy path, edge cases, and failure modes (see references/evaluation.md).
+10. **CI gate**: Golden tests run on every prompt/tool change. Block if score drops below threshold.
+11. **Safety scan**: Check for prompt injection surfaces, tool permission leaks, data exposure (see references/safety.md).
+
+### Phase 4: Release
+
+12. **Registry update**: Bump version, update dependency graph.
+13. **Changelog**: Record what changed (prompt, tool, threshold) and why.
+14. **Cost baseline**: Record baseline cost per invocation before release.
+
+## Gate Checklist (Must-Pass)
+
+Before any agent code enters production, verify:
+
+- [ ] Prompt file exists with front-matter (version, description, author)
+- [ ] Prompt version is referenced in registry entry
+- [ ] All tool schemas have description and typed parameters
+- [ ] All tools have error handling (retry, fallback, or abort)
+- [ ] Agent registry entry exists and dependencies are up-to-date
+- [ ] Golden test suite exists and passes with score >= 80%
+- [ ] Tracing spans are emitted for every LLM and tool call
+- [ ] Cost tags are attached to every LLM call
+- [ ] Input validation exists (no raw user input in system prompt)
+- [ ] Tool permissions are least-privilege 
+- [ ] Degradation detection metrics are configured and baseline recorded
+
+## Phase 5: Monitor
+
+15. **Degradation detection**: Monitor cache hit rate, error rate, cost per call over time. Alert if any metric drops 20% below baseline (see references/agent-observability.md).
+16. **Incident response**: When degradation detected, freeze prompt version, roll back to last known good version, and trigger golden test suite. See references/incident-response.md.
+
+## Reference Files
+
+Load these when deeper guidance is needed:
+
+- references/prompt-management.md -- Front-matter schema, versioning strategy, caching optimization
+- references/agent-registry.md -- Registry schema, dependency tracking, impact analysis
+- references/tool-calling.md -- Tool schema design, error recovery patterns, orchestration
+- references/evaluation.md -- Evaluation dimensions, golden test structure, CI integration
+- references/safety.md -- Injection prevention, permission model, data isolation
+- references/agent-observability.md -- Span design, trace model, cost attribution, degradation detection
+- references/incident-response.md -- Freeze, rollback, and golden test trigger during production incidents 
+
+## Validation Script
+
+```
+python scripts/validate_agent_standards.py <agent-project-dir>
+```
+
+Checks: prompt files exist with front-matter, registry entry exists, tool schemas have error handling, golden tests exist, tracing calls present.

--- a/skills/agent-dev-standards/agents/openai.yaml
+++ b/skills/agent-dev-standards/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Agent Development Standards"
+  short_description: "Quality standards for production-grade Agent development: Prompt, Registry, Tool, Evaluation, Observability, Safety"
+  default_prompt: "Use agent-dev-standards skill to develop this Agent. Check the 6-pillar gate before production."

--- a/skills/agent-dev-standards/references/agent-observability.md
+++ b/skills/agent-dev-standards/references/agent-observability.md
@@ -1,0 +1,53 @@
+# Agent Observability
+
+Span design, trace model, and cost attribution for Agents.
+
+## Span Design
+
+Each Agent operation emits spans:
+
+| Span | Parent | Attributes |
+|------|--------|------------|
+| agent.run | (root) | agent_name, prompt_version, session_id |
+| llm.call | agent.run | model, input_tokens, output_tokens, cost |
+| tool.call | agent.run | tool_name, parameters, duration_ms, status |
+| tool.retry | tool.call | attempt, error, backoff_ms |
+
+## Trace Model
+
+A complete trace captures the full agent execution:
+
+`
+Trace: agent.run (code-reviewer, v1.2.0)
+  +-- llm.call (decide_action)
+  +-- tool.call (search_documents, query="auth bug", status=success)
+  |     +-- tool.retry (attempt 2, timeout 5s)
+  +-- llm.call (process_results, tokens=1200)
+  +-- tool.call (comment, pr_id=42, status=success)
+  +-- llm.call (final_summary, tokens=800)
+`
+
+## Cost Attribution
+
+Every LLM call must be tagged for cost tracking:
+
+`python
+# OpenTelemetry-style span attributes
+span.set_attribute("agent.name", "code-reviewer")
+span.set_attribute("prompt.version", "1.2.0")
+span.set_attribute("tool.name", "search_documents")
+span.set_attribute("cost.usd", 0.0042)
+`
+
+This enables querying cost by agent, cost by prompt version, cost by tool.
+
+## Degradation Detection
+
+Monitor these metrics over time (from the reliability series):
+
+| Metric | Warning | Critical |
+|--------|---------|----------|
+| Avg tool calls per task | > 20 | > 30 |
+| Error rate | > 5% | > 15% |
+| Cache hit rate drop | > 10% in 7d | > 25% in 7d |
+| Cost per invocation | > 2x baseline | > 5x baseline |

--- a/skills/agent-dev-standards/references/agent-registry.md
+++ b/skills/agent-dev-standards/references/agent-registry.md
@@ -1,0 +1,33 @@
+# Agent Registry
+Single source of truth for all Agent metadata and dependencies.
+## Registry Schema (registry.yaml)
+```yaml
+agents:
+  - name: code-reviewer
+    version: 2.1.0
+    description: Automated code review agent
+    prompt_ref: agents/code-reviewer/prompt.md@1.2.0
+    tools:
+      - search_code
+      - read_file
+      - comment
+    dependencies:
+      - shared/coding-standards@1.1.0
+      - shared/output-format@2.0.0
+    evaluation:
+      golden_suite: tests/golden/code-reviewer/
+      min_score: 0.85
+    cost_baseline:
+      input_tokens: 2500
+      output_tokens: 800
+      cost_per_call: 0.012
+    owner: team-ai
+    tags: [production, code-review]
+```
+## Dependency Impact Analysis
+When a shared prompt changes, the registry answers: which agents depend on it, what version do they pin, which need re-evaluation.
+## Registry Operations
+- Register: Add new agent entry
+- Update: Bump version, update dependency refs
+- Impact: List affected agents for a given dependency change
+- Validate: Check all prompt_refs exist and versions match

--- a/skills/agent-dev-standards/references/evaluation.md
+++ b/skills/agent-dev-standards/references/evaluation.md
@@ -1,0 +1,54 @@
+# Evaluation
+
+Golden test structure and CI integration for Agent evaluation.
+
+## Evaluation Dimensions
+
+| Dimension | What it measures | Target |
+|-----------|-----------------|--------|
+| Tool Selection | Agent picks the right tool for the task | >= 90% |
+| Parameter Accuracy | Tool call parameters are correct | >= 95% |
+| Chain Completion | Multi-step task completes without hang | >= 85% |
+| Error Recovery | Agent recovers from tool failures gracefully | >= 80% |
+| Output Quality | Final output meets requirements | >= 85% |
+
+## Golden Test Structure
+
+`
+tests/golden/<agent-name>/
+  happy-path/
+    test_basic_review.json
+    test_standard_pr.json
+  edge-cases/
+    test_empty_result.json
+    test_max_input.json
+  failure-modes/
+    test_tool_timeout.json
+    test_invalid_input.json
+    test_partial_result.json
+`
+
+Each test case is a JSON file describing the expected behavior:
+
+`json
+{
+  "input": {
+    "pr_diff": "diff --git a/src/main.py b/src/main.py",
+    "rules": "Check for security issues"
+  },
+  "expected_behavior": {
+    "tool_calls": ["search_code", "comment"],
+    "min_tool_calls": 1,
+    "max_tool_calls": 5
+  },
+  "expected_output_contains": ["security issue", "vulnerability"],
+  "expected_output_not_contains": ["I think", "might be"]
+}
+`
+
+## CI Integration
+
+1. Run golden suite on every prompt/tool change.
+2. Compare scores against baseline (stored in registry.yaml).
+3. Block merge if any dimension drops below threshold.
+4. Generate diff report: "tool_selection 92% -> 88% (FAIL)".

--- a/skills/agent-dev-standards/references/incident-response.md
+++ b/skills/agent-dev-standards/references/incident-response.md
@@ -1,0 +1,21 @@
+# Incident Response
+
+When an Agent degrades in production, follow this runbook.
+
+## Trigger Conditions
+
+| Signal | Threshold | Action |
+|--------|-----------|--------|
+| Cache hit rate drop | > 10% in 7 days | Freeze prompt version |
+| Error rate spike | > 15% in 1 hour | Rollback to last golden |
+| Cost per call spike | > 5x baseline | Rollback, investigate |
+| User complaint rate | > 3 reports/day | Trigger golden test suite |
+
+## Runbook
+
+1. **Freeze**: Pin all prompt versions to current. No new changes until incident resolved.
+2. **Diagnose**: Compare current golden test scores against baseline. Identify which dimension(s) degraded.
+3. **Rollback**: Revert to last known good version (previous major/minor).
+4. **Verify**: Run golden test suite on rolled-back version. Confirm scores >= baseline.
+5. **Root cause**: Link the degradation to a specific change (prompt version, tool change, dependency upgrade).
+6. **Remediate**: Fix the root cause, re-run golden suite, promote new version.

--- a/skills/agent-dev-standards/references/prompt-management.md
+++ b/skills/agent-dev-standards/references/prompt-management.md
@@ -1,0 +1,31 @@
+# Prompt Management
+
+Front-matter schema and versioning strategy for Agent prompts.
+## Front-Matter Schema
+```yaml
+---
+version: 1.2.0
+description: System prompt for code-reviewer agent
+author: team-ai
+created: 2026-06-01
+updated: 2026-08-15
+depends_on:
+  - shared/coding-standards@1.1.0
+  - shared/output-format@2.0.0
+tags: [code-review, security, style]
+cache_hint: stable_prefix
+---
+```
+## Versioning Rules
+- **major**: Breaking change (schema change, removed section)
+- **minor**: Non-breaking addition (new rule, new example)
+- **patch**: Fix (typo, clarification, formatting)
+## Caching Optimization
+1. Static prefix: Place stable instructions before dynamic content.
+2. Cache hint: Set cache_hint in front-matter.
+3. Version pin: Production loads pinned version, not latest.
+## Loading Pattern
+```python
+prompt = PromptLoader.load('agents/code-reviewer/prompt.md', version='1.2.0')
+system_prompt = prompt.static + dynamic_context
+```

--- a/skills/agent-dev-standards/references/safety.md
+++ b/skills/agent-dev-standards/references/safety.md
@@ -1,0 +1,19 @@
+# Safety
+Injection prevention, permission model, and data isolation.
+## Prompt Injection Prevention
+1. Input isolation: Never interpolate raw user input into system prompt.
+2. Instruction boundary: System prompt ends with a clear delimiter.
+3. Output validation: Check generated content for leaked system prompt.
+4. Rate limit: Cap tool calls per session (max 50).
+## Permission Model
+| Level | Operations | Example |
+|-------|-----------|---------|
+| read-only | read, search, list | Document search agent |
+| write-scoped | read + write to specific paths | Code review agent |
+| exec-scoped | read + write + exec whitelisted commands | Coding agent |
+| admin | full access | Setup agent |
+## Data Isolation
+1. Agent sessions are isolated: no cross-session data access.
+2. Tool outputs are scoped: agent can only see results of tools it called.
+3. Sensitive data masking: API keys, passwords, PII filtered.
+4. Audit log: every tool call logged with caller, target, timestamp, result.

--- a/skills/agent-dev-standards/references/tool-calling.md
+++ b/skills/agent-dev-standards/references/tool-calling.md
@@ -1,0 +1,69 @@
+# Tool Calling
+
+Tool schema design and error recovery patterns for Agent tools.
+
+## Tool Schema Design
+
+Every tool must have a typed JSON Schema:
+
+`json
+{
+  "name": "search_documents",
+  "description": "Search indexed documents by query string",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "query": {
+        "type": "string",
+        "description": "Search query, max 200 characters"
+      },
+      "limit": {
+        "type": "integer",
+        "description": "Max results to return, 1 to 20",
+        "minimum": 1,
+        "maximum": 20
+      }
+    },
+    "required": ["query"]
+  }
+}
+`
+
+Key rules:
+- Every parameter must have description, type, and constraints (minimum, maximum, enum).
+- Required fields listed explicitly in required array.
+- Description tells WHEN to use this tool, not just what it does.
+
+## Error Recovery Patterns
+
+Every tool must define 4 outcomes:
+
+| Outcome | Signal | Recovery |
+|---------|--------|----------|
+| Success | Returns expected data | Normal flow continues |
+| Partial | Returns partial data + warning | Flag to agent, continue with caveat |
+| Retryable | Network timeout, rate limit | Retry with exponential backoff (max 3 attempts) |
+| Terminal | Invalid input, auth failure | Abort chain, report error to agent |
+
+`python
+# Example: retryable error handler
+def search_documents(query: str, limit: int = 10):
+    for attempt in range(3):
+        try:
+            result = client.search(query, size=limit)
+            return {"status": "success", "data": result}
+        except TimeoutError:
+            if attempt < 2:
+                time.sleep(2 ** attempt)  # backoff: 1s, 2s, 4s
+                continue
+            return {"status": "retryable", "error": "timeout after 3 attempts"}
+        except AuthError:
+            return {"status": "terminal", "error": "auth failure"}
+`
+
+## Orchestration Principles
+
+1. Tools are single-responsibility: one tool, one job.
+2. Tool chains must have circuit breaker: abort after N consecutive failures.
+3. Tool output must be structured (JSON), not free text.
+4. Every tool call logged with latency, token cost, and result status.

--- a/skills/agent-dev-standards/scripts/validate_agent_standards.py
+++ b/skills/agent-dev-standards/scripts/validate_agent_standards.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Validate agent project against development standards."""
+import os, sys, json
+
+def check_prompt_files(agent_dir):
+    issues = []
+    prompt_dir = os.path.join(agent_dir, "prompts")
+    if not os.path.isdir(prompt_dir):
+        return ["No prompts/ directory found"]
+    for f in os.listdir(prompt_dir):
+        if f.endswith(".md"):
+            with open(os.path.join(prompt_dir, f)) as fh:
+                content = fh.read()
+            if not content.startswith("---"):
+                issues.append(f + ": missing front-matter")
+    return issues
+
+def check_registry(agent_dir):
+    rp = os.path.join(agent_dir, "registry.yaml")
+    if not os.path.isfile(rp):
+        return ["No registry.yaml found"]
+    return []
+
+def check_tool_schemas(agent_dir):
+    issues = []
+    td = os.path.join(agent_dir, "tools")
+    if not os.path.isdir(td):
+        return ["No tools/ directory found"]
+    for f in os.listdir(td):
+        if f.endswith((".py", ".ts")):
+            with open(os.path.join(td, f)) as fh:
+                c = fh.read().lower()
+            if not any(x in c for x in ["retry", "except", "catch"]):
+                issues.append(f + ": no error handling found")
+    return issues
+
+def check_golden_tests(agent_dir):
+    issues = []
+    gd = os.path.join(agent_dir, "tests", "golden")
+    if not os.path.isdir(gd):
+        return ["No tests/golden/ directory found"]
+    count = len([f for f in os.listdir(gd) if f.endswith(".json")])
+    if count < 10:
+        issues.append(f"Only {count} golden tests (minimum 10 required)")
+    return issues
+
+def check_tracing(agent_dir):
+    issues = []
+    src_dir = os.path.join(agent_dir, "src")
+    if not os.path.isdir(src_dir):
+        return ["No src/ directory found to scan for tracing"]
+    for root, dirs, files in os.walk(src_dir):
+        for f in files:
+            if f.endswith((".py", ".ts")):
+                with open(os.path.join(root, f)) as fh:
+                    c = fh.read().lower()
+                if any(x in c for x in ["span", "tracer", "otel"]):
+                    return issues
+    return ["No tracing spans found in source code"]
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: validate_agent_standards.py <agent-dir>")
+        sys.exit(1)
+    ad = sys.argv[1]
+    if not os.path.isdir(ad):
+        print(f"Error: {ad} not found")
+        sys.exit(1)
+    checks = {
+        "Prompt files": check_prompt_files(ad),
+        "Registry": check_registry(ad),
+        "Tool schemas": check_tool_schemas(ad),
+        "Golden tests": check_golden_tests(ad),
+        "Tracing": check_tracing(ad),
+    }
+    total = 0
+    print(f"=== Agent Standards Validation: {ad} ===")
+    for name, issues in checks.items():
+        status = "PASS" if not issues else f"FAIL ({len(issues)} issues)"
+        print(f"  [{status}] {name}")
+        for i in issues:
+            print(f"         - {i}")
+            total += 1
+    print()
+    if total == 0:
+        print("Result: ALL CHECKS PASSED")
+        sys.exit(0)
+    else:
+        print(f"Result: {total} issue(s) found")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Submitting the `agent-dev-standards` skill via Hermes Skills Hub.

This skill was scanned by the Hermes Skills Guard before submission.