### PR TITLE
mcp-builder: update evaluation.py default model to claude-sonnet-5

### DIFF
--- a/skills/mcp-builder/reference/evaluation.md
+++ b/skills/mcp-builder/reference/evaluation.md
@@ -485,7 +485,7 @@ positional arguments:
 optional arguments:
   -h, --help            Show help message
   -t, --transport       Transport type: stdio, sse, or http (default: stdio)
-  -m, --model           Claude model to use (default: claude-3-7-sonnet-20250219)
+  -m, --model           Claude model to use (default: claude-sonnet-5)
   -o, --output          Output file for report (default: print to stdout)
 
 stdio options:
@@ -596,7 +596,7 @@ If many evaluations fail:
 ### Timeout Issues
 
 If tasks are timing out:
-- Use a more capable model (e.g., `claude-3-7-sonnet-20250219`)
+- Use a more capable model than the default (e.g., `-m claude-opus-5`)
 - Check if tools are returning too much data
 - Verify pagination is working correctly
 - Consider simplifying complex questions

--- a/skills/mcp-builder/scripts/evaluation.py
+++ b/skills/mcp-builder/scripts/evaluation.py
@@ -220,10 +220,10 @@ TASK_TEMPLATE = """
 async def run_evaluation(
     eval_path: Path,
     connection: Any,
-    model: str = "claude-3-7-sonnet-20250219",
+    model: str = "claude-sonnet-5",
 ) -> str:
     """Run evaluation with MCP server tools."""
-    print("🚀 Starting Evaluation")
+    print(f"🚀 Starting Evaluation (model: {model})")
 
     client = Anthropic()
 
@@ -315,13 +315,13 @@ Examples:
   python evaluation.py -t sse -u https://example.com/mcp -H "Authorization: Bearer token" eval.xml
 
   # Evaluate an HTTP MCP server with custom model
-  python evaluation.py -t http -u https://example.com/mcp -m claude-3-5-sonnet-20241022 eval.xml
+  python evaluation.py -t http -u https://example.com/mcp -m claude-opus-5 eval.xml
         """,
     )
 
     parser.add_argument("eval_file", type=Path, help="Path to evaluation XML file")
     parser.add_argument("-t", "--transport", choices=["stdio", "sse", "http"], default="stdio", help="Transport type (default: stdio)")
-    parser.add_argument("-m", "--model", default="claude-3-7-sonnet-20250219", help="Claude model to use (default: claude-3-7-sonnet-20250219)")
+    parser.add_argument("-m", "--model", default="claude-sonnet-5", help="Claude model to use (default: claude-sonnet-5)")
 
     stdio_group = parser.add_argument_group("stdio options")
     stdio_group.add_argument("-c", "--command", help="Command to run MCP server (stdio only)")


### PR DESCRIPTION
## What

`skills/mcp-builder/scripts/evaluation.py` defaulted to `claude-3-7-sonnet-20250219` in both the `run_evaluation()` signature and the `-m/--model` argparse option, and `reference/evaluation.md` recommended that same snapshot as the "more capable" alternative under troubleshooting. This PR points both defaults at `claude-sonnet-5`, updates the usage text in `reference/evaluation.md` to match, and rewords the troubleshooting bullet to suggest a step up from the default (`-m claude-opus-5`) rather than the default itself. It also prints the model id in the run header so a score is always attributable to a baseline, and updates the `--help` example that passed `claude-3-5-sonnet-20241022` so it no longer points at a retired snapshot.

## Why

The harness exists to tell an MCP author whether their tool descriptions are good enough for a current agent to use, and scoring against a three-generation-old model measures the wrong thing. `claude-sonnet-5` is the id this repo's own `skills/claude-api/shared/model-migration.md` lists as the replacement for `claude-3-7-sonnet-20250219`, and model ids in this repo are bare aliases with no date suffix, so the default will not break when an old snapshot is retired.

Fixes #1716

## Verification

- `python3 -m py_compile skills/mcp-builder/scripts/evaluation.py` exits 0.
- `evaluation.py --help` (argparse, with `connections` stubbed) prints `-m, --model MODEL     Claude model to use (default: claude-sonnet-5)` and exits 0.
- `grep -rn "claude-3-7\|claude-3-5" skills/mcp-builder` returns no matches.
- Note: running `--help` directly with `mcp` 2.1.1 installed fails in `connections.py` (`streamablehttp_client` import). That reproduces identically on `main` and is unrelated to this change.
