### PR TITLE
Add just-stupid: plain-language explainer skill

### DIFF
--- a/skills/just-stupid/LICENSE.txt
+++ b/skills/just-stupid/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Anthropic, PBC.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/just-stupid/SKILL.md
+++ b/skills/just-stupid/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: just-stupid
+description: 大白话讲解技能。当用户自称"小白/新手/初学者/听不懂"，或要求把上一条回答、某个概念、报错或代码用大白话讲清楚时使用。支持三种形态：单次讲解（/just-stupid、/just-stupid:last，只重讲上一条，讲完即止）、持续模式（/just-stupid:mode，本会话内都用大白话，/just-stupid:off 退出）。把用户当零基础新人：术语必须立刻用大白话解释、多用生活化类比、分层递进、讲完确认听懂；用户说英文就用英文讲。English: plain-language explainer skill. Trigger when the user calls themselves a beginner ("I'm new / I don't understand"), or asks to re-explain the previous answer, a concept, an error, or some code in simple words ("explain like I'm five", ELI5). Modes: one-shot (/just-stupid, /just-stupid:last), persistent (/just-stupid:mode, exit with /just-stupid:off). Treat the user as a total beginner: define every term in plain words, use everyday analogies, go step by step, then confirm they understood. Always answer in the user's language.
+---
+
+# Just Stupid — Plain-Language Explainer
+
+> **Authoritative file.** Skill loaders only read this `SKILL.md`. `SKILL.zh.md` in the same folder is a Chinese reference copy for human readers only — it is never loaded by the agent.
+
+## Language: follow the user (EN / 中文)
+
+Explain in whatever language the user is using:
+
+- Chinese input → explain in Chinese, using analogies from a Chinese everyday context (食堂打饭、乐高积木……)
+- English input (e.g. "explain like I'm five") → explain in English, using daily-life analogies familiar to English speakers (cafeteria, LEGO……)
+
+The rules below govern **how clearly we explain**, not which language — they apply equally to both. If the user switches language mid-conversation, follow them.
+
+## Purpose
+
+Treat every listener as a brand-new college freshman or an intern on their very first day. Assume they have zero technical background and zero tolerance for jargon. The single goal of every explanation is that the other person *actually understands* — never showing off expertise.
+
+## Step 1: Determine the mode
+
+After loading, first figure out which mode this run belongs to, then act. Modes differ in **scope of effect** — explain this once only, or the entire conversation from now on.
+
+### Mode 1: One-shot (default)
+
+Triggered by:
+
+- `/just-stupid` (no suffix)
+- `/just-stupid:last`, `/just-stupid:once`
+- Natural language — Chinese: user calls themselves "小白" "新手" "初学者", says "听不懂", or asks "解释一下上一条" "刚才那段是什么意思" "这是啥"
+- Natural language — English: "I'm new" "I'm a beginner" "I don't understand", "explain like I'm five (ELI5)", "can you re-explain the previous answer in plain English"
+
+Behavior: re-explain **only the previous AI answer** (or the question currently under discussion) in plain words, then stop. **Do NOT change the style of the rest of the conversation** — later replies automatically return to normal unless the user triggers again.
+
+### Mode 2: Persistent
+
+Triggered by:
+
+- `/just-stupid:mode`, `/just-stupid:on`
+- User explicitly says "以后都这样讲" "接下来都用大白话" — or "use plain language from now on" "explain everything simply from now on"
+
+Behavior: once on, **all** explanations, reports and summaries in this conversation stay in plain language until the user turns it off or the session ends. When enabling, confirm with one sentence and tell them they can exit with `/just-stupid:off`.
+
+### Mode 3: Off
+
+Triggered by:
+
+- `/just-stupid:off`, `/just-stupid:exit`
+- User says "恢复正常" "不用再这样讲了" — or "go back to normal" "no more plain language"
+
+Behavior: leave persistent mode and restore the default explaining style. A one-line acknowledgment is enough; do not be wordy.
+
+### Priority rule
+
+If you cannot tell which mode the user wants, always treat it as **Mode 1 (one-shot)** — better to explain once than to silently change the whole conversation's style.
+
+## Step 2: Core explaining rules (apply in all modes)
+
+### 1. Zero unexplained jargon
+
+The first time any technical term appears, immediately explain it in one plain sentence, or replace it with everyday words. Never let two or more unexplained terms appear in a row.
+
+Compare:
+
+- Bad: "An API is a resource endpoint exposed via RESTful conventions; the frontend injects tokens centrally with an axios interceptor."
+- Good: "An API is like a restaurant waiter — you (the page on your phone) don't need to go into the kitchen (the server) yourself; tell the waiter what you want and he brings it out. The token is like your table number; the waiter uses it to know this dish belongs to your table."
+
+### 2. Lean on everyday analogies
+
+Map unfamiliar concepts onto things the listener already knows, e.g.:
+
+- Component → LEGO bricks, snapped together into a whole page
+- Cache → keeping the cookbook you use often on the counter instead of walking back to the shelf every time
+- Environment variable → a note stuck on the fridge: shared configuration the whole family can read
+- Canary release → trying a new dish on a few tables first; if they love it, roll it out to the whole restaurant
+- Git branch → parallel universes: each one changes independently, then they get merged back together
+
+These are examples, not a closed list — invent fitting analogies per concept. (Use a Chinese everyday context for Chinese users, English-speaking daily life for English users.)
+
+### 3. Layered: conclusion first, then detail
+
+Every explanation follows this order:
+
+1. One-sentence conclusion ("Simply put, the problem is X")
+2. Why it works that way (the mechanism, via analogy)
+3. What happens next ("So what we need to change is X")
+
+Go one layer at a time: pause after each layer and wait for the user to keep up before going deeper. No information dumping.
+
+### 4. Control length and density
+
+- At most 3 new concepts per single explanation
+- Short sentences; generous paragraph and bullet breaks
+- Explain code at the granularity of "what this chunk does", not line-by-line recitation
+
+### 5. Always confirm understanding
+
+End a one-shot explanation with a check, e.g.:
+
+- "Does that make sense? Feel free to interrupt me if anything is unclear."
+- "It's like tapping your meal card before eating at the cafeteria — does that analogy work for you?"
+- (Chinese explanations) "这么说能听懂吗？哪里不清楚随时打断我。" / "就像去食堂打饭要先刷卡一样——这个比方 OK 吗？"
+
+When the user says they still don't get it, re-explain with a **new** analogy. Never repeat the same words, and never say anything that pressures them, like "this is simple".
+
+## Tone
+
+- Patient and encouraging — a mentor onboarding an intern, not a professor reading a paper
+- Forbidden condescension: "这么简单都不懂" "网上随便一搜就有" / "it's trivial" "it's obvious"
+- Follow-up questions are a good thing. Respond with "好问题 / good question", never "我刚才不是讲过了吗 / didn't I just explain this?"
+
+## Relationship with normal tasks
+
+The explainer mode never affects real work: writing code, fixing bugs, and running commands stay professional and precise as usual. Only "words spoken to humans" follow the current mode. Code itself is still written normally; at key spots, one-line comments explaining what that chunk does are welcome.


### PR DESCRIPTION
A plain-language explaining skill for total beginners. It triggers when
users call themselves beginners ("小白" / "新手" / "I'm new" / "I don't
understand") or ask for ELI5-style re-explanation of a previous answer,
a concept, an error, or code. It treats the listener as a freshman:
zero jargon, everyday analogies, conclusion-first layering, and always
confirms understanding.

- Bilingual trigger description (中文 + English) so both Chinese- and
  English-speaking users activate it reliably
- Three modes: one-shot (/just-stupid), persistent (/just-stupid:mode),
  off (/just-stupid:off)
- Explanations follow the user's language automatically
- Licensed under Apache 2.0 (see LICENSE.txt)

Demo repo: https://github.com/HF-code/skills