### PR TITLE
Drop six unused locals from the description optimizer report

### DIFF
--- a/skills/skill-creator/scripts/generate_report.py
+++ b/skills/skill-creator/scripts/generate_report.py
@@ -16,7 +16,6 @@ from pathlib import Path
 def generate_html(data: dict, auto_refresh: bool = False, skill_name: str = "") -> str:
     """Generate HTML report from loop output data. If auto_refresh is True, adds a meta refresh tag."""
     history = data.get("history", [])
-    holdout = data.get("holdout", 0)
     title_prefix = html.escape(skill_name + " \u2014 ") if skill_name else ""
 
     # Get all unique queries from train and test sets, with should_trigger info
@@ -154,7 +153,6 @@ def generate_html(data: dict, auto_refresh: bool = False, skill_name: str = "") 
 
     # Summary section
     best_test_score = data.get('best_test_score')
-    best_train_score = data.get('best_train_score')
     html_parts.append(f"""
     <div class="summary">
         <p><strong>Original:</strong> {html.escape(data.get('original_description', 'N/A'))}</p>
@@ -211,10 +209,6 @@ def generate_html(data: dict, auto_refresh: bool = False, skill_name: str = "") 
     # Add rows for each iteration
     for h in history:
         iteration = h.get("iteration", "?")
-        train_passed = h.get("train_passed", h.get("passed", 0))
-        train_total = h.get("train_total", h.get("total", 0))
-        test_passed = h.get("test_passed")
-        test_total = h.get("test_total")
         description = h.get("description", "")
         train_results = h.get("train_results", h.get("results", []))
         test_results = h.get("test_results", [])


### PR DESCRIPTION
`generate_html` in the skill-creator optimizer report still fetches `holdout` and `best_train_score`, and the history loop fetches `train_passed`, `train_total`, `test_passed`, and `test_total` on every iteration. None of the six names is read anywhere. The row scores come from `aggregate_runs`, which recomputes correct and total counts directly from the per-query results, so the four loop locals look like leftovers from before that helper landed.

Removing them changes no output. It just makes the script honest about where its numbers come from, which matters in a report people read while deciding whether to trust an optimized description.

A pyflakes pass over the bundled scripts is what surfaced these, if you would like me to send through anything else it finds.