### PR TITLE
quick_validate: reject empty skill descriptions

### DIFF
--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -75,13 +75,14 @@ def validate_skill(skill_path):
     if not isinstance(description, str):
         return False, f"Description must be a string, got {type(description).__name__}"
     description = description.strip()
-    if description:
-        # Check for angle brackets
-        if '<' in description or '>' in description:
-            return False, "Description cannot contain angle brackets (< or >)"
-        # Check description length (max 1024 characters per spec)
-        if len(description) > 1024:
-            return False, f"Description is too long ({len(description)} characters). Maximum is 1024 characters."
+    if not description:
+        return False, "Description cannot be empty"
+    # Check for angle brackets
+    if '<' in description or '>' in description:
+        return False, "Description cannot contain angle brackets (< or >)"
+    # Check description length (max 1024 characters per spec)
+    if len(description) > 1024:
+        return False, f"Description is too long ({len(description)} characters). Maximum is 1024 characters."
 
     # Validate compatibility field if present (optional)
     compatibility = frontmatter.get('compatibility', '')


### PR DESCRIPTION
`quick_validate.py` accepts `description: ""` (or whitespace-only): the presence check passes because the key exists, and `if description:` then skips the angle-bracket and length checks entirely, so the skill validates.

That matters beyond the script itself. The description is the one field agents read to decide when to load a skill — an empty one makes the skill undiscoverable — and `package_skill.py` imports `validate_skill`, so skill-creator packages such skills without complaint.

The fix is one guard: strip, then fail with "Description cannot be empty" when nothing remains. The existing angle-bracket and length checks de-indent unchanged.

Verified: `description: ""` and `description: "   "` now fail, a normal description and the skill-creator skill itself still pass, and `validate_skill` imported the way `package_skill.py` uses it returns `(True, 'Skill is valid!')` on a valid skill.