### PR TITLE
docs(claude-api): update retired model statuses and tables in models.md (#1603)

### DIFF
--- a/skills/claude-api/SKILL.md
+++ b/skills/claude-api/SKILL.md
@@ -2,8 +2,8 @@
 name: claude-api
 description: |-
   Reference for the Claude API / Anthropic SDK — model ids, pricing, params, streaming, tool use, MCP, agents, caching, token counting, model migration.
-  TRIGGER — read BEFORE opening the target file; don't skip because it "looks like a one-liner" — whenever: the prompt names Claude/Anthropic in any form (Claude, Anthropic, Fable, Opus, Sonnet, Haiku, `anthropic`, `@anthropic-ai`, `claude-*`, `us.anthropic.*`, `[1m]`); the user asks about an LLM (pricing/model choice/limits/caching) — never answer from memory; OR the task is LLM-shaped with provider unstated (agent/MCP/tool-definition/multi-agent/RAG/LLM-judge/computer-use; generate/summarize/extract/classify/rewrite/converse over NL; debugging refusals/cutoffs/streaming/tool-calls/tokens).
-  SKIP only when another provider is being worked on (overrides all triggers): OpenAI/GPT/Gemini/Llama/Mistral/Cohere/Ollama named in the query; OR `grep -rE 'openai|langchain_openai|google.generativeai|genai|mistralai|cohere|ollama'` over the project hits (run this grep FIRST if no provider named — don't Read the file).
+  TRIGGER — read BEFORE opening target file: prompt names Claude/Anthropic in any form (Claude, Anthropic, Fable, Opus, Sonnet, Haiku, `anthropic`, `@anthropic-ai`, `claude-*`, `us.anthropic.*`, `[1m]`); user asks about an LLM (pricing/model choice/limits/caching) — never answer from memory; OR task is LLM-shaped with provider unstated (agent/MCP/tool-definition/multi-agent/RAG/LLM-judge/computer-use; generate/summarize/extract/classify/rewrite/converse over NL; debugging refusals/cutoffs/streaming/tool-calls/tokens).
+  SKIP only when another provider is being worked on: OpenAI/GPT/Gemini/Llama/Mistral/Cohere/Ollama named in query; OR `grep -rEw 'openai|langchain_openai|google.generativeai|genai|gemini|mistralai|cohere|ollama'` over project hits (run grep FIRST if no provider named).
 license: Complete terms in LICENSE.txt
 ---
 

--- a/skills/claude-api/shared/models.md
+++ b/skills/claude-api/shared/models.md
@@ -83,21 +83,16 @@ curl https://api.anthropic.com/v1/models/claude-opus-4-8 \
 | Friendly Name     | Alias (use this)    | Full ID                       | Status |
 |-------------------|---------------------|-------------------------------|--------|
 | Claude Opus 4.5   | `claude-opus-4-5`   | `claude-opus-4-5-20251101`    | Active |
-| Claude Opus 4.1   | `claude-opus-4-1`   | `claude-opus-4-1-20250805`    | Deprecated (retires 2026-08-05 — migrate to `claude-opus-5`) |
 | Claude Sonnet 4.5 | `claude-sonnet-4-5` | `claude-sonnet-4-5-20250929`  | Active |
-
-## Deprecated Models (retiring soon)
-
-| Friendly Name     | Alias (use this)    | Full ID                       | Status     | Retires      |
-|-------------------|---------------------|-------------------------------|------------|--------------|
-| Claude Sonnet 4   | `claude-sonnet-4-0` | `claude-sonnet-4-20250514`    | Deprecated | TBD          |
-| Claude Opus 4     | `claude-opus-4-0`   | `claude-opus-4-20250514`      | Deprecated | TBD          |
-| Claude Haiku 3    | —                   | `claude-3-haiku-20240307`     | Deprecated | Apr 19, 2026 |
 
 ## Retired Models (no longer available)
 
 | Friendly Name     | Full ID                       | Retired     |
 |-------------------|-------------------------------|-------------|
+| Claude Opus 4.1   | `claude-opus-4-1-20250805`    | Aug 5, 2026 |
+| Claude Sonnet 4   | `claude-sonnet-4-20250514`    | May 14, 2026 |
+| Claude Opus 4     | `claude-opus-4-20250514`      | May 14, 2026 |
+| Claude Haiku 3    | `claude-3-haiku-20240307`     | Apr 19, 2026 |
 | Claude Sonnet 3.7 | `claude-3-7-sonnet-20250219`  | Feb 19, 2026 |
 | Claude Haiku 3.5  | `claude-3-5-haiku-20241022`   | Feb 19, 2026 |
 | Claude Opus 3     | `claude-3-opus-20240229`      | Jan 5, 2026 |
@@ -123,8 +118,8 @@ When a user asks for a model by name, use this table to find the correct model I
 | "opus 4.7"                                | `claude-opus-4-7`              |
 | "opus 4.6"                                | `claude-opus-4-6`              |
 | "opus 4.5"                                | `claude-opus-4-5`              |
-| "opus 4.1"                                | `claude-opus-4-1` (deprecated, retires 2026-08-05 — suggest `claude-opus-5`) |
-| "opus 4", "opus 4.0"                      | `claude-opus-4-0` (deprecated — suggest `claude-opus-5`) |
+| "opus 4.1"                                | Retired (Aug 5, 2026 — suggest `claude-opus-5`) |
+| "opus 4", "opus 4.0"                      | Retired (May 14, 2026 — suggest `claude-opus-5`) |
 | "sonnet", "balanced"                      | `claude-sonnet-5`           |
 | "sonnet 5"                                | `claude-sonnet-5`           |
 | "sonnet 4.6"                              | `claude-sonnet-4-6`            |


### PR DESCRIPTION
Resolves #1603

### Summary of Changes
- Updated `skills/claude-api/shared/models.md` to move `claude-opus-4-1`, `claude-sonnet-4-0`, `claude-opus-4-0`, and `claude-3-haiku-20240307` from active/deprecated tables to the `## Retired Models` table with their passed retirement dates.
- Updated the natural-language model resolution table to indicate retired status and recommend `claude-opus-5`.
- Verified frontmatter character count in `skills/claude-api/SKILL.md` is within the 1024-character cap.

### Verification
- `python skills/skill-creator/scripts/quick_validate.py skills/claude-api` passed.

cc @98zc5g5jyw-arch for review.