### PR TITLE
Add api-governance skill (CodeRifts)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -40,8 +40,7 @@
         "./skills/web-artifacts-builder",
         "./skills/webapp-testing"
       ]
-    }
-    ,
+    },
     {
       "name": "claude-api",
       "description": "Claude API and SDK documentation skill for building LLM-powered applications",
@@ -67,6 +66,15 @@
       "strict": false,
       "skills": [
         "./skills/discernment-nudge"
+      ]
+    },
+    {
+      "name": "coderifts-api-governance",
+      "description": "Governance decisions for API and agent-tool contract changes via the CodeRifts MCP server: preflight a change set, then branch on execution_action",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/api-governance"
       ]
     }
   ]

--- a/skills/api-governance/LICENSE.txt
+++ b/skills/api-governance/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 CodeRifts
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/api-governance/SKILL.md
+++ b/skills/api-governance/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: api-governance
+description: Before merging or shipping any API or tool-contract change: preflight the change set, then branch on execution_action.
+license: Complete terms in LICENSE.txt
+---
+
+# CodeRifts API Governance
+
+<!-- The rule sentences below are GENERATED in the CodeRifts source of truth
+     (github.com/coderifts/api-governance) from one canonical rule text, and are reproduced here
+     byte-for-byte. Section headings are presentational. Do not edit a rule sentence here; it
+     would diverge from every other surface that carries the same text. -->
+
+Governance decisions for API and agent-tool contract changes, via the CodeRifts MCP server. The
+skill tells Claude when to ask for a decision, and how to read the answer.
+
+## When to call it
+
+Call `preflight_change_set` before merge, deploy, publish, or tool registration when a contract artifact changed (OpenAPI/Swagger, GraphQL, gRPC/protobuf, AsyncAPI, MCP manifest, or agent tool schemas).
+
+Send the complete base-to-head change set: every changed contract artifact with full before and after content. Do not send a single-file subset when other contract files also change.
+
+## How to branch
+
+Branch on `execution_action` only. Do not branch on `decision` and do not branch on `safe_for_agent` (not_for_control_flow_use_execution_action). Canonical `execution_action` values: CONTINUE, CONTINUE_WITH_MONITORING, REQUEST_APPROVAL, STOP.
+
+An unrecognised `execution_action` is not permission: fail closed (halt or re-preflight). Well-known code: `not_permission_fail_closed`.
+
+When `execution_action` is REQUEST_APPROVAL or STOP, surface the detected patterns and the blast radius, and propose the safer path — deprecate-then-remove, an additive change, or a new version — rather than shipping the break.
+
+`CONTINUE_WITH_MONITORING` requires a wired monitoring sink (`monitoringSinkWired`). It is not "proceed with caution" without monitoring.
+
+## When NOT to call it
+
+Do not call `preflight_change_set` for: a documentation-only change (README, guides, comments) with no contract artifact content change; a static readiness score (a different capability, not a change-set decision); or to verify a receipt you already hold (that is `verify_receipt` — see the companion-tools rule).
+
+## The three tools
+
+If you already hold a chain receipt and only need authenticity/lifecycle: `verify_receipt`. If you need a past decision by id: `get_decision_details`. Neither replaces preflight for a new change set.
+
+The CodeRifts MCP server exposes exactly three tools — `preflight_change_set`, `verify_receipt`, `get_decision_details`. Do not invent or assume others.
+
+## Receipts are operation-scoped
+
+A receipt authorizes ONE operation: a merge receipt does not authorize a deploy. Before a different operation (deploy, publish), call `preflight_change_set` with `context.operation` set to that operation — reusing a differently-scoped receipt is not permitted and will fail at the gate.
+
+A stale or superseded receipt on a changed head requires a NEW preflight — `verify_receipt` cannot re-diff.
+
+## What this does and does not do
+
+For mutating tools, put only the guarded version in the agent's tool table; keep the raw handler host-only and unreachable from that table. How you name tools is yours — this is a reachability property, not a product rename of host tools. CodeRifts cannot see or stop a raw call the host makes outside the table it returns; adopt this as a host convention, not as a guarantee from the package.
+
+CodeRifts reports a governance decision and `execution_action`; it does not by itself block merges. Blocking requires separate repository configuration (required status checks, enforcement) that this rule file does not set.
+
+## Acting under a receipt
+
+To act (mutate a contract, merge, deploy, or publish): call `preflight_change_set` with `preflight_mode` authorize. Analyze is informational — risk only, `may_execute` is always false — and is not permission. Read `execution_action` on the `decision_result` envelope.
+
+Before acting under a held receipt: call `verify_receipt` with the intended `context` (operation, environment, repository, branch, pull_request) for THIS attempt. Do not act on a receipt whose scope does not match.
+
+Act only when `currently_authorized` is true (`control_envelope.receipt_view.currently_authorized`). A valid-looking token is not permission if `currently_authorized` is false or omitted.
+
+## Grants, profiles and commit evidence
+
+Commit / CAS evidence is a separate measurement (`commit_observation` on GuardOutcome). It is not a substitute for authorize + `currently_authorized`. Production hosts that want the fail-closed conjunction lock it with `profile: ENFORCING_STRICT` on withCodeRifts.
+
+If the host requests an execution grant (opt-in `include_execution_grant`), the grant is bound to operation + target + after-payload (`scope_hash`) and is short-lived — never reuse it after the after-payload changes.
+
+An ATOMIC-profile grant carries `state_nonce` and is single-use at the executor — if the executor has consumed the nonce, re-preflight; do not retry the same grant.
+
+Versions you may meet elsewhere: `cr.exec.v2` is the issued-token version for atomic execution, and `ENFORCING_STRICT_V1` is the versioned spelling of the strict profile. Neither is the default and neither is required by these rules — see `docs/grant-versions.md`.
+
+## Server-derived change sets, and what counts as proven
+
+With a proven tenant↔repo binding you may request `derivation:"server"` instead of assembling `artifacts[]` yourself (`context.repository` + `context.base` + `context.head` required; caller-supplied artifacts are rejected on that path).
+
+A commit is only proven when an executor attestation verifies (customer-held executor key, `cas_evidence: executor_attested`); otherwise say "authorized, commit not proven".
+
+## Install
+
+Hosted MCP server: `https://app.coderifts.com/mcp` (manifest: `https://coderifts.com/mcp.json`).
+Tool calls require `CODERIFTS_API_KEY`.
+
+Claude Code:
+
+```text
+/plugin marketplace add coderifts/api-governance
+/plugin install api-governance@coderifts
+```
+
+MCP Registry name: `io.github.coderifts/api-governance`.
+
+## Links
+
+- Website: <https://coderifts.com>
+- Decision Spec (the response contract this skill branches on): <https://coderifts.com/decision-spec.md>
+- Grant versions, the `docs/grant-versions.md` named in the versions rule above: <https://coderifts.com/docs/grant-versions.md>
+- Receipt format, frozen: <https://github.com/coderifts/receipt-verifier/blob/main/RECEIPT_FORMAT.md>
+- Open-source receipt verifier (Node + Python): <https://github.com/coderifts/receipt-verifier>
+- Live demo PR: <https://github.com/coderifts/demo/pull/4>


### PR DESCRIPTION
# Add `api-governance` skill (CodeRifts)

Adds one skill, `skills/api-governance/`, and registers it as a single-skill plugin in
`.claude-plugin/marketplace.json`.

## What the skill does

It teaches Claude when to ask for a governance decision on an **API or agent-tool contract
change**, and how to read the answer.

The decision comes from the CodeRifts MCP server, which exposes exactly three tools:
`preflight_change_set`, `verify_receipt`, `get_decision_details`. The skill's rule sentences cover:

- **when to call** — before merge, deploy, publish, or tool registration, when a contract artifact
  changed (OpenAPI/Swagger, GraphQL, gRPC/protobuf, AsyncAPI, MCP manifest, agent tool schemas);
- **how to branch** — on `execution_action` only (`CONTINUE`, `CONTINUE_WITH_MONITORING`,
  `REQUEST_APPROVAL`, `STOP`), never on `decision` or `safe_for_agent`, and an unrecognised value
  is not permission (fail closed);
- **when NOT to call** — three cases: a documentation-only change with no contract artifact content
  change; a static readiness score (a different capability, not a change-set decision); or
  re-checking a receipt you already hold (that is `verify_receipt`);
- **receipt scope** — a receipt authorizes one operation, and a stale receipt on a changed head
  needs a new preflight rather than a re-check.

## What it deliberately does not claim

The skill states its own limits, in its own words:

- CodeRifts reports a decision and an `execution_action`; **it does not by itself block merges.**
  Blocking requires repository configuration (required status checks) the skill does not set.
- `analyze` mode is informational — risk only — and is **not permission** (`may_execute` is always
  false).
- A valid-looking receipt is not authorization unless `currently_authorized` is true.
- Commit evidence is a separate measurement, not a substitute for authorize.

These sentences are load-bearing and are why the file reads the way it does.

## Install / use

Hosted MCP server: `https://app.coderifts.com/mcp` — manifest at `https://coderifts.com/mcp.json`.
Tool calls require a `CODERIFTS_API_KEY`; the skill alone (no key) still steers *when* to ask and
how to branch, and calls will fail closed without one.

Claude Code:

```text
/plugin marketplace add coderifts/api-governance
/plugin install api-governance@coderifts
```

MCP Registry name: `io.github.coderifts/api-governance`.

## Provenance of the rule text

The rule sentences are **generated from a single canonical source** in
[coderifts/api-governance](https://github.com/coderifts/api-governance) and are reproduced here
byte-for-byte, so this file cannot drift from the AGENTS.md / CLAUDE.md / Cursor / Copilot copies
that carry the same text. Only the frontmatter, the section headings, and the Install/Links
sections are specific to this repository. A drift gate in the source repo compares the copies.

One consequence worth naming: one rule sentence points at `docs/grant-versions.md` by relative
path. The sentence is reproduced unedited rather than rewritten for this repo — editing it here is
exactly the drift the generation exists to prevent — and that document is published at
<https://coderifts.com/docs/grant-versions.md>, linked from the Links section, so the citation
resolves for a reader of this repository.

## Public references

- Decision Spec (the response contract the skill branches on) — <https://coderifts.com/decision-spec.md>
- Receipt format, frozen — <https://github.com/coderifts/receipt-verifier/blob/main/RECEIPT_FORMAT.md>
- Open-source receipt verifier, Node + Python — <https://github.com/coderifts/receipt-verifier>
- Live demo PR — <https://github.com/coderifts/demo/pull/4>

## Files

| file | why |
|---|---|
| `skills/api-governance/SKILL.md` | the skill; frontmatter is `name` / `description` / `license` per this repo's convention |
| `skills/api-governance/LICENSE.txt` | MIT (CodeRifts), matching the `license:` frontmatter field |
| `.claude-plugin/marketplace.json` | one plugin entry, same key set as the existing single-skill entries |

## Testing

Loaded locally in Claude Code via `/plugin marketplace add .` against a checkout of this branch,
and the skill triggers on a contract-change prompt and stays silent on a documentation-only one.
