### PR TITLE
fix(claude-api): anchor SKIP provider grep to prevent matching substrings like coherent (#1624)

### DIFF
--- a/skills/claude-api/SKILL.md
+++ b/skills/claude-api/SKILL.md
@@ -3,7 +3,7 @@ name: claude-api
 description: |-
   Reference for the Claude API / Anthropic SDK — model ids, pricing, params, streaming, tool use, MCP, agents, caching, token counting, model migration.
   TRIGGER — read BEFORE opening the target file; don't skip because it "looks like a one-liner" — whenever: the prompt names Claude/Anthropic in any form (Claude, Anthropic, Fable, Opus, Sonnet, Haiku, `anthropic`, `@anthropic-ai`, `claude-*`, `us.anthropic.*`, `[1m]`); the user asks about an LLM (pricing/model choice/limits/caching) — never answer from memory; OR the task is LLM-shaped with provider unstated (agent/MCP/tool-definition/multi-agent/RAG/LLM-judge/computer-use; generate/summarize/extract/classify/rewrite/converse over NL; debugging refusals/cutoffs/streaming/tool-calls/tokens).
-  SKIP only when another provider is being worked on (overrides all triggers): OpenAI/GPT/Gemini/Llama/Mistral/Cohere/Ollama named in the query; OR `grep -rE 'openai|langchain_openai|google.generativeai|genai|mistralai|cohere|ollama'` over the project hits (run this grep FIRST if no provider named — don't Read the file).
+  SKIP only when another provider is being worked on (overrides all triggers): OpenAI/GPT/Gemini/Llama/Mistral/Cohere/Ollama named in the query; OR `grep -rE '\b(openai|langchain_openai|google\.generativeai|genai|mistralai|cohere|ollama)\b'` over the project hits (run this grep FIRST if no provider named — don't Read the file).
 license: Complete terms in LICENSE.txt
 ---
 


### PR DESCRIPTION
Closes #1624

## Summary
Anchor the provider pattern in `skills/claude-api/SKILL.md`'s SKIP clause with word boundaries so that substrings in common English words (such as "coherent" or "coherence") do not trigger a false-positive skip.

## Problem
In `skills/claude-api/SKILL.md`, the SKIP clause uses `grep -rE 'openai|langchain_openai|google.generativeai|genai|mistralai|cohere|ollama'`. Because `cohere` was unanchored, any repository containing ordinary English words like "coherent" or "coherence" matched the grep pattern and inadvertently disabled the `claude-api` skill.

## Fix
Anchor the regex pattern with word boundaries `\b(openai|langchain_openai|google\.generativeai|genai|mistralai|cohere|ollama)\b` so that matches only occur on exact word tokens for third-party provider names rather than substrings of normal words.