### PR TITLE
fix(skill-creator): resolve Windows eval harness pipe reading and probe command leakage

### DIFF
--- a/skills/skill-creator/scripts/improve_description.py
+++ b/skills/skill-creator/scripts/improve_description.py
@@ -186,7 +186,7 @@ Please respond with only the new description text in <new_description> tags, not
     if log_dir:
         log_dir.mkdir(parents=True, exist_ok=True)
         log_file = log_dir / f"improve_iter_{iteration or 'unknown'}.json"
-        log_file.write_text(json.dumps(transcript, indent=2))
+        log_file.write_text(json.dumps(transcript, indent=2), encoding="utf-8")
 
     return description
 
@@ -205,10 +205,10 @@ def main():
         print(f"Error: No SKILL.md found at {skill_path}", file=sys.stderr)
         sys.exit(1)
 
-    eval_results = json.loads(Path(args.eval_results).read_text())
+    eval_results = json.loads(Path(args.eval_results).read_text(encoding="utf-8"))
     history = []
     if args.history:
-        history = json.loads(Path(args.history).read_text())
+        history = json.loads(Path(args.history).read_text(encoding="utf-8"))
 
     name, _, content = parse_skill_md(skill_path)
     current_description = eval_results["description"]

--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -8,9 +8,10 @@ for a set of queries. Outputs results as JSON.
 import argparse
 import json
 import os
-import select
+import queue
 import subprocess
 import sys
+import threading
 import time
 import uuid
 from concurrent.futures import ProcessPoolExecutor, as_completed
@@ -19,15 +20,39 @@ from pathlib import Path
 from scripts.utils import parse_skill_md
 
 
+def cleanup_probe_commands(project_root: Path | str, skill_name: str | None = None) -> None:
+    """Safely clean up leftover probe command files in .claude/commands/."""
+    try:
+        commands_dir = Path(project_root) / ".claude" / "commands"
+        if commands_dir.is_dir():
+            pattern = f"{skill_name}-skill-*.md" if skill_name else "*-skill-*.md"
+            for f in commands_dir.glob(pattern):
+                try:
+                    f.unlink()
+                except OSError:
+                    pass
+    except Exception:
+        pass
+
+
 def find_project_root() -> Path:
-    """Find the project root by walking up from cwd looking for .claude/.
+    """Find the project root by walking up from cwd looking for .claude/ or .git/.
 
     Mimics how Claude Code discovers its project root, so the command file
-    we create ends up where claude -p will look for it.
+    we create ends up where claude -p will look for it. Explicitly avoids
+    treating the user's home directory (~/.claude) as a project root so probe
+    files are not leaked into global user commands.
     """
-    current = Path.cwd()
+    current = Path.cwd().resolve()
+    try:
+        home = Path.home().resolve()
+    except Exception:
+        home = None
+
     for parent in [current, *current.parents]:
-        if (parent / ".claude").is_dir():
+        if home is not None and parent == home:
+            break
+        if (parent / ".claude").is_dir() or (parent / ".git").is_dir():
             return parent
     return current
 
@@ -65,7 +90,7 @@ def run_single_query(
             f"# {skill_name}\n\n"
             f"This skill handles: {skill_description}\n"
         )
-        command_file.write_text(command_content)
+        command_file.write_text(command_content, encoding="utf-8")
 
         cmd = [
             "claude",
@@ -92,93 +117,122 @@ def run_single_query(
 
         triggered = False
         start_time = time.time()
-        buffer = ""
         # Track state for stream event detection
         pending_tool_name = None
         accumulated_json = ""
 
+        # Background reader thread with Queue avoids Windows select() incompatibilities on pipes
+        q: queue.Queue[bytes | None] = queue.Queue()
+
+        def _enqueue_output(out_pipe, queue_dest):
+            try:
+                for line in iter(out_pipe.readline, b""):
+                    queue_dest.put(line)
+            except Exception:
+                pass
+            finally:
+                queue_dest.put(None)
+
+        reader_thread = threading.Thread(
+            target=_enqueue_output,
+            args=(process.stdout, q),
+            daemon=True,
+        )
+        reader_thread.start()
+
         try:
             while time.time() - start_time < timeout:
-                if process.poll() is not None:
-                    remaining = process.stdout.read()
-                    if remaining:
-                        buffer += remaining.decode("utf-8", errors="replace")
+                remaining_time = timeout - (time.time() - start_time)
+                if remaining_time <= 0:
                     break
 
-                ready, _, _ = select.select([process.stdout], [], [], 1.0)
-                if not ready:
+                try:
+                    line_bytes = q.get(timeout=min(remaining_time, 0.5))
+                except queue.Empty:
+                    if process.poll() is not None and q.empty():
+                        break
                     continue
 
-                chunk = os.read(process.stdout.fileno(), 8192)
-                if not chunk:
+                if line_bytes is None:
                     break
-                buffer += chunk.decode("utf-8", errors="replace")
 
-                while "\n" in buffer:
-                    line, buffer = buffer.split("\n", 1)
-                    line = line.strip()
-                    if not line:
-                        continue
+                line = line_bytes.decode("utf-8", errors="replace").strip()
+                if not line:
+                    continue
 
-                    try:
-                        event = json.loads(line)
-                    except json.JSONDecodeError:
-                        continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
 
-                    # Early detection via stream events
-                    if event.get("type") == "stream_event":
-                        se = event.get("event", {})
-                        se_type = se.get("type", "")
+                # Early detection via stream events
+                if event.get("type") == "stream_event":
+                    se = event.get("event", {})
+                    se_type = se.get("type", "")
 
-                        if se_type == "content_block_start":
-                            cb = se.get("content_block", {})
-                            if cb.get("type") == "tool_use":
-                                tool_name = cb.get("name", "")
-                                if tool_name in ("Skill", "Read"):
-                                    pending_tool_name = tool_name
-                                    accumulated_json = ""
-                                else:
-                                    return False
-
-                        elif se_type == "content_block_delta" and pending_tool_name:
-                            delta = se.get("delta", {})
-                            if delta.get("type") == "input_json_delta":
-                                accumulated_json += delta.get("partial_json", "")
-                                if clean_name in accumulated_json:
-                                    return True
-
-                        elif se_type in ("content_block_stop", "message_stop"):
-                            if pending_tool_name:
-                                return clean_name in accumulated_json
-                            if se_type == "message_stop":
+                    if se_type == "content_block_start":
+                        cb = se.get("content_block", {})
+                        if cb.get("type") == "tool_use":
+                            tool_name = cb.get("name", "")
+                            if tool_name in ("Skill", "Read"):
+                                pending_tool_name = tool_name
+                                accumulated_json = ""
+                            else:
                                 return False
 
-                    # Fallback: full assistant message
-                    elif event.get("type") == "assistant":
-                        message = event.get("message", {})
-                        for content_item in message.get("content", []):
-                            if content_item.get("type") != "tool_use":
-                                continue
-                            tool_name = content_item.get("name", "")
-                            tool_input = content_item.get("input", {})
-                            if tool_name == "Skill" and clean_name in tool_input.get("skill", ""):
-                                triggered = True
-                            elif tool_name == "Read" and clean_name in tool_input.get("file_path", ""):
-                                triggered = True
-                            return triggered
+                    elif se_type == "content_block_delta" and pending_tool_name:
+                        delta = se.get("delta", {})
+                        if delta.get("type") == "input_json_delta":
+                            accumulated_json += delta.get("partial_json", "")
+                            if clean_name in accumulated_json:
+                                return True
 
-                    elif event.get("type") == "result":
+                    elif se_type in ("content_block_stop", "message_stop"):
+                        if pending_tool_name:
+                            return clean_name in accumulated_json
+                        if se_type == "message_stop":
+                            return False
+
+                # Fallback: full assistant message
+                elif event.get("type") == "assistant":
+                    message = event.get("message", {})
+                    for content_item in message.get("content", []):
+                        if content_item.get("type") != "tool_use":
+                            continue
+                        tool_name = content_item.get("name", "")
+                        tool_input = content_item.get("input", {})
+                        if tool_name == "Skill" and clean_name in tool_input.get("skill", ""):
+                            triggered = True
+                        elif tool_name == "Read" and clean_name in tool_input.get("file_path", ""):
+                            triggered = True
                         return triggered
+
+                elif event.get("type") == "result":
+                    return triggered
         finally:
             # Clean up process on any exit path (return, exception, timeout)
             if process.poll() is None:
-                process.kill()
-                process.wait()
+                try:
+                    process.kill()
+                except OSError:
+                    pass
+                try:
+                    process.wait(timeout=2)
+                except Exception:
+                    pass
+            if process.stdout:
+                try:
+                    process.stdout.close()
+                except OSError:
+                    pass
 
         return triggered
     finally:
-        if command_file.exists():
-            command_file.unlink()
+        try:
+            if command_file.exists():
+                command_file.unlink()
+        except OSError:
+            pass
 
 
 def run_eval(
@@ -193,67 +247,71 @@ def run_eval(
     model: str | None = None,
 ) -> dict:
     """Run the full eval set and return results."""
+    cleanup_probe_commands(project_root, skill_name)
     results = []
 
-    with ProcessPoolExecutor(max_workers=num_workers) as executor:
-        future_to_info = {}
-        for item in eval_set:
-            for run_idx in range(runs_per_query):
-                future = executor.submit(
-                    run_single_query,
-                    item["query"],
-                    skill_name,
-                    description,
-                    timeout,
-                    str(project_root),
-                    model,
-                )
-                future_to_info[future] = (item, run_idx)
+    try:
+        with ProcessPoolExecutor(max_workers=num_workers) as executor:
+            future_to_info = {}
+            for item in eval_set:
+                for run_idx in range(runs_per_query):
+                    future = executor.submit(
+                        run_single_query,
+                        item["query"],
+                        skill_name,
+                        description,
+                        timeout,
+                        str(project_root),
+                        model,
+                    )
+                    future_to_info[future] = (item, run_idx)
 
-        query_triggers: dict[str, list[bool]] = {}
-        query_items: dict[str, dict] = {}
-        for future in as_completed(future_to_info):
-            item, _ = future_to_info[future]
-            query = item["query"]
-            query_items[query] = item
-            if query not in query_triggers:
-                query_triggers[query] = []
-            try:
-                query_triggers[query].append(future.result())
-            except Exception as e:
-                print(f"Warning: query failed: {e}", file=sys.stderr)
-                query_triggers[query].append(False)
+            query_triggers: dict[str, list[bool]] = {}
+            query_items: dict[str, dict] = {}
+            for future in as_completed(future_to_info):
+                item, _ = future_to_info[future]
+                query = item["query"]
+                query_items[query] = item
+                if query not in query_triggers:
+                    query_triggers[query] = []
+                try:
+                    query_triggers[query].append(future.result())
+                except Exception as e:
+                    print(f"Warning: query failed: {e}", file=sys.stderr)
+                    query_triggers[query].append(False)
 
-    for query, triggers in query_triggers.items():
-        item = query_items[query]
-        trigger_rate = sum(triggers) / len(triggers)
-        should_trigger = item["should_trigger"]
-        if should_trigger:
-            did_pass = trigger_rate >= trigger_threshold
-        else:
-            did_pass = trigger_rate < trigger_threshold
-        results.append({
-            "query": query,
-            "should_trigger": should_trigger,
-            "trigger_rate": trigger_rate,
-            "triggers": sum(triggers),
-            "runs": len(triggers),
-            "pass": did_pass,
-        })
+        for query, triggers in query_triggers.items():
+            item = query_items[query]
+            trigger_rate = sum(triggers) / len(triggers)
+            should_trigger = item["should_trigger"]
+            if should_trigger:
+                did_pass = trigger_rate >= trigger_threshold
+            else:
+                did_pass = trigger_rate < trigger_threshold
+            results.append({
+                "query": query,
+                "should_trigger": should_trigger,
+                "trigger_rate": trigger_rate,
+                "triggers": sum(triggers),
+                "runs": len(triggers),
+                "pass": did_pass,
+            })
 
-    passed = sum(1 for r in results if r["pass"])
-    total = len(results)
+        passed = sum(1 for r in results if r["pass"])
+        total = len(results)
 
-    return {
-        "skill_name": skill_name,
-        "description": description,
-        "results": results,
-        "summary": {
-            "total": total,
-            "passed": passed,
-            "failed": total - passed,
-        },
-    }
+        return {
+            "skill_name": skill_name,
+            "description": description,
+            "results": results,
+            "summary": {
+                "total": total,
+                "passed": passed,
+                "failed": total - passed,
+            },
+        }
+    finally:
+        cleanup_probe_commands(project_root, skill_name)
 
 
 def main():
@@ -269,7 +327,7 @@ def main():
     parser.add_argument("--verbose", action="store_true", help="Print progress to stderr")
     args = parser.parse_args()
 
-    eval_set = json.loads(Path(args.eval_set).read_text())
+    eval_set = json.loads(Path(args.eval_set).read_text(encoding="utf-8"))
     skill_path = Path(args.skill_path)
 
     if not (skill_path / "SKILL.md").exists():

--- a/skills/skill-creator/scripts/run_loop.py
+++ b/skills/skill-creator/scripts/run_loop.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 from scripts.generate_report import generate_html
 from scripts.improve_description import improve_description
-from scripts.run_eval import find_project_root, run_eval
+from scripts.run_eval import cleanup_probe_commands, find_project_root, run_eval
 from scripts.utils import parse_skill_md
 
 
@@ -76,142 +76,145 @@ def run_loop(
     history = []
     exit_reason = "unknown"
 
-    for iteration in range(1, max_iterations + 1):
-        if verbose:
-            print(f"\n{'='*60}", file=sys.stderr)
-            print(f"Iteration {iteration}/{max_iterations}", file=sys.stderr)
-            print(f"Description: {current_description}", file=sys.stderr)
-            print(f"{'='*60}", file=sys.stderr)
-
-        # Evaluate train + test together in one batch for parallelism
-        all_queries = train_set + test_set
-        t0 = time.time()
-        all_results = run_eval(
-            eval_set=all_queries,
-            skill_name=name,
-            description=current_description,
-            num_workers=num_workers,
-            timeout=timeout,
-            project_root=project_root,
-            runs_per_query=runs_per_query,
-            trigger_threshold=trigger_threshold,
-            model=model,
-        )
-        eval_elapsed = time.time() - t0
-
-        # Split results back into train/test by matching queries
-        train_queries_set = {q["query"] for q in train_set}
-        train_result_list = [r for r in all_results["results"] if r["query"] in train_queries_set]
-        test_result_list = [r for r in all_results["results"] if r["query"] not in train_queries_set]
-
-        train_passed = sum(1 for r in train_result_list if r["pass"])
-        train_total = len(train_result_list)
-        train_summary = {"passed": train_passed, "failed": train_total - train_passed, "total": train_total}
-        train_results = {"results": train_result_list, "summary": train_summary}
-
-        if test_set:
-            test_passed = sum(1 for r in test_result_list if r["pass"])
-            test_total = len(test_result_list)
-            test_summary = {"passed": test_passed, "failed": test_total - test_passed, "total": test_total}
-            test_results = {"results": test_result_list, "summary": test_summary}
-        else:
-            test_results = None
-            test_summary = None
-
-        history.append({
-            "iteration": iteration,
-            "description": current_description,
-            "train_passed": train_summary["passed"],
-            "train_failed": train_summary["failed"],
-            "train_total": train_summary["total"],
-            "train_results": train_results["results"],
-            "test_passed": test_summary["passed"] if test_summary else None,
-            "test_failed": test_summary["failed"] if test_summary else None,
-            "test_total": test_summary["total"] if test_summary else None,
-            "test_results": test_results["results"] if test_results else None,
-            # For backward compat with report generator
-            "passed": train_summary["passed"],
-            "failed": train_summary["failed"],
-            "total": train_summary["total"],
-            "results": train_results["results"],
-        })
-
-        # Write live report if path provided
-        if live_report_path:
-            partial_output = {
-                "original_description": original_description,
-                "best_description": current_description,
-                "best_score": "in progress",
-                "iterations_run": len(history),
-                "holdout": holdout,
-                "train_size": len(train_set),
-                "test_size": len(test_set),
-                "history": history,
-            }
-            live_report_path.write_text(generate_html(partial_output, auto_refresh=True, skill_name=name))
-
-        if verbose:
-            def print_eval_stats(label, results, elapsed):
-                pos = [r for r in results if r["should_trigger"]]
-                neg = [r for r in results if not r["should_trigger"]]
-                tp = sum(r["triggers"] for r in pos)
-                pos_runs = sum(r["runs"] for r in pos)
-                fn = pos_runs - tp
-                fp = sum(r["triggers"] for r in neg)
-                neg_runs = sum(r["runs"] for r in neg)
-                tn = neg_runs - fp
-                total = tp + tn + fp + fn
-                precision = tp / (tp + fp) if (tp + fp) > 0 else 1.0
-                recall = tp / (tp + fn) if (tp + fn) > 0 else 1.0
-                accuracy = (tp + tn) / total if total > 0 else 0.0
-                print(f"{label}: {tp+tn}/{total} correct, precision={precision:.0%} recall={recall:.0%} accuracy={accuracy:.0%} ({elapsed:.1f}s)", file=sys.stderr)
-                for r in results:
-                    status = "PASS" if r["pass"] else "FAIL"
-                    rate_str = f"{r['triggers']}/{r['runs']}"
-                    print(f"  [{status}] rate={rate_str} expected={r['should_trigger']}: {r['query'][:60]}", file=sys.stderr)
-
-            print_eval_stats("Train", train_results["results"], eval_elapsed)
-            if test_summary:
-                print_eval_stats("Test ", test_results["results"], 0)
-
-        if train_summary["failed"] == 0:
-            exit_reason = f"all_passed (iteration {iteration})"
+    try:
+        for iteration in range(1, max_iterations + 1):
             if verbose:
-                print(f"\nAll train queries passed on iteration {iteration}!", file=sys.stderr)
-            break
+                print(f"\n{'='*60}", file=sys.stderr)
+                print(f"Iteration {iteration}/{max_iterations}", file=sys.stderr)
+                print(f"Description: {current_description}", file=sys.stderr)
+                print(f"{'='*60}", file=sys.stderr)
 
-        if iteration == max_iterations:
-            exit_reason = f"max_iterations ({max_iterations})"
+            # Evaluate train + test together in one batch for parallelism
+            all_queries = train_set + test_set
+            t0 = time.time()
+            all_results = run_eval(
+                eval_set=all_queries,
+                skill_name=name,
+                description=current_description,
+                num_workers=num_workers,
+                timeout=timeout,
+                project_root=project_root,
+                runs_per_query=runs_per_query,
+                trigger_threshold=trigger_threshold,
+                model=model,
+            )
+            eval_elapsed = time.time() - t0
+
+            # Split results back into train/test by matching queries
+            train_queries_set = {q["query"] for q in train_set}
+            train_result_list = [r for r in all_results["results"] if r["query"] in train_queries_set]
+            test_result_list = [r for r in all_results["results"] if r["query"] not in train_queries_set]
+
+            train_passed = sum(1 for r in train_result_list if r["pass"])
+            train_total = len(train_result_list)
+            train_summary = {"passed": train_passed, "failed": train_total - train_passed, "total": train_total}
+            train_results = {"results": train_result_list, "summary": train_summary}
+
+            if test_set:
+                test_passed = sum(1 for r in test_result_list if r["pass"])
+                test_total = len(test_result_list)
+                test_summary = {"passed": test_passed, "failed": test_total - test_passed, "total": test_total}
+                test_results = {"results": test_result_list, "summary": test_summary}
+            else:
+                test_results = None
+                test_summary = None
+
+            history.append({
+                "iteration": iteration,
+                "description": current_description,
+                "train_passed": train_summary["passed"],
+                "train_failed": train_summary["failed"],
+                "train_total": train_summary["total"],
+                "train_results": train_results["results"],
+                "test_passed": test_summary["passed"] if test_summary else None,
+                "test_failed": test_summary["failed"] if test_summary else None,
+                "test_total": test_summary["total"] if test_summary else None,
+                "test_results": test_results["results"] if test_results else None,
+                # For backward compat with report generator
+                "passed": train_summary["passed"],
+                "failed": train_summary["failed"],
+                "total": train_summary["total"],
+                "results": train_results["results"],
+            })
+
+            # Write live report if path provided
+            if live_report_path:
+                partial_output = {
+                    "original_description": original_description,
+                    "best_description": current_description,
+                    "best_score": "in progress",
+                    "iterations_run": len(history),
+                    "holdout": holdout,
+                    "train_size": len(train_set),
+                    "test_size": len(test_set),
+                    "history": history,
+                }
+                live_report_path.write_text(generate_html(partial_output, auto_refresh=True, skill_name=name), encoding="utf-8")
+
             if verbose:
-                print(f"\nMax iterations reached ({max_iterations}).", file=sys.stderr)
-            break
+                def print_eval_stats(label, results, elapsed):
+                    pos = [r for r in results if r["should_trigger"]]
+                    neg = [r for r in results if not r["should_trigger"]]
+                    tp = sum(r["triggers"] for r in pos)
+                    pos_runs = sum(r["runs"] for r in pos)
+                    fn = pos_runs - tp
+                    fp = sum(r["triggers"] for r in neg)
+                    neg_runs = sum(r["runs"] for r in neg)
+                    tn = neg_runs - fp
+                    total = tp + tn + fp + fn
+                    precision = tp / (tp + fp) if (tp + fp) > 0 else 1.0
+                    recall = tp / (tp + fn) if (tp + fn) > 0 else 1.0
+                    accuracy = (tp + tn) / total if total > 0 else 0.0
+                    print(f"{label}: {tp+tn}/{total} correct, precision={precision:.0%} recall={recall:.0%} accuracy={accuracy:.0%} ({elapsed:.1f}s)", file=sys.stderr)
+                    for r in results:
+                        status = "PASS" if r["pass"] else "FAIL"
+                        rate_str = f"{r['triggers']}/{r['runs']}"
+                        print(f"  [{status}] rate={rate_str} expected={r['should_trigger']}: {r['query'][:60]}", file=sys.stderr)
 
-        # Improve the description based on train results
-        if verbose:
-            print(f"\nImproving description...", file=sys.stderr)
+                print_eval_stats("Train", train_results["results"], eval_elapsed)
+                if test_summary:
+                    print_eval_stats("Test ", test_results["results"], 0)
 
-        t0 = time.time()
-        # Strip test scores from history so improvement model can't see them
-        blinded_history = [
-            {k: v for k, v in h.items() if not k.startswith("test_")}
-            for h in history
-        ]
-        new_description = improve_description(
-            skill_name=name,
-            skill_content=content,
-            current_description=current_description,
-            eval_results=train_results,
-            history=blinded_history,
-            model=model,
-            log_dir=log_dir,
-            iteration=iteration,
-        )
-        improve_elapsed = time.time() - t0
+            if train_summary["failed"] == 0:
+                exit_reason = f"all_passed (iteration {iteration})"
+                if verbose:
+                    print(f"\nAll train queries passed on iteration {iteration}!", file=sys.stderr)
+                break
 
-        if verbose:
-            print(f"Proposed ({improve_elapsed:.1f}s): {new_description}", file=sys.stderr)
+            if iteration == max_iterations:
+                exit_reason = f"max_iterations ({max_iterations})"
+                if verbose:
+                    print(f"\nMax iterations reached ({max_iterations}).", file=sys.stderr)
+                break
 
-        current_description = new_description
+            # Improve the description based on train results
+            if verbose:
+                print(f"\nImproving description...", file=sys.stderr)
+
+            t0 = time.time()
+            # Strip test scores from history so improvement model can't see them
+            blinded_history = [
+                {k: v for k, v in h.items() if not k.startswith("test_")}
+                for h in history
+            ]
+            new_description = improve_description(
+                skill_name=name,
+                skill_content=content,
+                current_description=current_description,
+                eval_results=train_results,
+                history=blinded_history,
+                model=model,
+                log_dir=log_dir,
+                iteration=iteration,
+            )
+            improve_elapsed = time.time() - t0
+
+            if verbose:
+                print(f"Proposed ({improve_elapsed:.1f}s): {new_description}", file=sys.stderr)
+
+            current_description = new_description
+    finally:
+        cleanup_probe_commands(project_root, name)
 
     # Find the best iteration by TEST score (or train if no test set)
     if test_set:
@@ -258,7 +261,7 @@ def main():
     parser.add_argument("--results-dir", default=None, help="Save all outputs (results.json, report.html, log.txt) to a timestamped subdirectory here")
     args = parser.parse_args()
 
-    eval_set = json.loads(Path(args.eval_set).read_text())
+    eval_set = json.loads(Path(args.eval_set).read_text(encoding="utf-8"))
     skill_path = Path(args.skill_path)
 
     if not (skill_path / "SKILL.md").exists():
@@ -275,7 +278,7 @@ def main():
         else:
             live_report_path = Path(args.report)
         # Open the report immediately so the user can watch
-        live_report_path.write_text("<html><body><h1>Starting optimization loop...</h1><meta http-equiv='refresh' content='5'></body></html>")
+        live_report_path.write_text("<html><body><h1>Starting optimization loop...</h1><meta http-equiv='refresh' content='5'></body></html>", encoding="utf-8")
         webbrowser.open(str(live_report_path))
     else:
         live_report_path = None
@@ -310,15 +313,15 @@ def main():
     json_output = json.dumps(output, indent=2)
     print(json_output)
     if results_dir:
-        (results_dir / "results.json").write_text(json_output)
+        (results_dir / "results.json").write_text(json_output, encoding="utf-8")
 
     # Write final HTML report (without auto-refresh)
     if live_report_path:
-        live_report_path.write_text(generate_html(output, auto_refresh=False, skill_name=name))
+        live_report_path.write_text(generate_html(output, auto_refresh=False, skill_name=name), encoding="utf-8")
         print(f"\nReport: {live_report_path}", file=sys.stderr)
 
     if results_dir and live_report_path:
-        (results_dir / "report.html").write_text(generate_html(output, auto_refresh=False, skill_name=name))
+        (results_dir / "report.html").write_text(generate_html(output, auto_refresh=False, skill_name=name), encoding="utf-8")
 
     if results_dir:
         print(f"Results saved to: {results_dir}", file=sys.stderr)

--- a/skills/skill-creator/scripts/utils.py
+++ b/skills/skill-creator/scripts/utils.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 def parse_skill_md(skill_path: Path) -> tuple[str, str, str]:
     """Parse a SKILL.md file, returning (name, description, full_content)."""
-    content = (skill_path / "SKILL.md").read_text()
+    content = (skill_path / "SKILL.md").read_text(encoding="utf-8")
     lines = content.split("\n")
 
     if lines[0].strip() != "---":


### PR DESCRIPTION
## Summary
- Replaced `select.select()` on pipes in `run_eval.py` with a thread-safe `queue.Queue` reader thread, avoiding WinSock-only `select()` crashes on Windows anonymous pipes.
- Updated `find_project_root()` to explicitly avoid matching `Path.home()` (`~/.claude`), ensuring probe command files are never written to the user's global command directory.
- Added `cleanup_probe_commands()` invoked at start and in `finally` blocks across `run_eval.py` and `run_loop.py` to guarantee probe files (`*-skill-*.md`) are safely deleted even when runs are interrupted or fail.
- Added explicit `utf-8` encoding across file operations in `run_eval.py`, `run_loop.py`, `improve_description.py`, and `utils.py` to avoid Windows ANSI/cp1252 decoding errors.

Fixes #1692

cc @98zc5g5jyw-arch for review