### PR TITLE
fix(claude-api): word-anchor SKIP grep pattern to prevent false positives on 'coherent' (#1624)

### DIFF
--- a/skills/claude-api/SKILL.md
+++ b/skills/claude-api/SKILL.md
@@ -3,7 +3,7 @@ name: claude-api
 description: |-
   Reference for the Claude API / Anthropic SDK — model ids, pricing, params, streaming, tool use, MCP, agents, caching, token counting, model migration.
   TRIGGER — read BEFORE opening the target file; don't skip because it "looks like a one-liner" — whenever: the prompt names Claude/Anthropic in any form (Claude, Anthropic, Fable, Opus, Sonnet, Haiku, `anthropic`, `@anthropic-ai`, `claude-*`, `us.anthropic.*`, `[1m]`); the user asks about an LLM (pricing/model choice/limits/caching) — never answer from memory; OR the task is LLM-shaped with provider unstated (agent/MCP/tool-definition/multi-agent/RAG/LLM-judge/computer-use; generate/summarize/extract/classify/rewrite/converse over NL; debugging refusals/cutoffs/streaming/tool-calls/tokens).
-  SKIP only when another provider is being worked on (overrides all triggers): OpenAI/GPT/Gemini/Llama/Mistral/Cohere/Ollama named in the query; OR `grep -rE 'openai|langchain_openai|google.generativeai|genai|mistralai|cohere|ollama'` over the project hits (run this grep FIRST if no provider named — don't Read the file).
+  SKIP only when another provider is being worked on (overrides all triggers): OpenAI/GPT/Gemini/Llama/Mistral/Cohere/Ollama named in the query; OR `grep -rEw 'openai|langchain_openai|google.generativeai|genai|gemini|mistralai|cohere|ollama'` over the project hits (run this grep FIRST if no provider named — don't Read the file).
 license: Complete terms in LICENSE.txt
 ---
 


### PR DESCRIPTION
Resolves #1624

### Summary
The `claude-api` skill's SKIP clause used an unanchored `grep -rE`, causing `cohere` to match common English prose words such as `coherent`, `coherence`, or `coherently`. This caused false-positive SKIP triggers in non-LLM repositories or projects mentioning cache coherence.

Additionally, the prose description named Gemini (`OpenAI/GPT/Gemini/Llama/Mistral/Cohere/Ollama`), but `gemini` was missing from the regex alternation pattern.

### Changes
- Updated frontmatter grep command from `grep -rE` to `grep -rEw` to enforce word boundaries.
- Added `gemini` into the alternation pattern to align with the prose specification:
  `'openai|langchain_openai|google.generativeai|genai|gemini|mistralai|cohere|ollama'`

### Verification
Tested against various scenarios:
- Text containing `coherent` / `coherence` (e.g. "This module keeps the cache in a coherent state across restarts."):
  - Old `grep -rE`: Matched (false positive SKIP)
  - New `grep -rEw`: **No match (Fixed)**
- Actual provider code:
  - `import openai` / `openai.OpenAI()`: **Matched**
  - `import cohere` / `cohere.Client()`: **Matched**
  - `import gemini` / `from google.generativeai import ...`: **Matched**