### PR TITLE
Fix/claude api description limit

### DIFF
--- a/skills/claude-api/SKILL.md
+++ b/skills/claude-api/SKILL.md
@@ -2,7 +2,7 @@
 name: claude-api
 description: |-
   Reference for the Claude API / Anthropic SDK — model ids, pricing, params, streaming, tool use, MCP, agents, caching, token counting, model migration.
-  TRIGGER — read BEFORE opening the target file; don't skip because it "looks like a one-liner" — whenever: the prompt names Claude/Anthropic in any form (Claude, Anthropic, Fable, Opus, Sonnet, Haiku, `anthropic`, `@anthropic-ai`, `claude-*`, `us.anthropic.*`, `[1m]`); the user asks about an LLM (pricing/model choice/limits/caching) — never answer from memory; OR the task is LLM-shaped with provider unstated (agent/MCP/tool-definition/multi-agent/RAG/LLM-judge/computer-use; generate/summarize/extract/classify/rewrite/converse over NL; debugging refusals/cutoffs/streaming/tool-calls/tokens).
+  TRIGGER — read BEFORE opening the target file; whenever: prompt names Claude/Anthropic in any form (Claude, Anthropic, Fable, Opus, Sonnet, Haiku, `anthropic`, `@anthropic-ai`, `claude-*`, `us.anthropic.*`, `[1m]`); user asks about an LLM (pricing/model choice/limits/caching) — never answer from memory; OR task is LLM-shaped with provider unstated (agent/MCP/tool-definition/multi-agent/RAG/LLM-judge/computer-use; generate/summarize/extract/classify/rewrite/converse over NL; debugging refusals/cutoffs/streaming/tool-calls/tokens).
   SKIP only when another provider is being worked on (overrides all triggers): OpenAI/GPT/Gemini/Llama/Mistral/Cohere/Ollama named in the query; OR `grep -rE 'openai|langchain_openai|google.generativeai|genai|mistralai|cohere|ollama'` over the project hits (run this grep FIRST if no provider named — don't Read the file).
 license: Complete terms in LICENSE.txt
 ---

--- a/skills/pptx/SKILL.md
+++ b/skills/pptx/SKILL.md
@@ -233,6 +233,8 @@ ls -1 "$PWD"/slide-*.jpg
 
 **After fixes, rerun all four commands above** — the PDF must be regenerated from the edited `.pptx` before `pdftoppm` can reflect your changes.
 
+**Never drive a locally installed Office application (PowerPoint, Word, Excel) to render or convert — on Windows or anywhere else.** Office COM automation can attach to an Office instance that the user already has open, so calling `Quit()` can close their entire Office session and `Close()` can close their presentation, potentially losing unsaved work. If LibreOffice is missing on Windows, install it (`winget install TheDocumentFoundation.LibreOffice`) and rerun the commands above. If it can't be installed, skip visual QA and say so — COM automation is not a fallback. Should COM be unavoidable for some other task, operate only on the presentation you opened and never call `Quit()` or `Close()` on a shared instance.
+
 ## Dependencies
 
 `pptxgenjs` (npm, preinstalled — install only if `require('pptxgenjs')` fails) · `markitdown[pptx]`, `Pillow`, `defusedxml`, `lxml` (pip — text dump, thumbnail, clean, validate) · LibreOffice (`soffice`, auto-configured for sandboxed environments via `scripts/office/soffice.py`) · `pdftoppm` (Poppler)


### PR DESCRIPTION
## Summary

* Shorten the `claude-api` skill frontmatter description to comply with the 1,024-character limit.
* Preserve the existing positive and negative trigger conditions.
* Leave the skill body unchanged.

## Validation

* `python -X utf8 skills\skill-creator\scripts\quick_validate.py skills\claude-api` → `Skill is valid!`
* `git diff --check` passes.

Fixes #1613
