### PR TITLE
docs: use HTTPS for agentskills.io link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> **Note:** This repository contains Anthropic's implementation of skills for Claude. For information about the Agent Skills standard, see [agentskills.io](http://agentskills.io).
+> **Note:** This repository contains Anthropic's implementation of skills for Claude. For information about the Agent Skills standard, see [agentskills.io](https://agentskills.io).
 
 [![skills.sh](https://skills.sh/b/anthropics/skills)](https://skills.sh/anthropics/skills)
 


### PR DESCRIPTION
The note at the top of the README links to agentskills.io over `http://`, while every other link in the file uses `https://`.

`http://agentskills.io` currently returns a **308 permanent redirect** to `https://agentskills.io/`, so this updates the link to point directly at the canonical HTTPS URL — matching the rest of the README and avoiding an unnecessary redirect hop.

No content changes; documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)