### PR TITLE
docs(docx): declare python-docx and defusedxml in dependencies

### DIFF
--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -88,4 +88,4 @@ The script writes `comments.xml`, `commentsExtended.xml`, `commentsIds.xml`, `co
 
 ## Dependencies
 
-`docx` (npm, preinstalled — install only if `require('docx')` fails) · `pandoc` · LibreOffice (`soffice`) · `pdftoppm` (Poppler)
+`docx` (npm, preinstalled — install only if `require('docx')` fails) · `defusedxml`, `python-docx` (pip) · `pandoc` · LibreOffice (`soffice`) · `pdftoppm` (Poppler)


### PR DESCRIPTION
Fixes #1461

### Summary
The `skills/docx/SKILL.md` dependencies section previously only listed npm `docx`, pandoc, LibreOffice, and pdftoppm. However, the docx helper scripts (such as `merge_runs.py` and validators) require Python dependencies including `defusedxml` and `python-docx`.

This PR explicitly lists `defusedxml, python-docx (pip)` in the Dependencies section of `skills/docx/SKILL.md`.

cc @98zc5g5jyw-arch for review