### PR TITLE
fix(pdf): handle bare strings and pairs in choice field /Opt options (#1469)

### DIFF
--- a/skills/pdf/scripts/extract_form_field_info.py
+++ b/skills/pdf/scripts/extract_form_field_info.py
@@ -35,10 +35,19 @@ def make_field_dict(field, field_id):
     elif ft == "/Ch":
         field_dict["type"] = "choice"
         states = field.get("/_States_", [])
-        field_dict["choice_options"] = [{
-            "value": state[0],
-            "text": state[1],
-        } for state in states]
+        choice_options = []
+        for state in states:
+            if isinstance(state, (list, tuple)):
+                choice_options.append({
+                    "value": state[0],
+                    "text": state[1] if len(state) > 1 else state[0],
+                })
+            else:
+                choice_options.append({
+                    "value": state,
+                    "text": state,
+                })
+        field_dict["choice_options"] = choice_options
     else:
         field_dict["type"] = f"unknown ({ft})"
     return field_dict


### PR DESCRIPTION
Fixes #1469

In `skills/pdf/scripts/extract_form_field_info.py`:
PDF choice fields (`/Ch`) can specify `/Opt` options either as bare text strings or as two-element `[export_value, display_name]` pairs. Update `make_field_dict` to inspect each option's type so bare strings are preserved as full strings rather than sliced character-by-character.

cc @98zc5g5jyw-arch for review