### PR TITLE
feat: add buffer-api Agent Skill (Buffer GraphQL scheduling for any agent)

### DIFF
--- a/skills/buffer-api/LICENSE.txt
+++ b/skills/buffer-api/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 JPeetz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/buffer-api/SKILL.md
+++ b/skills/buffer-api/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: buffer-api
 description: "Use the Buffer GraphQL API to schedule and manage social media posts. Use when the user wants to create, schedule, edit, delete, or retrieve posts or drafts in a Buffer queue; distribute content across multiple social platforms (Instagram, Threads, LinkedIn, X/Twitter, Facebook, Google Business, Mastodon, YouTube, Pinterest, Bluesky); add public-URL media (images/video) to scheduled posts; build threads or first-comments for networks that support them; list connected Buffer channels; or check a queued post's status. Do NOT trigger for platform-native posting APIs (e.g. TikTok Direct Post) when Buffer is the intended scheduler; Buffer holds approved integration for auto-posting owned accounts."
-license: MIT
+license: Complete terms in LICENSE.txt
 ---
 
 # Buffer API — Schedule, Manage & Analyze Social Posts

--- a/skills/buffer-api/SKILL.md
+++ b/skills/buffer-api/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: buffer-api
+description: "Use the Buffer GraphQL API to schedule and manage social media posts. Use when the user wants to create, schedule, edit, delete, or retrieve posts or drafts in a Buffer queue; distribute content across multiple social platforms (Instagram, Threads, LinkedIn, X/Twitter, Facebook, Google Business, Mastodon, YouTube, Pinterest, Bluesky); add public-URL media (images/video) to scheduled posts; build threads or first-comments for networks that support them; list connected Buffer channels; or check a queued post's status. Do NOT trigger for platform-native posting APIs (e.g. TikTok Direct Post) when Buffer is the intended scheduler; Buffer holds approved integration for auto-posting owned accounts."
+license: MIT
+---
+
+# Buffer API — Schedule, Manage & Analyze Social Posts
+
+Use Buffer's GraphQL API to schedule, manage, and analyze social posts across
+many platforms from any AI agent.
+
+## When to Use
+- Create/schedule/edit/delete/retrieve posts or drafts in a Buffer queue.
+- Distribute content across platforms (Instagram, Threads, LinkedIn, X, Facebook,
+  Google Business, Mastodon, YouTube, Pinterest, Bluesky).
+- Add public-URL media (image/video) to scheduled posts; threads; first comments.
+- List connected Buffer channels; poll a post to `sent`.
+- The single approved route for automated owned-account posting (e.g. TikTok).
+
+## Prerequisites
+- Buffer account with ≥1 connected channel and an API key
+  (https://publish.buffer.com/settings/api). The key acts on your own account.
+- Auth: `Authorization: Bearer <API_KEY>` on every POST to `https://api.buffer.com`
+  (GraphQL, `Content-Type: application/json`).
+- Media on a post must be a PUBLIC url. See `references/media-and-metadata.md`.
+
+## Endpoint & Auth
+```
+POST https://api.buffer.com
+Authorization: Bearer <API_KEY>
+Content-Type: application/json
+{ "query": "<graphql>", "variables": {} }
+```
+GraphQL only. Explore at https://developers.buffer.com/explorer.html. `DateTime` is ISO 8601 UTC.
+
+## 1. Account & Organization
+```
+query { account { id email organizations { id name } } }
+```
+## 2. Channels
+```
+query { channels(input: { organizationId: "ORG_ID" }) { id name service type } }
+```
+`service` = platform (instagram/tiktok/linkedin/twitter/mastodon/youtube/pinterest/bluesky/facebook/gbp). `type` = Page/Profile/Business/Group/Account.
+
+## 3. Create a Post
+```
+mutation {
+  createPost(input: {
+    text: "...", channelId: "CHANNEL_ID", schedulingType: automatic,
+    mode: addToQueue            # addToQueue | customScheduled
+    # dueAt: "2026-03-10T15:00:00.000Z"   # required when mode=customScheduled
+  }) {
+    ... on PostActionSuccess { post { id text dueAt } }
+    ... on MutationError { message }
+  }
+}
+```
+Required: `text`, `channelId`, `schedulingType: automatic`. Always spread both
+success and error members (unions).
+
+## 4. Media / Assets (public URL only)
+```
+createPost(input: { text:"...", channelId:"...", schedulingType: automatic,
+  mode: addToQueue,
+  assets: [ { image: { url: "https://cdn.example.com/img.jpg" } } ] })
+  { ... on PostActionSuccess { post { id assets { id mimeType } } } ... on MutationError { message } }
+```
+`url` MUST be public (Buffer fetches it). Verify with `curl -sI <url>` returns 200.
+
+## 5. Retrieve / Manage
+- One post (status poll): `query { post(input: { id: "ID" }) { id status dueAt } }`
+  — there is NO `getPost`; status `scheduled` → `sent` → `error`. Check `== "sent"`.
+- List (cursor): `posts(first: N, after: CUR, input:{organizationId, filter:{status:[], channelIds:[]}})`
+- Edit `editPost`, Delete `deletePost(input:{...})`, reorder `movePostInQueue`.
+
+## 6. Ideas & Metrics
+- `createIdea(input:{organizationId, ideaGroupId, text, media})`, `ideas(input:)`, `ideaGroups(input:)`.
+- Once sent: `post(input:{id}){ metrics }`, `aggregatedPostMetrics`, `dailyPostingLimits`.
+
+## Per-Network Metadata (selected)
+- Threads/X/Bluesky/Mastodon: `metadata.<net>.thread` for threaded posts.
+- LinkedIn/Facebook/Instagram: first comment; Instagram `postType` (post/story/reel)
+  and per-image `userTags`; Pinterest `boardId`.
+You only provide metadata for the network the channel belongs to. Details in `references/media-and-metadata.md`.
+
+## Pitfalls (hard-won)
+1. GraphQL only — legacy REST retired (401 "Public API tokens are not accepted for REST API access").
+2. Poll via `post(input:{id})`, not `getPost` (no such field).
+3. `status == "sent"` (string `sent`, not `published`).
+4. Asset URL must be public; no blob upload mutation.
+5. Non-ASCII JSON bodies: use `requests`/JSON-safe client, not `urllib` (latin-1 crash).
+6. Close repeat = already queued; treat `ok=false` as queued, don't re-submit.
+7. Queue limits → read message, don't blind-retry.
+8. Custom scalars (`OrganizationId!/ChannelId!/PostId!`) differ from generic `ID!` — type vars correctly or inline literals (verified live).
+
+## References
+- `references/api-reference.md` — full schema (queries/mutations/types/unions).
+- `references/media-and-metadata.md` — media hosting + per-network metadata.
+- `scripts/buffer_graphql.py` — dependency-light GraphQL helper (stdlib, utf-8 safe).
+
+## Verification
+- `python3 scripts/buffer_graphql.py --query "{ account { id organizations { id } } }"`
+  (set BUFFER_API_KEY) → returns account.
+- After createPost, poll `post(input:{id})` until `status == "sent"`.

--- a/skills/buffer-api/references/api-reference.md
+++ b/skills/buffer-api/references/api-reference.md
@@ -1,0 +1,124 @@
+# Buffer GraphQL API — Full Reference
+
+Complete operation + type catalogue distilled from https://developers.buffer.com/reference.html
+(endpoint `https://api.buffer.com`, Bearer auth). Use for anything beyond the quick
+operations in SKILL.md.
+
+## Operations (queries & mutations)
+
+### Queries
+| Query | Input | Returns | Notes |
+|---|---|---|---|
+| `account` | — | `Account` | authenticated user + profile |
+| `channel` | `input:{id}` | `Channel` | single channel by ID |
+| `channels` | `input:{organizationId, filter}` | `[Channel]` | all channels for org, current-user permissions |
+| `post` | `input:{id}` | `Post` | **single post by id — there is NO `getPost`** |
+| `posts` | `first, after, input:{organizationId, filter}` | `PostsResults` | cursor-paginated posts; filter `status`,`channelIds` |
+| `aggregatedPostMetrics` | `input:{...}` | `AggregatedPostMetrics` | aggregate metrics across posts/channels |
+| `dailyPostingLimits` | `input:{...}` | `[DailyPostingLimitStatus]` | per-channel daily caps |
+| `ideas` | `first, after, input:{organizationId}` | `IdeasConnection` | list ideas (cursor) |
+| `ideaGroups` | `input:{...}` | `[IdeaGroup]` | idea board groups |
+| `postTemplate` 🧪 | `input:{id}` | `PostTemplate` | single template |
+| `postTemplates` 🧪 | `first, after, input:{...}` | `PostTemplatesConnection` | list templates |
+
+### Mutations
+| Mutation | Input | Union/Return | Notes |
+|---|---|---|---|
+| `createPost` | `CreatePostInput` | `PostActionPayload` | create/schedule a post |
+| `editPost` | `EditPostInput` | `PostActionPayload` | edit a post |
+| `deletePost` | `DeletePostInput` | `DeletePostPayload` | delete a post |
+| `movePostInQueue` ⚠️ | `MovePostInQueueInput` | `MovePostInQueuePayload` | reorder queued (experimental) |
+| `createIdea` | `CreateIdeaInput` | `CreateIdeaPayload` | save an idea |
+| `createPostTemplate` 🧪 | `CreatePostTemplateInput` | `CreatePostTemplatePayload` | create a template |
+| `updatePostTemplate` 🧪 | `UpdatePostTemplateInput` | `UpdatePostTemplatePayload` | update a template |
+| `deletePostTemplate` 🧪 | `DeletePostTemplateInput` | `DeletePostTemplatePayload` | delete a template |
+
+## Key types & union shapes
+
+### PostActionPayload (createPost/editPost result) — UNION of:
+- `PostActionSuccess` { `post: Post` }
+- `NotFoundError`, `UnauthorizedError`, `UnexpectedError`, `RestProxyError`,
+  `LimitReachedError`, `InvalidInputError`
+Spread: `{ ... on PostActionSuccess { post { id text dueAt } } ... on MutationError { message } }`
+
+### DeletePostPayload — UNION of `DeletePostSuccess` | `VoidMutationError`
+### MovePostInQueuePayload — `PostActionSuccess` | `VoidMutationError`
+### PostMetadata — UNION per network:
+`InstagramPostMetadata | FacebookPostMetadata | LinkedInPostMetadata |
+TwitterPostMetadata | PinterestPostMetadata | GoogleBusinessPostMetadata |
+YoutubePostMetadata | MastodonPostMetadata | TiktokPostMetadata |
+ThreadsPostMetadata | BlueskyPostMetadata`
+
+### Post (core fields)
+`id`, `text`, `channelId`, `dueAt` (DateTime ISO 8601), `status`
+(`scheduled`→`sent`→`error`), `assets` (`[PostAsset]`: id, mimeType, url, alt),
+`metrics` (`PostMetrics` when sent), `metadata` (per-network `PostMetadata`).
+
+### Channel (core fields)
+`id`, `name`, `service` (platform), `type` (Page/Profile/Business/Group/Account),
+`organizationId`, `descriptor`, `avatar`, `externalLink`, `isDisconnected`,
+`isLocked` (locked = cannot post), `isQueuePaused`, `linkShortening`,
+`postingSchedule`, `weeklyPostingLimit`, `metadata` (per-network:
+BlueskyMetadata.serverUrl, MastodonMetadata.{maxCharacters, serverUrl},
+PinterestMetadata.boards, FacebookMetadata.locationData, TiktokMetadata,
+TwitterMetadata.subscriptionType, LinkedInMetadata…), `timezone`.
+
+### Account (core fields)
+`id`, `email`, `backupEmail`, `avatar`, `createdAt`, `organizations`, `timezone`,
+`name`, `preferences`, `connectedApps`.
+
+### PostAsset
+`id`, `mimeType`, `url`, `size`, `alt`, `source`. (Attached via `assets` input by
+public URL — see media reference.)
+
+### Ideas
+`Idea` (idea, media: List[IdeaMedia(id, url, thumbnailUrl, type, size, alt, source)]),
+`IdeaGroup` { id, name, isLocked }. `IdeaMediaSource` (Unsplash/Giphy source: name,
+id, trigger, author, authorUrl).
+
+### Scalars
+`AccountId`, `ChannelId`, `OrganizationId`, `PostId`, `DraftId`, `IdeaId`,
+`InvitationId`, `NoteId`, `PostGroupId`, `PostTemplateId`, `TagId`, `Uuid`,
+`DateTime` (ISO 8601), `Email` (normalized-lowercase).
+
+**GOTCHA — custom scalars are NOT interchangeable with generic `ID` (verified live).**
+If a query declares a variable as `ID!` but the field expects `OrganizationId!` /
+`ChannelId!` / `PostId!`, GraphQL validation FAILS:
+`Variable "$oid" of type "ID!" used in position expecting type "OrganizationId!"`.
+Fix: either inline the value as a string literal, or type the variable with the
+correct custom scalar, e.g. `query Q($oid: OrganizationId!){...}`.
+
+### Enums
+`ScheduleOption` (account prefs), `ConnectedAppCategory`, `MediaType`,
+`ChannelAction`, `Product`, `Service`, `ChannelType`, `DayOfWeek`,
+`PostTemplateVisibility`, `ChannelLinkShortening` statuses.
+
+## Shared input shapes
+- `CreatePostInput`: `text`, `channelId`, `schedulingType: automatic`,
+  `mode: addToQueue | customScheduled`, `dueAt` (custom), `assets:[]`,
+  `metadata: PostInputMetaData` (per-network).
+- `EditPostInput`: `id` (postId), plus `text`, `mode`, `dueAt`, `assets` you change.
+- `DeletePostInput`: `postId` (or `input:{ id }` equivalent).
+- `IdeasInput` / `IdeaMediaInput`: see media reference (url required on media).
+
+## Pagination
+- `posts`, `ideas`, `postTemplates` use **cursor-based**: top-level `first: Int`
+  (+ `after: String` cursor from `pageInfo.endCursor`).
+- Page through until `hasNextPage == false`.
+
+## Polling a post to "sent"
+Poll `post(input: { id: "ID" }) { id status }` until `status == "sent"`.
+The string is `sent`, NOT `published`. There is no `getPost` query field.
+
+## Auth / endpoint recap
+- `POST https://api.buffer.com`, header `Authorization: Bearer <key>`.
+- Key is account-scoped (your own Buffer account). Get at
+  https://publish.buffer.com/settings/api.
+- Buffer also publishes an MCP server: `https://mcp.buffer.com/mcp` with the same
+  Bearer header (see SKILL.md "MCP alternative").
+- Legacy REST `api.bufferapp.com/1/` is RETIRED (2027-02-01). Ignore any doc that
+  shows `/1/`.
+
+---
+Sourced 2026-08-21 from https://developers.buffer.com (reference.html). Re-verify
+against that page for schema drift.

--- a/skills/buffer-api/references/media-and-metadata.md
+++ b/skills/buffer-api/references/media-and-metadata.md
@@ -1,0 +1,121 @@
+# Buffer — Media & Per-Network Metadata Reference
+
+Load this when the task involves images/video per-network configuration, threads,
+first comments, or post-type selection. Progressive-disclosure detail that stays
+out of the main SKILL.md.
+
+## Public media URLs (required for assets)
+
+Buffer fetches post assets from a **public URL** — there is no blob upload mutation.
+
+- Host the image/video where it is publicly reachable (a CDN, S3/Cloudflare R2 with
+  a public URL, or a CMS media library that returns a public URL — e.g. a WordPress
+  `wp-json/wp/v2/media` upload's `source_url`).
+- **Verify before creating the post:**
+  ```
+  curl -sI <public_url> | head -1
+  ```
+  Expect `HTTP/1.1 200 OK` (or `204 No Content`). If it 403s/404s to an anonymous
+  client (or your agent fetch), Buffer will fail to fetch it too. Also make sure the
+  URL is not signed with an expiring query param if the post is scheduled far out.
+- Video: `assets: [ { video: { url: "https://.../clip.mp4" , thumbnailUrl: "https://.../thumb.jpg" } } ]`
+  `thumbnailUrl` is strongly suggested so preview cards render.
+
+## `assets` union
+```
+assets: [ {
+  image:    { url, alt }
+} | {
+  video:    { url, thumbnailUrl }
+} | {
+  document: { url, name }
+} | {
+  link:     { url, title }
+} ]
+```
+Each `assets` entry is a union member: exactly ONE of image/video/document/link.
+`alt` (alternative text) is a first-class accessibility field on image media.
+
+## Per-network `metadata` on createPost
+
+You only provide the metadata object for the network the channel belongs to. The
+top-level `metadata` key wraps per-network objects.
+
+### Instagram  (`metadata: { instagram: {...} }`)
+- **postType:** `post` | `story` | `reel` (post is default).
+- **firstComment:** text posted as the first comment (also used by some networks).
+- **userTags (per image):** tag users on a specific image:
+  ```
+  metadata: { instagram: {
+    postType: "post",
+    images: [ { url: "https://...", userTags: [ { username: "handle" } ] } ]
+  } }
+  ```
+  User tags are positioned per image via `image.metadata.userTags` (not network metadata).
+
+### LinkedIn
+- `metadata.linkedin.firstComment` — a first comment under the scheduled post.
+
+### Facebook
+- `metadata.facebook.firstComment` — like LinkedIn, a first comment on the post.
+
+### Threads / X (Twitter) / Bluesky / Mastodon — threaded posts
+- `metadata.threads.thread`, `metadata.twitter.thread`, `metadata.bluesky.thread`,
+  `metadata.mastodon.thread` — build a thread of N tweets/posts.
+  Thread shape (example per net):
+  ```
+  createPost(input: {
+    text: "Post 1 of the thread"
+    channelId: "X_CHANNEL"
+    schedulingType: automatic mode: addToQueue
+    metadata: { twitter: { thread: [
+      { text: "Post 1" }, { text: "Post 2" }, { text: "Post 3" }
+    ] } }
+  })
+  ```
+  Threads schedule as one logical item in the queue.
+
+### Pinterest
+- **boardId** — attach the pin to a board:
+  `metadata: { pinterest: { boardId: "BOARD_ID" } }`
+  Boards come from `channels(...){ pinterest { boards { id name } } }` or the
+  Pinterest metadata on the channel.
+
+### LinkedIn / Google Business (first-comment like)
+- `metadata.linkedin.firstComment` (as above).
+- Google Business Profiles: `metadata.googleBusinessPost` variants differ — see the
+  union `GoogleBusinessPostDetails` (WhatsNew / Offer / Event).
+
+## Scheduling (recap)
+- `mode` values: `addToQueue` (next open slot) | `customScheduled` (with `dueAt` ISO 8601 UTC).
+- `schedulingType` is always `automatic` (there is no manual).
+- A **paused** channel/posting schedule won't publish queued items — check
+  `channel.isQueuePaused` (it's a field on Channel).
+
+## Ideas (save content for later)
+- Create: `createIdea(input: { organizationId, ideaGroupId, text, media: [ { url, alt } ] })`
+- List: `ideas(input: { organizationId } )`, `ideaGroups(input: { organizationId })`
+- `media` on an idea is the IdeaMediaInput: `url` (required), `alt`, `thumbnailUrl`,
+  `type` (image|gif|video|document|link|unsupported), `size`, `source`.
+- Video is NOT exposed/supported on public API ideas (even though type hints video).
+
+## Post template (preview 🧪)
+- `postTemplates` / `createPostTemplate` / `editPostTemplate` / `deletePostTemplate`
+  are preview-phase. `{{placeholders}}` in body; taxonomy fields are Buffer-curated
+  and setting them by third-parties is ignored. Unless you need templates, skip.
+
+## Metrics
+- Once sent, per-network engagement is normalized under `Post.metrics`:
+  `impressions`, `reach`, `reactions`, `comments`, `shares`, `clicks` (fields vary
+  per network; Buffer maps the standard set).
+- `aggregatedPostMetrics(input: { organizationId, since, until })` and
+  `dailyPostingLimits` (per-channel caps) give a dashboard view.
+
+## Practical pitfalls (repeat of SKILL.md, more detail)
+- image/video URL must be PUBLIC and reachable by Buffer. No signed S3 links that
+  expire before the scheduled time. Host on a3 / your CDN / WordPress media.
+- Do NOT pass binary media as a data URI in `url` — Buffer expects a real public web URL.
+- Keep `alt` + `thumbnailUrl` where offered; accessibility and card previews.
+- For a batch of different network metadata, you must create ONE post PER channel (they
+  are per-channel records) — the API is channel-scoped, not cross-poster. If you need
+  multi-network from one command, loop per channel, each with its own metadata + assets.

--- a/skills/buffer-api/scripts/buffer_graphql.py
+++ b/skills/buffer-api/scripts/buffer_graphql.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""
+buffer_graphql.py — minimal, safe Buffer GraphQL helper.
+
+Dependency-light (stdlib only: urllib + json) so it runs anywhere an agent has
+Python, and it AVOIDS the latin-1 / non-ASCII crash by utf-8 encoding the JSON
+body explicitly.
+
+Buffer API facts baked in:
+- Endpoint: https://api.buffer.com  (POST, Content-Type: application/json)
+- Auth: Authorization: Bearer <API_KEY>
+- All mutations/queries are GraphQL only (no REST). Legacy REST is retired.
+- createPost etc. return UNIONS — spread both success and error members.
+- Webhook-style poll uses query post(input:{ id }) { status } — there is NO getPost field.
+
+Usage (run with any python on the host):
+  python3 buffer_graphql.py --help
+  python3 buffer_graphql.py --query "{ account { id organizations { id } } }"
+  python3 buffer_graphql.py --query "query Q($id: ID!){ post(input:{id:$id}){ id status } }" --vars '{"id":"..."}'
+  python3 buffer_graphql.py --query "..." --key sk-or-            # or set BUFFER_API_KEY env
+
+Only reads the Buffer API key from env BUFFER_API_KEY or --key. Never echoes it.
+"""
+import argparse, json, os, sys, urllib.request, urllib.error
+
+ENDPOINT = "https://api.buffer.com"
+
+
+def post(query: str, variables, key: str, timeout: int = 60):
+    payload = {"query": query}
+    if variables:
+        payload["variables"] = variables
+    # UTF-8 encode so non-ASCII (em dashes, quotes) never hit urllib's latin-1 default
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        ENDPOINT, data=body, method="POST",
+        headers={"Content-Type": "application/json",
+                 "Authorization": f"Bearer {key}",
+                 "User-Agent": "buffer-graphql-skill/1.0"},
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Buffer GraphQL helper (see module docstring).")
+    ap.add_argument("--query", required=True, help="GraphQL query or mutation")
+    ap.add_argument("--vars", default=None, help="JSON object (string) of variables")
+    ap.add_argument("--key", default=None, help="Buffer API key (else BUFFER_API_KEY env)")
+    ap.add_argument("--pretty", action="store_true", help="pretty-print JSON output")
+    args = ap.parse_args()
+
+    key = args.key or os.environ.get("BUFFER_API_KEY")
+    if not key:
+        print("No Buffer API key: pass --key or set BUFFER_API_KEY env.", file=sys.stderr)
+        return 2
+
+    vars_obj = json.loads(args.vars) if args.vars else {}
+    try:
+        data = post(args.query, vars_obj, key)
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", "ignore")
+        print(json.dumps({"error": {"status": e.code, "body": body}}, indent=2))
+        return 1
+    except Exception as e:
+        print(json.dumps({"error": type(e).__name__ + ": " + str(e)}, indent=2))
+        return 1
+
+    if args.pretty:
+        print(json.dumps(data, indent=2))
+    else:
+        print(json.dumps(data))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Adds a portable Agent Skill for the **Buffer GraphQL API** — schedule, manage, and analyze social posts from any AI agent (Claude, Cursor, Codex, OpenClaw, Hermes, n8n).

## What it covers
- Account / organization / channel discovery
- Post create / schedule (`addToQueue` / `customScheduled`) / edit / delete / reorder
- Image / video / document / link assets (public-URL media), threads, first comments
- Per-network metadata (Instagram post type + user tags, Pinterest board, threaded posts on Threads/X/Bluesky/Mastodon, LinkedIn/Facebook first comment)
- Post retrieval + status polling (`post(input:)` → `sent`), cursor pagination
- Ideas, post metrics, daily posting limits, post templates (preview)
- Hard-won pitfalls: GraphQL-only, custom scalars ≠ `ID`, `post()` not `getPost`, `sent` not `published`, utf-8/latin-1, no blob upload, already-queued dedupe

## Verification
Tested live against `api.buffer.com` with a real key: `account` and `channels` queries returned correctly; documented the custom-scalar gotcha found during testing.

Skill follows the Agent Skills spec (name + description + license frontmatter, progressive disclosure, bundled scripts).