### PR TITLE
fix(mcp-builder): validate command is non-empty in MCPConnectionStdio

### DIFF
--- a/skills/mcp-builder/scripts/connections.py
+++ b/skills/mcp-builder/scripts/connections.py
@@ -75,6 +75,8 @@ class MCPConnectionStdio(MCPConnection):
 
     def __init__(self, command: str, args: list[str] = None, env: dict[str, str] = None):
         super().__init__()
+        if not isinstance(command, str) or not command.strip():
+            raise ValueError("Command must be a non-empty string")
         self.command = command
         self.args = args or []
         self.env = env


### PR DESCRIPTION
Validates that the `command` parameter passed to `MCPConnectionStdio` is a non-empty string.

Fixes #1619

cc @98zc5g5jyw-arch for review