### PR TITLE
docs(xlsx): add presentation gotchas for merged banners and headers/footers

### DIFF
--- a/skills/xlsx/SKILL.md
+++ b/skills/xlsx/SKILL.md
@@ -74,6 +74,8 @@ literal `#NAME?` baked into the file you deliver.
 - **`data_only=True` is destructive if you save.** That workbook has no formulas left, so saving replaces every one with a literal — permanently.
 - **`data_only=True` on a file openpyxl just wrote returns `None` everywhere** — run `recalc.py` first. (A formula whose result is `""` also reads back as `None`.)
 - **Merged cells: write the top-left anchor only.** Every other cell in the range is a `MergedCell` whose `.value` is read-only.
+- **Banner / title cells with fills:** For a title or banner spanning multiple columns, merge the cells across the table width (`ws.merge_cells("A1:G1")`); background fill and long text do not overflow reliably across unmerged cells and will get clipped.
+- **Literal `&` in headers/footers must be doubled (`&&`).** `&` starts a field code in Excel header/footer strings (`&C` for center, `&L`, `&R`, `&P`, `&D`), so `"Revenue & Costs"` misinterprets `&C` as the center-section code. Write `"Revenue && Costs"` to render a literal `&`.
 - **`.xlsm` loses its macros unless you pass `keep_vba=True`** to `load_workbook`.
 - **A sheet name containing a space must be quoted** in a cross-sheet reference: `='Assumptions Inputs'!$B$5`. Unquoted, it evaluates to `#VALUE!`.
 


### PR DESCRIPTION
Fixes #1440

### Summary
Adds two openpyxl presentation gotchas to `skills/xlsx/SKILL.md`:
1. Banner / title cells with fills: merge cells across table width so fill and text do not get clipped at boundaries.
2. Literal `&` in headers and footers must be doubled (`&&`) to avoid being parsed as header/footer section codes (e.g. `&C`).

cc @98zc5g5jyw-arch for review