### PR TITLE
Add scnet-hpc skill

### DIFF
--- a/skills/scnet-hpc/LICENSE.txt
+++ b/skills/scnet-hpc/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 scnet-hpc contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/scnet-hpc/SKILL.md
+++ b/skills/scnet-hpc/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: scnet-hpc
+description: Configure and operate SCNet HPC clusters through SSH and Slurm, including profile-based resource requests, job submission and diagnosis, environment preparation, and accelerator compatibility checks. Use for SCNet access, Slurm CPU/DCU jobs, Hygon DCU/DTK, offline compute nodes, or adding and verifying cluster profiles. Treat other accelerator platforms as unverified until tested on their target compute nodes.
+---
+
+# SCNet HPC
+
+Operate SCNet clusters from repository profiles and target-cluster evidence. The included
+accelerator guidance is validated primarily for Hygon DCU/DTK and `gfx9xx`; do not transfer
+those capability conclusions to other accelerator stacks. The repository scripts support Linux
+and macOS natively. On Windows, use WSL2; native Windows execution is not supported.
+
+## 中文说明
+
+本技能用于通过 SSH 和 Slurm 操作 SCNet 超算集群，覆盖基于 profile 的资源申请、作业生成与诊断、环境准备，以及加速器兼容性验证。Linux 和 macOS 可直接运行仓库脚本；Windows 不提供原生脚本入口，建议使用 WSL2。官方 SCNet 客户端支持 Windows 10 及以上、macOS 12 Monterey 及以上（ARM/x86），下载地址见 [SCNet 客户端下载页](https://www.scnet.cn/ui/mall/client/download)。
+
+## Source of truth
+
+- Read `clusters/<cluster>.conf` before reporting connection, partition, memory, hardware,
+  module, network, or known-limit information.
+- Treat `clusters/.cache/<cluster>.auto.conf` as optional, time-sensitive probe data that
+  overrides matching profile fields.
+- Verify dynamic scheduler state on the target cluster when the task depends on current
+  availability, limits, or node count.
+- Do not infer one cluster's parameters from another cluster.
+
+List available profiles with:
+
+```bash
+ls clusters/*.conf
+```
+
+If more than one profile exists, require an explicit cluster selection before generating a
+job, changing SSH configuration, submitting work, or installing software.
+
+## Route the task
+
+Read only the references required for the current operation:
+
+| Operation | Reference |
+|---|---|
+| Configure or repair SSH access | `references/setup.md` |
+| Prepare Python, modules, virtual environments, or offline dependencies | `references/environment.md` |
+| Diagnose Slurm, runtime, library, network, or accelerator failures | `references/troubleshooting.md` |
+| Add or refresh a cluster profile | `references/adding-cluster.md` |
+| Work with Hygon DCU, DTK, HIP libraries, profiling, migration, or containers | `references/hygon-dcu-development.md` |
+| Evaluate software compatibility or prepare a public compatibility report | `references/software-compatibility.md` |
+| Provide English operating instructions | `references/quickstart-en.md` |
+
+Cluster parameters always come from the selected profile, including when an example in a
+reference uses different values.
+
+## Execution boundaries
+
+- Read-only inspection and local script generation do not authorize SSH configuration changes,
+  dependency installation, job submission, job cancellation, or remote file deletion.
+- Before a remote mutation, resolve the target cluster, command, paths, and expected effect.
+- A compute-node probe consumes scheduler resources. Run it only when the user requests
+  submission or verification that requires compute-node evidence.
+- Preserve existing SSH configuration. `scripts/setup-ssh.sh` adds a missing host entry and
+  backs up a conflicting destination key; it does not rewrite an existing host block.
+- Do not place credentials, usernames, internal hosts, node names, job IDs, private mirrors, or
+  absolute home paths in committed profiles or public reports.
+
+## Operational invariants
+
+1. **Scheduler constraints are profile-specific.** If `MIN_GRES` is non-empty, request at least
+   that accelerator resource unless an independent CPU partition is selected.
+2. **Memory requests follow the partition limit.** When `DEF_MEM_PER_CPU` is defined, keep
+   requested memory within `cpus-per-task × DEF_MEM_PER_CPU`. Use `scripts/new-job.sh` to
+   calculate a conservative value.
+3. **Framework validation belongs on compute nodes.** A login node may lack accelerator
+   libraries even after modules are loaded. Use `srun`, `sbatch`, or the compute probe for
+   imports, kernels, collectives, and accelerator capabilities.
+4. **Offline nodes require staged dependencies.** When `COMPUTE_NODE_OFFLINE=yes`, download or
+   build dependencies on a networked node and disable runtime downloads in the job.
+5. **Test files use shared storage.** Create per-job temporary directories under
+   `$HOME/.scnet-hpc/tmp/$SLURM_JOB_ID`; do not depend on `/tmp` being shared across nodes.
+6. **Job exit status must propagate.** Capture the workload return code and terminate the batch
+   script with `exit "$rc"`. Evaluate both accounting state and job logs.
+7. **Compatibility claims require target-node evidence.** Package resolution or import success
+   alone is insufficient for native extensions and accelerator software. Validate the relevant
+   ABI, import, kernel, functional, and end-to-end layers.
+
+## Repository tools
+
+| Tool | Purpose |
+|---|---|
+| `scripts/setup-ssh.sh` | Install a supplied key and add an SSH host entry |
+| `scripts/new-job.sh` | Generate a profile-aware Slurm script |
+| `scripts/probe-cluster.sh` | Produce an initial profile from read-only login-node probes |
+| `scripts/refresh-cluster.sh` | Refresh dynamic profile fields; compute probing is opt-in |
+| `scripts/run-compute-probe.sh` | Submit a minimal accelerator capability probe |
+
+Use `scripts/new-job.sh --cluster <name> ...` for routine job generation. Validate the generated
+script with `sbatch --test-only` before submission when the target cluster supports it.
+
+## Evidence and reporting
+
+Distinguish:
+
+- profile values;
+- live scheduler observations;
+- login-node observations;
+- compute-node observations;
+- conclusions inferred from those observations.
+
+For failures, report the failing command, relevant log excerpt, scheduler state and exit code,
+target profile, and the next bounded diagnostic action. For compatibility results, state the
+software and toolchain versions, accelerator architecture, validation layer reached, and
+untested boundaries.

--- a/skills/scnet-hpc/SKILL.md
+++ b/skills/scnet-hpc/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: scnet-hpc
 description: Configure and operate SCNet HPC clusters through SSH and Slurm, including profile-based resource requests, job submission and diagnosis, environment preparation, and accelerator compatibility checks. Use for SCNet access, Slurm CPU/DCU jobs, Hygon DCU/DTK, offline compute nodes, or adding and verifying cluster profiles. Treat other accelerator platforms as unverified until tested on their target compute nodes.
+license: Complete terms in LICENSE.txt
 ---
 
 # SCNet HPC

--- a/skills/scnet-hpc/clusters/_template.conf
+++ b/skills/scnet-hpc/clusters/_template.conf
@@ -1,0 +1,62 @@
+# 集群 profile 模板
+#
+# 新增集群：
+#   1. cp _template.conf <集群短名>.conf
+#   2. 填下面的值（不确定的用 scripts/probe-cluster.sh 探测）
+#   3. scripts/setup-ssh.sh --cluster <集群短名> <私钥文件> [用户名]
+#
+# CLUSTER_ID / SSH_HOST / SSH_PORT 是必填连接参数，应写死；其余可留空。
+# 留空的项脚本会跳过、文档里显示为「未探测」。旧 profile 漏填 SSH_HOST 时，
+# _common.sh 会临时从本机 ssh config 补全，但新集群仍建议在此显式填写。
+
+# ---- 连接（必填）----
+CLUSTER_ID=""                            # 短名，同时用作 ssh 别名，如 "zzeshell"
+CLUSTER_DESC=""                          # 人类可读描述，如 "海光 DCU（郑州）"
+SSH_HOST=""                              # 如 "xxx.scnet.cn"
+SSH_PORT="22"
+HOME_BASE="/public/home"                 # 家目录父路径
+
+KEY_NAME_MARKER=""                       # 私钥文件名里的主机标识，如 "_xxx.scnet.cn_"
+NEEDS_UPDATE_HOSTKEYS_NO="no"            # 平台主机密钥签名有问题时设 yes
+
+# ---- 调度器 ----
+SCHEDULER="slurm"
+PARTITION=""
+
+DEF_MEM_PER_CPU=""                       # MB。scontrol show partition <名> 里的 DefMemPerCPU
+DEF_MEM_PER_CPU_CPU=""                   # 可选：CPU 分区不同于默认分区时填写
+MIN_GRES=""                              # QOS 强制的最小 GRES，如 "dcu:1"；无则留空
+GRES_TYPE=""                             # "dcu" / "gpu" / "npu" 等
+MAX_WALLTIME=""
+
+# ---- 硬件 ----
+ACCEL_NAME=""                            # 如 "海光 BW1000 DCU" / "NVIDIA A100"
+ACCEL_ARCH=""                            # 如 "gfx936" / "sm80"
+ACCEL_PER_NODE=""
+ACCEL_MEM_GB=""
+CPUS_PER_NODE=""
+CPU_MODEL=""
+NODE_MEM_GB=""
+NODE_COUNT=""                            # 通常留空/作回退；运行时优先实时查 TotalNodes
+LOGIN_NODES=""
+HOME_QUOTA_GB=""
+
+# ---- 软件栈 ----
+TOOLCHAIN=""                             # "DTK" / "CUDA" / "ROCm" 等
+TOOLCHAIN_VERSION=""
+TOOLCHAIN_PATH=""
+MODULE_LOADS=""                          # 空格分隔的 module load 参数
+PYTHON_MODULE=""                         # 计算节点缺少 python3 时加载的 Python module
+
+DEFAULT_VENV=""                          # 相对家目录的 venv 路径
+
+# ---- 网络 ----
+NET_OK=""
+NET_BLOCKED=""
+PIP_INDEX="https://pypi.tuna.tsinghua.edu.cn/simple"
+COMPUTE_NODE_OFFLINE="yes"               # 多数超算的计算节点无外网
+TMP_SHARED="no"
+
+# ---- 已知问题 ----
+LOGIN_NODE_MISSING_LIBS=""               # 登录节点缺失的库
+KNOWN_LIMITATIONS=""                     # 硬件/软件栈的能力缺口

--- a/skills/scnet-hpc/clusters/kseshell.conf
+++ b/skills/scnet-hpc/clusters/kseshell.conf
@@ -1,0 +1,90 @@
+# kseshell —— 海光 Z100 DCU 集群（连接字段已按平台填写）
+#
+# SCNet 昆山集群。与郑州（zzeshell / BW1000 / gfx936）的主要差别：
+#   - 加速器是 Z100 (gfx906)，单机 4 卡、每卡 16GB（BW1000 是 8 卡 × 64GB）
+#   - 有独立的 CPU 队列，纯 CPU 作业可提交（郑州只有一个强制要 DCU 的队列）
+#   - DEF_MEM_PER_CPU=3569（郑州 3888）
+#   - DTK 路径和 SSH 端口因平台配置而异
+
+# ---- 连接 ----
+CLUSTER_ID="kseshell"
+CLUSTER_DESC="海光 Z100 DCU（昆山）"
+SSH_HOST="cancon.hpccube.com"
+SSH_PORT="65023"
+HOME_BASE="/public/home"
+
+KEY_NAME_MARKER="_<CLUSTER_HOST>_"
+NEEDS_UPDATE_HOSTKEYS_NO="no"            # 实测无坏签名告警
+
+# ---- 调度器 ----
+SCHEDULER="slurm"
+
+# 默认用 DCU 队列。纯 CPU 作业改用 kshcnormal（见下面 PARTITIONS_*）
+PARTITION="kshdnormal"
+
+DEF_MEM_PER_CPU="3569"                   # 实测边界：32核 111gb 通过 / 112gb 被拒
+MIN_GRES="dcu:1"                         # kshdnormal 的 QOS 强制；CPU 队列无此限制
+GRES_TYPE="dcu"
+MAX_WALLTIME="333-08:00:00"
+
+# 这个集群有多个队列，用途不同：
+#   kshcnormal   CPU 队列，3557 节点，QOS=partition_cpu，无 GRES 约束
+#   kshdnormal   DCU 队列，571 节点，QOS=partition_normal_7584，MinTRES=gres/dcu=1
+#   kshdAI       DCU 队列，39 节点，QOS=partition_kshdAI，无 GRES 强制，但时限仅 2 小时
+#   kshcsctest / kshdsctest   测试队列，时限 3 天
+PARTITION_CPU="kshcnormal"
+PARTITION_DCU="kshdnormal"
+PARTITION_DCU_SHORT="kshdAI"             # 时限 2:00:00
+
+# ---- 硬件 ----
+ACCEL_NAME="海光 Z100 DCU (Device 66a1)"
+ACCEL_ARCH="gfx906"
+ACCEL_PER_NODE="4"
+ACCEL_MEM_GB="16"                        # 实测 16368 MiB/卡
+ACCEL_CU="64"                            # Compute Unit
+ACCEL_TDP_W="300"
+CPUS_PER_NODE="32"
+CPU_MODEL="Hygon C86 7185 32-core"
+NODE_MEM_GB="123"
+NODE_COUNT="1368"                        # 回退值；运行时优先实时查 TotalNodes
+LOGIN_NODES="login01 / login02（示意）"
+HOME_QUOTA_GB="2950"                     # /public 文件系统总量，非个人独占
+
+# ---- 软件栈 ----
+TOOLCHAIN="DTK"
+TOOLCHAIN_VERSION="26.04"
+TOOLCHAIN_PATH=""
+MODULE_LOADS="compiler/dtk/26.04"
+# 可用版本很多：22.10 / 23.04 / 23.10 / 24.04.x / 25.04.x / 26.04
+# 实测 26.04、25.04.4、24.04.3 都能正常识别 4 张 gfx906
+PYTHON_MODULE="python/3.8.10"            # 计算节点默认无 python3
+
+DEFAULT_VENV=""                          # 尚未建 venv；系统 python3 是 3.8.5，无 torch
+
+# ---- 网络 ----
+NET_OK="pypi.org pypi.tuna.tsinghua.edu.cn modelscope.cn github.com"
+NET_BLOCKED="huggingface.co"
+PIP_INDEX="https://pypi.tuna.tsinghua.edu.cn/simple"
+COMPUTE_NODE_OFFLINE="yes"
+TMP_SHARED="no"
+
+# ---- 已知问题 ----
+LOGIN_NODE_MISSING_LIBS=""               # 登录节点无 torch（未装），非缺库
+
+# gfx906 是 Vega 20 代架构，比 gfx936 更老：
+#   - 无 FP8 硬件支持（gfx906 连 BF16 矩阵指令都没有，只有 FP16/FP32）
+#   - 无 Matrix Core（MFMA 指令），矩阵运算靠 SIMD
+#   - 单卡仅 16GB，大模型必须多卡切分或量化
+# 具体的 torch/Triton 能力待建 venv 后实测，参考 references/adding-cluster.md
+KNOWN_LIMITATIONS="gfx906 (Vega20) 无 FP8/BF16 硬件支持、无 MFMA Matrix Core；\
+无 BF16 数据类型支持；计算节点默认无 python3，需 module load python/3.8.10；\
+单卡显存仅 16GB；torch/Triton 可用性待实测；\
+CentOS 7.6 / glibc 2.17 环境优先使用 manylinux_2_17 wheel，onnxruntime 通常锁定 1.16.3；\
+MinerU 3.4.x 需 Python >=3.10，旧版 magika 兼容方案需单独验证 API；\
+GROMACS 原生 HIP 路径需显式确认 CMake、DTK、目标架构和 FFTW，不能把 CUDA 兼容层性能直接外推到 HIP"
+
+# ---- 作业脚本注意 ----
+# module load 必须在 login shell 里执行。非交互 shell（如 heredoc 里）module
+# 函数未定义，会静默失败、ROCM_PATH 不设置、rocminfo 无输出。
+# 解法：作业脚本用 #!/bin/bash 后直接 module load（sbatch 会走 login shell），
+# 或在 heredoc 内包一层 bash -l。

--- a/skills/scnet-hpc/clusters/wuzhshell.conf
+++ b/skills/scnet-hpc/clusters/wuzhshell.conf
@@ -1,0 +1,60 @@
+# wuzhshell —— 乌镇超算（wuzh02.hpccube.com）
+
+# ---- 连接 ----
+CLUSTER_ID="wuzhshell"
+CLUSTER_DESC="乌镇超算（wuzh02）"
+SSH_HOST="wuzh02.hpccube.com"
+SSH_PORT="65091"
+HOME_BASE="/work/home"
+
+KEY_NAME_MARKER="_<CLUSTER_HOST>_"
+NEEDS_UPDATE_HOSTKEYS_NO="no"
+
+# ---- 调度器 ----
+SCHEDULER="slurm"
+
+# 默认使用 DCU 队列；纯 CPU 作业改用 wzhcnormal。
+PARTITION="wzhdnormal"
+
+DEF_MEM_PER_CPU="3634"
+MIN_GRES="dcu:1"
+GRES_TYPE="dcu"
+MAX_WALLTIME="333-08:00:00"
+
+# CPU 队列和 DCU 队列。
+PARTITION_CPU="wzhcnormal"
+PARTITION_DCU="wzhdnormal"
+
+# ---- 硬件 ----
+ACCEL_NAME="海光 Z100 DCU (Z100SM)"
+ACCEL_ARCH="gfx906"
+ACCEL_PER_NODE="4"
+ACCEL_MEM_GB="16"
+CPUS_PER_NODE="32"
+CPU_MODEL="Hygon C86 7285 32-core Processor"
+NODE_MEM_GB="123"
+NODE_COUNT="434"
+LOGIN_NODES="login01 / login02（示意）"
+HOME_QUOTA_GB="2000"
+
+# ---- 软件栈 ----
+TOOLCHAIN="DTK"
+TOOLCHAIN_VERSION="26.04"
+TOOLCHAIN_PATH=""
+MODULE_LOADS="compiler/dtk/26.04"
+PYTHON_MODULE="python/3.8.10"
+
+DEFAULT_VENV=""
+
+# ---- 网络 ----
+NET_OK="pypi.org pypi.tuna.tsinghua.edu.cn modelscope.cn github.com"
+NET_BLOCKED="huggingface.co"
+PIP_INDEX="https://pypi.tuna.tsinghua.edu.cn/simple"
+COMPUTE_NODE_OFFLINE="yes"
+TMP_SHARED="no"
+
+# ---- 已知问题 ----
+LOGIN_NODE_MISSING_LIBS=""
+KNOWN_LIMITATIONS="gfx906 (Vega20) 无 FP8/BF16 硬件支持、无 MFMA Matrix Core；\
+单卡显存 16GB；计算节点默认无 torch（module load compiler/dtk/26.04 后仍无 torch，需建 venv）；\
+计算节点无外网（PROBE_NET_PYPI=OFFLINE）；DCU FP8/Triton/bitsandbytes 待装 torch 后实测"

--- a/skills/scnet-hpc/clusters/xianshell.conf
+++ b/skills/scnet-hpc/clusters/xianshell.conf
@@ -1,0 +1,66 @@
+# xianshell —— 西安集群（eshell111.hpccube.com）
+#
+# 2026-08-17 完成登录节点、Slurm 和计算节点实测。
+# 计算探针使用 xahdnormal 分区、1 张 DCU，并将所有临时文件放在共享家目录。
+
+# ---- 连接 ----
+CLUSTER_ID="xianshell"
+CLUSTER_DESC="西安集群（eshell111）"
+SSH_HOST="eshell111.hpccube.com"
+SSH_PORT="65082"
+HOME_BASE="/work/home"
+
+# 私钥文件名形如：<用户名>_eshell111.hpccube.com_RsaKeyExpireTime_<日期>.txt
+KEY_NAME_MARKER="_eshell111.hpccube.com_"
+NEEDS_UPDATE_HOSTKEYS_NO="no"
+
+# ---- 调度器 ----
+SCHEDULER="slurm"
+PARTITION="xahdnormal"
+DEF_MEM_PER_CPU="3570"
+MIN_GRES="dcu:1"                         # sbatch --test-only 实测：不申请即 QOSMinGRES
+GRES_TYPE="dcu"
+MAX_WALLTIME="333-08:00:00"
+
+# xahcnormal 是异构 CPU 队列（5609 节点，少量节点也带 DCU）。
+PARTITION_CPU="xahcnormal"
+PARTITION_DCU="xahdnormal"
+
+# ---- 硬件 ----
+ACCEL_NAME="海光 Z100 DCU (Z100SM)"
+ACCEL_ARCH="gfx906"
+ACCEL_PER_NODE="4"
+ACCEL_MEM_GB="16"                        # PyTorch 实测 16368 MiB
+CPUS_PER_NODE="32"                       # Slurm xahdnormal 可调度 CPU；节点物理 64 核
+CPU_MODEL="Hygon C86 7285 32-core Processor"
+NODE_MEM_GB="123"
+NODE_COUNT="465"
+LOGIN_NODES="登录节点（实测，公开 profile 已脱敏）"
+HOME_QUOTA_GB="450"                      # /work 文件系统容量，非个人独占配额
+
+# ---- 软件栈 ----
+TOOLCHAIN="DTK"
+TOOLCHAIN_VERSION="26.04"
+TOOLCHAIN_PATH="/public/software/compiler/dtk-26.04"
+MODULE_LOADS="compiler/dtk/26.04"
+PYTHON_MODULE="python/3.8.10"             # 计算节点显式加载，避免依赖用户私有 PATH
+DEFAULT_VENV=""
+
+# 平台自带的可运行 PyTorch 环境（能力探针专用）：
+#   module load Pytorch/1.10.0-hpcx-gcc-7.3.1
+# 该模块会 purge 环境并改用 DTK 22.10.1，不能与上面的 DTK 26.04 同时加载。
+
+# ---- 网络 ----
+NET_OK="pypi.org pypi.tuna.tsinghua.edu.cn modelscope.cn github.com"
+NET_BLOCKED="huggingface.co"
+PIP_INDEX="https://pypi.tuna.tsinghua.edu.cn/simple"
+COMPUTE_NODE_OFFLINE="yes"
+TMP_SHARED="no"
+
+# ---- 已知问题 ----
+LOGIN_NODE_MISSING_LIBS=""
+KNOWN_LIMITATIONS="平台 PyTorch 1.10.0a0+git2040069-dtk2210 仅探测到 BF16，无 FP8 dtype，torch._scaled_mm 跳过；\
+Triton 未安装；bitsandbytes 未安装；计算节点无法访问 pypi.org；\
+平台 PyTorch module 固定加载 DTK 22.10.1，与默认 DTK 26.04 不可混用；\
+远端缺少 C.UTF-8 locale，SSH 和作业启动会产生 setlocale 警告但不影响执行；\
+测试任务临时目录必须使用 \$HOME/.scnet-hpc/tmp/\$SLURM_JOB_ID，不使用 /tmp"

--- a/skills/scnet-hpc/clusters/zzeshell.conf
+++ b/skills/scnet-hpc/clusters/zzeshell.conf
@@ -1,0 +1,74 @@
+# zzeshell —— 海光 DCU 集群（连接字段已按平台填写）
+#
+# 这是一个集群 profile。新增集群时复制本文件改值即可，
+# 脚本和文档都从这里读配置，不硬编码。
+
+# ---- 连接 ----
+CLUSTER_ID="zzeshell"                    # 短名，同时用作 ssh 别名
+CLUSTER_DESC="海光 BW1000 DCU（郑州）"
+SSH_HOST="zzeshell.scnet.cn"
+SSH_PORT="65032"
+HOME_BASE="/public/home"                 # 家目录父路径，实际家目录是 $HOME_BASE/$USER
+
+# 私钥文件名里的主机标识，用于从文件名推断用户名
+# 形如 <用户名>_<集群主机>_RsaKeyExpireTime_<日期>.txt
+KEY_NAME_MARKER="_<CLUSTER_HOST>_"
+
+# 平台对 SSH 主机密钥轮换扩展返回错误签名，需要 UpdateHostKeys no 抑制告警
+NEEDS_UPDATE_HOSTKEYS_NO="yes"
+
+# ---- 调度器 ----
+SCHEDULER="slurm"
+PARTITION="hx1hdnormal"
+
+# 每 CPU 默认内存（MB）。内存上限 = cpus-per-task × 此值
+DEF_MEM_PER_CPU="3800"                   # 2026-08-16 实测；旧值 3888
+
+# QOS 强制的最小 GRES。非空表示每个作业必须申请，纯 CPU 作业会被拒
+MIN_GRES="dcu:1"
+
+# GRES 类型名（--gres=<此值>:N）
+GRES_TYPE="dcu"
+
+MAX_WALLTIME="3-00:00:00"
+
+# ---- 硬件 ----
+ACCEL_NAME="海光 BW1000 DCU"
+ACCEL_ARCH="gfx936"
+ACCEL_PER_NODE="8"
+ACCEL_MEM_GB="64"
+CPUS_PER_NODE="128"
+CPU_MODEL="Hygon C86"
+NODE_MEM_GB="498"
+NODE_COUNT="131"                         # 回退值；运行时优先实时查 TotalNodes
+LOGIN_NODES="login01 / login02（有负载均衡）"
+HOME_QUOTA_GB="1450"                     # /public 文件系统总量，非个人独占
+
+# ---- 软件栈 ----
+TOOLCHAIN="DTK"                          # 海光的 ROCm 发行版
+TOOLCHAIN_VERSION="26.04"
+TOOLCHAIN_PATH=""
+MODULE_LOADS="compiler/gcc/9.3.0 compiler/dtk/26.04"
+PYTHON_MODULE=""                         # 计算节点可用 python3，无需额外加载
+
+# 默认 venv 路径（相对家目录）。因人而异，装完可改
+DEFAULT_VENV="softwares/bitsandbytes/venv"
+
+# ---- 网络 ----
+# 登录节点可达的域名（用于文档和 pip 源选择）
+NET_OK="pypi.org pypi.tuna.tsinghua.edu.cn modelscope.cn github.com"
+NET_BLOCKED="huggingface.co"
+PIP_INDEX="https://pypi.tuna.tsinghua.edu.cn/simple"
+COMPUTE_NODE_OFFLINE="yes"               # 计算节点是否完全无外网
+TMP_SHARED="no"                          # /tmp 是否跨节点共享
+
+# ---- 已知的平台特有问题 ----
+# 登录节点缺失的库（导致无法在登录节点 import 深度学习框架）
+LOGIN_NODE_MISSING_LIBS="libgalaxyhip.so.5"
+
+# 已验证的加速器能力限制
+KNOWN_LIMITATIONS="Triton 不可用（实测 libgcvm.so.17git 或 libamdhip64.so 缺 hipDrvLaunchKernelEx）；\
+FP8 无硬件计算支持（torch._scaled_mm 拒绝 gfx936）；\
+bitsandbytes 8-bit 不可用（hipBLASLt 无 gfx936 INT8 algo）；\
+纯 PyTorch 软件反量化可作为大模型推理退路，但单序列解码约 0.93–1.12 tok/s；\
+依赖 Triton、硬件 FP8 或 CUDA-only kernel 的推理框架需先做计算节点探针"

--- a/skills/scnet-hpc/references/adding-cluster.md
+++ b/skills/scnet-hpc/references/adding-cluster.md
@@ -1,0 +1,157 @@
+# 新增一个集群
+
+这套 skill 的集群参数都在 `clusters/*.conf`，脚本从 profile 读取。新增集群
+通常只需增加一个 profile；若调度器或字段语义不同，仍需扩展脚本。
+
+## 配置流程
+
+### 1. 验证基础连接
+
+用平台控制台下载的私钥，临时连一次：
+
+```bash
+chmod 600 <私钥>
+ssh -i <私钥> -p <端口> <用户名>@<主机名> 'hostname; whoami'
+```
+
+连接失败时检查：私钥是否过期、本机 IP 是否在平台白名单、端口是否可达。
+
+### 2. 添加临时 SSH 别名
+
+```bash
+cat >> ~/.ssh/config <<'EOF'
+
+Host newcluster-tmp
+  HostName <主机名>
+  User <用户名>
+  Port <端口>
+  IdentityFile <私钥路径>
+  IdentitiesOnly yes
+EOF
+```
+
+### 3. 生成初始 profile
+
+```bash
+./scripts/probe-cluster.sh newcluster-tmp <集群短名> > clusters/<集群短名>.conf
+```
+
+脚本会自动填：SSH 参数、调度器类型、分区、`DEF_MEM_PER_CPU`、QOS 的 `MIN_GRES`、
+节点规格、网络可达性、登录节点缺失的库、家目录容量。
+
+**探测不到的项会留空并在文件末尾列出**，不填入推测值。
+
+### 4. 补齐手工项
+
+profile 末尾的注释列出了还需确认的。主要是：
+
+**`SSH_HOST` / `SSH_PORT`** —— 固定连接参数，应写死。本机已配置 SSH 别名时，
+可用 `ssh -G <别名>` 查出 `hostname` 和 `port` 后填进 profile。
+
+**加速器型号和架构** —— 在计算节点跑：
+
+```bash
+# AMD/海光系
+srun -p <分区> --gres=<类型>:1 --time=00:05:00 bash -lc 'module load <模块>; rocminfo | grep -i gfx'
+# NVIDIA
+srun -p <分区> --gres=gpu:1 --time=00:05:00 nvidia-smi --query-gpu=name --format=csv
+```
+
+**module 名** —— `ssh <集群> 'module avail 2>&1'` 中选择与目标环境匹配的编译器和加速器 SDK。
+
+**`NEEDS_UPDATE_HOSTKEYS_NO`** —— 如果连接时看到
+`client_global_hostkeys_prove_confirm: server gave bad signature`，设成 `yes`。
+
+**`KEY_NAME_MARKER`** —— 根据私钥文件名格式设置。若形如
+`zhangsan_xxx.scnet.cn_RsaKeyExpireTime_2027-01-01.txt`，则设
+`KEY_NAME_MARKER="_<集群主机>_"`，脚本就能自动提取用户名。
+
+### 5. 用正式流程重配连接
+
+删掉第 2 步的临时段，然后：
+
+```bash
+./scripts/setup-ssh.sh --cluster <集群短名> <私钥文件> <用户名>
+```
+
+公开 profile 使用占位符时，`<用户名>` 必须显式传入；如果已在本地私有 profile
+里填了真实 `KEY_NAME_MARKER`，可以省略。
+
+### 6. 验证加速器能力并记录结论
+
+加速器能力必须以目标计算节点的探针结果为准，不能从上游 ROCm、CUDA 或其他集群的结果推断。
+
+所有探针和测试任务的临时文件必须放在共享家目录中，例如
+`$HOME/.scnet-hpc/tmp/$SLURM_JOB_ID`。不要使用 `/tmp` 或从根目录创建临时目录；作业
+启动后应导出 `TMPDIR`、`TMP`、`TEMP` 指向该目录。
+
+用一个探针作业测这些：
+
+```python
+import torch
+p = torch.cuda.get_device_properties(0)
+print("arch:", getattr(p, "gcnArchName", "?"), "| major", p.major, "minor", p.minor)
+
+# 低精度数据类型
+for dt in ["float8_e4m3fn", "float8_e5m2", "float8_e8m0fnu", "bfloat16"]:
+    print(dt, hasattr(torch, dt))
+
+# 硬件加速的低精度 matmul
+try:
+    a = torch.randn(64, 128).to(torch.float8_e4m3fn).cuda()
+    b = torch.randn(128, 64).to(torch.float8_e4m3fn).cuda().t().contiguous().t()
+    torch._scaled_mm(a, b, scale_a=torch.tensor(1.).cuda(),
+                     scale_b=torch.tensor(1.).cuda(), out_dtype=torch.bfloat16)
+    print("_scaled_mm: OK")
+except Exception as e:
+    print("_scaled_mm:", type(e).__name__, str(e)[:120])
+
+# Triton（很多推理框架的前提）
+try:
+    import triton, triton.language as tl
+    @triton.jit
+    def k(x, y, o, n, BLOCK: tl.constexpr):
+        i = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+        m = i < n
+        tl.store(o + i, tl.load(x + i, mask=m) + tl.load(y + i, mask=m), mask=m)
+    n = 4096
+    x = torch.randn(n, device="cuda"); y = torch.randn(n, device="cuda")
+    o = torch.empty_like(x)
+    k[(triton.cdiv(n, 256),)](x, y, o, n, BLOCK=256)
+    torch.cuda.synchronize()
+    print("triton: OK, err", (o - (x + y)).abs().max().item())
+except Exception as e:
+    print("triton:", type(e).__name__, str(e)[:200])
+```
+
+把结论写进 profile 的 `KNOWN_LIMITATIONS`，格式参考已有的 profile。
+
+Triton 是多种推理框架的运行前提；不可用时，对应的 Triton 执行路径也不可用（SGLang 的 FP8 路径、vLLM 的 ROCm MoE 后端、transformers 的 finegrained-fp8）。该结论应在框架适配前确认。
+
+已有集群后续不必重跑完整流程，可用
+`./scripts/refresh-cluster.sh --cluster <集群短名> --compute` 动态刷新调度器、
+内存、分区、网络和计算节点能力，结果写到 `clusters/.cache/<集群短名>.auto.conf`。
+
+## profile 字段参考
+
+必填三项：`CLUSTER_ID`、`SSH_HOST`、`SSH_PORT`。其余留空则脚本跳过、文档显示为未探测。
+
+影响脚本行为的关键项：
+
+| 字段 | 谁用 | 留空的后果 |
+|---|---|---|
+| `MIN_GRES` | 文档提示 | 不提示 QOS 强制申请加速器 |
+| `GRES_TYPE` | `new-job.sh` | 生成的脚本不含 `--gres` |
+| `DEF_MEM_PER_CPU` | `new-job.sh` | 生成的脚本不含 `--mem`，需手填 |
+| `MODULE_LOADS` | `new-job.sh` | 生成的脚本不含 `module load` |
+| `PYTHON_MODULE` | `run-compute-probe.sh` | 计算节点缺 python3 时可能找不到解释器 |
+| `DEFAULT_VENV` | `new-job.sh` | 生成的脚本不含 venv 激活 |
+| `NODE_COUNT` | 运行时回退 | 实时查 TotalNodes 失败时使用该值 |
+| `KEY_NAME_MARKER` | `setup-ssh.sh` | 无法从文件名推断用户名，需显式传 |
+| `NEEDS_UPDATE_HOSTKEYS_NO` | `setup-ssh.sh` | 不写 `UpdateHostKeys no` |
+| `COMPUTE_NODE_OFFLINE` | `new-job.sh` | 不设 `HF_HUB_OFFLINE` |
+
+## 非 Slurm 调度器
+
+目前 `new-job.sh` 只支持 Slurm（`SCHEDULER="slurm"`）。PBS/LSF 集群可以填
+profile 的其他字段用于文档和连接，但作业脚本要手写。

--- a/skills/scnet-hpc/references/environment.md
+++ b/skills/scnet-hpc/references/environment.md
@@ -1,0 +1,176 @@
+# 集群环境
+
+具体参数在 `clusters/<集群短名>.conf`，本文讲通用方法。
+
+## 读取和核验集群参数
+
+```bash
+cat clusters/<集群短名>.conf
+```
+
+任务依赖当前状态时，执行现场核验：
+
+```bash
+ssh <集群> 'scontrol show partition <分区>'     # DefMemPerCPU / MaxTime / TotalNodes
+ssh <集群> 'sinfo -p <分区> -o "%n %c %m %G %t"'  # 每节点 CPU/内存/GRES/状态
+ssh <集群> 'sacctmgr show qos where name=<QOS名> format=Name,MinTRES%30,MaxTRES%30 -P'
+```
+
+也可使用动态刷新脚本，登录节点只读探测不会提交作业：
+
+```bash
+./scripts/refresh-cluster.sh --cluster <集群短名> --dry-run
+```
+
+其中分区节点数 `NODE_COUNT` 默认每次加载集群时实时查询 `TotalNodes`。
+
+节点状态含义：`idle` 空闲、`mix` 部分占用、`alloc` 全占、`drain`/`drng` 不可调度
+（维护中）。实际可用节点常少于总数。
+
+**登录节点常有负载均衡**，两次 `hostname` 结果可能不同。这不影响使用（家目录共享），
+但如果在某台登录节点起了后台进程，下次登录可能落到另一台看不到它。
+
+## 加速器软件栈
+
+国产超算的加速器 SDK 通常通过 module 加载，profile 的 `MODULE_LOADS` 记录了
+需要 load 的模块。以海光 DTK 为例：
+
+```bash
+module load compiler/gcc/9.3.0 compiler/dtk/26.04
+```
+
+DTK 是海光对 ROCm 的发行版，含 HIP、rocBLAS、hipBLASLt、MIOpen、RCCL 等，
+把 ROCm 的部分库改了名（如 `libgalaxyhip.so` 对应 `libamdhip64.so`）。
+
+列出可用模块：
+
+```bash
+ssh <集群> 'module avail 2>&1'
+```
+
+## Python 环境
+
+超算通常没有系统级的 torch，用 venv 或 conda env。profile 的 `DEFAULT_VENV`
+记录默认环境路径（相对家目录）。
+
+```bash
+module load <MODULE_LOADS>                       # 必须先 load
+source ~/<DEFAULT_VENV>/bin/activate
+```
+
+必须先加载工具链模块，再激活 Python 环境；否则，`import torch` 会报缺共享库：
+
+```
+ImportError: libgalaxyhip.so.5: cannot open shared object file
+```
+
+昆山计算节点默认没有 `python3` 命令，需额外加载：
+
+```bash
+module load python/3.8.10
+```
+
+## 厂商预编译的 wheel
+
+国产加速器的 torch 等框架需要厂商适配版，文件名带厂商标记。海光示例：
+
+```
+torch-2.7.1+das.opt1.dtk2604-cp312-...whl
+flash_attn-2.8.3+das.opt1.dtk2604.torch271-...whl
+```
+
+`+das.opt1.dtk2604` 表示针对 DTK 26.04 编译。**不要用 PyPI 的通用版覆盖这些**
+——通用版是 CUDA 或上游 ROCm 编译的，在国产加速器上跑不起来。装其他包时如果
+pip 想升级 torch，加 `--no-deps` 阻止。
+
+## 装依赖
+
+当计算节点无外网时，在具备网络访问的登录节点准备依赖：
+
+```bash
+source ~/<venv>/bin/activate
+pip install -i <PIP_INDEX> <包名>
+```
+
+`PIP_INDEX` 在 profile 里。镜像选择以 profile 和现场可达性为准。
+
+安装后在目标计算节点验证（登录节点可能 import 不了框架）：
+
+```bash
+srun -p <分区> --gres=<类型>:1 --cpus-per-task=8 --mem=30gb --time=00:05:00 \
+  bash -lc 'module load <模块>
+    source ~/<venv>/bin/activate
+    python3 -c "import <包名>; print(\"ok\")"'
+```
+
+## 下载模型
+
+profile 的 `NET_BLOCKED` 记录了不可达的站点。国内超算通常 `huggingface.co`
+不通，用 modelscope：
+
+```bash
+python3 -c "
+from modelscope import snapshot_download
+snapshot_download('<repo>', cache_dir='/public/home/$USER/models/_ms_cache')
+"
+```
+
+若 ModelScope 首次下载结果不完整或只保留 `.lock` 文件，可使用
+`allow_patterns` 单独补：
+
+```python
+snapshot_download(repo, cache_dir=..., allow_patterns=["inference/*", "*.json"])
+```
+
+下载后核验所需文件、数量和校验信息。
+
+## 家目录布局约定
+
+```
+models/                所有模型权重
+scripts/               作业脚本
+├── lib/               可复用的 Python 模块（作业里通过 PYTHONPATH 引用）
+├── probes/            诊断/探针脚本
+├── deprecated/        已确认走不通的路线（隔开避免误用）
+└── logs/              作业日志（所有 #SBATCH --output 指向这里）
+softwares/             代码、venv、编译产物
+├── projects/          各项目工作目录
+└── _archive/          历史日志、一次性脚本
+```
+
+让所有 `#SBATCH --output` 指向 `scripts/logs/`，否则日志会散落在提交目录。
+
+## 迁移环境目录
+
+**移动含 venv / conda env 的目录前，检查 `bin/` 下的 shebang。** conda 把解释器
+绝对路径写死在 `pip`、`torchrun` 等入口点第一行，直接移动会报 bad interpreter：
+
+```bash
+cd <env>/bin
+for f in *; do
+  head -c2 "$f" 2>/dev/null | grep -q '^#!' || continue
+  head -1 "$f" | grep -q "<旧路径>" && sed -i "1s|<旧路径>|<新路径>|" "$f"
+done
+```
+
+迁移后验证入口脚本和环境前缀：
+
+```bash
+<新路径>/bin/python -c "import sys; print(sys.prefix)"
+<新路径>/bin/pip --version
+```
+
+同时检查作业脚本里的硬编码路径（`#SBATCH --output`、`source .../activate`、
+`PYTHONPATH`）。
+
+## 磁盘
+
+```bash
+df -h ~                    # 文件系统使用情况
+du -sh */ | sort -h        # 各目录体积（大目录很慢，考虑放后台）
+```
+
+`df` 显示的是**整个文件系统**的容量，不一定是你的个人配额。查个人配额要用
+平台特定的命令（如 `lfs quota`）或看控制台。
+
+模型权重是主要占用，几个大模型就是几百 GB。

--- a/skills/scnet-hpc/references/hygon-dcu-development.md
+++ b/skills/scnet-hpc/references/hygon-dcu-development.md
@@ -1,0 +1,74 @@
+# 海光 DCU 开发与工具库索引
+
+本页整理光合开发者社区的公开入口。站点内容会更新；版本、支持的操作系统、驱动、固件和安装包必须以官方页面当前选择结果为准，不要从本文复制旧版本组合。
+
+## 使用顺序
+
+1. 打开[开发指南](https://developer.sourcefind.cn/developer-channel)，选择 DCU 产品系列、操作系统和版本。
+2. 按页面顺序完成驱动安装、固件更新、DTK 或 DAS 环境部署，再考虑容器化部署。
+3. 打开 [DTK 资源页](https://developer.sourcefind.cn/dtk)，下载与目标系统匹配的 DTK，并从文档目录选择对应版本手册。
+4. 在计算节点用最小探针验证驱动、运行时、编译器、目标架构和所需库；集群 module 中的实际版本优先于网页示例。
+5. 需要模型、镜像、代码或课程时，从下方资源入口继续查找。
+
+## 官方入口
+
+| 入口 | 用途 |
+|---|---|
+| [开发指南](https://developer.sourcefind.cn/developer-channel) | 产品与系统选择；驱动、VBIOS、DTK、DAS、容器部署步骤 |
+| [文档中心](https://developer.sourcefind.cn/document/) | 官方文档检索；页面可能要求浏览器会话或登录 |
+| [DTK](https://developer.sourcefind.cn/dtk) | DTK 下载、文档、FAQ、教程和版本动态 |
+| [DTK 下载目录](https://download.sourcefind.cn:65024/1/main) | 安装包与版本目录 |
+| [DTK 最新文档目录](https://download.sourcefind.cn:65024/1/main/latest/Document) | 当前发布版文档集合 |
+| [DCU 上手指南](https://developer.sourcefind.cn/gitbook/dcu_tutorial/index.html) | 入门教程；可能跳转统一登录 |
+| [DAS](https://das.sourcefind.cn:55011/portal/) | 应用分析与相关工具入口 |
+| [DAP](https://dap.sourcefind.cn/) | 开发与适配平台入口 |
+| [代码仓库](https://developer.sourcefind.cn/codes/) | 示例、适配代码和项目 |
+| [模型仓库](https://developer.sourcefind.cn/modelzoo/list) | DCU 模型资源 |
+| [镜像仓库](https://harbor.sourcefind.cn:5443/) | 容器镜像；使用前确认登录和拉取权限 |
+| [科学计算](https://dos.sourcefind.cn:50275/portal/#/home) | 科学计算软件与服务 |
+| [C86 DevKit](https://c86.sourcefind.cn/documents) | 海光 CPU/C86 开发资料；不要与 DCU/DTK 文档混用 |
+| [DTK 论坛答疑区](https://forum.sourcefind.cn/cate/1_42_43_44/seq/0) | 数学库、运行时、编译器与适配问题 |
+
+## DTK 软件栈索引
+
+DTK 是面向 DCU 应用开发、优化和部署的工具包。官方资源页将其能力分为以下几层。
+
+| 类别 | 组件或主题 | 何时查 |
+|---|---|---|
+| 异构编程语言 | HIP、OpenCL、OpenACC、OpenMP；CUDA 兼容与迁移 | 新项目选编程模型，或移植 CUDA 程序 |
+| 编译与运行时 | Fortran/C/C++ 编译器、HIP Runtime、运行时库、CUDA 兼容层 | 编译失败、运行时 API、设备与内存管理 |
+| 基础数学库 | BLAS/rocBLAS、LAPACK、SPARSE | 线性代数、稀疏计算及性能调优 |
+| AI/算子库 | CNN/卷积算子库 | 深度学习算子和 dynamic shape 性能 |
+| C++ 并行库 | Thrust、CUB | 并行算法、扫描、归约和设备端原语 |
+| 通信库 | 集合通信、DUSHMEM/单边低延迟通信 | 多卡、跨卡通信和 PGAS 风格访问 |
+| 分析与调试 | 性能分析器、调试器、监控器、DAS | 定位热点、内存错误、同步错误和利用率问题 |
+| 迁移工具 | GPUfusion、CUDA 兼容工具与移植流程 | 评估和转换 CUDA 工程 |
+| 部署 | 国产操作系统、虚拟化、容器、高速互联 | 裸机/module 与容器环境选择 |
+
+官方 DTK 页面当前直接列出的手册示例包括：
+
+- `HIP Runtime API开发手册`
+- `rocBLAS库使用手册`
+- `DUSHMEM库使用手册`
+
+不要把示例文件名当成完整目录。优先进入“最新文档目录”，再按已安装 DTK 版本选择同版本手册。
+
+## 按任务选资料
+
+| 任务 | 先查 | 随后验证 |
+|---|---|---|
+| 新装环境 | 开发指南 → DTK 下载 | `module list`、编译器版本、`rocminfo` |
+| 写 HIP 程序 | HIP Runtime API、编译器文档 | 最小 kernel 编译与运行 |
+| CUDA 项目迁移 | CUDA 兼容课程、GPUfusion、移植流程 | 构建系统、架构宏、CUDA 专属 API |
+| 加速线性代数 | rocBLAS/BLAS、LAPACK、SPARSE 手册 | 数据类型、布局、目标架构、算法可用性 |
+| 深度学习算子 | CNN/卷积算子库、框架适配文档 | dynamic shape、精度、workspace 和 fallback |
+| 多卡通信 | 通信库、DUSHMEM 手册 | 拓扑、进程启动方式、跨节点支持 |
+| 性能问题 | DAS、性能分析教程、监控工具 | 热点、传输、同步、占用率 |
+| 容器部署 | 开发指南的容器化步骤、镜像仓库 | 设备映射、驱动/用户态兼容、Slurm 集成 |
+
+## 安全与准确性
+
+- 不公开记录账号、token、私钥、用户目录、作业 ID、内部地址或受限下载链接。
+- 公开页面出现的版本号只是页面抓取时的状态；安装前重新选择产品和系统。
+- 网页声明“支持”不等于目标集群可用。最终以计算节点实测和集群 profile 的 `KNOWN_LIMITATIONS` 为准。
+- 不把 ROCm/CUDA 上游能力自动等同于 DTK 能力。对 Triton、FP8、INT8、通信算法和特定架构内核逐项探测。

--- a/skills/scnet-hpc/references/quickstart-en.md
+++ b/skills/scnet-hpc/references/quickstart-en.md
@@ -1,0 +1,127 @@
+# SCNet HPC English Quick Start
+
+This guide covers the common workflow for SCNet clusters. Current repository profiles focus
+mainly on Hygon DCU/DTK systems. Always read the target profile before using a partition,
+memory value, accelerator type, module, or home-directory path.
+
+The repository scripts support Linux and macOS natively. On Windows, use WSL2; native Windows
+execution and Git Bash are not fully validated. This is separate from the official SCNet desktop
+client, which supports Windows 10+ and macOS 12 Monterey+.
+
+## 1. Inspect the available profiles
+
+```bash
+ls clusters/*.conf
+sed -n '1,220p' clusters/<cluster>.conf
+```
+
+Check at least `PARTITION`, `PARTITION_CPU`, `GRES_TYPE`, `MIN_GRES`,
+`DEF_MEM_PER_CPU`, `MODULE_LOADS`, `COMPUTE_NODE_OFFLINE`, and
+`KNOWN_LIMITATIONS`.
+
+## 2. Install the skill
+
+```bash
+git clone https://github.com/lql341/scnet-hpc.git
+cd scnet-hpc
+./scripts/install.sh
+```
+
+The repository is designed to be shared by Codex, Claude Code, and OpenCode. Installation
+paths depend on the local agent layout; `install.sh --link` is useful when developing the
+skill from a shared source directory.
+
+## 3. Configure SSH
+
+Download the private key from the SCNet console, then run:
+
+```bash
+./scripts/setup-ssh.sh --cluster <cluster> <private-key-file> <username>
+ssh <cluster>
+```
+
+The script installs the key under `~/.ssh`, adds an SSH config entry, and tests the
+connection. Do not commit private keys, usernames, internal node names, or personal paths.
+
+## 4. Generate a Slurm job
+
+Accelerator job:
+
+```bash
+./scripts/new-job.sh --cluster <cluster> myjob 1 8 00:20:00
+```
+
+CPU-only job, when the profile defines `PARTITION_CPU`:
+
+```bash
+./scripts/new-job.sh --cluster <cluster> --cpu-only build 0 32 01:00:00
+```
+
+Explicit partition override:
+
+```bash
+./scripts/new-job.sh --cluster <cluster> --partition <partition> probe 1 8 00:10:00
+```
+
+The generator calculates a safe memory request from the profile, adds GRES only when
+needed, configures a shared temporary directory, enables offline mode when appropriate,
+and propagates the program exit code.
+
+Create the remote log directory before submission:
+
+```bash
+ssh <cluster> 'mkdir -p ~/scripts/logs'
+```
+
+Upload the generated script and validate the request before queueing it:
+
+```bash
+scp myjob.slurm <cluster>:~/scripts/
+ssh <cluster> 'sbatch --test-only ~/scripts/myjob.slurm'
+ssh <cluster> 'sbatch ~/scripts/myjob.slurm'
+```
+
+## 5. Monitor and debug
+
+```bash
+squeue -u "$USER"
+squeue -j <job-id> --start
+sacct -j <job-id> --format=JobID,State%14,ExitCode,Elapsed,MaxRSS -P
+scancel <job-id>
+```
+
+Do not trust `COMPLETED` alone. Read both stdout and stderr, and make sure the job script
+ends with the real program exit code.
+
+For short experiments, request an interactive allocation with `srun`. Use the partition,
+GRES type, CPU count, and memory limit from the target profile.
+
+## 6. SCNet environment rules
+
+- Login nodes are for source management, dependency preparation, file operations, and
+  scheduler commands. Whether package indexes and model sites are reachable is cluster-specific.
+- Compute nodes are often offline. Download dependencies, models, and kernels before the job.
+- A DCU partition may require at least one accelerator even for a CPU-oriented command.
+- Memory limits may be tied to `cpus-per-task × DefMemPerCPU`.
+- Do not use system `/tmp` for files that must be shared across login and compute nodes.
+- Loading a module on a login node does not prove that the runtime works on a compute node.
+- Hygon DCU software capabilities depend on the exact DTK, driver, framework, and `gfx` target.
+
+## 7. Refresh and probe a cluster
+
+```bash
+./scripts/refresh-cluster.sh --cluster <cluster> --dry-run
+./scripts/refresh-cluster.sh --cluster <cluster>
+./scripts/refresh-cluster.sh --cluster <cluster> --compute
+```
+
+The default refresh performs read-only login-node checks. `--compute` submits a small Slurm
+job to test the accelerator runtime and therefore consumes cluster resources.
+
+For detailed diagnostics, see the Chinese references:
+
+- `references/setup.md`
+- `references/environment.md`
+- `references/troubleshooting.md`
+- `references/software-compatibility.md`
+- `references/hygon-dcu-development.md`

--- a/skills/scnet-hpc/references/quickstart-en.md
+++ b/skills/scnet-hpc/references/quickstart-en.md
@@ -19,19 +19,7 @@ Check at least `PARTITION`, `PARTITION_CPU`, `GRES_TYPE`, `MIN_GRES`,
 `DEF_MEM_PER_CPU`, `MODULE_LOADS`, `COMPUTE_NODE_OFFLINE`, and
 `KNOWN_LIMITATIONS`.
 
-## 2. Install the skill
-
-```bash
-git clone https://github.com/lql341/scnet-hpc.git
-cd scnet-hpc
-./scripts/install.sh
-```
-
-The repository is designed to be shared by Codex, Claude Code, and OpenCode. Installation
-paths depend on the local agent layout; `install.sh --link` is useful when developing the
-skill from a shared source directory.
-
-## 3. Configure SSH
+## 2. Configure SSH
 
 Download the private key from the SCNet console, then run:
 
@@ -43,7 +31,7 @@ ssh <cluster>
 The script installs the key under `~/.ssh`, adds an SSH config entry, and tests the
 connection. Do not commit private keys, usernames, internal node names, or personal paths.
 
-## 4. Generate a Slurm job
+## 3. Generate a Slurm job
 
 Accelerator job:
 
@@ -81,7 +69,7 @@ ssh <cluster> 'sbatch --test-only ~/scripts/myjob.slurm'
 ssh <cluster> 'sbatch ~/scripts/myjob.slurm'
 ```
 
-## 5. Monitor and debug
+## 4. Monitor and debug
 
 ```bash
 squeue -u "$USER"
@@ -96,7 +84,7 @@ ends with the real program exit code.
 For short experiments, request an interactive allocation with `srun`. Use the partition,
 GRES type, CPU count, and memory limit from the target profile.
 
-## 6. SCNet environment rules
+## 5. SCNet environment rules
 
 - Login nodes are for source management, dependency preparation, file operations, and
   scheduler commands. Whether package indexes and model sites are reachable is cluster-specific.
@@ -107,7 +95,7 @@ GRES type, CPU count, and memory limit from the target profile.
 - Loading a module on a login node does not prove that the runtime works on a compute node.
 - Hygon DCU software capabilities depend on the exact DTK, driver, framework, and `gfx` target.
 
-## 7. Refresh and probe a cluster
+## 6. Refresh and probe a cluster
 
 ```bash
 ./scripts/refresh-cluster.sh --cluster <cluster> --dry-run

--- a/skills/scnet-hpc/references/setup.md
+++ b/skills/scnet-hpc/references/setup.md
@@ -1,0 +1,136 @@
+# 连接配置详解
+
+集群的主机名、端口等参数来自 `clusters/<集群短名>.conf`。
+本文用 `<集群>`、`<主机名>`、`<端口>` 表示从 profile 读出的值。
+
+## 手工配置
+
+```bash
+# 1. 装私钥
+mkdir -p ~/.ssh && chmod 700 ~/.ssh
+cp <下载的私钥> ~/.ssh/id_rsa_<集群>
+chmod 600 ~/.ssh/id_rsa_<集群>
+
+# macOS：清除下载文件的隔离属性，否则某些工具拒绝读取
+xattr -c ~/.ssh/id_rsa_<集群>
+
+# 2. 建 socket 目录（长连接用）
+mkdir -p ~/.ssh/sockets && chmod 700 ~/.ssh/sockets
+
+# 3. 追加下面的段到 ~/.ssh/config，然后 chmod 600 ~/.ssh/config
+```
+
+```
+Host <集群> <主机名>
+  HostName <主机名>
+  User <你的用户名>
+  Port <端口>
+  IdentityFile ~/.ssh/id_rsa_<集群>
+  IdentitiesOnly yes
+  # 以下两行仅 macOS 支持，Linux 上会报 unknown option
+  UseKeychain yes
+  AddKeysToAgent yes
+  # 长连接
+  ControlMaster auto
+  ControlPath ~/.ssh/sockets/%r@%h-%p
+  ControlPersist 10m
+  # 保活
+  ServerAliveInterval 60
+  ServerAliveCountMax 3
+  TCPKeepAlive yes
+  # 仅当 profile 里 NEEDS_UPDATE_HOSTKEYS_NO=yes 时才加这行
+  UpdateHostKeys no
+```
+
+## SSH 选项说明
+
+**`ControlPersist 10m` 而非 `yes`**：永久驻留的 master 在笔记本休眠或换网络后会
+变成失效 socket，可能留下需要清理的失效 socket。10 分钟覆盖一次交互操作的节奏，又能自然回收。
+实测复用后单条命令从约 2 秒降到 0.57 秒。
+
+**`ServerAliveInterval 60`**：应用层心跳，防止空闲 SSH 会话被中间网关静默切断。
+用于保持长时间空闲会话。`TCPKeepAlive` 是 TCP 层的，两者互补。
+
+**`UpdateHostKeys no`**：部分平台的服务端对主机密钥轮换扩展返回错误签名：
+
+```
+client_global_hostkeys_prove_confirm: server gave bad signature for RSA key 0
+```
+
+该设置仅禁用服务端主机密钥轮换扩展；首次主机密钥仍按正常流程校验。仅在出现该告警且 profile 标记 `NEEDS_UPDATE_HOSTKEYS_NO=yes` 的集群上使用。
+
+**`IdentitiesOnly yes`**：只用指定的私钥。ssh-agent 里密钥多时，避免因尝试次数
+过多被服务端拒绝。
+
+## macOS 与 Linux 差异
+
+| 项 | macOS | Linux |
+|---|---|---|
+| `UseKeychain` / `AddKeysToAgent` | 支持 | **不支持**，报 unknown option |
+| 下载文件隔离属性 | 需 `xattr -c` | 无此概念 |
+| `sed -i` | 需 `sed -i ''`（BSD sed） | `sed -i`（GNU sed） |
+
+`setup-ssh.sh` 检测 `uname -s` 自动处理前两项。
+
+## 长连接管理
+
+```bash
+ssh -O check <集群>     # 查看 master 状态
+ssh -O exit <集群>      # 手工断开（网络切换后卡住时用）
+```
+
+## 密钥有效期
+
+超算平台的私钥通常有有效期，文件名里就带，例如
+`<用户名>_<主机>_RsaKeyExpireTime_2026-10-29_12-51-40.txt` 表示 2026-10-29 过期。
+到期前从控制台重新下载并重跑 setup 脚本。
+
+profile 里的 `KEY_NAME_MARKER` 就是用来从这种文件名里提取用户名的；公开
+`scnet-hpc` profile 使用 `_<CLUSTER_HOST>_` 占位符，所以安装时通常需要显式传
+用户名，或在本地私有 profile 中补齐真实标记。
+
+查看密钥指纹：
+
+```bash
+ssh-keygen -lf ~/.ssh/id_rsa_<集群>
+```
+
+## 加 passphrase（可选）
+
+```bash
+ssh-keygen -p -f ~/.ssh/id_rsa_<集群>
+```
+
+配合 macOS 的 `UseKeychain yes` + `AddKeysToAgent yes`，只需首次输入一次。
+
+## 常见连接失败
+
+| 现象 | 原因 |
+|---|---|
+| `Permission denied (publickey)` | 私钥过期，或本机 IP 不在平台白名单 |
+| `Connection timed out` | 端口被本地网络阻断（超算常用非 22 端口）|
+| `Bad owner or permissions on config` | `chmod 600 ~/.ssh/config` |
+| `WARNING: UNPROTECTED PRIVATE KEY` | `chmod 600 ~/.ssh/id_rsa_<集群>` |
+| 首次连接等待主机指纹确认 | 在等确认主机指纹，加 `-o StrictHostKeyChecking=accept-new` |
+
+多数超算平台有 **IP 白名单**，换网络（家里/公司/热点）后可能连不上，
+需要去控制台加当前 IP。
+
+## 在脚本里调用
+
+```bash
+ssh -o BatchMode=yes <集群> '<命令>'
+```
+
+`BatchMode=yes` 让认证失败立刻返回，而不是卡在密码提示上等输入。写自动化脚本时
+应启用，以避免自动化流程等待交互输入。
+
+## 文件传输
+
+```bash
+scp local.py <集群>:/public/home/$USER/scripts/
+scp <集群>:/public/home/$USER/scripts/logs/job_123.log .
+rsync -avz --progress ./dir/ <集群>:/public/home/$USER/dir/   # 大量文件
+```
+
+上述命令复用 SSH profile 中的连接参数。

--- a/skills/scnet-hpc/references/software-compatibility.md
+++ b/skills/scnet-hpc/references/software-compatibility.md
@@ -1,0 +1,78 @@
+## 国产超算软件兼容性排查
+
+### 验证顺序
+
+1. **系统 ABI**：确认发行版、glibc、CPU 架构和节点类型；检查 wheel 的 `manylinux` 标签是否高于目标 glibc。
+2. **工具链**：记录 GCC/Clang、DTK、HIP、CMake、MPI、Python 和框架版本；登录节点可用不等于计算节点可用。
+3. **最小探针**：在目标计算节点验证 import、设备枚举、最小 kernel、一个真实功能和退出码。
+4. **依赖路径**：区分 pip/conda 解析失败、运行时动态库失败、框架 kernel 不支持和模型/数据下载失败。
+5. **端到端结果**：记录成功条件、性能、显存/内存、失败日志和未验证范围。
+
+### 编译型软件的分层验证
+
+- **把编译放到计算节点**：C++/HIP 大型构建的峰值内存可能远高于登录节点限额。
+  编译器进程被 OOM kill 时，先换到有明确内存配额的计算作业，先排除资源限制，再判断源码问题。
+- **只生成目标架构**：显式设置目标 `gfx` 架构。默认同时生成多个架构会成倍增加
+  编译时间、产物体积和峰值内存。
+- **升级工具链后重跑最小构建**：DTK/编译器升级可能改变 wrapper 头、host/device
+  编译模式或默认链接路径。保存 verbose compile command，与上一版本逐项比较。
+- **区分节点环境**：登录/CPU 节点可能加载得到 module，却缺少只在加速器节点完整
+  可见的 HSA/HIP 库或符号链接。以目标计算节点解析到的真实库文件为准，必要时通过
+  CMake cache 变量显式传入，不创建全局假链接。
+- **先串行能力、后并行能力**：先完成无 MPI 的单卡最小构建和功能验证，再开启 MPI，
+  最后测试 GPU-aware 通信与多卡扩展，以隔离编译器、运行库和通信栈问题。
+
+### GPU-aware MPI 的验证边界
+
+系统 MPI 能启动多进程，不代表它带加速器感知能力。先记录 MPI 构建参数，并做
+GPU-aware on/off 对照。单节点验证可先固定共享内存与 self 传输，减少 UCX/IB
+站点配置带来的变量；这只能证明单节点路径，不能外推到跨节点通信。
+
+多卡扩展通常同时依赖足够大的问题规模、较高的计算/通信比以及可用的 GPU-aware
+路径。小问题或低计算密度任务扩展不佳，不足以单独证明硬件或 MPI 配置错误。
+
+### 数值与性能验收
+
+加速器移植至少应同时报告：CPU/参考实现的关键数值偏差、守恒量或长期稳定性、
+单卡问题规模扫描、固定规模的 1/2/单节点全卡强扩展、GPU-aware on/off 对照、
+峰值内存/显存，以及每项测试的退出码和完整日志。性能通过不能替代正确性验证。
+
+### 已验证的典型边界
+
+- **gfx936 / BW1000**：Triton、硬件 FP8 `torch._scaled_mm`、部分 bitsandbytes INT8 路径可能不可用；纯 PyTorch 软件反量化可作为兼容路径，但需要单独做性能和精度验证。
+- **gfx906 / Z100**：CentOS 7.6 的 glibc 2.17 会限制 manylinux wheel 版本；安装 Python 软件时优先选 manylinux2014 / manylinux_2_17 兼容包。MinerU 场景中，Python 3.10 + onnxruntime 1.16.3 是已验证方向，magika 版本/API 需要随源码适配。
+- **GROMACS HIP**：先验证 CMake 最低版本、DTK 的 `lib`/`lib64` CMake 路径、目标架构、FFTW 预置和 SIMD；CUDA 兼容层与原生 HIP 的性能不可直接互相推断。
+
+### 作业验证模板
+
+```bash
+set -o pipefail
+python3 -c 'import torch; print(torch.__version__); print(torch.cuda.is_available())'
+python3 -c 'import <target_package>; print("import ok")'
+<minimal_function_test>
+rc=$?
+echo "test_exit_code=$rc"
+exit "$rc"
+```
+
+不能只依据 `sacct` 的 `COMPLETED` 判定成功。脚本必须显式传递最后一个测试命令的退出码，并同时读取 `.out/.err`。
+
+### 公开报告模板
+
+标题采用“项目 + 加速器/平台 + 编译与性能/兼容性测试报告”。正文可按以下顺序：
+
+1. 环境信息
+2. 编译过程与主要难题
+3. 最终方案与验证结果
+4. 测试数据与资源占用
+5. 已知限制与注意事项
+6. 适用范围与可复用结论
+7. 附录：快速复现命令
+
+发布前扫描：
+
+```bash
+rg -n -i 'ssh|password|token|secret|/home/|/public/|/Users/|@[A-Za-z0-9.-]+|192\.168\.|10\.|172\.(1[6-9]|2[0-9]|3[0-1])\.|job [0-9]+|作业编号|节点名' report.html
+```
+
+将命中项替换为占位符或概括描述；保留版本、架构、错误类型、性能数据和验证边界。

--- a/skills/scnet-hpc/references/troubleshooting.md
+++ b/skills/scnet-hpc/references/troubleshooting.md
@@ -1,0 +1,231 @@
+# 排查作业失败
+
+## 作业状态与实际退出码
+
+bash 脚本里 Python 崩了之后，bash 继续执行后面的行，作业以**最后一条命令**的退出码
+结束。真实案例：
+
+```
+$ sacct -j <JOB_ID> --format=JobID,JobName,State,ExitCode,Elapsed
+<JOB_ID> | example-job | COMPLETED | 0:0 | 00:34:32
+```
+
+该记录不能证明 Python 工作负载成功。Python 可能已在第 3 分钟抛出 `ValueError`，而日志末尾仍打印脚本中
+写的 `===== COMPLETE =====`。
+
+排查时先读取日志和工作负载退出码，再结合调度器 State 判断。
+
+预防：脚本末尾写
+
+```bash
+rc=$?
+echo "### python exit=$rc"
+exit $rc
+```
+
+## 日志被进度条淹没时
+
+`transformers` 加载权重的进度条写到 stderr，会刷出几万字符：
+
+```bash
+grep -v "Loading weights" job_123.err | tail -50
+# 或者只看 Python traceback
+grep -A30 "Traceback" job_123.err | head -60
+```
+
+## 按报错分类
+
+### `QOSMinGRES`
+
+```
+sbatch: error: min tres(gres/dcu) request 0 exceeds per-job max tres limit 1
+       for qos <QOS名>
+sbatch: error: QOSMinGRES
+```
+
+该分区要求每个作业至少申请 1 张 DCU。补充 `--gres=dcu:N`；纯 CPU 负载也受该分区策略约束。
+
+### `too much memory was requested relative to the number of CPUs`
+
+违反 `--mem ≤ cpus-per-task × DEF_MEM_PER_CPU`（值见 profile）。
+要么降 `--mem`，要么加 `--cpus-per-task`。
+
+### `libmsgpackc.so.2` / `libgalaxyhip.so.5: cannot open shared object file`
+
+三种可能：
+
+1. **在登录节点跑 torch** —— 郑州集群最近实测是缺 `libgalaxyhip.so.5`，旧环境
+   报过 `libmsgpackc.so.2`；即使 `module load` 之后也 import 不了。必须用
+   `srun`/`sbatch`。
+2. **忘了 `module load`** —— venv 激活前必须先
+   `module load compiler/gcc/9.3.0 compiler/dtk/26.04`。
+3. **顺序错了** —— 先激活 venv 再 module load 也会失败，顺序必须是 module 在前。
+
+### `Name or service not known` / `Hugging Face Hub is in offline mode`
+
+计算节点在访问外网。典型的是 `transformers` 的 kernel 下载机制：
+
+```
+ValueError: Version 4 of 'kernels-community/finegrained-fp8' is not available
+           in the local cache and Hugging Face Hub is in offline mode
+```
+
+或者更慢的版本（httpx 超时后才报）：
+
+```
+httpcore.ConnectError: [Errno -2] Name or service not known
+```
+
+脚本里加 `export HF_HUB_OFFLINE=1` 让它立刻失败而不是慢慢超时。但根本问题是**这个
+库需要运行时下载**，得找不依赖下载的替代路径。
+
+### `cannot get address for 'hipDrvLaunchKernelEx' from libamdhip64.so`
+
+Triton。DTK 26.04 的 HIP 运行时缺上游 ROCm 7 的 API，Triton 的 AMD backend 加载
+即失败。该软件栈不能使用此 Triton 路径，依赖对应 Triton kernel 的框架也不适用（SGLang FP8、vLLM ROCm
+MoE、transformers finegrained-fp8）。
+
+郑州集群最近还会先报另一种缺库：
+
+```
+ImportError: libgcvm.so.17git: cannot open shared object file
+```
+
+本质相同，都是 Triton 在当前 DTK/DCU 软件栈上不可用，继续调整 Triton kernel 参数不能解决该运行时缺失。
+
+### `torch._scaled_mm is only supported on CUDA devices with compute capability >= 9.0 or 8.9, or ROCm MI300+`
+
+gfx936 不支持硬件 FP8 计算。需要软件反量化（把 FP8 权重转成 BF16 再算）。
+
+### 退出码 53，且**完全没有日志文件**
+
+`#SBATCH` 是注释行，**Slurm 不做变量展开**。日志路径里写 `$USER` 会被当成字面量
+目录名，作业启动就失败：
+
+```
+$ sacct -j <ID> --format=State,ExitCode
+FAILED|0:53
+$ cat ~/scripts/logs/myjob_<ID>.log
+cat: No such file or directory        ← 连日志都没有，因为写不进去
+```
+
+两个原因都会导致这个：
+
+1. `--output` / `--error` 路径里有未展开的变量（`$USER`、`$HOME`）
+2. **日志目录不存在** —— Slurm 不会自动创建
+
+处理方法：`#SBATCH` 里写完整字面量路径，提交前 `mkdir -p <日志目录>`。
+`scripts/new-job.sh` 会展开好用户名并提示建目录。
+
+### `module load` 静默失败：作业返回 0 但 `ROCM_PATH` 没设置
+
+某些集群的 module 函数只在 **login shell** 里定义。用普通 `#!/bin/bash` 时
+`module load` 什么都不做，也不报错：
+
+```
+ROCM_PATH=未设置
+--- 架构 ---           ← rocminfo 无输出
+--- 显存 ---           ← rocm-smi 无输出
+### python exit=0      ← 作业「成功」了
+```
+
+该现象可能返回退出码 0，因此还需检查模块环境变量和探针输出。该行为已在昆山集群观测。
+
+处理方法：shebang 用 `#!/bin/bash -l`，或在 heredoc 内包一层 `bash -l`。
+`scripts/new-job.sh` 生成的脚本已经用 `bash -l`。
+
+自检：作业里打印 `echo "ROCM_PATH=${ROCM_PATH:-未设置}"`，未设置就说明没生效。
+
+### `python3: command not found`（昆山计算节点）
+
+昆山计算节点 `module purge` 后没有 `python3` 命令，裸 `python` 是 Python 2，
+会再报：
+
+```
+SyntaxError: Non-ASCII character '\xe5' ... no encoding declared
+```
+
+处理方法：作业脚本里显式加载 Python 3 module：
+
+```bash
+module load python/3.8.10
+```
+
+`scripts/run-compute-probe.sh` 会自动从 `module avail` 探测 `python/3.*` 模块，
+但普通业务作业仍需在 `MODULE_LOADS` 或 `PYTHON_MODULE` 里带上。
+
+### `TIMEOUT`
+
+`--time` 不够。注意大模型加载本身就很慢（DeepSeek V4 加载 154B 权重约 27 分钟），
+`--time` 要留足加载 + 计算的总时间。
+
+### OOM（进程被杀，日志突然截断）
+
+```bash
+sacct -j <ID> --format=JobID,State,MaxRSS,ReqMem -P
+```
+
+注意 `MaxRSS` **只出现在 `.batch` 子步骤那一行**，主作业行是空的：
+
+```
+JobID|MaxRSS|ReqMem
+<JOB_ID>||115G              ← 主行没有 MaxRSS
+<JOB_ID>.batch|120586316K|  ← 实际峰值在这里
+```
+
+`MaxRSS` 接近 `cpus × DEF_MEM_PER_CPU` 就是 CPU 内存不够，加 `--cpus-per-task`。
+上例申请了 `--mem=115gb` 而实际用到 120GB —— 因为 cgroup 按
+`32 × 3888MB = 121.5GB` 给（该集群 DEF_MEM_PER_CPU=3888），`--mem` 只是请求量。
+
+GPU OOM 会有明确的 `torch.cuda.OutOfMemoryError`，看每卡分配：
+
+```python
+for i in range(torch.cuda.device_count()):
+    print(i, torch.cuda.memory_allocated(i) / 1024**3, "GB")
+```
+
+### 作业一直 `PD (Priority)` 不动
+
+该状态表示等待调度资源。查询预计启动时间：
+
+```bash
+squeue -j <ID> --start
+sinfo -p <分区> -o "%n %t"           # 有几台 idle
+```
+
+`drain`/`drng` 状态的节点不参与调度，忙时可能等很久。
+
+## 调试策略
+
+按成本递增的顺序执行验证，避免使用完整模型诊断基础环境问题：
+
+1. **纯逻辑**（不需要 GPU/torch）→ 本地 Python 直接跑
+2. **需要 torch/DCU 但数据量小** → `srun` 交互式，约 5 秒拿到节点
+3. **小规模真实数据** → 2 分钟的 `sbatch` 探针作业
+4. **完整模型** → 最后才做
+
+例如，反量化实现应先通过小规模数值测试，再运行完整模型。
+
+**探针作业模板**：只读 metadata 不加载权重，几秒就出结果：
+
+```python
+from safetensors import safe_open
+with safe_open(path, framework="pt", device="cpu") as f:
+    sl = f.get_slice(key)
+    print(key, sl.get_shape(), sl.get_dtype())   # 不读实际数据
+```
+
+## 检查作业真正在干什么
+
+```bash
+# 作业跑在哪个节点
+squeue -j <ID> -o "%N"
+
+# 在作业运行期间检查目标节点进程
+ssh <节点名> 'top -b -n1 -u $USER | head -20'
+
+# GPU 占用
+srun --jobid=<ID> --overlap rocm-smi
+```
+
+`--overlap` 让新的 srun 步骤共享已有作业的资源分配，避免为诊断步骤重新申请一份资源。

--- a/skills/scnet-hpc/scripts/_common.sh
+++ b/skills/scnet-hpc/scripts/_common.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# 加载集群 profile。被其他脚本 source。
+#
+#   . "$(dirname "$0")/_common.sh"
+#   load_cluster "$CLUSTER"        # 空则自动选择
+#
+# 自动选择规则：clusters/ 下只有一个非模板 profile 时用它，否则要求显式指定。
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLUSTER_DIR="$REPO_ROOT/clusters"
+
+die() { printf '错误: %s\n' "$1" >&2; exit 1; }
+info() { printf '  %s\n' "$1"; }
+
+list_clusters() {
+    find "$CLUSTER_DIR" -maxdepth 1 -name '*.conf' ! -name '_*' -exec basename {} .conf \; 2>/dev/null | sort
+}
+
+refresh_live_node_count() {
+    [ "${SCNET_HPC_LIVE_NODE_COUNT:-yes}" != "no" ] || return 0
+    [ "${SCHEDULER:-slurm}" = "slurm" ] || return 0
+    [ -n "${CLUSTER_ID:-}" ] || return 0
+    [ -n "${PARTITION:-}" ] || return 0
+
+    local live
+    live=$(ssh -o BatchMode=yes -o ConnectTimeout=10 -o ServerAliveInterval=15 -o ServerAliveCountMax=2 \
+        "$CLUSTER_ID" "scontrol show partition ${PARTITION}" 2>/dev/null \
+        | tr ' ' '\n' | sed -n 's/^TotalNodes=//p' | head -1)
+
+    if [[ "$live" =~ ^[0-9]+$ ]] && [ "$live" -gt 0 ]; then
+        NODE_COUNT="$live"
+        NODE_COUNT_SOURCE="live"
+    else
+        NODE_COUNT_SOURCE="${NODE_COUNT_SOURCE:-profile/cache}"
+    fi
+}
+
+load_cluster() {
+    local want="${1:-}"
+    local available
+    available=$(list_clusters)
+
+    [ -n "$available" ] || die "clusters/ 下没有可用的 profile。
+从模板新建一个：
+  cp $CLUSTER_DIR/_template.conf $CLUSTER_DIR/<集群短名>.conf"
+
+    if [ -z "$want" ]; then
+        local count
+        count=$(printf '%s\n' "$available" | grep -c .)
+        if [ "$count" -eq 1 ]; then
+            want="$available"
+        else
+            die "有多个集群 profile，请用 --cluster <名> 指定：
+$(printf '%s\n' "$available" | sed 's/^/  /')"
+        fi
+    fi
+
+    local conf="$CLUSTER_DIR/$want.conf"
+    [ -f "$conf" ] || die "找不到 profile: $conf
+可用的：
+$(printf '%s\n' "$available" | sed 's/^/  /')"
+
+    # shellcheck disable=SC1090
+    . "$conf"
+
+    [ -n "${CLUSTER_ID:-}" ] || die "$conf 里 CLUSTER_ID 为空"
+    : "${SSH_PORT:=22}"
+    : "${HOME_BASE:=/public/home}"
+
+    # SSH_HOST/SSH_PORT 应以 profile 为准。这里只作为兼容回退：
+    # 旧 profile 漏填时，从本机 ~/.ssh/config 动态补全，避免脚本直接失败。
+    if [ -z "${SSH_HOST:-}" ]; then
+        SSH_HOST="$(ssh -G "$CLUSTER_ID" 2>/dev/null | awk '/^hostname /{print $2; exit}')"
+    fi
+    if [ -z "${SSH_PORT:-}" ]; then
+        SSH_PORT="$(ssh -G "$CLUSTER_ID" 2>/dev/null | awk '/^port /{print $2; exit}')"
+    fi
+    REMOTE_USER_DETECTED="$(ssh -G "$CLUSTER_ID" 2>/dev/null | awk '/^user /{print $2; exit}')"
+    : "${REMOTE_USER_DETECTED:=}"
+
+    # 用于设置新连接的新集群仍需明确的 SSH_HOST/SSH_PORT；已有本机 ssh 别名时
+    # 这里会从 ssh -G 补齐。若仍为空，给一个可操作的错误。
+    [ -n "$SSH_HOST" ] || die "$conf 里 SSH_HOST 为空，且 ssh -G ${CLUSTER_ID} 也解析不到 HostName；请先配置 ~/.ssh/config 或补 profile。"
+
+    CLUSTER_CONF="$conf"
+    CLUSTER_AUTO_CONF="$CLUSTER_DIR/.cache/$want.auto.conf"
+    if [ "${SCNET_HPC_USE_AUTO:-yes}" != "no" ] && [ -f "$CLUSTER_AUTO_CONF" ]; then
+        # shellcheck disable=SC1090
+        . "$CLUSTER_AUTO_CONF"
+    fi
+
+    refresh_live_node_count
+}
+
+# 从参数里摘出 --cluster <名>，剩下的放进 REST[]
+parse_cluster_arg() {
+    CLUSTER=""
+    REST=()
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --cluster)
+                [ $# -ge 2 ] || die "--cluster 缺少参数"
+                CLUSTER="$2"
+                shift 2
+                ;;
+            --cluster=*) CLUSTER="${1#*=}"; shift ;;
+            *) REST+=("$1"); shift ;;
+        esac
+    done
+    if [ -n "$CLUSTER" ]; then
+        [[ "$CLUSTER" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] \
+            || die "集群短名包含不安全字符"
+    fi
+}

--- a/skills/scnet-hpc/scripts/compute-probe.py
+++ b/skills/scnet-hpc/scripts/compute-probe.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""在目标计算节点上做一次最小能力探针。
+
+输出统一使用 PROBE_ 前缀的 KEY=value 行，方便 refresh-cluster.sh 解析。
+每个检查都独立捕获异常，单项失败不会中断后续检查。
+"""
+
+import os
+import urllib.request
+
+
+def emit(key, value):
+    print("PROBE_{}={}".format(key, value), flush=True)
+
+
+def short_error(exc, limit=180):
+    text = str(exc).replace("\n", " ")
+    return "{}:{}".format(type(exc).__name__, text[:limit])
+
+
+try:
+    import torch
+    emit("TORCH_VERSION", torch.__version__)
+    cuda_available = bool(torch.cuda.is_available())
+    emit("CUDA_AVAILABLE", "1" if cuda_available else "0")
+
+    if cuda_available:
+        count = torch.cuda.device_count()
+        emit("DEVICE_COUNT", count)
+
+        props = torch.cuda.get_device_properties(0)
+        emit("DEVICE_NAME", getattr(props, "name", "unknown").replace("\n", " "))
+
+        arch = getattr(props, "gcnArchName", None)
+        if arch is None:
+            arch = "{}.{}".format(getattr(props, "major", "?"), getattr(props, "minor", "?"))
+        emit("ARCH", arch)
+
+        total_memory = getattr(props, "total_memory", 0)
+        emit("MEM_MIB", int(total_memory // (1024 * 1024)))
+
+        have_dtypes = []
+        for dtype_name in ["float8_e4m3fn", "float8_e5m2", "float8_e8m0fnu", "bfloat16"]:
+            if hasattr(torch, dtype_name):
+                have_dtypes.append(dtype_name)
+        emit("DTYPES", ",".join(have_dtypes))
+
+        # 硬件 FP8 matmul
+        try:
+            if hasattr(torch, "float8_e4m3fn") and hasattr(torch, "_scaled_mm"):
+                a = torch.randn(64, 128).to(torch.float8_e4m3fn).cuda()
+                b = torch.randn(128, 64).to(torch.float8_e4m3fn).cuda().t().contiguous().t()
+                torch._scaled_mm(
+                    a,
+                    b,
+                    scale_a=torch.tensor(1.0).cuda(),
+                    scale_b=torch.tensor(1.0).cuda(),
+                    out_dtype=torch.bfloat16,
+                )
+                torch.cuda.synchronize()
+                emit("SCALED_MM", "OK")
+            else:
+                emit("SCALED_MM", "SKIP:float8_e4m3fn_or_scaled_mm_missing")
+        except Exception as exc:
+            emit("SCALED_MM", "ERR:" + short_error(exc))
+
+        # Triton 内核
+        try:
+            import triton
+            import triton.language as tl
+
+            @triton.jit
+            def add_kernel(x, y, out, n, BLOCK: tl.constexpr):
+                idx = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+                mask = idx < n
+                tl.store(out + idx, tl.load(x + idx, mask=mask) + tl.load(y + idx, mask=mask), mask=mask)
+
+            n = 4096
+            x = torch.randn(n, device="cuda")
+            y = torch.randn(n, device="cuda")
+            out = torch.empty_like(x)
+            add_kernel[(triton.cdiv(n, 256),)](x, y, out, n, BLOCK=256)
+            torch.cuda.synchronize()
+            max_err = float((out - (x + y)).abs().max().item())
+            emit("TRITON", "OK err={:.3g}".format(max_err))
+        except Exception as exc:
+            emit("TRITON", "ERR:" + short_error(exc, 240))
+
+        # bitsandbytes：先看能否 import；是否真正可用仍需业务级测试
+        try:
+            import bitsandbytes as bnb
+            emit("BITSANDBYTES", "IMPORT_OK version={}".format(getattr(bnb, "__version__", "unknown")))
+        except Exception as exc:
+            emit("BITSANDBYTES", "IMPORT_ERR:" + short_error(exc))
+    else:
+        emit("DEVICE_COUNT", 0)
+except Exception as exc:
+    emit("TORCH_IMPORT", "ERR:" + short_error(exc, 240))
+
+# 计算节点外网
+try:
+    urllib.request.urlopen("https://pypi.org", timeout=5)
+    emit("NET_PYPI", "ONLINE")
+except Exception:
+    emit("NET_PYPI", "OFFLINE")
+
+# 测试任务统一使用家目录中的 TMPDIR；记录实际路径，确认规则生效。
+try:
+    tmp_dir = os.environ.get("TMPDIR", "")
+    emit("TMPDIR", tmp_dir)
+    emit("TMP_IN_HOME", "1" if tmp_dir and os.path.commonpath([os.path.expanduser("~"), tmp_dir]) == os.path.expanduser("~") else "0")
+except Exception as exc:
+    emit("TMPDIR", "ERR:" + short_error(exc))
+
+print("PROBE_EXIT=0", flush=True)

--- a/skills/scnet-hpc/scripts/new-job.sh
+++ b/skills/scnet-hpc/scripts/new-job.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# 生成一个符合目标集群所有约束的作业脚本骨架。
+#
+#   ./new-job.sh [--cluster <集群短名>] [--cpu-only] [--partition <分区>] \
+#     <作业名> [加速器数] [cpu数] [时长]
+#
+# 内存按 cpus × DEF_MEM_PER_CPU 自动取安全值，避免手算出错。
+
+set -euo pipefail
+
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_common.sh"
+
+parse_cluster_arg "$@"
+set -- "${REST[@]+${REST[@]}}"
+
+# --user <名>：远端用户名与本地不同时指定（日志路径需要真实用户名）
+REMOTE_USER=""
+REFRESH=no
+USE_AUTO=yes
+CPU_ONLY=no
+PARTITION_OVERRIDE=""
+ARGS=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --user) [ $# -ge 2 ] || die "--user 缺少参数"; REMOTE_USER="$2"; shift 2 ;;
+        --user=*) REMOTE_USER="${1#*=}"; shift ;;
+        --partition) [ $# -ge 2 ] || die "--partition 缺少参数"; PARTITION_OVERRIDE="$2"; shift 2 ;;
+        --partition=*) PARTITION_OVERRIDE="${1#*=}"; shift ;;
+        --cpu-only) CPU_ONLY=yes; shift ;;
+        --refresh) REFRESH=yes; shift ;;
+        --no-auto) USE_AUTO=no; shift ;;
+        *) ARGS+=("$1"); shift ;;
+    esac
+done
+set -- "${ARGS[@]+${ARGS[@]}}"
+
+NAME="${1:-}"
+ACCEL="${2:-1}"
+CPUS="${3:-8}"
+TIME="${4:-00:20:00}"
+
+if [ -z "$NAME" ]; then
+    cat >&2 <<EOF
+用法: $0 [--cluster <集群短名>] [--user <远端用户名>] [--cpu-only]
+       [--partition <分区>] [--refresh|--no-auto] <作业名> [加速器数] [cpu数] [时长]
+
+例子:
+  $0 probe                    # 1 卡, 8 核, 20 分钟（探针）
+  $0 infer 8 32 01:30:00      # 8 卡, 32 核, 1.5 小时（大模型）
+  $0 --cpu-only build 0 32 01:00:00  # 使用 profile 的 CPU 分区，不申请加速器
+
+可用集群: $(list_clusters | tr '\n' ' ')
+EOF
+    exit 1
+fi
+
+[[ "$NAME" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$ ]] \
+    || die "作业名只允许 1-64 个字母、数字、点、下划线或连字符，且必须以字母或数字开头"
+[[ "$ACCEL" =~ ^[0-9]+$ ]] || die "加速器数必须是非负整数"
+[[ "$CPUS" =~ ^[1-9][0-9]*$ ]] || die "CPU 数必须是正整数"
+[[ "$TIME" =~ ^([0-9]+-)?[0-9]{1,2}:[0-9]{2}:[0-9]{2}$ ]] \
+    || die "时长格式应为 HH:MM:SS 或 D-HH:MM:SS"
+if [ -n "$REMOTE_USER" ]; then
+    [[ "$REMOTE_USER" =~ ^[A-Za-z0-9._-]+$ ]] || die "远端用户名包含不安全字符"
+fi
+if [ -n "$PARTITION_OVERRIDE" ]; then
+    [[ "$PARTITION_OVERRIDE" =~ ^[A-Za-z0-9._-]+$ ]] || die "分区名包含不安全字符"
+fi
+
+if [ "$REFRESH" = yes ]; then
+    "$REPO_ROOT/scripts/refresh-cluster.sh" --cluster "${CLUSTER:-}"
+fi
+
+export SCNET_HPC_USE_AUTO="$USE_AUTO"
+load_cluster "$CLUSTER"
+
+[ "${SCHEDULER:-slurm}" = "slurm" ] \
+    || die "暂只支持 slurm，${CLUSTER_ID} 用的是 ${SCHEDULER}"
+
+if [ "$CPU_ONLY" = yes ]; then
+    [ -n "${PARTITION_CPU:-}" ] \
+        || die "${CLUSTER_ID} profile 未定义 PARTITION_CPU，不能使用 --cpu-only"
+    EFFECTIVE_PARTITION="${PARTITION_OVERRIDE:-$PARTITION_CPU}"
+    ACCEL=0
+    [ -n "${DEF_MEM_PER_CPU_CPU:-}" ] && DEF_MEM_PER_CPU="$DEF_MEM_PER_CPU_CPU"
+else
+    EFFECTIVE_PARTITION="${PARTITION_OVERRIDE:-${PARTITION:-}}"
+fi
+[ -n "$EFFECTIVE_PARTITION" ] || die "目标分区为空，请补 profile 或使用 --partition"
+
+# 内存上限 = cpus × DEF_MEM_PER_CPU，留 1GB 余量避免边界抖动
+if [ -n "${DEF_MEM_PER_CPU:-}" ]; then
+    MEM_MB=$(( CPUS * DEF_MEM_PER_CPU ))
+    MEM_GB=$(( MEM_MB / 1024 ))
+    [ "$MEM_GB" -gt 1 ] && MEM_GB=$(( MEM_GB - 1 ))
+    MEM_LINE="#SBATCH --mem=${MEM_GB}gb"
+    MEM_NOTE="${MEM_GB}gb（上限 $(( MEM_MB / 1024 )).$(( MEM_MB % 1024 * 100 / 1024 ))gb）"
+else
+    MEM_LINE="# DEF_MEM_PER_CPU 未在 profile 中设置，未生成 --mem"
+    MEM_NOTE="未设置"
+fi
+
+# QOS 强制申请加速器时必须写 --gres
+GRES_LINE=""
+if [ "$CPU_ONLY" != yes ] && [ -n "${GRES_TYPE:-}" ] && [ "$ACCEL" -gt 0 ]; then
+    GRES_LINE="#SBATCH --gres=${GRES_TYPE}:${ACCEL}"
+    [ -n "${MIN_GRES:-}" ] && GRES_LINE="$GRES_LINE          # 必须：QOS 要求最少 ${MIN_GRES}"
+fi
+if [ "$CPU_ONLY" != yes ] && [ -n "${MIN_GRES:-}" ] && [ "$ACCEL" -eq 0 ]; then
+    die "默认/指定分区要求至少 ${MIN_GRES}；请申请加速器或使用 --cpu-only"
+fi
+
+# 远端用户名。#SBATCH 是注释行，Slurm 不做变量展开 —— 日志路径里写 $USER
+# 会被当成字面量目录名，作业以 exit 53 失败且不产生日志。所以这里必须展开成
+# 真实用户名。默认取本地用户名，不同时用 --user 覆盖。
+REMOTE_USER="${REMOTE_USER:-${REMOTE_USER_DETECTED:-$(whoami)}}"
+[[ "$REMOTE_USER" =~ ^[A-Za-z0-9._-]+$ ]] || die "探测到的远端用户名包含不安全字符，请用 --user 显式指定"
+HOME_DIR="${HOME_BASE}/${REMOTE_USER}"
+
+# 脚本体（非 #SBATCH 行）里可以正常用 $USER
+MODULES=""
+[ -n "${MODULE_LOADS:-}" ] && MODULES="module load ${MODULE_LOADS}"
+VENV_LINE=""
+[ -n "${DEFAULT_VENV:-}" ] && VENV_LINE="source ${HOME_DIR}/${DEFAULT_VENV}/bin/activate"
+
+OFFLINE_LINES=""
+if [ "${COMPUTE_NODE_OFFLINE:-yes}" = "yes" ]; then
+    OFFLINE_LINES="# 计算节点无外网：让 Hub 请求立刻失败，而不是等 httpx 超时
+export HF_HUB_OFFLINE=1
+export TRANSFORMERS_OFFLINE=1"
+fi
+
+OUT="${NAME}.slurm"
+[ -e "$OUT" ] && die "$OUT 已存在"
+
+cat > "$OUT" <<EOF
+#!/bin/bash -l
+# 目标集群: ${CLUSTER_ID} (${CLUSTER_DESC:-$SSH_HOST})
+#
+# 使用 "bash -l"，因为部分集群仅在 login
+# shell 中定义 module 函数。普通 "#!/bin/bash" 可能使 module load 静默失败，作业仍
+# 返回 0，但 ROCM_PATH 未设置且能力工具无输出。该行为已在昆山集群观测。
+#SBATCH --job-name=${NAME}
+#SBATCH --partition=${EFFECTIVE_PARTITION}
+${GRES_LINE}
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=${CPUS}
+${MEM_LINE}
+#SBATCH --time=${TIME}
+#SBATCH --output=${HOME_DIR}/scripts/logs/${NAME}_%j.log
+#SBATCH --error=${HOME_DIR}/scripts/logs/${NAME}_%j.err
+
+module purge
+${MODULES}
+${VENV_LINE}
+
+# 集群测试/作业的临时文件统一放共享家目录，不使用节点本地 /tmp。
+JOB_TMPDIR="${HOME_DIR}/.scnet-hpc/tmp/\${SLURM_JOB_ID:-manual-\$\$}"
+mkdir -p "\$JOB_TMPDIR"
+export TMPDIR="\$JOB_TMPDIR"
+export TMP="\$JOB_TMPDIR"
+export TEMP="\$JOB_TMPDIR"
+
+${OFFLINE_LINES}
+
+echo "### node=\$(hostname) jobid=\$SLURM_JOB_ID"
+date +"%Y-%m-%d %H:%M:%S"
+
+python3 - <<'PYEOF'
+import torch
+print("torch", torch.__version__, "|", torch.cuda.get_device_name(0),
+      "| devices", torch.cuda.device_count())
+
+# TODO: 在这里写你的代码
+PYEOF
+
+rc=\$?
+echo "### python exit=\$rc"
+date +"%Y-%m-%d %H:%M:%S"
+# 传播工作负载退出码，避免调度器状态掩盖 Python 失败
+exit \$rc
+EOF
+
+chmod +x "$OUT"
+
+# 清掉 profile 缺项造成的空行
+sed -i.bak '/^$/N;/^\n$/D' "$OUT" 2>/dev/null && rm -f "$OUT.bak"
+
+echo "已生成 $OUT"
+echo "  集群=${CLUSTER_ID}  ${GRES_TYPE:-加速器}=${ACCEL}  CPU=${CPUS}  内存=${MEM_NOTE}  时长=${TIME}"
+echo "  分区=${EFFECTIVE_PARTITION}  模式=$([ "$CPU_ONLY" = yes ] && echo CPU || echo accelerator)  节点数=${NODE_COUNT:-未探测}（来源：${NODE_COUNT_SOURCE:-profile/cache}）"
+echo "  日志目录=${HOME_DIR}/scripts/logs（用户名 ${REMOTE_USER}，不对请加 --user）"
+echo
+echo "上传并提交："
+echo "  scp $OUT ${CLUSTER_ID}:${HOME_DIR}/scripts/"
+echo "  ssh ${CLUSTER_ID} 'mkdir -p ${HOME_DIR}/scripts/logs && sbatch --test-only ${HOME_DIR}/scripts/$OUT'"
+echo
+echo "要求：logs 目录必须先存在；否则作业会以 exit 53 失败且不产生日志。"

--- a/skills/scnet-hpc/scripts/probe-cluster.sh
+++ b/skills/scnet-hpc/scripts/probe-cluster.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# 探测一个已能 SSH 登录的集群，输出可直接保存为 profile 的内容。
+#
+#   ./probe-cluster.sh <ssh别名或host> [集群短名] > ../clusters/<集群短名>.conf
+#
+# 新增集群时先手工能 ssh 上去，再跑这个脚本自动填大部分字段。
+# 探测不到的项留空并注释说明，不猜。
+
+set -euo pipefail
+
+TARGET="${1:-}"
+NAME="${2:-$TARGET}"
+
+[ -n "$TARGET" ] || { echo "用法: $0 <ssh别名或host> [集群短名]" >&2; exit 1; }
+
+r() { ssh -o BatchMode=yes -o ConnectTimeout=15 "$TARGET" "$1" 2>/dev/null || true; }
+
+echo "==> 探测 $TARGET ..." >&2
+
+# 先确认能连上，否则后面全是空值
+probe_ok=$(r 'echo yes')
+[ "$probe_ok" = "yes" ] || { echo "错误: 无法通过 ssh 连接 $TARGET" >&2; exit 1; }
+
+USER_REMOTE=$(r 'whoami')
+LOGIN_HOST=$(r 'hostname')
+HOME_REAL=$(r 'echo $HOME')
+HOME_BASE_V=$(dirname "$HOME_REAL")
+
+# ---- 调度器 ----
+SCHED="unknown"
+r 'command -v sbatch'  >/dev/null && [ -n "$(r 'command -v sbatch')" ]  && SCHED="slurm"
+[ "$SCHED" = "unknown" ] && [ -n "$(r 'command -v qsub')" ] && SCHED="pbs"
+
+PART=""; DEFMEM=""; MAXWALL=""; MINGRES=""; GRESTYPE=""
+NODECNT=""; CPUS_N=""; NODEMEM=""
+
+if [ "$SCHED" = "slurm" ]; then
+    # 取第一个 up 状态的分区
+    PART=$(r "sinfo -h -o '%P %a' | awk '\$2==\"up\"{print \$1; exit}'" | tr -d '*')
+
+    if [ -n "$PART" ]; then
+        SCON=$(r "scontrol show partition $PART")
+        DEFMEM=$(printf '%s' "$SCON" | tr ' ' '\n' | sed -n 's/^DefMemPerCPU=//p' | head -1)
+        MAXWALL=$(printf '%s' "$SCON" | tr ' ' '\n' | sed -n 's/^MaxTime=//p' | head -1)
+        NODECNT=$(printf '%s' "$SCON" | tr ' ' '\n' | sed -n 's/^TotalNodes=//p' | head -1)
+
+        # QOS 的 MinTRES（如 gres/dcu=1）—— 决定是否强制申请加速器
+        QOSN=$(printf '%s' "$SCON" | tr ' ' '\n' | sed -n 's/^QoS=//p' | head -1)
+        if [ -n "$QOSN" ] && [ "$QOSN" != "N/A" ]; then
+            MINTRES=$(r "sacctmgr -nP show qos where name=$QOSN format=MinTRES")
+            # gres/dcu=1 -> dcu:1
+            MINGRES=$(printf '%s' "$MINTRES" | sed -n 's|.*gres/\([a-z]*\)=\([0-9]*\).*|\1:\2|p')
+        fi
+
+        # 节点规格取第一台
+        NODEINFO=$(r "sinfo -h -p $PART -o '%c|%m|%G' | head -1")
+        CPUS_N=$(printf '%s' "$NODEINFO" | cut -d'|' -f1)
+        NODEMEM=$(printf '%s' "$NODEINFO" | cut -d'|' -f2 | awk '{printf "%d", $1/1024}')
+        # gres 形如 dcu:Hygon:8(S:0-7) 或 gpu:a100:4
+        # 先砍掉括号里的 socket 映射，再取最后一段数字，否则会抓到 "0-7"
+        GRESRAW=$(printf '%s' "$NODEINFO" | cut -d'|' -f3)
+        GRESBASE=${GRESRAW%%(*}
+        GRESTYPE=$(printf '%s' "$GRESBASE" | cut -d: -f1)
+        ACCEL_N=$(printf '%s' "$GRESBASE" | awk -F: '{print $NF}' | tr -dc '0-9')
+    fi
+fi
+
+CPU_MODEL_V=$(r "lscpu | sed -n 's/^Model name:[[:space:]]*//p' | head -1")
+
+# ---- 网络（登录节点）----
+# 超时给足 15s 并重试：某些站点首包慢，单次探测会误判成不可达
+net_ok=""; net_bad=""
+for h in pypi.org pypi.tuna.tsinghua.edu.cn modelscope.cn huggingface.co github.com; do
+    reachable="no"
+    for _ in 1 2; do
+        code=$(r "timeout 15 curl -sI https://$h -o /dev/null -w '%{http_code}'")
+        case "$code" in 2*|3*) reachable="yes"; break ;; esac
+    done
+    if [ "$reachable" = "yes" ]; then
+        net_ok="$net_ok $h"
+    else
+        net_bad="$net_bad $h"
+    fi
+done
+
+# ---- 登录节点能否 import torch ----
+torch_login=$(r 'python3 -c "import torch" 2>&1 | tail -1')
+missing_lib=$(printf '%s' "$torch_login" | sed -n 's/^ImportError: \([^:]*\.so[^:]*\).*/\1/p')
+
+QUOTA=$(r "df -BG $HOME_REAL 2>/dev/null | awk 'NR==2{gsub(/[^0-9]/,\"\",\$2); print \$2}'")
+
+echo "==> 完成，输出 profile" >&2
+
+cat <<EOF
+# ${NAME} —— 自动探测于 $(date +%Y-%m-%d)
+# 探测源: ssh ${TARGET} (登录节点 ${LOGIN_HOST})
+# 留空的项表示未能自动探测，请手工确认后填写。
+
+# ---- 连接 ----
+CLUSTER_ID="${NAME}"
+CLUSTER_DESC=""
+SSH_HOST="$(ssh -G "$TARGET" 2>/dev/null | awk '/^hostname /{print $2}')"
+SSH_PORT="$(ssh -G "$TARGET" 2>/dev/null | awk '/^port /{print $2}')"
+HOME_BASE="${HOME_BASE_V}"
+
+KEY_NAME_MARKER=""
+NEEDS_UPDATE_HOSTKEYS_NO="no"
+
+# ---- 调度器 ----
+SCHEDULER="${SCHED}"
+PARTITION="${PART}"
+DEF_MEM_PER_CPU="${DEFMEM}"
+MIN_GRES="${MINGRES}"
+GRES_TYPE="${GRESTYPE}"
+MAX_WALLTIME="${MAXWALL}"
+
+# ---- 硬件 ----
+ACCEL_NAME=""
+ACCEL_ARCH=""
+ACCEL_PER_NODE="${ACCEL_N:-}"
+ACCEL_MEM_GB=""
+CPUS_PER_NODE="${CPUS_N}"
+CPU_MODEL="${CPU_MODEL_V}"
+NODE_MEM_GB="${NODEMEM}"
+NODE_COUNT="${NODECNT}"
+LOGIN_NODES="${LOGIN_HOST}"
+HOME_QUOTA_GB="${QUOTA}"
+
+# ---- 软件栈 ----
+TOOLCHAIN=""
+TOOLCHAIN_VERSION=""
+TOOLCHAIN_PATH=""
+MODULE_LOADS=""
+DEFAULT_VENV=""
+
+# ---- 网络 ----
+NET_OK="$(echo "$net_ok" | sed 's/^ //')"
+NET_BLOCKED="$(echo "$net_bad" | sed 's/^ //')"
+PIP_INDEX="https://pypi.tuna.tsinghua.edu.cn/simple"
+COMPUTE_NODE_OFFLINE="yes"
+TMP_SHARED="no"
+
+# ---- 已知问题 ----
+LOGIN_NODE_MISSING_LIBS="${missing_lib}"
+KNOWN_LIMITATIONS=""
+
+# 探测时登录节点 import torch 的结果（供参考）：
+#   ${torch_login:-（无输出，可能已可用）}
+#
+# 还需手工确认的：
+#   - ACCEL_NAME / ACCEL_ARCH：在计算节点跑
+#       srun -p ${PART} ${MINGRES:+--gres=$MINGRES} --time=00:05:00 rocminfo | grep gfx
+#     或 nvidia-smi --query-gpu=name --format=csv
+#   - MODULE_LOADS：module avail 里挑编译器和加速器 SDK
+#   - KNOWN_LIMITATIONS：跑一次能力探针（见 references/troubleshooting.md）
+EOF

--- a/skills/scnet-hpc/scripts/refresh-cluster.sh
+++ b/skills/scnet-hpc/scripts/refresh-cluster.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+# 动态刷新 clusters/.cache/<集群>.auto.conf。
+#
+# 用法：
+#   ./refresh-cluster.sh [--cluster <集群短名>] [--compute] [--dry-run]
+#
+# 默认只做登录节点上的只读探测；--compute 会提交一个 1 卡、4 核、10 分钟的小作业，
+# 到计算节点实测加速器、Triton、FP8、外网等能力。生成的缓存会覆盖 profile 的同名字段。
+
+set -euo pipefail
+
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_common.sh"
+
+parse_cluster_arg "$@"
+set -- "${REST[@]+${REST[@]}}"
+
+COMPUTE=no
+DRY_RUN=no
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --compute|-c) COMPUTE=yes; shift ;;
+        --dry-run|-n) DRY_RUN=yes; shift ;;
+        -h|--help) sed -n '2,14p' "$0" | sed 's/^# \?//'; exit 0 ;;
+        *) die "未知参数: $1" ;;
+    esac
+done
+
+load_cluster "$CLUSTER"
+
+r() {
+    ssh -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=15 -o ServerAliveCountMax=3 \
+        "$CLUSTER_ID" "$1" 2>/dev/null || true
+}
+
+probe_value() {
+    local key="$1"
+    printf '%s\n' "${COMPUTE_OUT:-}" | awk -F= -v k="$key" '$1 == k { sub(/^[^=]+=/,""); print; exit }'
+}
+
+add_known_limit() {
+    local item="$1"
+    [ -n "$item" ] || return 0
+    case "$item" in
+        *Triton*)
+            if printf '%s' "$KNOWN_LIMITS_NEW" | grep -q 'Triton'; then return 0; fi
+            ;;
+        *FP8*)
+            if printf '%s' "$KNOWN_LIMITS_NEW" | grep -q 'FP8'; then return 0; fi
+            ;;
+        *BF16*)
+            if printf '%s' "$KNOWN_LIMITS_NEW" | grep -q 'BF16'; then return 0; fi
+            ;;
+        *bitsandbytes*)
+            if printf '%s' "$KNOWN_LIMITS_NEW" | grep -q 'bitsandbytes'; then return 0; fi
+            ;;
+    esac
+    KNOWN_LIMITS_NEW="${KNOWN_LIMITS_NEW:+${KNOWN_LIMITS_NEW}；}${item}"
+}
+
+info "==> 动态探测 ${CLUSTER_ID} (${CLUSTER_DESC:-$SSH_HOST})"
+probe_ok=$(r 'echo yes')
+[ "$probe_ok" = "yes" ] || die "无法通过 ssh 连接 ${CLUSTER_ID}"
+
+# ---- 连接和登录节点基础信息 ----
+DETECTED_HOST="$(ssh -G "$CLUSTER_ID" 2>/dev/null | awk '/^hostname /{print $2; exit}')"
+DETECTED_PORT="$(ssh -G "$CLUSTER_ID" 2>/dev/null | awk '/^port /{print $2; exit}')"
+DETECTED_USER="$(ssh -G "$CLUSTER_ID" 2>/dev/null | awk '/^user /{print $2; exit}')"
+LOGIN_HOST=$(r 'hostname')
+REMOTE_HOME=$(r 'echo $HOME')
+HOME_BASE_NEW=$(dirname "$REMOTE_HOME")
+CPU_MODEL_NEW=$(r "lscpu | sed -n 's/^Model name:[[:space:]]*//p' | head -1")
+QUOTA_NEW=$(r "df -BG $REMOTE_HOME 2>/dev/null | awk 'NR==2{gsub(/[^0-9]/,\"\",\$2); print \$2}'")
+
+# ---- 调度器 ----
+SCHED_NEW="unknown"
+if [ -n "$(r 'command -v sbatch')" ]; then
+    SCHED_NEW="slurm"
+elif [ -n "$(r 'command -v qsub')" ]; then
+    SCHED_NEW="pbs"
+fi
+
+PART_NEW=""
+DEFMEM_NEW=""
+MAXWALL_NEW=""
+MINGRES_NEW=""
+GRESTYPE_NEW=""
+NODECNT_NEW=""
+CPUS_NEW=""
+NODEMEM_NEW=""
+ACCEL_NEW=""
+
+if [ "$SCHED_NEW" = "slurm" ]; then
+    # 优先沿用 profile 现有分区，只在它已经不再 up 时才改选第一个 up 分区。
+    if [ -n "${PARTITION:-}" ]; then
+        PART_STATE=$(r "sinfo -h -p ${PARTITION} -o '%a' | head -1")
+        [ "$PART_STATE" = "up" ] && PART_NEW="$PARTITION"
+    fi
+    if [ -z "$PART_NEW" ]; then
+        PART_NEW=$(r "sinfo -h -o '%P %a' | awk '\$2==\"up\"{print \$1; exit}'" | tr -d '*')
+    fi
+
+    if [ -n "$PART_NEW" ]; then
+        SCON=$(r "scontrol show partition $PART_NEW")
+        DEFMEM_NEW=$(printf '%s' "$SCON" | tr ' ' '\n' | sed -n 's/^DefMemPerCPU=//p' | head -1)
+        MAXWALL_NEW=$(printf '%s' "$SCON" | tr ' ' '\n' | sed -n 's/^MaxTime=//p' | head -1)
+        NODECNT_NEW=$(printf '%s' "$SCON" | tr ' ' '\n' | sed -n 's/^TotalNodes=//p' | head -1)
+
+        QOS_NEW=$(printf '%s' "$SCON" | tr ' ' '\n' | sed -n 's/^QoS=//p' | head -1)
+        if [ -n "$QOS_NEW" ] && [ "$QOS_NEW" != "N/A" ]; then
+            MINTRES=$(r "sacctmgr -nP show qos where name=$QOS_NEW format=MinTRES")
+            MINGRES_NEW=$(printf '%s' "$MINTRES" | sed -n 's|.*gres/\([a-z]*\)=\([0-9]*\).*|\1:\2|p')
+        fi
+
+        NODEINFO=$(r "sinfo -h -p $PART_NEW -o '%c|%m|%G' | head -1")
+        CPUS_NEW=$(printf '%s' "$NODEINFO" | cut -d'|' -f1)
+        NODEMEM_NEW=$(printf '%s' "$NODEINFO" | cut -d'|' -f2 | awk '{printf "%d", $1/1024}')
+        GRESRAW=$(printf '%s' "$NODEINFO" | cut -d'|' -f3)
+        GRESBASE=${GRESRAW%%(*}
+        GRESTYPE_NEW=$(printf '%s' "$GRESBASE" | cut -d: -f1)
+        ACCEL_NEW=$(printf '%s' "$GRESBASE" | awk -F: '{print $NF}' | tr -dc '0-9')
+    fi
+fi
+
+# ---- 登录节点网络 ----
+NET_OK_NEW=""
+NET_BLOCKED_NEW=""
+for h in pypi.org pypi.tuna.tsinghua.edu.cn modelscope.cn huggingface.co github.com; do
+    reachable=no
+    for _ in 1 2; do
+        code=$(r "timeout 15 curl -sI https://$h -o /dev/null -w '%{http_code}'")
+        case "$code" in
+            2*|3*) reachable=yes; break ;;
+        esac
+    done
+    if [ "$reachable" = yes ]; then
+        NET_OK_NEW="${NET_OK_NEW:+$NET_OK_NEW }$h"
+    else
+        NET_BLOCKED_NEW="${NET_BLOCKED_NEW:+$NET_BLOCKED_NEW }$h"
+    fi
+done
+
+# ---- 登录节点 torch 缺库 ----
+torch_login=$(r 'python3 -c "import torch" 2>&1 | tail -1')
+MISSING_LIB_NEW=$(printf '%s' "$torch_login" | sed -n 's/^ImportError: \([^:]*\.so[^:]*\).*/\1/p')
+
+# ---- module 候选（只记录，不自动覆盖 MODULE_LOADS）----
+MODULE_CANDIDATES_NEW=$(r "bash -lc 'module avail 2>&1' | awk '/compiler\\/(dtk|rocm)/{print}' | sort -u | head -30")
+
+# ---- 计算节点能力（可选）----
+COMPUTE_OUT=""
+ACCEL_NAME_NEW=""
+ACCEL_ARCH_NEW=""
+ACCEL_MEM_NEW=""
+COMPUTE_OFFLINE_NEW=""
+KNOWN_LIMITS_NEW=""
+
+if [ "$COMPUTE" = yes ] && [ "$DRY_RUN" = no ]; then
+    info "==> 提交计算节点小探针（约 1 卡、4 核、10 分钟）"
+    COMPUTE_OUT="$( { "$REPO_ROOT/scripts/run-compute-probe.sh" --cluster "$CLUSTER_ID"; } 2>&1 )" || true
+    if ! printf '%s\n' "$COMPUTE_OUT" | grep -q '^PROBE_'; then
+        info "计算节点探针未产生有效 PROBE 输出："
+        printf '%s\n' "$COMPUTE_OUT" | sed 's/^/    /' >&2
+        COMPUTE_OUT=""
+    fi
+fi
+
+if [ "$COMPUTE" = yes ] && [ -n "$COMPUTE_OUT" ]; then
+    CUDA_AVAILABLE=$(probe_value PROBE_CUDA_AVAILABLE)
+    ACCEL_NAME_NEW=$(probe_value PROBE_DEVICE_NAME)
+    case "$ACCEL_NAME_NEW" in
+        BW|BW1000) ACCEL_NAME_NEW="海光 BW1000 DCU" ;;
+    esac
+    ACCEL_ARCH_NEW=$(probe_value PROBE_ARCH)
+
+    MEM_MIB=$(probe_value PROBE_MEM_MIB)
+    if [[ "$MEM_MIB" =~ ^[0-9]+$ ]]; then
+        ACCEL_MEM_NEW=$(( (MEM_MIB + 1023) / 1024 ))
+    fi
+
+    case "$(probe_value PROBE_NET_PYPI)" in
+        OFFLINE) COMPUTE_OFFLINE_NEW=yes ;;
+        ONLINE) COMPUTE_OFFLINE_NEW=no ;;
+    esac
+
+    if [ "$CUDA_AVAILABLE" = "0" ]; then
+        KNOWN_LIMITS_NEW="torch.cuda 不可用"
+    fi
+
+    DTYPES=$(probe_value PROBE_DTYPES)
+    case ",$DTYPES," in
+        *,bfloat16,*) ;;
+        *) KNOWN_LIMITS_NEW="${KNOWN_LIMITS_NEW:+${KNOWN_LIMITS_NEW}；}无 BF16 数据类型支持" ;;
+    esac
+
+    SCALED=$(probe_value PROBE_SCALED_MM)
+    case "$SCALED" in
+        ERR:*) KNOWN_LIMITS_NEW="${KNOWN_LIMITS_NEW:+${KNOWN_LIMITS_NEW}；}硬件 FP8 torch._scaled_mm 不可用（${SCALED}）" ;;
+    esac
+
+    TRITON=$(probe_value PROBE_TRITON)
+    case "$TRITON" in
+        ERR:*) KNOWN_LIMITS_NEW="${KNOWN_LIMITS_NEW:+${KNOWN_LIMITS_NEW}；}Triton 不可用（${TRITON}）" ;;
+    esac
+
+    BNB=$(probe_value PROBE_BITSANDBYTES)
+    case "$BNB" in
+        IMPORT_ERR:*) KNOWN_LIMITS_NEW="${KNOWN_LIMITS_NEW:+${KNOWN_LIMITS_NEW}；}bitsandbytes 导入失败（${BNB}）" ;;
+    esac
+
+    # 保留 profile 中已有的人工验证结论，并将动态结果置于前面。
+    if [ -n "${KNOWN_LIMITATIONS:-}" ]; then
+        OLD_IFS="$IFS"
+        IFS='；'
+        for item in $KNOWN_LIMITATIONS; do
+            add_known_limit "$item"
+        done
+        IFS="$OLD_IFS"
+    fi
+elif [ "$COMPUTE" = yes ]; then
+    info "计算节点探针没有返回结果，保留 profile 中的加速器和限制信息。"
+fi
+
+build_cache() {
+    echo "# 由 scripts/refresh-cluster.sh 自动生成于 $(date '+%Y-%m-%d %H:%M:%S')"
+    echo "# 登录节点: ${LOGIN_HOST:-未探测}"
+    echo "# 这是动态探测缓存，会覆盖 profile 中的同名字段；删除本文件即可回退到纯 profile。"
+    printf 'SSH_HOST=%q\n' "${DETECTED_HOST:-$SSH_HOST}"
+    printf 'SSH_PORT=%q\n' "${DETECTED_PORT:-$SSH_PORT}"
+    printf 'REMOTE_USER_DETECTED=%q\n' "${DETECTED_USER:-${REMOTE_USER_DETECTED:-}}"
+    printf 'HOME_BASE=%q\n' "${HOME_BASE_NEW:-$HOME_BASE}"
+    printf 'SCHEDULER=%q\n' "${SCHED_NEW:-${SCHEDULER:-}}"
+    printf 'PARTITION=%q\n' "${PART_NEW:-${PARTITION:-}}"
+    printf 'DEF_MEM_PER_CPU=%q\n' "${DEFMEM_NEW:-${DEF_MEM_PER_CPU:-}}"
+    printf 'MIN_GRES=%q\n' "${MINGRES_NEW:-${MIN_GRES:-}}"
+    printf 'GRES_TYPE=%q\n' "${GRESTYPE_NEW:-${GRES_TYPE:-}}"
+    printf 'MAX_WALLTIME=%q\n' "${MAXWALL_NEW:-${MAX_WALLTIME:-}}"
+    printf 'CPUS_PER_NODE=%q\n' "${CPUS_NEW:-${CPUS_PER_NODE:-}}"
+    printf 'NODE_MEM_GB=%q\n' "${NODEMEM_NEW:-${NODE_MEM_GB:-}}"
+    printf 'NODE_COUNT=%q\n' "${NODECNT_NEW:-${NODE_COUNT:-}}"
+    printf 'ACCEL_PER_NODE=%q\n' "${ACCEL_NEW:-${ACCEL_PER_NODE:-}}"
+    printf 'CPU_MODEL=%q\n' "${CPU_MODEL_NEW:-${CPU_MODEL:-}}"
+    printf 'LOGIN_NODES=%q\n' "${LOGIN_HOST:-${LOGIN_NODES:-}}"
+    printf 'HOME_QUOTA_GB=%q\n' "${QUOTA_NEW:-${HOME_QUOTA_GB:-}}"
+    printf 'NET_OK=%q\n' "${NET_OK_NEW:-${NET_OK:-}}"
+    printf 'NET_BLOCKED=%q\n' "${NET_BLOCKED_NEW:-${NET_BLOCKED:-}}"
+    printf 'LOGIN_NODE_MISSING_LIBS=%q\n' "${MISSING_LIB_NEW:-${LOGIN_NODE_MISSING_LIBS:-}}"
+    printf 'MODULE_CANDIDATES=%q\n' "${MODULE_CANDIDATES_NEW:-}"
+
+    if [ "$COMPUTE" = yes ]; then
+        printf 'ACCEL_NAME=%q\n' "${ACCEL_NAME_NEW:-${ACCEL_NAME:-}}"
+        printf 'ACCEL_ARCH=%q\n' "${ACCEL_ARCH_NEW:-${ACCEL_ARCH:-}}"
+        printf 'ACCEL_MEM_GB=%q\n' "${ACCEL_MEM_NEW:-${ACCEL_MEM_GB:-}}"
+        printf 'COMPUTE_NODE_OFFLINE=%q\n' "${COMPUTE_OFFLINE_NEW:-${COMPUTE_NODE_OFFLINE:-}}"
+        printf 'KNOWN_LIMITATIONS=%q\n' "${KNOWN_LIMITS_NEW:-${KNOWN_LIMITATIONS:-}}"
+    else
+        printf 'COMPUTE_NODE_OFFLINE=%q\n' "${COMPUTE_NODE_OFFLINE:-}"
+        printf 'KNOWN_LIMITATIONS=%q\n' "${KNOWN_LIMITATIONS:-}"
+    fi
+}
+
+mkdir -p "$CLUSTER_DIR/.cache"
+if [ "$DRY_RUN" = yes ]; then
+    info "==> dry-run，不写缓存"
+    build_cache
+else
+    AUTO_TMP="$CLUSTER_AUTO_CONF.tmp.$$"
+    build_cache > "$AUTO_TMP"
+    mv "$AUTO_TMP" "$CLUSTER_AUTO_CONF"
+    info "==> 已写入 $CLUSTER_AUTO_CONF"
+
+    if [ "$COMPUTE" = yes ] && [ -n "$COMPUTE_OUT" ]; then
+        PROBE_LOG="$CLUSTER_DIR/.cache/${CLUSTER_ID}.probe.log"
+        printf '%s\n' "$COMPUTE_OUT" > "$PROBE_LOG"
+        info "==> 原始探针输出已保存 $PROBE_LOG"
+    fi
+fi

--- a/skills/scnet-hpc/scripts/run-compute-probe.sh
+++ b/skills/scnet-hpc/scripts/run-compute-probe.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# 在目标集群计算节点运行一次最小能力探针，输出 PROBE_ 开头的解析结果。
+#
+# 用法：
+#   ./run-compute-probe.sh [--cluster <集群短名>] [--cpus 4] [--time 00:10:00] [--accelerators 1]
+
+set -euo pipefail
+
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_common.sh"
+
+parse_cluster_arg "$@"
+set -- "${REST[@]+${REST[@]}}"
+
+CPUS=4
+TIME=00:10:00
+ACCEL=1
+REMOTE_USER=""
+PYTHON_BIN=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --cpus) [ $# -ge 2 ] || die "--cpus 缺少参数"; CPUS="$2"; shift 2 ;;
+        --cpus=*) CPUS="${1#*=}"; shift ;;
+        --time) [ $# -ge 2 ] || die "--time 缺少参数"; TIME="$2"; shift 2 ;;
+        --time=*) TIME="${1#*=}"; shift ;;
+        --accelerators) [ $# -ge 2 ] || die "--accelerators 缺少参数"; ACCEL="$2"; shift 2 ;;
+        --accelerators=*) ACCEL="${1#*=}"; shift ;;
+        --user) [ $# -ge 2 ] || die "--user 缺少参数"; REMOTE_USER="$2"; shift 2 ;;
+        --user=*) REMOTE_USER="${1#*=}"; shift ;;
+        --python) [ $# -ge 2 ] || die "--python 缺少参数"; PYTHON_BIN="$2"; shift 2 ;;
+        --python=*) PYTHON_BIN="${1#*=}"; shift ;;
+        -h|--help) sed -n '2,10p' "$0" | sed 's/^# \?//'; exit 0 ;;
+        *) die "未知参数: $1" ;;
+    esac
+done
+
+[[ "$CPUS" =~ ^[1-9][0-9]*$ ]] || die "CPU 数必须是正整数"
+[[ "$ACCEL" =~ ^[1-9][0-9]*$ ]] || die "加速器数必须是正整数"
+[[ "$TIME" =~ ^([0-9]+-)?[0-9]{1,2}:[0-9]{2}:[0-9]{2}$ ]] \
+    || die "时长格式应为 HH:MM:SS 或 D-HH:MM:SS"
+if [ -n "$REMOTE_USER" ]; then
+    [[ "$REMOTE_USER" =~ ^[A-Za-z0-9._-]+$ ]] || die "远端用户名包含不安全字符"
+fi
+if [ -n "$PYTHON_BIN" ]; then
+    [[ "$PYTHON_BIN" =~ ^[A-Za-z0-9_./-]+$ ]] || die "Python 命令包含不安全字符"
+fi
+
+[ -n "${CLUSTER:-}" ] || die "请用 --cluster <集群短名> 指定集群。"
+load_cluster "$CLUSTER"
+
+[ "${SCHEDULER:-slurm}" = "slurm" ] || die "${CLUSTER_ID} 不是 Slurm 调度器，暂不支持自动计算节点探针。"
+[ -n "${PARTITION:-}" ] || die "${CLUSTER_ID} 的 PARTITION 为空，无法提交计算节点探针。"
+
+REMOTE_USER="${REMOTE_USER:-${REMOTE_USER_DETECTED:-$(whoami)}}"
+[[ "$REMOTE_USER" =~ ^[A-Za-z0-9._-]+$ ]] || die "探测到的远端用户名包含不安全字符，请用 --user 显式指定"
+HOME_DIR="${HOME_BASE}/${REMOTE_USER}"
+PROBE_DIR="${HOME_DIR}/.scnet-hpc/probes"
+PROBE_BASE="${PROBE_DIR}/compute-probe"
+
+ssh_cmd() { ssh -o BatchMode=yes -o ConnectTimeout=20 -o ServerAliveInterval=15 -o ServerAliveCountMax=3 "$@"; }
+scp_cmd() { scp -o BatchMode=yes -o ConnectTimeout=20 "$@"; }
+
+PYTHON_MODULE_LINE=""
+if [ -z "${PYTHON_MODULE:-}" ]; then
+    PYTHON_MODULE_DETECTED="$(ssh_cmd "$CLUSTER_ID" "bash -lc 'module avail 2>&1'" 2>/dev/null \
+        | awk '/^(python|apps\/python)\/3\./{print $1; exit}')"
+    [ -n "$PYTHON_MODULE_DETECTED" ] && PYTHON_MODULE="$PYTHON_MODULE_DETECTED"
+fi
+[ -n "${PYTHON_MODULE:-}" ] && PYTHON_MODULE_LINE="module load ${PYTHON_MODULE}"
+
+MEM_LINE=""
+if [ -n "${DEF_MEM_PER_CPU:-}" ]; then
+    MEM_MB=$(( CPUS * DEF_MEM_PER_CPU ))
+    MEM_GB=$(( MEM_MB / 1024 ))
+    [ "$MEM_GB" -gt 1 ] && MEM_GB=$(( MEM_GB - 1 ))
+    MEM_LINE="#SBATCH --mem=${MEM_GB}gb"
+fi
+
+GRES_LINE=""
+if [ -n "${GRES_TYPE:-}" ]; then
+    GRES_LINE="#SBATCH --gres=${GRES_TYPE}:${ACCEL}"
+fi
+
+MODULE_LINE=""
+[ -n "${MODULE_LOADS:-}" ] && MODULE_LINE="module load ${MODULE_LOADS}"
+
+VENV_LINE=""
+[ -n "${DEFAULT_VENV:-}" ] && VENV_LINE="source ${HOME_DIR}/${DEFAULT_VENV}/bin/activate"
+
+TMPDIR_LOCAL=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_LOCAL"' EXIT
+cp "$REPO_ROOT/scripts/compute-probe.py" "$TMPDIR_LOCAL/compute-probe.py"
+
+cat > "$TMPDIR_LOCAL/probe.slurm" <<EOF
+#!/bin/bash -l
+#SBATCH --job-name=scnet_hpc_probe
+#SBATCH --partition=${PARTITION}
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=${CPUS}
+${GRES_LINE}
+${MEM_LINE}
+#SBATCH --time=${TIME}
+#SBATCH --output=${HOME_DIR}/scripts/logs/scnet-hpc-probe_%j.out
+#SBATCH --error=${HOME_DIR}/scripts/logs/scnet-hpc-probe_%j.err
+
+module purge
+${MODULE_LINE}
+${PYTHON_MODULE_LINE}
+${VENV_LINE}
+
+# 探针临时文件必须位于共享家目录，不能使用计算节点本地 /tmp。
+JOB_TMPDIR="${HOME_DIR}/.scnet-hpc/tmp/\${SLURM_JOB_ID:-manual-\$\$}"
+mkdir -p "\$JOB_TMPDIR"
+export TMPDIR="\$JOB_TMPDIR"
+export TMP="\$JOB_TMPDIR"
+export TEMP="\$JOB_TMPDIR"
+export HF_HUB_OFFLINE=1
+export TRANSFORMERS_OFFLINE=1
+
+# 部分集群 module purge 后没有 python3 这个命令，按候选名兜底找 Python。
+PYTHON_BIN="${PYTHON_BIN}"
+if [ -z "\$PYTHON_BIN" ]; then
+    for candidate in python3 python3.8 python3.9 python3.10 python3.11; do
+        if command -v "\$candidate" >/dev/null 2>&1; then
+            PYTHON_BIN="\$candidate"
+            break
+        fi
+    done
+fi
+[ -n "\$PYTHON_BIN" ] || { echo "PYTHON_NOT_FOUND" >&2; exit 127; }
+"\$PYTHON_BIN" ${PROBE_BASE}.py
+rc=\$?
+echo "PROBE_EXIT=\$rc"
+exit \$rc
+EOF
+
+ssh_cmd "$CLUSTER_ID" "mkdir -p ${HOME_DIR}/scripts/logs ${PROBE_DIR} ${HOME_DIR}/.scnet-hpc/tmp"
+scp_cmd -q "$TMPDIR_LOCAL/compute-probe.py" "${CLUSTER_ID}:${PROBE_BASE}.py"
+scp_cmd -q "$TMPDIR_LOCAL/probe.slurm" "${CLUSTER_ID}:${PROBE_BASE}.slurm"
+
+JOBID=$(ssh_cmd "$CLUSTER_ID" "cd ${HOME_DIR} && sbatch --parsable --wait ${PROBE_BASE}.slurm" | tail -1)
+OUT=$(ssh_cmd "$CLUSTER_ID" "cat ${HOME_DIR}/scripts/logs/scnet-hpc-probe_${JOBID}.out" 2>/dev/null || true)
+ERR=$(ssh_cmd "$CLUSTER_ID" "cat ${HOME_DIR}/scripts/logs/scnet-hpc-probe_${JOBID}.err" 2>/dev/null || true)
+
+if [ -n "$OUT" ]; then
+    printf '%s\n' "$OUT"
+else
+    printf '%s\n' "$ERR" >&2
+fi
+
+ssh_cmd "$CLUSTER_ID" "rm -f ${PROBE_BASE}.py ${PROBE_BASE}.slurm ${HOME_DIR}/scripts/logs/scnet-hpc-probe_${JOBID}.out ${HOME_DIR}/scripts/logs/scnet-hpc-probe_${JOBID}.err; rm -rf ${HOME_DIR}/.scnet-hpc/tmp/${JOBID}"

--- a/skills/scnet-hpc/scripts/setup-ssh.sh
+++ b/skills/scnet-hpc/scripts/setup-ssh.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# 在一台新的个人电脑（macOS / Linux）上配置到超算集群的 SSH 连接。
+#
+#   ./setup-ssh.sh [--cluster <集群短名>] <私钥文件> [用户名]
+#
+# 集群参数从 clusters/<集群短名>.conf 读取。只有一个 profile 时可省略 --cluster。
+# 幂等：重复运行只补齐缺失项，不覆盖已有的正确配置。
+
+set -euo pipefail
+
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_common.sh"
+
+parse_cluster_arg "$@"
+set -- "${REST[@]+${REST[@]}}"
+
+KEY_SRC="${1:-}"
+USER_NAME="${2:-}"
+
+if [ -z "$KEY_SRC" ]; then
+    cat >&2 <<EOF
+用法: $0 [--cluster <集群短名>] <私钥文件> [用户名]
+
+私钥从超算平台控制台下载。
+
+可用的集群 profile：
+$(list_clusters | sed 's/^/  /')
+EOF
+    exit 1
+fi
+
+SCNET_HPC_LIVE_NODE_COUNT=no
+load_cluster "$CLUSTER"
+unset SCNET_HPC_LIVE_NODE_COUNT
+
+[ -f "$KEY_SRC" ] || die "找不到私钥文件: $KEY_SRC"
+grep -q "BEGIN.*PRIVATE KEY" "$KEY_SRC" \
+    || die "$KEY_SRC 看起来不是私钥（没有 'BEGIN ... PRIVATE KEY' 头）"
+
+KEY_DST="$HOME/.ssh/id_rsa_${CLUSTER_ID}"
+SSH_CONFIG="$HOME/.ssh/config"
+SOCKET_DIR="$HOME/.ssh/sockets"
+
+# 从文件名推断用户名，形如 <用户名>_<主机标识>_RsaKeyExpireTime_<日期>.txt
+if [ -z "$USER_NAME" ] && [ -n "${KEY_NAME_MARKER:-}" ]; then
+    base=$(basename "$KEY_SRC")
+    case "$base" in
+        *"$KEY_NAME_MARKER"*) USER_NAME="${base%%"$KEY_NAME_MARKER"*}" ;;
+    esac
+fi
+[ -n "$USER_NAME" ] || die "无法从文件名推断用户名，请作为最后一个参数传入"
+
+echo "==> 集群: ${CLUSTER_ID} (${CLUSTER_DESC:-$SSH_HOST})"
+echo "==> 用户名: ${USER_NAME}"
+
+# ---------------------------------------------------------------- 私钥
+echo "==> 安装私钥"
+mkdir -p "$HOME/.ssh"
+chmod 700 "$HOME/.ssh"
+
+if [ -f "$KEY_DST" ] && ! cmp -s "$KEY_SRC" "$KEY_DST"; then
+    backup="$KEY_DST.bak.$(date +%Y%m%d%H%M%S)"
+    cp "$KEY_DST" "$backup"
+    info "已存在不同的私钥，备份到 $(basename "$backup")"
+fi
+
+# 源和目标可能是同一个文件（重复运行时），cp 会报错
+if [ "$(cd "$(dirname "$KEY_SRC")" && pwd)/$(basename "$KEY_SRC")" != "$KEY_DST" ]; then
+    cp "$KEY_SRC" "$KEY_DST"
+fi
+chmod 600 "$KEY_DST"
+
+# macOS 的下载文件带隔离属性，会让某些工具拒绝读取
+if [ "$(uname -s)" = "Darwin" ]; then
+    xattr -c "$KEY_DST" 2>/dev/null || true
+fi
+info "$KEY_DST (600)"
+
+if ssh-keygen -y -f "$KEY_DST" > "$KEY_DST.pub" 2>/dev/null; then
+    chmod 644 "$KEY_DST.pub"
+    info "$(ssh-keygen -lf "$KEY_DST" 2>/dev/null | awk '{print $1, $2, $4}')"
+else
+    rm -f "$KEY_DST.pub"
+    info "私钥有 passphrase，跳过公钥推导"
+fi
+
+# ---------------------------------------------------------------- config
+echo "==> 配置 ~/.ssh/config"
+mkdir -p "$SOCKET_DIR"
+chmod 700 "$SOCKET_DIR"
+touch "$SSH_CONFIG"
+chmod 600 "$SSH_CONFIG"
+
+# Host 行可能列多个别名（"Host a b"），按词比对而不是用正则拼
+if awk -v alias="$CLUSTER_ID" '
+        $1 == "Host" { for (i = 2; i <= NF; i++) if ($i == alias) { found = 1; exit } }
+        END { exit(found ? 0 : 1) }
+    ' "$SSH_CONFIG"; then
+    info "已存在 Host ${CLUSTER_ID}，跳过（如需重配请先手工删除该段）"
+else
+    # macOS 的 ssh-agent 能存进 Keychain；Linux 上这两个选项不被识别
+    keychain_opts=""
+    if [ "$(uname -s)" = "Darwin" ]; then
+        keychain_opts="
+  UseKeychain yes
+  AddKeysToAgent yes"
+    fi
+
+    hostkey_opt=""
+    if [ "${NEEDS_UPDATE_HOSTKEYS_NO:-no}" = "yes" ]; then
+        hostkey_opt="
+  # 该平台对主机密钥轮换扩展返回错误签名，关掉以消除告警噪音
+  # （首次记录的主机密钥仍在正常校验，不影响安全性）
+  UpdateHostKeys no"
+    fi
+
+    cat >> "$SSH_CONFIG" <<EOF
+
+Host ${CLUSTER_ID} ${SSH_HOST}
+  HostName ${SSH_HOST}
+  User ${USER_NAME}
+  Port ${SSH_PORT}
+  IdentityFile ${KEY_DST}
+  IdentitiesOnly yes${keychain_opts}
+  # 长连接：复用同一条 TCP/认证通道，后续命令从 ~2s 降到 ~0.5s
+  ControlMaster auto
+  ControlPath ${SOCKET_DIR}/%r@%h-%p
+  ControlPersist 10m
+  # 保活：防止空闲会话被中间网关静默切断
+  ServerAliveInterval 60
+  ServerAliveCountMax 3
+  TCPKeepAlive yes${hostkey_opt}
+EOF
+    info "已追加 Host ${CLUSTER_ID}"
+fi
+
+# ---------------------------------------------------------------- 验证
+echo "==> 测试连接"
+if out=$(ssh -o BatchMode=yes -o ConnectTimeout=20 \
+             -o StrictHostKeyChecking=accept-new \
+             "$CLUSTER_ID" 'echo OK; hostname; whoami' 2>&1); then
+    printf '%s\n' "$out" | sed 's/^/  /'
+    echo
+    echo "完成。用法：ssh ${CLUSTER_ID}"
+else
+    printf '%s\n' "$out" | sed 's/^/  /'
+    echo
+    die "连接失败。检查：私钥是否过期、本机 IP 是否在平台白名单内、端口 ${SSH_PORT} 是否可达"
+fi


### PR DESCRIPTION
## What

Adds `scnet-hpc`, a skill for operating SCNet HPC clusters through profile-based SSH and Slurm workflows.

## Scope

- Profile-specific SCNet connection, partition, memory, module, and accelerator guidance.
- SSH setup, Slurm job generation, cluster discovery, profile refresh, and compute-node probes.
- Hygon DCU/DTK development and evidence-based compatibility checks.
- Linux and macOS native scripts; Windows through WSL2.

## Structure

- `SKILL.md` contains routing, safety boundaries, and operational invariants.
- `references/` contains focused setup, environment, troubleshooting, accelerator, and compatibility guidance.
- `scripts/` contains deterministic shell/Python helpers.
- `clusters/` contains public profile templates and packaged SCNet profiles.

## Verification

- Agent Skill validator passes.
- `bash -n` passes for all shell scripts.
- `python3 -m py_compile` passes for the compute probe.
- `git diff --check` passes.

The canonical source is maintained at https://github.com/lql341/scnet-hpc. The submission intentionally excludes the repository installer, CI files, tests, and DSH-specific bundle files.