### PR TITLE
skill-creator: trigger eval mounts the probe as a skill, not a command

### DIFF
--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -9,6 +9,7 @@ import argparse
 import json
 import os
 import select
+import shutil
 import subprocess
 import sys
 import time
@@ -22,8 +23,11 @@ from scripts.utils import parse_skill_md
 def find_project_root() -> Path:
     """Find the project root by walking up from cwd looking for .claude/.
 
-    Mimics how Claude Code discovers its project root, so the command file
-    we create ends up where claude -p will look for it.
+    Mimics how Claude Code discovers its project root, so the skill we mount
+    ends up where claude -p will look for it. Note: the project root must be
+    a folder the user has previously TRUSTED in Claude Code — project skills
+    are not loaded from untrusted folders, and the eval then reports a zero
+    trigger rate for every query regardless of the description under test.
     """
     current = Path.cwd()
     for parent in [current, *current.parents]:
@@ -42,30 +46,44 @@ def run_single_query(
 ) -> bool:
     """Run a single query and return whether the skill was triggered.
 
-    Creates a command file in .claude/commands/ so it appears in Claude's
+    Mounts a transient skill under .claude/skills/ so it appears in Claude's
     available_skills list, then runs `claude -p` with the raw query.
     Uses --include-partial-messages to detect triggering early from
     stream events (content_block_start) rather than waiting for the
     full assistant message, which only arrives after tool execution.
+
+    Earlier versions wrote a .claude/commands/ file instead. Commands are
+    user-invoked slash commands: on current Claude Code versions (measured on
+    2.1.234) they never surface in the model's available_skills, so every
+    query scored as non-triggering and the eval could not distinguish any two
+    descriptions — the optimization loop's score was frozen at exactly the
+    count of should-not-trigger queries.
+
+    The mount directory keeps a per-run unique suffix so parallel workers
+    never collide on the filesystem and cleanup cannot remove a sibling's
+    live mount. The catalog entry is keyed on the directory name, so the
+    suffix is kept short and word-free — a long, machine-looking name reads
+    as debris and can depress triggering.
     """
     unique_id = uuid.uuid4().hex[:8]
-    clean_name = f"{skill_name}-skill-{unique_id}"
-    project_commands_dir = Path(project_root) / ".claude" / "commands"
-    command_file = project_commands_dir / f"{clean_name}.md"
+    clean_name = f"{skill_name}-{unique_id[:6]}"
+    skill_dir = Path(project_root) / ".claude" / "skills" / clean_name
+    skill_file = skill_dir / "SKILL.md"
 
     try:
-        project_commands_dir.mkdir(parents=True, exist_ok=True)
+        skill_dir.mkdir(parents=True, exist_ok=True)
         # Use YAML block scalar to avoid breaking on quotes in description
         indented_desc = "\n  ".join(skill_description.split("\n"))
-        command_content = (
+        skill_content = (
             f"---\n"
+            f"name: {clean_name}\n"
             f"description: |\n"
             f"  {indented_desc}\n"
             f"---\n\n"
             f"# {skill_name}\n\n"
             f"This skill handles: {skill_description}\n"
         )
-        command_file.write_text(command_content)
+        skill_file.write_text(skill_content)
 
         cmd = [
             "claude",
@@ -177,8 +195,8 @@ def run_single_query(
 
         return triggered
     finally:
-        if command_file.exists():
-            command_file.unlink()
+        if skill_dir.exists():
+            shutil.rmtree(skill_dir, ignore_errors=True)
 
 
 def run_eval(


### PR DESCRIPTION
## Problem

`run_eval.py` writes the description under test into `.claude/commands/`. Commands are **user-invoked slash commands**: on current Claude Code versions (measured on 2.1.234, macOS) they never surface in the model's `available_skills`, so no query ever triggers and every description scores identically. Measured symptom: a full `run_loop.py` run over 20 queries × 5 iterations kept train and test scores frozen at exactly the count of should-not-trigger queries — for the original description, for hand-written pushier ones, and for the loop's own increasingly aggressive proposals. Every should-trigger query sat at `trigger_rate: 0.0` throughout. A score that cannot move is measuring the mount, not the skill, and `best_description` degrades to a tie-break on the original.

## Fix

Mount a transient `SKILL.md` under `.claude/skills/<name>-<uuid6>/` instead. The existing stream detection already watches the `Skill` tool, and the catalog keys on the directory name, so the rest of the pipeline is unchanged.

Two secondary findings folded in:

- **The unique suffix stays short and word-free.** The catalog entry is the directory name; in probes, a long machine-looking mount (`analysis-skill-deadbeef`) went unconsulted — the model inspected the file with `cat` rather than invoke it — while the same description under a plain or short-suffixed name (`analysis-zz9x4q`) triggered first-thing. (Confounded with description strength across probes, so recorded as naming guidance in a comment rather than claimed as a hard result.)
- **The project root must be a folder the user has previously trusted in Claude Code.** Project skills are not loaded from untrusted folders, which silently reproduces the same all-zero symptom. Documented in `find_project_root`'s docstring.

## Verification

End to end on a real skill (a project-internal analysis guide), serial and with parallel workers:

| | before (commands mount) | after (skills mount) |
|---|---|---|
| should-trigger query | 0.0 — for every description tried | 1.0 |
| near-miss negative | 0.0 (vacuously) | 0.0 (genuinely — the entry is visible and not consulted) |

With the fix in place the eval discriminates descriptions: a deliberately thin description measured 0/10 on realistic should-trigger queries, a rewritten one 4/10 with all 10 near-miss negatives held — the before/after the tool exists to produce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)