### PR TITLE
fix(mcp-builder): specify utf-8 encoding in evaluation.py file writes (#1669)

### DIFF
--- a/skills/mcp-builder/scripts/evaluation.py
+++ b/skills/mcp-builder/scripts/evaluation.py
@@ -363,7 +363,7 @@ Examples:
         report = await run_evaluation(args.eval_file, connection, args.model)
 
         if args.output:
-            args.output.write_text(report)
+            args.output.write_text(report, encoding="utf-8")
             print(f"\n✅ Report saved to {args.output}")
         else:
             print("\n" + report)


### PR DESCRIPTION
Closes #1669

## Problem
In `skills/mcp-builder/scripts/evaluation.py`, the evaluation report is written using `args.output.write_text(report)` without specifying an encoding. On Windows systems where the default locale encoding is `cp1252`, attempting to write reports containing emoji markers (`✅`, `❌`) or non-ASCII characters results in a `UnicodeEncodeError`. Because this occurs on the final write step after all evaluation tasks have finished, the entire run's output is lost.

## Fix
Added explicit `encoding="utf-8"` to `args.output.write_text(report, encoding="utf-8")` in `skills/mcp-builder/scripts/evaluation.py`.

## Testing
- Verified Python syntax compilation using `py_compile`.
- Tested encoding behavior with emoji report output.