### PR TITLE
fix(webapp-testing): prevent pipe buffer deadlock and ensure process group cleanup in with_server.py (#1625)

### DIFF
--- a/skills/webapp-testing/scripts/with_server.py
+++ b/skills/webapp-testing/scripts/with_server.py
@@ -14,6 +14,8 @@ Usage:
       -- python test.py
 """
 
+import os
+import signal
 import subprocess
 import socket
 import time
@@ -69,8 +71,9 @@ def main():
             process = subprocess.Popen(
                 server['cmd'],
                 shell=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
             )
             server_processes.append(process)
 
@@ -93,11 +96,16 @@ def main():
         print(f"\nStopping {len(server_processes)} server(s)...")
         for i, process in enumerate(server_processes):
             try:
-                process.terminate()
+                os.killpg(os.getpgid(process.pid), signal.SIGTERM)
                 process.wait(timeout=5)
             except subprocess.TimeoutExpired:
-                process.kill()
+                try:
+                    os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+                except (ProcessLookupError, OSError):
+                    pass
                 process.wait()
+            except (ProcessLookupError, OSError):
+                pass
             print(f"Server {i+1} stopped")
         print("All servers stopped")
 


### PR DESCRIPTION
Fixes #1625

In `skills/webapp-testing/scripts/with_server.py`:
- Set `stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL` to prevent pipe buffer exhaustion and deadlock for verbose background servers.
- Pass `start_new_session=True` to spawn servers in isolated process groups and kill the entire process group with `os.killpg(os.getpgid(process.pid), ...)` during cleanup.

cc @98zc5g5jyw-arch for review