### PR TITLE
skill-creator: fix three eval-harness defects that silently report a 0.0 trigger rate

### DIFF
--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -393,6 +393,31 @@ While it runs, periodically tail the output to give the user updates on which it
 
 This handles the full optimization loop automatically. It splits the eval set into 60% train and 40% held-out test, evaluates the current description (running each query 3 times to get a reliable trigger rate), then calls Claude to propose improvements based on what failed. It re-evaluates each new description on both train and test, iterating up to 5 times. When it's done, it opens an HTML report in the browser showing the results per iteration and returns JSON with `best_description` — selected by test score rather than train score to avoid overfitting.
 
+### Evaluating a skill that is already installed
+
+By default the eval writes a uniquely-named copy of the skill into
+`.claude/commands/` and checks whether Claude invoked *that* name. If the skill
+under test is already on the load path, Claude invokes the real skill instead,
+the unique name never appears, and every query is scored as a miss - the run
+completes normally and reports a 0.0 trigger rate across the board.
+
+Pass `--use-installed` to match the installed skill by its real name:
+
+```bash
+python -m scripts.run_eval \
+  --eval-set <path-to-trigger-eval.json> \
+  --skill-path <path-to-skill> \
+  --use-installed
+```
+
+This measures the description the skill currently ships with, so it is the right
+mode for auditing skills already in use. It cannot be combined with
+`--description`, because a candidate description is injected through the probe
+copy that `--use-installed` skips; passing both is rejected rather than silently
+ignoring the override. For the same reason `run_loop.py`, which tests candidate
+descriptions, always uses the probe mechanism - uninstall or temporarily move the
+skill out of the load path before optimizing it.
+
 ### How skill triggering works
 
 Understanding the triggering mechanism helps design better eval queries. Skills appear in Claude's `available_skills` list with their name + description, and Claude decides whether to consult a skill based on that description. The important thing to know is that Claude only consults skills for tasks it can't easily handle on its own — simple, one-step queries like "read this PDF" may not trigger a skill even if the description matches perfectly, because Claude can handle them directly with basic tools. Complex, multi-step, or specialized queries reliably trigger skills when the description matches.

--- a/skills/skill-creator/eval-viewer/generate_review.py
+++ b/skills/skill-creator/eval-viewer/generate_review.py
@@ -91,7 +91,7 @@ def build_run(root: Path, run_dir: Path) -> dict | None:
     for candidate in [run_dir / "eval_metadata.json", run_dir.parent / "eval_metadata.json"]:
         if candidate.exists():
             try:
-                metadata = json.loads(candidate.read_text())
+                metadata = json.loads(candidate.read_text(encoding="utf-8"))
                 prompt = metadata.get("prompt", "")
                 eval_id = metadata.get("eval_id")
             except (json.JSONDecodeError, OSError):
@@ -104,7 +104,7 @@ def build_run(root: Path, run_dir: Path) -> dict | None:
         for candidate in [run_dir / "transcript.md", run_dir / "outputs" / "transcript.md"]:
             if candidate.exists():
                 try:
-                    text = candidate.read_text()
+                    text = candidate.read_text(encoding="utf-8")
                     match = re.search(r"## Eval Prompt\n\n([\s\S]*?)(?=\n##|$)", text)
                     if match:
                         prompt = match.group(1).strip()
@@ -131,7 +131,7 @@ def build_run(root: Path, run_dir: Path) -> dict | None:
     for candidate in [run_dir / "grading.json", run_dir.parent / "grading.json"]:
         if candidate.exists():
             try:
-                grading = json.loads(candidate.read_text())
+                grading = json.loads(candidate.read_text(encoding="utf-8"))
             except (json.JSONDecodeError, OSError):
                 pass
             if grading:
@@ -222,7 +222,7 @@ def load_previous_iteration(workspace: Path) -> dict[str, dict]:
     feedback_path = workspace / "feedback.json"
     if feedback_path.exists():
         try:
-            data = json.loads(feedback_path.read_text())
+            data = json.loads(feedback_path.read_text(encoding="utf-8"))
             feedback_map = {
                 r["run_id"]: r["feedback"]
                 for r in data.get("reviews", [])
@@ -255,7 +255,7 @@ def generate_html(
 ) -> str:
     """Generate the complete standalone HTML page with embedded data."""
     template_path = Path(__file__).parent / "viewer.html"
-    template = template_path.read_text()
+    template = template_path.read_text(encoding="utf-8")
 
     # Build previous_feedback and previous_outputs maps for the template
     previous_feedback: dict[str, str] = {}
@@ -336,7 +336,7 @@ class ReviewHandler(BaseHTTPRequestHandler):
             benchmark = None
             if self.benchmark_path and self.benchmark_path.exists():
                 try:
-                    benchmark = json.loads(self.benchmark_path.read_text())
+                    benchmark = json.loads(self.benchmark_path.read_text(encoding="utf-8"))
                 except (json.JSONDecodeError, OSError):
                     pass
             html = generate_html(runs, self.skill_name, self.previous, benchmark)
@@ -366,7 +366,7 @@ class ReviewHandler(BaseHTTPRequestHandler):
                 data = json.loads(body)
                 if not isinstance(data, dict) or "reviews" not in data:
                     raise ValueError("Expected JSON object with 'reviews' key")
-                self.feedback_path.write_text(json.dumps(data, indent=2) + "\n")
+                self.feedback_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
                 resp = b'{"ok":true}'
                 self.send_response(200)
             except (json.JSONDecodeError, OSError, ValueError) as e:
@@ -424,14 +424,14 @@ def main() -> None:
     benchmark = None
     if benchmark_path and benchmark_path.exists():
         try:
-            benchmark = json.loads(benchmark_path.read_text())
+            benchmark = json.loads(benchmark_path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
             pass
 
     if args.static:
         html = generate_html(runs, skill_name, previous, benchmark)
         args.static.parent.mkdir(parents=True, exist_ok=True)
-        args.static.write_text(html)
+        args.static.write_text(html, encoding="utf-8")
         print(f"\n  Static viewer written to: {args.static}\n")
         sys.exit(0)
 

--- a/skills/skill-creator/scripts/aggregate_benchmark.py
+++ b/skills/skill-creator/scripts/aggregate_benchmark.py
@@ -87,7 +87,7 @@ def load_run_results(benchmark_dir: Path) -> dict:
         metadata_path = eval_dir / "eval_metadata.json"
         if metadata_path.exists():
             try:
-                with open(metadata_path) as mf:
+                with open(metadata_path, encoding="utf-8") as mf:
                     eval_id = json.load(mf).get("eval_id", eval_idx)
             except (json.JSONDecodeError, OSError):
                 eval_id = eval_idx
@@ -117,7 +117,7 @@ def load_run_results(benchmark_dir: Path) -> dict:
                     continue
 
                 try:
-                    with open(grading_file) as f:
+                    with open(grading_file, encoding="utf-8") as f:
                         grading = json.load(f)
                 except json.JSONDecodeError as e:
                     print(f"Warning: Invalid JSON in {grading_file}: {e}")
@@ -139,7 +139,7 @@ def load_run_results(benchmark_dir: Path) -> dict:
                 timing_file = run_dir / "timing.json"
                 if result["time_seconds"] == 0.0 and timing_file.exists():
                     try:
-                        with open(timing_file) as tf:
+                        with open(timing_file, encoding="utf-8") as tf:
                             timing_data = json.load(tf)
                         result["time_seconds"] = timing_data.get("total_duration_seconds", 0.0)
                         result["tokens"] = timing_data.get("total_tokens", 0)
@@ -374,13 +374,13 @@ def main():
     output_md = output_json.with_suffix(".md")
 
     # Write benchmark.json
-    with open(output_json, "w") as f:
+    with open(output_json, "w", encoding="utf-8") as f:
         json.dump(benchmark, f, indent=2)
     print(f"Generated: {output_json}")
 
     # Write benchmark.md
     markdown = generate_markdown(benchmark)
-    with open(output_md, "w") as f:
+    with open(output_md, "w", encoding="utf-8") as f:
         f.write(markdown)
     print(f"Generated: {output_md}")
 

--- a/skills/skill-creator/scripts/generate_report.py
+++ b/skills/skill-creator/scripts/generate_report.py
@@ -311,12 +311,12 @@ def main():
     if args.input == "-":
         data = json.load(sys.stdin)
     else:
-        data = json.loads(Path(args.input).read_text())
+        data = json.loads(Path(args.input).read_text(encoding="utf-8"))
 
     html_output = generate_html(data, skill_name=args.skill_name)
 
     if args.output:
-        Path(args.output).write_text(html_output)
+        Path(args.output).write_text(html_output, encoding="utf-8")
         print(f"Report written to {args.output}", file=sys.stderr)
     else:
         print(html_output)

--- a/skills/skill-creator/scripts/improve_description.py
+++ b/skills/skill-creator/scripts/improve_description.py
@@ -186,7 +186,7 @@ Please respond with only the new description text in <new_description> tags, not
     if log_dir:
         log_dir.mkdir(parents=True, exist_ok=True)
         log_file = log_dir / f"improve_iter_{iteration or 'unknown'}.json"
-        log_file.write_text(json.dumps(transcript, indent=2))
+        log_file.write_text(json.dumps(transcript, indent=2), encoding="utf-8")
 
     return description
 
@@ -205,10 +205,10 @@ def main():
         print(f"Error: No SKILL.md found at {skill_path}", file=sys.stderr)
         sys.exit(1)
 
-    eval_results = json.loads(Path(args.eval_results).read_text())
+    eval_results = json.loads(Path(args.eval_results).read_text(encoding="utf-8"))
     history = []
     if args.history:
-        history = json.loads(Path(args.history).read_text())
+        history = json.loads(Path(args.history).read_text(encoding="utf-8"))
 
     name, _, content = parse_skill_md(skill_path)
     current_description = eval_results["description"]

--- a/skills/skill-creator/scripts/package_skill.py
+++ b/skills/skill-creator/scripts/package_skill.py
@@ -21,7 +21,7 @@ EXCLUDE_DIRS = {"__pycache__", "node_modules"}
 EXCLUDE_GLOBS = {"*.pyc"}
 EXCLUDE_FILES = {".DS_Store"}
 # Directories excluded only at the skill root (not when nested deeper).
-ROOT_EXCLUDE_DIRS = {"evals"}
+ROOT_EXCLUDE_DIRS = {"evals", "tests"}
 
 
 def should_exclude(rel_path: Path) -> bool:

--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -19,7 +19,7 @@ def validate_skill(skill_path):
         return False, "SKILL.md not found"
 
     # Read and validate frontmatter
-    content = skill_md.read_text()
+    content = skill_md.read_text(encoding="utf-8")
     if not content.startswith('---'):
         return False, "No YAML frontmatter found"
 

--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -8,9 +8,10 @@ for a set of queries. Outputs results as JSON.
 import argparse
 import json
 import os
-import select
+import queue
 import subprocess
 import sys
+import threading
 import time
 import uuid
 from concurrent.futures import ProcessPoolExecutor, as_completed
@@ -32,6 +33,137 @@ def find_project_root() -> Path:
     return current
 
 
+class TriggerDetector:
+    """Incremental state machine over `claude -p --output-format stream-json` lines.
+
+    Kept separate from process handling so it can be exercised against recorded
+    transcripts without spawning Claude.
+    """
+
+    def __init__(self, clean_name: str):
+        self.clean_name = clean_name
+        self.pending_tool_name = None
+        self.accumulated_json = ""
+        self.triggered = False
+
+    def feed(self, line: str) -> bool | None:
+        """Consume one line. Returns the verdict once known, else None."""
+        line = line.strip()
+        if not line:
+            return None
+
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            return None
+
+        if event.get("type") == "stream_event":
+            se = event.get("event", {})
+            se_type = se.get("type", "")
+
+            if se_type == "content_block_start":
+                cb = se.get("content_block", {})
+                if cb.get("type") == "tool_use":
+                    tool_name = cb.get("name", "")
+                    if tool_name in ("Skill", "Read"):
+                        self.pending_tool_name = tool_name
+                        self.accumulated_json = ""
+                    else:
+                        return False
+
+            elif se_type == "content_block_delta" and self.pending_tool_name:
+                delta = se.get("delta", {})
+                if delta.get("type") == "input_json_delta":
+                    self.accumulated_json += delta.get("partial_json", "")
+                    if self.clean_name in self.accumulated_json:
+                        return True
+
+            elif se_type in ("content_block_stop", "message_stop"):
+                if self.pending_tool_name:
+                    return self.clean_name in self.accumulated_json
+                if se_type == "message_stop":
+                    return False
+
+        elif event.get("type") == "assistant":
+            message = event.get("message", {})
+            for content_item in message.get("content", []):
+                if content_item.get("type") != "tool_use":
+                    continue
+                tool_name = content_item.get("name", "")
+                tool_input = content_item.get("input", {})
+                if tool_name == "Skill" and self.clean_name in tool_input.get("skill", ""):
+                    self.triggered = True
+                elif tool_name == "Read" and self.clean_name in tool_input.get("file_path", ""):
+                    self.triggered = True
+                return self.triggered
+
+        elif event.get("type") == "result":
+            return self.triggered
+
+        return None
+
+
+def detect_trigger(lines, clean_name: str) -> bool:
+    """Run TriggerDetector over an iterable of lines and return the verdict."""
+    detector = TriggerDetector(clean_name)
+    for line in lines:
+        verdict = detector.feed(line)
+        if verdict is not None:
+            return verdict
+    return detector.triggered
+
+
+def iter_process_lines(stream, deadline_check, poll_interval: float = 1.0):
+    """Yield decoded lines from `stream` as they arrive.
+
+    A reader thread feeds a queue so the main loop can still honour a timeout.
+    `select` is not usable here: on Windows it accepts sockets only, and calling
+    it on a pipe raises OSError, which the caller records as a non-trigger, so
+    every query is silently scored as a miss.
+    """
+    chunks: queue.Queue = queue.Queue()
+
+    def pump():
+        try:
+            while True:
+                data = stream.read1(8192)
+                if not data:
+                    break
+                chunks.put(data)
+        except (ValueError, OSError):
+            pass
+        finally:
+            chunks.put(None)
+
+    threading.Thread(target=pump, daemon=True).start()
+
+    buffer = ""
+    while deadline_check():
+        try:
+            chunk = chunks.get(timeout=poll_interval)
+        except queue.Empty:
+            continue
+        if chunk is None:
+            break
+        buffer += chunk.decode("utf-8", errors="replace")
+        while "\n" in buffer:
+            line, buffer = buffer.split("\n", 1)
+            yield line
+    if buffer:
+        yield buffer
+
+
+def resolve_probe_name(skill_name: str, unique_id: str, use_installed: bool) -> str:
+    """Name the eval looks for inside the Skill tool call.
+
+    When the skill under test is not installed, a uniquely-named copy is written
+    into .claude/commands/ and that name is what Claude invokes. When the skill
+    IS already installed, Claude invokes the real skill instead, the unique probe
+    name never appears, and matching on it reports a false miss for every query.
+    """
+    return skill_name if use_installed else f"{skill_name}-skill-{unique_id}"
+
+
 def run_single_query(
     query: str,
     skill_name: str,
@@ -39,33 +171,34 @@ def run_single_query(
     timeout: int,
     project_root: str,
     model: str | None = None,
+    use_installed: bool = False,
 ) -> bool:
     """Run a single query and return whether the skill was triggered.
 
-    Creates a command file in .claude/commands/ so it appears in Claude's
-    available_skills list, then runs `claude -p` with the raw query.
-    Uses --include-partial-messages to detect triggering early from
-    stream events (content_block_start) rather than waiting for the
-    full assistant message, which only arrives after tool execution.
+    Unless `use_installed` is set, creates a command file in .claude/commands/ so
+    the description under test appears in the available_skills list. Uses
+    --include-partial-messages to detect triggering early from stream events
+    rather than waiting for the full assistant message.
     """
     unique_id = uuid.uuid4().hex[:8]
-    clean_name = f"{skill_name}-skill-{unique_id}"
+    clean_name = resolve_probe_name(skill_name, unique_id, use_installed)
     project_commands_dir = Path(project_root) / ".claude" / "commands"
     command_file = project_commands_dir / f"{clean_name}.md"
 
     try:
-        project_commands_dir.mkdir(parents=True, exist_ok=True)
-        # Use YAML block scalar to avoid breaking on quotes in description
-        indented_desc = "\n  ".join(skill_description.split("\n"))
-        command_content = (
-            f"---\n"
-            f"description: |\n"
-            f"  {indented_desc}\n"
-            f"---\n\n"
-            f"# {skill_name}\n\n"
-            f"This skill handles: {skill_description}\n"
-        )
-        command_file.write_text(command_content)
+        if not use_installed:
+            project_commands_dir.mkdir(parents=True, exist_ok=True)
+            # Use YAML block scalar to avoid breaking on quotes in description
+            indented_desc = "\n  ".join(skill_description.split("\n"))
+            command_content = (
+                f"---\n"
+                f"description: |\n"
+                f"  {indented_desc}\n"
+                f"---\n\n"
+                f"# {skill_name}\n\n"
+                f"This skill handles: {skill_description}\n"
+            )
+            command_file.write_text(command_content, encoding="utf-8")
 
         cmd = [
             "claude",
@@ -90,94 +223,19 @@ def run_single_query(
             env=env,
         )
 
-        triggered = False
         start_time = time.time()
-        buffer = ""
-        # Track state for stream event detection
-        pending_tool_name = None
-        accumulated_json = ""
-
         try:
-            while time.time() - start_time < timeout:
-                if process.poll() is not None:
-                    remaining = process.stdout.read()
-                    if remaining:
-                        buffer += remaining.decode("utf-8", errors="replace")
-                    break
-
-                ready, _, _ = select.select([process.stdout], [], [], 1.0)
-                if not ready:
-                    continue
-
-                chunk = os.read(process.stdout.fileno(), 8192)
-                if not chunk:
-                    break
-                buffer += chunk.decode("utf-8", errors="replace")
-
-                while "\n" in buffer:
-                    line, buffer = buffer.split("\n", 1)
-                    line = line.strip()
-                    if not line:
-                        continue
-
-                    try:
-                        event = json.loads(line)
-                    except json.JSONDecodeError:
-                        continue
-
-                    # Early detection via stream events
-                    if event.get("type") == "stream_event":
-                        se = event.get("event", {})
-                        se_type = se.get("type", "")
-
-                        if se_type == "content_block_start":
-                            cb = se.get("content_block", {})
-                            if cb.get("type") == "tool_use":
-                                tool_name = cb.get("name", "")
-                                if tool_name in ("Skill", "Read"):
-                                    pending_tool_name = tool_name
-                                    accumulated_json = ""
-                                else:
-                                    return False
-
-                        elif se_type == "content_block_delta" and pending_tool_name:
-                            delta = se.get("delta", {})
-                            if delta.get("type") == "input_json_delta":
-                                accumulated_json += delta.get("partial_json", "")
-                                if clean_name in accumulated_json:
-                                    return True
-
-                        elif se_type in ("content_block_stop", "message_stop"):
-                            if pending_tool_name:
-                                return clean_name in accumulated_json
-                            if se_type == "message_stop":
-                                return False
-
-                    # Fallback: full assistant message
-                    elif event.get("type") == "assistant":
-                        message = event.get("message", {})
-                        for content_item in message.get("content", []):
-                            if content_item.get("type") != "tool_use":
-                                continue
-                            tool_name = content_item.get("name", "")
-                            tool_input = content_item.get("input", {})
-                            if tool_name == "Skill" and clean_name in tool_input.get("skill", ""):
-                                triggered = True
-                            elif tool_name == "Read" and clean_name in tool_input.get("file_path", ""):
-                                triggered = True
-                            return triggered
-
-                    elif event.get("type") == "result":
-                        return triggered
+            lines = iter_process_lines(
+                process.stdout, lambda: time.time() - start_time < timeout
+            )
+            return detect_trigger(lines, clean_name)
         finally:
             # Clean up process on any exit path (return, exception, timeout)
             if process.poll() is None:
                 process.kill()
                 process.wait()
-
-        return triggered
     finally:
-        if command_file.exists():
+        if not use_installed and command_file.exists():
             command_file.unlink()
 
 
@@ -191,6 +249,7 @@ def run_eval(
     runs_per_query: int = 1,
     trigger_threshold: float = 0.5,
     model: str | None = None,
+    use_installed: bool = False,
 ) -> dict:
     """Run the full eval set and return results."""
     results = []
@@ -207,6 +266,7 @@ def run_eval(
                     timeout,
                     str(project_root),
                     model,
+                    use_installed,
                 )
                 future_to_info[future] = (item, run_idx)
 
@@ -267,9 +327,23 @@ def main():
     parser.add_argument("--trigger-threshold", type=float, default=0.5, help="Trigger rate threshold")
     parser.add_argument("--model", default=None, help="Model to use for claude -p (default: user's configured model)")
     parser.add_argument("--verbose", action="store_true", help="Print progress to stderr")
+    parser.add_argument(
+        "--use-installed",
+        action="store_true",
+        help="Match the skill by its real name instead of writing a uniquely-named "
+             "probe copy. Use when the skill under test is already installed, since "
+             "Claude invokes the real skill and the probe name never appears.",
+    )
     args = parser.parse_args()
 
-    eval_set = json.loads(Path(args.eval_set).read_text())
+    if args.use_installed and args.description:
+        parser.error(
+            "--description cannot be combined with --use-installed: the override is "
+            "injected through the probe copy, so with --use-installed the installed "
+            "skill supplies the description and the override is silently ignored."
+        )
+
+    eval_set = json.loads(Path(args.eval_set).read_text(encoding="utf-8"))
     skill_path = Path(args.skill_path)
 
     if not (skill_path / "SKILL.md").exists():
@@ -293,6 +367,7 @@ def main():
         runs_per_query=args.runs_per_query,
         trigger_threshold=args.trigger_threshold,
         model=args.model,
+        use_installed=args.use_installed,
     )
 
     if args.verbose:

--- a/skills/skill-creator/scripts/run_loop.py
+++ b/skills/skill-creator/scripts/run_loop.py
@@ -148,7 +148,7 @@ def run_loop(
                 "test_size": len(test_set),
                 "history": history,
             }
-            live_report_path.write_text(generate_html(partial_output, auto_refresh=True, skill_name=name))
+            live_report_path.write_text(generate_html(partial_output, auto_refresh=True, skill_name=name), encoding="utf-8")
 
         if verbose:
             def print_eval_stats(label, results, elapsed):
@@ -258,7 +258,7 @@ def main():
     parser.add_argument("--results-dir", default=None, help="Save all outputs (results.json, report.html, log.txt) to a timestamped subdirectory here")
     args = parser.parse_args()
 
-    eval_set = json.loads(Path(args.eval_set).read_text())
+    eval_set = json.loads(Path(args.eval_set).read_text(encoding="utf-8"))
     skill_path = Path(args.skill_path)
 
     if not (skill_path / "SKILL.md").exists():
@@ -275,7 +275,7 @@ def main():
         else:
             live_report_path = Path(args.report)
         # Open the report immediately so the user can watch
-        live_report_path.write_text("<html><body><h1>Starting optimization loop...</h1><meta http-equiv='refresh' content='5'></body></html>")
+        live_report_path.write_text("<html><body><h1>Starting optimization loop...</h1><meta http-equiv='refresh' content='5'></body></html>", encoding="utf-8")
         webbrowser.open(str(live_report_path))
     else:
         live_report_path = None
@@ -310,15 +310,15 @@ def main():
     json_output = json.dumps(output, indent=2)
     print(json_output)
     if results_dir:
-        (results_dir / "results.json").write_text(json_output)
+        (results_dir / "results.json").write_text(json_output, encoding="utf-8")
 
     # Write final HTML report (without auto-refresh)
     if live_report_path:
-        live_report_path.write_text(generate_html(output, auto_refresh=False, skill_name=name))
+        live_report_path.write_text(generate_html(output, auto_refresh=False, skill_name=name), encoding="utf-8")
         print(f"\nReport: {live_report_path}", file=sys.stderr)
 
     if results_dir and live_report_path:
-        (results_dir / "report.html").write_text(generate_html(output, auto_refresh=False, skill_name=name))
+        (results_dir / "report.html").write_text(generate_html(output, auto_refresh=False, skill_name=name), encoding="utf-8")
 
     if results_dir:
         print(f"Results saved to: {results_dir}", file=sys.stderr)

--- a/skills/skill-creator/scripts/utils.py
+++ b/skills/skill-creator/scripts/utils.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 def parse_skill_md(skill_path: Path) -> tuple[str, str, str]:
     """Parse a SKILL.md file, returning (name, description, full_content)."""
-    content = (skill_path / "SKILL.md").read_text()
+    content = (skill_path / "SKILL.md").read_text(encoding="utf-8")
     lines = content.split("\n")
 
     if lines[0].strip() != "---":

--- a/skills/skill-creator/tests/test_run_eval.py
+++ b/skills/skill-creator/tests/test_run_eval.py
@@ -1,0 +1,198 @@
+"""Regression tests for the skill-creator eval scripts.
+
+Standard library only, so they run with `python -m unittest` from the
+skill-creator directory without installing anything:
+
+    cd skills/skill-creator && python -m unittest discover -s tests -v
+
+Each test corresponds to a defect that made the eval harness report results
+that looked valid but were not.
+"""
+
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SKILL_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SKILL_ROOT))
+
+from scripts.run_eval import (  # noqa: E402
+    TriggerDetector,
+    detect_trigger,
+    iter_process_lines,
+    resolve_probe_name,
+)
+from scripts.utils import parse_skill_md  # noqa: E402
+
+
+# A real `claude -p --output-format stream-json --include-partial-messages`
+# fragment, recorded while evaluating a skill that was already installed.
+# Note the Skill tool is invoked with the skill's REAL name.
+RECORDED_SKILL_CALL = [
+    json.dumps(e)
+    for e in [
+        {"type": "stream_event", "event": {"type": "content_block_start", "index": 1,
+         "content_block": {"type": "tool_use", "id": "toolu_016RHCrFZW9n35pAYVv33Nrt",
+                           "name": "Skill", "input": {}}}},
+        {"type": "stream_event", "event": {"type": "content_block_delta", "index": 1,
+         "delta": {"type": "input_json_delta", "partial_json": ""}}},
+        {"type": "stream_event", "event": {"type": "content_block_delta", "index": 1,
+         "delta": {"type": "input_json_delta", "partial_json": '{"skill": "git-rescue'}}},
+        {"type": "stream_event", "event": {"type": "content_block_delta", "index": 1,
+         "delta": {"type": "input_json_delta", "partial_json": '", "args": "three'}}},
+        {"type": "stream_event", "event": {"type": "content_block_delta", "index": 1,
+         "delta": {"type": "input_json_delta",
+                   "partial_json": " commits landed on main, need to move them onto a branch"}}},
+        {"type": "stream_event", "event": {"type": "content_block_delta", "index": 1,
+         "delta": {"type": "input_json_delta", "partial_json": '"}'}}},
+        {"type": "stream_event", "event": {"type": "content_block_stop", "index": 1}},
+    ]
+]
+
+
+class TestInstalledSkillDetection(unittest.TestCase):
+    """The probe name never appears when the skill under test is installed."""
+
+    def test_probe_name_is_unique_when_skill_is_not_installed(self):
+        self.assertEqual(
+            resolve_probe_name("git-rescue", "abc12345", use_installed=False),
+            "git-rescue-skill-abc12345",
+        )
+
+    def test_probe_name_is_the_real_name_when_skill_is_installed(self):
+        self.assertEqual(
+            resolve_probe_name("git-rescue", "abc12345", use_installed=True),
+            "git-rescue",
+        )
+
+    def test_recorded_call_is_detected_under_the_real_skill_name(self):
+        self.assertTrue(detect_trigger(RECORDED_SKILL_CALL, "git-rescue"))
+
+    def test_recorded_call_is_missed_under_a_unique_probe_name(self):
+        # This is the defect: an installed skill is invoked by its real name, so
+        # matching on the generated probe name scores a genuine trigger as a miss
+        # and the whole eval reports a 0.0 trigger rate.
+        self.assertFalse(detect_trigger(RECORDED_SKILL_CALL, "git-rescue-skill-abc12345"))
+
+    def test_unrelated_skill_name_does_not_match(self):
+        self.assertFalse(detect_trigger(RECORDED_SKILL_CALL, "ship-pr"))
+
+    def test_non_skill_tool_ends_detection(self):
+        lines = [json.dumps(
+            {"type": "stream_event", "event": {"type": "content_block_start", "index": 0,
+             "content_block": {"type": "tool_use", "id": "t1", "name": "Bash", "input": {}}}}
+        )]
+        self.assertFalse(detect_trigger(lines, "git-rescue"))
+
+    def test_malformed_lines_are_skipped(self):
+        detector = TriggerDetector("git-rescue")
+        self.assertIsNone(detector.feed("not json at all"))
+        self.assertIsNone(detector.feed(""))
+
+    def test_full_assistant_message_fallback(self):
+        lines = [json.dumps({
+            "type": "assistant",
+            "message": {"content": [
+                {"type": "tool_use", "name": "Skill", "input": {"skill": "git-rescue"}}
+            ]},
+        })]
+        self.assertTrue(detect_trigger(lines, "git-rescue"))
+
+
+class TestProcessLineStreaming(unittest.TestCase):
+    """`select` cannot poll a pipe on Windows; it raises OSError there."""
+
+    def test_lines_are_read_from_a_real_subprocess_pipe(self):
+        script = (
+            "import sys\n"
+            "for i in range(3):\n"
+            "    sys.stdout.write('{\"n\": %d}\\n' % i)\n"
+            "    sys.stdout.flush()\n"
+        )
+        process = subprocess.Popen(
+            [sys.executable, "-c", script], stdout=subprocess.PIPE
+        )
+        try:
+            lines = [
+                line
+                for line in iter_process_lines(process.stdout, lambda: True)
+                if line.strip()
+            ]
+        finally:
+            if process.poll() is None:
+                process.kill()
+            process.wait()
+            process.stdout.close()
+
+        self.assertEqual([json.loads(line)["n"] for line in lines], [0, 1, 2])
+
+    def test_deadline_check_stops_iteration(self):
+        process = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(30)"],
+            stdout=subprocess.PIPE,
+        )
+        try:
+            lines = list(
+                iter_process_lines(process.stdout, lambda: False, poll_interval=0.01)
+            )
+        finally:
+            if process.poll() is None:
+                process.kill()
+            process.wait()
+            process.stdout.close()
+        self.assertEqual(lines, [])
+
+
+class TestNonAsciiSkillFiles(unittest.TestCase):
+    """Reading without an explicit encoding fails wherever the locale is not UTF-8."""
+
+    NON_ASCII_BODY = (
+        "---\n"
+        "name: sample-skill\n"
+        "description: Uses an em dash — plus curly quotes “like this” "
+        "and an arrow → in the description.\n"
+        "---\n\n"
+        "# Sample\n\nBody text — more punctuation ‘here’.\n"
+    )
+
+    def test_parse_skill_md_reads_non_ascii_content(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = Path(tmp) / "sample-skill"
+            skill_dir.mkdir()
+            (skill_dir / "SKILL.md").write_text(self.NON_ASCII_BODY, encoding="utf-8")
+
+            name, description, content = parse_skill_md(skill_dir)
+
+        self.assertEqual(name, "sample-skill")
+        self.assertIn("—", description)
+        self.assertIn("‘here’", content)
+
+    def test_scripts_never_open_files_without_an_encoding(self):
+        offenders = []
+        pattern = re.compile(r"\.read_text\(\)|\.write_text\(|with open\(")
+        for directory in ("scripts", "eval-viewer"):
+            for path in sorted((SKILL_ROOT / directory).glob("*.py")):
+                for lineno, line in enumerate(
+                    path.read_text(encoding="utf-8").splitlines(), 1
+                ):
+                    if "encoding=" in line or '"rb"' in line or '"wb"' in line:
+                        continue
+                    if pattern.search(line):
+                        offenders.append(
+                            "%s:%d: %s" % (path.name, lineno, line.strip())
+                        )
+
+        self.assertEqual(
+            offenders,
+            [],
+            "file IO without an explicit encoding will fail on non-UTF-8 locales:\n"
+            + "\n".join(offenders),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Three defects in `skill-creator`'s eval harness that share a failure mode: the run completes, prints well-formed JSON, and reports numbers that are wrong. Nothing errors out, so the output reads as a verdict on the skill rather than a broken measurement.

I hit these trying to measure trigger accuracy for seven skills I already had installed. The first run reported a 0.0 trigger rate across the board, which looked like a real result.

---

## 1. `--use-installed`: the eval cannot measure a skill that is installed

`run_single_query` writes a uniquely-named copy of the skill into `.claude/commands/` and checks whether Claude invoked *that* name:

```python
clean_name = f"{skill_name}-skill-{unique_id}"
...
if tool_name == "Skill" and clean_name in tool_input.get("skill", ""):
```

That holds only while the skill under test is **not** on the load path. When it is already installed, Claude invokes the real skill. Captured from `claude -p --output-format stream-json --include-partial-messages`, evaluating a `git-rescue` skill installed at user scope:

```json
{"type":"content_block_start","content_block":{"type":"tool_use","name":"Skill","input":{}}}
{"type":"content_block_delta","delta":{"type":"input_json_delta","partial_json":"{\"skill\": \"git-rescue"}}
{"type":"content_block_delta","delta":{"type":"input_json_delta","partial_json":"\", \"args\": \"three"}}
{"type":"content_block_delta","delta":{"type":"input_json_delta","partial_json":" commits landed on main in CoLateral repo, need to move them onto a branch"}}
{"type":"content_block_stop"}
```

The skill triggered, correctly and on the first turn. But the accumulated input is `{"skill": "git-rescue", ...}` and `clean_name` is `git-rescue-skill-4f2a91c8`, so the substring check fails and the query is scored as a miss. Every query fails identically, and the eval reports `"trigger_rate": 0.0` for a skill that fires exactly as intended.

This is the state any user is in when auditing skills they already use — which is what the description-optimization workflow in `SKILL.md` is for.

`--use-installed` matches the skill by its real name and skips writing the probe copy. On the same query and skill, the trigger rate goes from `0.00` to `1.00`.

It is rejected in combination with `--description`: a candidate description reaches Claude *through* the probe copy, so with `--use-installed` the installed skill supplies the description and the override would be silently ignored. `run_loop.py` is unchanged and still uses the probe, since testing candidate descriptions depends on it. `SKILL.md` documents both the flag and that constraint.

## 2. `select()` on a pipe is not portable

`run_single_query` polls the subprocess pipe with `select.select([process.stdout], [], [], 1.0)`. On Windows `select` accepts sockets only, so the first query raises:

```
OSError: [WinError 10093] Either the application has not called WSAStartup, or WSAStartup failed
```

`run_eval` catches this per future, warns on stderr, and appends `False`:

```python
except Exception as e:
    print(f"Warning: query failed: {e}", file=sys.stderr)
    query_triggers[query].append(False)
```

So the harness produces a complete, well-formed result in which every trigger rate is 0.0 — indistinguishable from a description that never fires. Replaced with a reader thread feeding a queue, preserving the existing timeout behaviour.

## 3. File IO relies on the platform default encoding

29 `read_text()` / `write_text()` / `open()` calls across `scripts/` and `eval-viewer/` do not name an encoding. On Windows that resolves to cp1252, so any skill containing a character outside it fails to read:

```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 4633:
character maps to <undefined>
```

Several skills in this repository use em dashes and curly quotes in `SKILL.md`, so on Windows `quick_validate.py` cannot read them — including skills shipped in the same `example-skills` bundle as `skill-creator` itself.

---

## Structure

Three commits, one per defect. The `--use-installed` commit also carries the tests, since the refactor it needs is what makes detection testable.

To keep the fix honest rather than incidental, `run_single_query` now delegates to three extracted pieces — `TriggerDetector` / `detect_trigger()` for the stream state machine, `iter_process_lines()` for the pipe, and `resolve_probe_name()` for the name choice. The state machine logic is unchanged; it is only lifted out so it can be run against a recorded transcript instead of a live subprocess.

## Tests

New `skills/skill-creator/tests/`, standard library only, no new dependencies:

```bash
cd skills/skill-creator && python -m unittest discover -s tests
```

12 tests, covering each defect:

- the recorded transcript above, asserted to match under the real skill name and to be **missed** under a probe name — the regression for defect 1
- a real subprocess pipe read to completion through `iter_process_lines`, plus deadline behaviour — defect 2
- a `SKILL.md` containing em dashes, curly quotes and an arrow, parsed end to end; plus a scan asserting no file IO relies on the default encoding — defect 3

The encoding scan fails against the current tree with 29 offending lines.

`tests/` is excluded from packaged `.skill` bundles alongside `evals/`, so this does not add weight to what ships.

## Verification

- 12/12 tests pass on Windows 11, Python 3.12.10
- `python -m compileall` clean across `scripts/` and `eval-viewer/`
- `quick_validate.py skills/skill-creator` passes
- End to end: a 2-query eval against an installed skill returns `1.00` for the should-trigger case and `0.00` for the should-not-trigger case. Before these changes the same eval returned `0.00` for both.

I have not been able to test on macOS or Linux. Defects 2 and 3 are Windows-only by nature; defect 1 and the test suite are platform-independent.
