### PR TITLE
fix(xlsx): make external_links_at_risk regex case-insensitive

### DIFF
--- a/skills/xlsx/scripts/recalc.py
+++ b/skills/xlsx/scripts/recalc.py
@@ -99,7 +99,10 @@ def external_links_at_risk(filename):
             if isinstance(getattr(dn, "value", None), str) and EXTERNAL_REF_RE.search(dn.value)
         ]
         name_re = (
-            re.compile(r"\b(" + "|".join(re.escape(n) for n in external_names) + r")\b")
+            re.compile(
+                r"\b(" + "|".join(re.escape(n) for n in external_names) + r")\b",
+                re.IGNORECASE,
+            )
             if external_names
             else None
         )


### PR DESCRIPTION
Fixes #1464

### Summary
In `skills/xlsx/scripts/recalc.py`, `external_links_at_risk()` builds a regex of external-linked defined names to check if recalculation could destroy cached external-link values. Excel defined names are case-insensitive, so referencing a name using different casing was missed.

This PR adds `re.IGNORECASE` when compiling `name_re`.

cc @98zc5g5jyw-arch for review