### PR TITLE
fix(pdf): refuse to overwrite input file in fill_fillable_fields

### DIFF
--- a/skills/pdf/scripts/fill_fillable_fields.py
+++ b/skills/pdf/scripts/fill_fillable_fields.py
@@ -1,4 +1,5 @@
 import json
+import os
 import sys
 
 from pypdf import PdfReader, PdfWriter
@@ -47,7 +48,13 @@ def fill_pdf_fields(input_pdf_path: str, fields_json_path: str, output_pdf_path:
         writer.update_page_form_field_values(writer.pages[page - 1], field_values, auto_regenerate=False)
 
     writer.set_need_appearances_writer(True)
-    
+
+    abs_in = os.path.abspath(input_pdf_path)
+    abs_out = os.path.abspath(output_pdf_path)
+    if abs_in == abs_out:
+        print(f"ERROR: output path matches input path ({output_pdf_path}); refusing to overwrite source file")
+        sys.exit(1)
+
     with open(output_pdf_path, "wb") as f:
         writer.write(f)
 


### PR DESCRIPTION
Fixes #1617.

## Problem

`fill_fillable_fields.py` wrote the output PDF unconditionally with no check for path collisions. Passing the same path for both input and output silently truncated and overwrote the source file — no error, no warning, no recovery.

## Fix

Added an `os.path.abspath` equality check before the write. If `output_pdf_path` resolves to the same filesystem path as `input_pdf_path`, the script exits with a clear error message before touching the file.

```python
abs_in = os.path.abspath(input_pdf_path)
abs_out = os.path.abspath(output_pdf_path)
if abs_in == abs_out:
    print(f"ERROR: output path matches input path ({output_pdf_path}); refusing to overwrite source file")
    sys.exit(1)
```

## Scope

One file changed (`skills/pdf/scripts/fill_fillable_fields.py`). Does not add a `--force` flag or block unrelated existing-file overwrites — those remain the caller's responsibility and are consistent with how the rest of the pdf skill's scripts behave.