### PR TITLE
fix(claude-api): word-anchor skip grep and add missing gemini token

### DIFF
--- a/skills/claude-api/SKILL.md
+++ b/skills/claude-api/SKILL.md
@@ -3,7 +3,7 @@ name: claude-api
 description: |-
   Reference for the Claude API / Anthropic SDK — model ids, pricing, params, streaming, tool use, MCP, agents, caching, token counting, model migration.
   TRIGGER — read BEFORE opening the target file; don't skip because it "looks like a one-liner" — whenever: the prompt names Claude/Anthropic in any form (Claude, Anthropic, Fable, Opus, Sonnet, Haiku, `anthropic`, `@anthropic-ai`, `claude-*`, `us.anthropic.*`, `[1m]`); the user asks about an LLM (pricing/model choice/limits/caching) — never answer from memory; OR the task is LLM-shaped with provider unstated (agent/MCP/tool-definition/multi-agent/RAG/LLM-judge/computer-use; generate/summarize/extract/classify/rewrite/converse over NL; debugging refusals/cutoffs/streaming/tool-calls/tokens).
-  SKIP only when another provider is being worked on (overrides all triggers): OpenAI/GPT/Gemini/Llama/Mistral/Cohere/Ollama named in the query; OR `grep -rE 'openai|langchain_openai|google.generativeai|genai|mistralai|cohere|ollama'` over the project hits (run this grep FIRST if no provider named — don't Read the file).
+  SKIP only when another provider is being worked on (overrides all triggers): OpenAI/GPT/Gemini/Llama/Mistral/Cohere/Ollama named in the query; OR `grep -rEw 'openai|langchain_openai|google.generativeai|genai|mistralai|cohere|gemini|ollama'` over the project hits (run this grep FIRST if no provider named — don't Read the file).
 license: Complete terms in LICENSE.txt
 ---
 


### PR DESCRIPTION
Fixes #1624

## Summary

Two defects in the `claude-api` skill's SKIP-clause grep, both reported in #1624:

### 1. False positive: unanchored `cohere` matches the English word "coherent"

`grep -rE 'cohere'` fires on any prose containing *coherent/coherence/coherently*. Because SKIP overrides all triggers, the skill silently disables itself in repos that merely contain ordinary English. Fix: `-rEw` (word-anchored), portable across GNU and BSD grep.

### 2. False negative: Gemini named in prose but absent from the pattern

The SKIP clause names Gemini as a provider but the grep had no `gemini` token — repos genuinely integrating Gemini via SDK were not detected by the SKIP check. Fix: added `gemini` to the alternation.

## Verification

```bash
# coherent no longer matches:
echo 'This module keeps the cache in a coherent state.' > a.md
grep -rlEw '...|cohere|...' .   # → (no match)  ✓

# genuine imports still match:
echo 'import openai' > b.py
echo 'from google import genai' > c.py
echo 'use gemini api' > d.txt
grep -rlEw 'openai|...|gemini|ollama' .   # → b.py c.py d.txt  ✓
```

## Note

This is a minimal fix scoped exactly to what #1624 identifies. The issue's broader design observation (frontmatter repo-wide grep vs the body's per-file scan in `## Before You Start`) is separable and left untouched.