### PR TITLE
Fail loudly when evaluation answers and questions diverge in count

### DIFF
--- a/skills/mcp-builder/scripts/evaluation.py
+++ b/skills/mcp-builder/scripts/evaluation.py
@@ -266,7 +266,7 @@ async def run_evaluation(
             summary=result["summary"] or "N/A",
             feedback=result["feedback"] or "N/A",
         )
-        for i, (qa_pair, result) in enumerate(zip(qa_pairs, results))
+        for i, (qa_pair, result) in enumerate(zip(qa_pairs, results, strict=True))
     ])
 
     return report


### PR DESCRIPTION
`generate_eval_report` in the mcp-builder skill pairs each QA pair with its result through `zip()`. The two lists should always match one to one, but if they ever drift apart, `zip` silently truncates and the report drops the unmatched rows. A broken run then reads as a clean run that happened to have fewer questions, which is the worst way for this script to fail because the person evaluating a description trusts the row count.

This passes `strict=True` so a length mismatch raises instead. It is the same pairing every other consumer of these two lists assumes.

One trade-off worth naming: `zip(strict=True)` needs Python 3.10, and 3.9 has been end of life since October 2025. If you would rather keep 3.9 compatibility, an explicit length check before the loop works just as well, and I am glad to switch it.

I left `webapp-testing/scripts/with_server.py` alone even though it has a similar bare `zip`, because it already validates `len(args.servers) != len(args.ports)` and exits before reaching it.