### PR TITLE
Add idea-skill to Partner Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,4 @@ The markdown content below contains the instructions, examples, and guidelines t
 Skills are a great way to teach Claude how to get better at using specific pieces of software. As we see awesome example skills from partners, we may highlight some of them here:
 
 - **Notion** - [Notion Skills for Claude](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0)
+- **idea-skill** - [idea-skill](https://github.com/NatanNarciso/idea-skill) turns a spoken idea into a fully tagged GitHub issue on the right GitHub Projects Kanban board, and turns an approved Claude Code plan into a merged PR — a pair of Claude Code Agent Skills (`/idea` and `ship`) plus a setup script, no server or extra infrastructure required.


### PR DESCRIPTION
## Summary

Add idea-skill to the README's Partner Skills section, following the
existing Notion entry's link-only format.

idea-skill is a pair of Claude Code Agent Skills (`/idea` and `ship`)
plus a one-shot setup script that turn a spoken idea into a fully tagged
GitHub issue on the right GitHub Projects (v2) Kanban board, and turn an
approved Claude Code plan into a merged PR — issue → branch → PR → merge
with confirmation gates before anything public happens.

It's maintained as a standalone, self-contained repo (own setup script,
issue/PR templates, and docs) rather than a single portable `SKILL.md`
folder — it depends on a per-user project registry and a per-repo
`setup.sh` run — so this PR only adds a link, matching how the existing
Notion entry is handled, rather than copying code into `skills/`.

- Repository: https://github.com/NatanNarciso/idea-skill
- Docs/wiki: https://github.com/NatanNarciso/idea-skill/wiki

This is a link-only README entry. It does not duplicate the skill or add
runtime dependencies to this repository.

## Test plan

- [x] Confirmed the diff touches only the Partner Skills bullet list in `README.md`
- [x] Verified the linked repo, wiki, and license are public and accessible