### PR TITLE
fix(skill-creator): sanitize skill_name in run_eval.py against path traversal (#1631)

### DIFF
--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -8,6 +8,7 @@ for a set of queries. Outputs results as JSON.
 import argparse
 import json
 import os
+import re
 import select
 import subprocess
 import sys
@@ -48,8 +49,9 @@ def run_single_query(
     stream events (content_block_start) rather than waiting for the
     full assistant message, which only arrives after tool execution.
     """
+    safe_name = re.sub(r'[^a-zA-Z0-9_-]', '-', skill_name).strip('-') or "skill"
     unique_id = uuid.uuid4().hex[:8]
-    clean_name = f"{skill_name}-skill-{unique_id}"
+    clean_name = f"{safe_name}-skill-{unique_id}"
     project_commands_dir = Path(project_root) / ".claude" / "commands"
     command_file = project_commands_dir / f"{clean_name}.md"
 
@@ -65,7 +67,7 @@ def run_single_query(
             f"# {skill_name}\n\n"
             f"This skill handles: {skill_description}\n"
         )
-        command_file.write_text(command_content)
+        command_file.write_text(command_content, encoding="utf-8")
 
         cmd = [
             "claude",


### PR DESCRIPTION
## Summary

Fixes #1631

- In  ():
  - Sanitize  by stripping unsafe characters and path separators using  before constructing  path.
  - Ensure  specifies  for cross-platform consistency.