### PR TITLE
feat(skill-creator): add user-invocable to allowed frontmatter properties (#1431)

### DIFF
--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -39,7 +39,7 @@ def validate_skill(skill_path):
         return False, f"Invalid YAML in frontmatter: {e}"
 
     # Define allowed properties
-    ALLOWED_PROPERTIES = {'name', 'description', 'license', 'allowed-tools', 'metadata', 'compatibility'}
+    ALLOWED_PROPERTIES = {'name', 'description', 'license', 'allowed-tools', 'metadata', 'compatibility', 'user-invocable'}
 
     # Check for unexpected properties (excluding nested keys under metadata)
     unexpected_keys = set(frontmatter.keys()) - ALLOWED_PROPERTIES


### PR DESCRIPTION
Fixes #1431

Add `user-invocable` to `ALLOWED_PROPERTIES` in `skills/skill-creator/scripts/quick_validate.py` so skills defining this frontmatter property pass validation.

cc @98zc5g5jyw-arch for review