### PR TITLE
Add pr-reviewer skill for systematic 7-dimension code review

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -40,8 +40,7 @@
         "./skills/web-artifacts-builder",
         "./skills/webapp-testing"
       ]
-    }
-    ,
+    },
     {
       "name": "claude-api",
       "description": "Claude API and SDK documentation skill for building LLM-powered applications",
@@ -67,6 +66,15 @@
       "strict": false,
       "skills": [
         "./skills/discernment-nudge"
+      ]
+    },
+    {
+      "name": "pr-reviewer",
+      "description": "Systematic seven-dimension code review for pull requests, branch diffs, and staged changes — findings classified as blocker/should-fix/nit with file:line anchors, instead of a superficial read",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/pr-reviewer"
       ]
     }
   ]

--- a/skills/pr-reviewer/LICENSE.txt
+++ b/skills/pr-reviewer/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Hahaknight
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/pr-reviewer/SKILL.md
+++ b/skills/pr-reviewer/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: pr-reviewer
+description: >
+  Use this skill when reviewing a pull request, a branch diff, staged
+  changes, or when the user asks to "review this", check a change for
+  problems, or look over a diff before committing or merging. Performs a
+  systematic seven-dimension review — correctness, security, performance,
+  contracts, error handling, tests, maintainability — instead of a
+  superficial read, and classifies every finding as blocker / should-fix /
+  nit with file:line anchors and a minimal suggested fix.
+---
+
+# PR Reviewer — Systematic Code Review
+
+You are a staff-level engineer doing review. Never rubber-stamp. Your job is to find what the author missed, not to praise.
+
+## Inputs (detect automatically)
+
+- `gh pr view N --json ...` + `gh pr diff N` → review a PR
+- `git diff main...HEAD` → review a branch
+- `git diff --staged` → review staged work
+- Explicit paths from the user
+
+If the diff is >2000 lines, review file-by-file in logical commits; sample the largest files fully, and say what you did NOT read.
+
+## Workflow
+
+1. **Context first (30 seconds)**: Read the PR/issue description and linked issues BEFORE the diff. State in one line what the change is supposed to do. If you can't state it, ask.
+2. **Read the tests before the implementation.** Tests reveal intended behavior.
+3. **Dimension sweep** — for each file, check in order; report only real findings:
+   - Correctness: off-by-one, null/undefined paths, race conditions, unhandled promise rejections, timezone/locale assumptions, encoding, integer overflow, stale cache/state after mutation
+   - Security: injection (SQL/command/template), authz on new endpoints, secrets in code/logs, path traversal, deserialization of user input, SSRF, missing input validation on trust boundaries
+   - Performance: N+1 queries, accidental O(n²) on hot paths, loading entire tables, sync I/O in async contexts, unbounded memory growth
+   - Contracts: API shape changes vs consumers, DB schema vs migrations vs ORM models, breaking config/env changes, type narrowing that pushes errors to callers
+   - Error handling: swallowed errors, errors logged-but-rethrown twice, missing rollback/cleanup on failure paths, partial-write states
+   - Tests: does the new behavior have a failing-without-change test? Are edge cases covered or only the happy path?
+   - Maintainability: duplicated logic that will drift, magic numbers, misleading names, dead code
+4. **Verify, don't speculate**: open the surrounding code and call sites for anything suspicious. A finding you can't ground in a specific line is noise — discard it.
+5. **Classify each finding**: `blocker` (must fix before merge) / `should-fix` / `nit`. One line each, file:line anchored, with the minimal suggested fix.
+
+## Output format
+
+```
+## Review: <one-line summary of the change>
+
+Verdict: APPROVE / APPROVE WITH NITS / REQUEST CHANGES
+
+### Blockers
+- `path/file.ts:42` — description + minimal fix
+
+### Should-fix
+- ...
+
+### Nits
+- ...
+
+### Questions for the author
+- ...
+```
+
+## Anti-patterns
+
+- DO NOT comment on style when a linter/formatter config exists in the repo — that's the linter's job.
+- DO NOT suggest rewrites when a 3-line fix works. Match the codebase's existing idiom.
+- DO NOT report a "missing test" for trivial type-only or config changes.
+- DO NOT approve because "tests pass" — passing tests do not review the diff. Read every changed line at least once.


### PR DESCRIPTION
## Summary

Adds `pr-reviewer`, a skill that turns code review from a superficial read into a systematic seven-dimension sweep — correctness, security, performance, contracts, error handling, tests, maintainability — with every finding classified as `blocker` / `should-fix` / `nit`, anchored to `file:line`, and paired with a minimal suggested fix.

- **`skills/pr-reviewer/SKILL.md`** — input detection (`gh pr diff`, branch diff, staged diff), the dimension checklist, output format (verdict + classified findings + questions for the author), and anti-patterns (no style comments when a linter exists, no rewrites when a 3-line fix works, no approving because tests pass).
- **`skills/pr-reviewer/LICENSE.txt`** — Apache 2.0.
- **`.claude-plugin/marketplace.json`** — registers the skill as its own plugin entry.

The engineering-workflow gap: current skills here cover documents, design, and API guidance well, but there is no review skill. This one is deliberately opinionated — it instructs the agent to read tests before implementation, verify suspicions in surrounding code before reporting, and discard any finding it cannot ground in a specific line.

I maintain a larger pack of engineering workflow skills (test generation, root-cause debugging, safe refactoring) at [Hahaknight/claude-skills-pro](https://github.com/Hahaknight/claude-skills-pro); this contribution is the standalone review skill from that pack, MIT-licensed there and Apache 2.0 here. Happy to adjust naming, description, or placement to fit the repo's conventions.