### PR TITLE
fix(skill-creator): prevent path traversal in run_eval

### DIFF
--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -8,6 +8,7 @@ for a set of queries. Outputs results as JSON.
 import argparse
 import json
 import os
+import re
 import select
 import subprocess
 import sys
@@ -49,9 +50,24 @@ def run_single_query(
     full assistant message, which only arrives after tool execution.
     """
     unique_id = uuid.uuid4().hex[:8]
-    clean_name = f"{skill_name}-skill-{unique_id}"
+    # Sanitize skill_name before using it in a file path: skill_name comes
+    # from SKILL.md frontmatter, which may be attacker-controlled, so it
+    # must not be allowed to contain path separators or ".." sequences.
+    # Mirror the strict pattern already enforced in quick_validate.py.
+    safe_skill_name = re.sub(r"[^a-z0-9-]", "", skill_name.lower())
+    if not safe_skill_name:
+        safe_skill_name = "skill"
+    clean_name = f"{safe_skill_name}-skill-{unique_id}"
     project_commands_dir = Path(project_root) / ".claude" / "commands"
-    command_file = project_commands_dir / f"{clean_name}.md"
+    command_file = (project_commands_dir / f"{clean_name}.md").resolve()
+
+    # Defense in depth: verify the resolved path actually stays within the
+    # intended commands directory before writing anything.
+    resolved_commands_dir = project_commands_dir.resolve()
+    if resolved_commands_dir not in command_file.parents:
+        raise ValueError(
+            f"Refusing to write command file outside {resolved_commands_dir}: {command_file}"
+        )
 
     try:
         project_commands_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## What changed?

* Fixed the path traversal vulnerability in `skills/skill-creator/scripts/run_eval.py`.
* Sanitized `skill_name` before using it to construct the generated command file path.
* Added a safe fallback when sanitization produces an empty skill name.
* Added a defense-in-depth check using `Path.resolve()` to ensure the final path remains inside the intended `~/.claude/commands/` directory.

## Why?

`skill_name` is read from the `SKILL.md` frontmatter and was used to construct the command file path without sufficient validation.

This could allow a malicious skill name containing path traversal sequences to cause the generated command file to be written outside the intended `~/.claude/commands/` directory.

The issue identified this as a potential arbitrary file-write vulnerability, with possible security impact if combined with other vulnerabilities.

## How?

The fix now:

1. Sanitizes `skill_name` using the existing strict naming pattern:

```python
re.sub(r"[^a-z0-9-]", "", skill_name.lower())
```

2. Falls back to `"skill"` if sanitization removes the entire name.

3. Resolves the final command-file path and verifies that it remains within the intended commands directory before writing.

This provides both input sanitization and a filesystem boundary check.

## Testing

Tested with malicious and invalid inputs, including:

```text
../../../../etc/cron.d/evil
a/b/c
```

These inputs are now sanitized and/or rejected by the path boundary check, ensuring generated files remain inside the intended commands directory.

## Security

This prevents `run_eval.py` from writing generated command files outside `~/.claude/commands/` through a malicious `skill_name`.

Fixes #1631
