### PR TITLE
fix(claude-api): shorten description to conform to 1024 char limit

### DIFF
--- a/skills/claude-api/SKILL.md
+++ b/skills/claude-api/SKILL.md
@@ -2,8 +2,8 @@
 name: claude-api
 description: |-
   Reference for the Claude API / Anthropic SDK — model ids, pricing, params, streaming, tool use, MCP, agents, caching, token counting, model migration.
-  TRIGGER — read BEFORE opening the target file; don't skip because it "looks like a one-liner" — whenever: the prompt names Claude/Anthropic in any form (Claude, Anthropic, Fable, Opus, Sonnet, Haiku, `anthropic`, `@anthropic-ai`, `claude-*`, `us.anthropic.*`, `[1m]`); the user asks about an LLM (pricing/model choice/limits/caching) — never answer from memory; OR the task is LLM-shaped with provider unstated (agent/MCP/tool-definition/multi-agent/RAG/LLM-judge/computer-use; generate/summarize/extract/classify/rewrite/converse over NL; debugging refusals/cutoffs/streaming/tool-calls/tokens).
-  SKIP only when another provider is being worked on (overrides all triggers): OpenAI/GPT/Gemini/Llama/Mistral/Cohere/Ollama named in the query; OR `grep -rE 'openai|langchain_openai|google.generativeai|genai|mistralai|cohere|ollama'` over the project hits (run this grep FIRST if no provider named — don't Read the file).
+  TRIGGER: Read whenever the prompt mentions Claude or Anthropic (Opus, Sonnet, Haiku, anthropic, @anthropic-ai, claude-*, us.anthropic.*), asks about LLM pricing/models/limits/caching, or involves LLM tasks with provider unstated (agent, MCP, tool use, RAG, multi-agent, NL generation/extraction/summarization, streaming/refusal debugging).
+  SKIP: Only when another provider is explicitly specified (OpenAI, GPT, Gemini, Llama, Mistral, Cohere, Ollama) or detected in project dependencies.
 license: Complete terms in LICENSE.txt
 ---
 


### PR DESCRIPTION
## Summary

Fixes validation error in `skills/claude-api/SKILL.md` where the frontmatter `description` exceeded the 1024-character limit enforced by `quick_validate.py` (1068 characters -> 638 characters).

## Verification

Ran `python3 skills/skill-creator/scripts/quick_validate.py skills/claude-api` and verified all 20 skills in the repository pass validation.