### PR TITLE
fix(skill-creator): remove trailing whitespace

### DIFF
--- a/skills/skill-creator/scripts/improve_description.py
+++ b/skills/skill-creator/scripts/improve_description.py
@@ -137,7 +137,7 @@ Here are some tips that we've found to work well in writing these descriptions:
 - The description competes with other skills for Claude's attention — make it distinctive and immediately recognizable.
 - If you're getting lots of failures after repeated attempts, change things up. Try different sentence structures or wordings.
 
-I'd encourage you to be creative and mix up the style in different iterations since you'll have multiple opportunities to try different approaches and we'll just grab the highest-scoring one at the end. 
+I'd encourage you to be creative and mix up the style in different iterations since you'll have multiple opportunities to try different approaches and we'll just grab the highest-scoring one at the end.
 
 Please respond with only the new description text in <new_description> tags, nothing else."""
 

--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -97,7 +97,7 @@ if __name__ == "__main__":
     if len(sys.argv) != 2:
         print("Usage: python quick_validate.py <skill_directory>")
         sys.exit(1)
-    
+
     valid, message = validate_skill(sys.argv[1])
     print(message)
     sys.exit(0 if valid else 1)


### PR DESCRIPTION
## Summary

- remove a trailing space from the `improve_description.py` prompt
- remove indentation from an otherwise blank line in `quick_validate.py`

## Verification

- `git diff --check`
- Python AST parsing for both changed scripts
- no-model stub invocation of `improve_description()` with a prompt-boundary assertion
- fresh-add whitespace check for the complete `skills/skill-creator` tree

This changes whitespace only. File modes, EOF state, control flow, APIs, and the skill inventory are unchanged.
