### PR TITLE
fix(skill-creator): sanitize skill_name in run_eval to prevent path traversal

### DIFF
--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -8,6 +8,7 @@ for a set of queries. Outputs results as JSON.
 import argparse
 import json
 import os
+import re
 import select
 import subprocess
 import sys
@@ -49,7 +50,8 @@ def run_single_query(
     full assistant message, which only arrives after tool execution.
     """
     unique_id = uuid.uuid4().hex[:8]
-    clean_name = f"{skill_name}-skill-{unique_id}"
+    sanitized_skill_name = re.sub(r"[^a-zA-Z0-9_-]", "-", skill_name)
+    clean_name = f"{sanitized_skill_name}-skill-{unique_id}"
     project_commands_dir = Path(project_root) / ".claude" / "commands"
     command_file = project_commands_dir / f"{clean_name}.md"
 


### PR DESCRIPTION
Sanitizes `skill_name` against path traversal patterns (such as `..` or path separators) using `re.sub` before constructing temporary command files in `.claude/commands/`.

Fixes #1631

cc @98zc5g5jyw-arch for review