### PR TITLE
fix(mcp-builder): specify utf-8 encoding when writing evaluation report (#1669)

### DIFF
--- a/skills/mcp-builder/scripts/evaluation.py
+++ b/skills/mcp-builder/scripts/evaluation.py
@@ -363,7 +363,7 @@ Examples:
         report = await run_evaluation(args.eval_file, connection, args.model)
 
         if args.output:
-            args.output.write_text(report)
+            args.output.write_text(report, encoding="utf-8")
             print(f"\n✅ Report saved to {args.output}")
         else:
             print("\n" + report)


### PR DESCRIPTION
## Summary

Fixes #1669

- In `skills/mcp-builder/scripts/evaluation.py`:
  - Pass `encoding="utf-8"` to `args.output.write_text(report, encoding="utf-8")`.
  - On Windows default installations, `Path.write_text()` uses the default locale encoding (`cp1252`), which crashes with `UnicodeEncodeError: 'charmap' codec can't encode character '❌'` when saving evaluation reports that contain emoji markers.