### PR TITLE
fix(mcp-builder): guard resource handler example against path traversal

### DIFF
--- a/skills/mcp-builder/reference/python_mcp_server.md
+++ b/skills/mcp-builder/reference/python_mcp_server.md
@@ -529,6 +529,10 @@ async def interactive_tool(resource_id: str, ctx: Context) -> str:
 Expose data as resources for efficient, template-based access:
 
 ```python
+import os
+
+DOCS_ROOT = os.path.realpath("./docs")
+
 @mcp.resource("file://documents/{name}")
 async def get_document(name: str) -> str:
     '''Expose documents as MCP resources.
@@ -536,7 +540,12 @@ async def get_document(name: str) -> str:
     Resources are useful for static or semi-static data that doesn't
     require complex parameters. They use URI templates for flexible access.
     '''
-    document_path = f"./docs/{name}"
+    # Resolve against DOCS_ROOT and verify the result stays inside it.
+    # Without this check a caller-supplied name like "../../etc/passwd"
+    # would escape the intended directory.
+    document_path = os.path.realpath(os.path.join(DOCS_ROOT, os.path.basename(name)))
+    if not document_path.startswith(DOCS_ROOT + os.sep):
+        raise ValueError(f"invalid document name: {name!r}")
     with open(document_path, "r") as f:
         return f.read()
 


### PR DESCRIPTION
Fixes #1618.

## Problem

The `get_document` example in `python_mcp_server.md` passed the MCP client-supplied `name` parameter directly into a file path:

```python
document_path = f"./docs/{name}"
```

A client requesting `file://documents/../../etc/passwd` would escape the `./docs/` directory entirely. Because this guide is intended to be copied into real MCP server implementations, the unsanitized pattern propagates into production code.

## Fix

Replace the bare f-string interpolation with a `realpath`-based bounds check:

```python
DOCS_ROOT = os.path.realpath("./docs")
document_path = os.path.realpath(os.path.join(DOCS_ROOT, os.path.basename(name)))
if not document_path.startswith(DOCS_ROOT + os.sep):
    raise ValueError(f"invalid document name: {name!r}")
```

`os.path.basename` strips any directory component from the input; `realpath` resolves symlinks; the `startswith` guard is the belt-and-suspenders check. The combined approach follows the pattern suggested in the issue and CWE-22 guidance.

## Scope

One file changed (`skills/mcp-builder/reference/python_mcp_server.md`). No runtime code touched.