### PR TITLE
fix(claude-api): anchor SKIP grep pattern and optimize frontmatter length (#1624)

### DIFF
--- a/skills/claude-api/SKILL.md
+++ b/skills/claude-api/SKILL.md
@@ -2,8 +2,8 @@
 name: claude-api
 description: |-
   Reference for the Claude API / Anthropic SDK — model ids, pricing, params, streaming, tool use, MCP, agents, caching, token counting, model migration.
-  TRIGGER — read BEFORE opening the target file; don't skip because it "looks like a one-liner" — whenever: the prompt names Claude/Anthropic in any form (Claude, Anthropic, Fable, Opus, Sonnet, Haiku, `anthropic`, `@anthropic-ai`, `claude-*`, `us.anthropic.*`, `[1m]`); the user asks about an LLM (pricing/model choice/limits/caching) — never answer from memory; OR the task is LLM-shaped with provider unstated (agent/MCP/tool-definition/multi-agent/RAG/LLM-judge/computer-use; generate/summarize/extract/classify/rewrite/converse over NL; debugging refusals/cutoffs/streaming/tool-calls/tokens).
-  SKIP only when another provider is being worked on (overrides all triggers): OpenAI/GPT/Gemini/Llama/Mistral/Cohere/Ollama named in the query; OR `grep -rE 'openai|langchain_openai|google.generativeai|genai|mistralai|cohere|ollama'` over the project hits (run this grep FIRST if no provider named — don't Read the file).
+  TRIGGER — read BEFORE opening target file; don't skip if it looks like a one-liner — whenever: prompt names Claude/Anthropic (Claude, Anthropic, Fable, Opus, Sonnet, Haiku, `anthropic`, `@anthropic-ai`, `claude-*`, `us.anthropic.*`, `[1m]`); user asks about an LLM (pricing/model choice/limits/caching) — never answer from memory; OR task is LLM-shaped with provider unstated (agent/MCP/tool-definition/multi-agent/RAG/LLM-judge/computer-use; generate/summarize/extract/classify/rewrite/converse over NL; debugging refusals/cutoffs/streaming/tool-calls/tokens).
+  SKIP only when another provider is worked on (overrides all triggers): OpenAI/GPT/Gemini/Llama/Mistral/Cohere/Ollama in query; OR `grep -rEw 'openai|langchain_openai|google.generativeai|genai|gemini|mistralai|cohere|ollama'` over project hits (run grep FIRST if no provider named — don't Read file).
 license: Complete terms in LICENSE.txt
 ---
 


### PR DESCRIPTION
Fixes #1624

Update the SKIP rule grep in `skills/claude-api/SKILL.md` to use `grep -rEw 'openai|langchain_openai|google.generativeai|genai|gemini|mistralai|cohere|ollama'` (word-boundary anchored and including `gemini`), and tighten description text so frontmatter passes validation under 1024 characters.

cc @98zc5g5jyw-arch for review