### PR TITLE
fix(mcp-builder): write evaluation report as UTF-8

### DIFF
--- a/skills/mcp-builder/scripts/evaluation.py
+++ b/skills/mcp-builder/scripts/evaluation.py
@@ -363,7 +363,7 @@ Examples:
         report = await run_evaluation(args.eval_file, connection, args.model)
 
         if args.output:
-            args.output.write_text(report)
+            args.output.write_text(report, encoding="utf-8")
             print(f"\n✅ Report saved to {args.output}")
         else:
             print("\n" + report)


### PR DESCRIPTION
Fixes #1669.

`Path.write_text()` defaults to the locale encoding. On Windows that is cp1252, and the report contains the ✅/❌ correctness markers from `TASK_TEMPLATE`. As soon as at least one task is marked incorrect, the run raises `UnicodeEncodeError` on the final `write_text()` call, and the entire paid-for evaluation result is discarded.

`PYTHONIOENCODING` does not help (it governs stdio, not pathlib).

Pass an explicit `encoding="utf-8"` so the report survives on any locale.