### PR TITLE
fix(skill-creator): rename expectations to assertions in evals.json schema

### DIFF
--- a/skills/skill-creator/references/schemas.md
+++ b/skills/skill-creator/references/schemas.md
@@ -17,7 +17,7 @@ Defines the evals for a skill. Located at `evals/evals.json` within the skill di
       "prompt": "User's example prompt",
       "expected_output": "Description of expected result",
       "files": ["evals/files/sample1.pdf"],
-      "expectations": [
+      "assertions": [
         "The output includes X",
         "The skill used script Y"
       ]
@@ -32,7 +32,7 @@ Defines the evals for a skill. Located at `evals/evals.json` within the skill di
 - `evals[].prompt`: The task to execute
 - `evals[].expected_output`: Human-readable description of success
 - `evals[].files`: Optional list of input file paths (relative to skill root)
-- `evals[].expectations`: List of verifiable statements
+- `evals[].assertions`: List of verifiable statements
 
 ---
 


### PR DESCRIPTION
## Summary

- Renames `expectations` to `assertions` in the `evals.json` schema section of `references/schemas.md` (field name + bullet), matching the five references in `SKILL.md`
- Leaves the `grading.json` section unchanged — `expectations` is correct there and is read by `aggregate_benchmark.py` and `viewer.html`

Fixes #587

## Context

`SKILL.md` uses `assertions` consistently (lines 145, 161, 195, 201, 205), but `schemas.md` called the same `evals.json` field `expectations`. Nothing reads `evals.json` programmatically, so this never caused a crash — just inconsistent hand-written eval files when a reader followed one doc versus the other.

## Test plan

- [ ] Verify `grading.json` expectations field is unchanged (the aggregation script and viewer depend on it)
- [ ] Confirm `SKILL.md` references to "assertions" now match the schema doc