### PR TITLE
fix(skill-creator): specify utf-8 encoding on file operations for Windows (#1686)

### DIFF
--- a/skills/skill-creator/scripts/generate_report.py
+++ b/skills/skill-creator/scripts/generate_report.py
@@ -311,13 +311,14 @@ def main():
     if args.input == "-":
         data = json.load(sys.stdin)
     else:
-        data = json.loads(Path(args.input).read_text())
+        data = json.loads(Path(args.input).read_text(encoding="utf-8"))
 
     html_output = generate_html(data, skill_name=args.skill_name)
 
     if args.output:
-        Path(args.output).write_text(html_output)
+        Path(args.output).write_text(html_output, encoding="utf-8")
         print(f"Report written to {args.output}", file=sys.stderr)
+
     else:
         print(html_output)
 

--- a/skills/skill-creator/scripts/improve_description.py
+++ b/skills/skill-creator/scripts/improve_description.py
@@ -205,10 +205,11 @@ def main():
         print(f"Error: No SKILL.md found at {skill_path}", file=sys.stderr)
         sys.exit(1)
 
-    eval_results = json.loads(Path(args.eval_results).read_text())
+    eval_results = json.loads(Path(args.eval_results).read_text(encoding="utf-8"))
     history = []
     if args.history:
-        history = json.loads(Path(args.history).read_text())
+        history = json.loads(Path(args.history).read_text(encoding="utf-8"))
+
 
     name, _, content = parse_skill_md(skill_path)
     current_description = eval_results["description"]

--- a/skills/skill-creator/scripts/package_skill.py
+++ b/skills/skill-creator/scripts/package_skill.py
@@ -14,7 +14,18 @@ import fnmatch
 import sys
 import zipfile
 from pathlib import Path
-from scripts.quick_validate import validate_skill
+
+if hasattr(sys.stdout, "reconfigure"):
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
+
+try:
+    from scripts.quick_validate import validate_skill
+except ModuleNotFoundError:
+    from quick_validate import validate_skill
+
 
 # Patterns to exclude when packaging skills.
 EXCLUDE_DIRS = {"__pycache__", "node_modules"}

--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -19,8 +19,9 @@ def validate_skill(skill_path):
         return False, "SKILL.md not found"
 
     # Read and validate frontmatter
-    content = skill_md.read_text()
+    content = skill_md.read_text(encoding='utf-8-sig')
     if not content.startswith('---'):
+
         return False, "No YAML frontmatter found"
 
     # Extract frontmatter

--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -269,8 +269,9 @@ def main():
     parser.add_argument("--verbose", action="store_true", help="Print progress to stderr")
     args = parser.parse_args()
 
-    eval_set = json.loads(Path(args.eval_set).read_text())
+    eval_set = json.loads(Path(args.eval_set).read_text(encoding="utf-8"))
     skill_path = Path(args.skill_path)
+
 
     if not (skill_path / "SKILL.md").exists():
         print(f"Error: No SKILL.md found at {skill_path}", file=sys.stderr)

--- a/skills/skill-creator/scripts/run_loop.py
+++ b/skills/skill-creator/scripts/run_loop.py
@@ -258,8 +258,9 @@ def main():
     parser.add_argument("--results-dir", default=None, help="Save all outputs (results.json, report.html, log.txt) to a timestamped subdirectory here")
     args = parser.parse_args()
 
-    eval_set = json.loads(Path(args.eval_set).read_text())
+    eval_set = json.loads(Path(args.eval_set).read_text(encoding="utf-8"))
     skill_path = Path(args.skill_path)
+
 
     if not (skill_path / "SKILL.md").exists():
         print(f"Error: No SKILL.md found at {skill_path}", file=sys.stderr)

--- a/skills/skill-creator/scripts/utils.py
+++ b/skills/skill-creator/scripts/utils.py
@@ -6,8 +6,9 @@ from pathlib import Path
 
 def parse_skill_md(skill_path: Path) -> tuple[str, str, str]:
     """Parse a SKILL.md file, returning (name, description, full_content)."""
-    content = (skill_path / "SKILL.md").read_text()
+    content = (skill_path / "SKILL.md").read_text(encoding="utf-8-sig")
     lines = content.split("\n")
+
 
     if lines[0].strip() != "---":
         raise ValueError("SKILL.md missing frontmatter (no opening ---)")

--- a/skills/skill-creator/tests/test_windows_encoding.py
+++ b/skills/skill-creator/tests/test_windows_encoding.py
@@ -1,0 +1,62 @@
+import sys
+import tempfile
+from pathlib import Path
+
+# Add scripts directory to sys.path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from package_skill import package_skill  # noqa: E402
+from quick_validate import validate_skill  # noqa: E402
+from utils import parse_skill_md  # noqa: E402
+
+
+
+def test_quick_validate_with_non_ascii_and_bom():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        skill_dir = Path(tmpdir) / "test-unicode-skill"
+        skill_dir.mkdir()
+        skill_md = skill_dir / "SKILL.md"
+
+        # UTF-8 with BOM (\ufeff) and non-ASCII characters (ō, CJK, emoji, dashes)
+        content = (
+            "\ufeff---\n"
+            "name: test-unicode-skill\n"
+            "description: \"Provjeri dostupnost artikla — Tōkyō 城市指南。\"\n"
+            "---\n"
+            "\n"
+            "# Test Unicode Skill\n"
+            "This skill handles café, 日本語, and 🚀 emoji.\n"
+        )
+        skill_md.write_bytes(content.encode("utf-8"))
+
+        valid, msg = validate_skill(skill_dir)
+        assert valid, f"Validation failed: {msg}"
+
+        name, desc, full = parse_skill_md(skill_dir)
+        assert name == "test-unicode-skill"
+        assert "Tōkyō" in desc
+
+
+def test_package_skill_with_non_ascii():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        skill_dir = tmp_path / "unicode-package-skill"
+        skill_dir.mkdir()
+        skill_md = skill_dir / "SKILL.md"
+
+        content = (
+            "---\n"
+            "name: unicode-package-skill\n"
+            "description: \"Package test with non-ASCII: café, Tōkyō, 🚀.\"\n"
+            "---\n"
+            "\n"
+            "Body.\n"
+        )
+        skill_md.write_text(content, encoding="utf-8")
+
+        out_dir = tmp_path / "dist"
+        out_dir.mkdir()
+        packaged = package_skill(skill_dir, out_dir)
+        assert packaged is not None
+        assert packaged.exists()
+        assert packaged.suffix == ".skill"


### PR DESCRIPTION
## Summary

Fixes #1686

### Root Cause
On Windows systems where Python defaults to ANSI/cp1252 instead of UTF-8, scripts in `skills/skill-creator/scripts/` calling `read_text()` or `write_text()` without an explicit encoding raise `UnicodeDecodeError` (e.g. `'charmap' codec can't decode byte 0x8d...`) on any SKILL.md or eval JSON containing non-ASCII text (accented Latin, CJK, dashes, or emoji). Additionally, terminal emoji logging in `package_skill.py` can crash with `UnicodeEncodeError` under Windows console encodings.

### Changes
1. **`quick_validate.py` & `utils.py`**:
   - Use `encoding='utf-8-sig'` when reading `SKILL.md`, supporting standard UTF-8 as well as files with a UTF-8 BOM.
2. **`run_eval.py`, `improve_description.py`, `run_loop.py`, `generate_report.py`**:
   - Specify `encoding='utf-8'` on `read_text()` and `write_text()` operations.
3. **`package_skill.py`**:
   - Reconfigure stdout with `sys.stdout.reconfigure(encoding="utf-8", errors="replace")` if available to protect emoji output on Windows.
   - Add fallback import handling for `validate_skill`.
4. **Unit Tests**:
   - Add `skills/skill-creator/tests/test_windows_encoding.py` covering non-ASCII characters, UTF-8 BOM, and packaging.

### Verification
- `pytest skills/skill-creator/tests/test_windows_encoding.py` passed (2/2).
- `ruff check skills/skill-creator/tests/test_windows_encoding.py` passed.
