### PR TITLE
fix(skill-creator): prevent nested claude subprocess from inheriting stdin in run_eval.py (#1414)

### DIFF
--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -84,6 +84,7 @@ def run_single_query(
 
         process = subprocess.Popen(
             cmd,
+            stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             cwd=project_root,


### PR DESCRIPTION
Fixes #1414

Pass `stdin=subprocess.DEVNULL` to `subprocess.Popen` in `run_single_query()` so nested `claude -p` subprocesses do not inherit standard input and block on interactive input.

cc @98zc5g5jyw-arch for review