### PR TITLE
docs: fix README reference to nonexistent template-skill folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ You can use Anthropic's pre-built skills, and upload custom skills, via the Clau
 
 # Creating a Basic Skill
 
-Skills are simple to create - just a folder with a `SKILL.md` file containing YAML frontmatter and instructions. You can use the **template-skill** in this repository as a starting point:
+Skills are simple to create - just a folder with a `SKILL.md` file containing YAML frontmatter and instructions. You can use the [template](./template) in this repository as a starting point:
 
 ```markdown
 ---


### PR DESCRIPTION
## Summary
- The README's "Creating a Basic Skill" section told readers to use a **template-skill** folder as a starting point, but the repository's actual folder is named `template` (see [`./template`](./template)). This PR fixes the reference and links it, matching the naming already used in the "Skill Sets" section above.

## Test plan
- [x] Verified `template/` exists and `template-skill/` does not
- [x] Confirmed the link renders correctly relative to the README

🤖 Generated with [Claude Code](https://claude.com/claude-code)