### PR TITLE
fix(docx,pptx,xlsx): decode git diff output as UTF-8 in redlining validator

### DIFF
--- a/skills/docx/scripts/office/validators/redlining.py
+++ b/skills/docx/scripts/office/validators/redlining.py
@@ -201,7 +201,8 @@ class RedliningValidator:
                         str(modified_file),
                     ],
                     capture_output=True,
-                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
                 )
 
                 if result.stdout.strip():
@@ -229,7 +230,8 @@ class RedliningValidator:
                         str(modified_file),
                     ],
                     capture_output=True,
-                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
                 )
 
                 if result.stdout.strip():

--- a/skills/pptx/scripts/office/validators/redlining.py
+++ b/skills/pptx/scripts/office/validators/redlining.py
@@ -201,7 +201,8 @@ class RedliningValidator:
                         str(modified_file),
                     ],
                     capture_output=True,
-                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
                 )
 
                 if result.stdout.strip():
@@ -229,7 +230,8 @@ class RedliningValidator:
                         str(modified_file),
                     ],
                     capture_output=True,
-                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
                 )
 
                 if result.stdout.strip():

--- a/skills/xlsx/scripts/office/validators/redlining.py
+++ b/skills/xlsx/scripts/office/validators/redlining.py
@@ -201,7 +201,8 @@ class RedliningValidator:
                         str(modified_file),
                     ],
                     capture_output=True,
-                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
                 )
 
                 if result.stdout.strip():
@@ -229,7 +230,8 @@ class RedliningValidator:
                         str(modified_file),
                     ],
                     capture_output=True,
-                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
                 )
 
                 if result.stdout.strip():


### PR DESCRIPTION
Fixes #1707.

`_get_git_word_diff` writes both temp files as UTF-8 but ran `git diff` with `subprocess.run(..., text=True)`, which decodes with the locale codec (`cp1252` on default Windows). As reported, that produces either silent mojibake (arrows, curly quotes, em dashes) or a `UnicodeDecodeError` on subprocess's reader thread, which leaves `result.stdout` as `None` and surfaces later as a misleading `AttributeError`.

This replaces `text=True` with an explicit codec matching what the files were written with, at both call sites:

```python
capture_output=True,
encoding="utf-8",
errors="replace",
```

The change is applied identically to the byte-identical `skills/{docx,pptx,xlsx}/scripts/office/validators/redlining.py` (SHA-256 verified equal before and after). `errors="replace"` additionally guarantees the reader thread cannot raise, removing the `stdout is None` failure mode entirely.

Verification on Windows (locale `cp936`, UTF-8 mode off), stubbing only the module's unrelated imports and calling the real `RedliningValidator._get_git_word_diff`:

- `before -> x` / `after → y` → round-trips U+2192 correctly (old style mojibake'd it).
- Devanagari `नमस्ते` and Cyrillic U+050F additions → round-trip correctly (old style corrupted U+050F to U+8A6E under `cp936`, and crashes under `cp1252` per the issue).

No test suite exists for this script and no other behavior changes; the diff is the two `subprocess.run` kwargs in each of the three files.
