### PR TITLE
Add portable CC for Codex Agent Skill

### DIFF
--- a/skills/cc-for-codex/LICENSE.txt
+++ b/skills/cc-for-codex/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Anthropic, PBC.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/cc-for-codex/SKILL.md
+++ b/skills/cc-for-codex/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: cc-for-codex
+description: >
+  Use an explicitly requested, locally installed Claude Code CLI as an
+  independent second agent from Codex for reviews, bounded investigations,
+  and resumable handoffs. Trigger when the user asks Codex to consult, review
+  with, delegate to, or hand work to Claude Code; do not invoke it implicitly.
+license: Complete terms in LICENSE.txt
+---
+
+# CC for Codex
+
+This is a portable instruction skill for Codex. It describes how to use a
+user-owned Claude Code installation from a Codex task. The production bridge,
+permission guards, session ledger, and test suite live in the standalone
+[CC for Codex repository](https://github.com/sanchitmonga22/cc-for-codex);
+this skill deliberately keeps the Agent Skills layer small and portable.
+
+## Before invoking Claude
+
+1. Confirm that the user asked for Claude Code, or explicitly approved the
+   delegation. Never invoke a second model merely because it might be useful.
+2. Tell the user that the local Claude process will use their existing Claude
+   login/provider configuration and may consume Anthropic plan or API usage.
+3. Resolve the current repository and read its `AGENTS.md` and `CLAUDE.md`
+   before requesting review or edits.
+4. Verify the local CLI with `claude --version`. If the tested bridge is
+   installed, run its local doctor command before a live request:
+
+   ```text
+   <cc-for-codex-checkout>/plugins/cc-for-codex/scripts/cc-for-codex doctor --json
+   ```
+
+   If the bridge is not installed, stop and offer the installation steps in
+   [installation.md](references/installation.md). Do not silently assemble a
+   raw shell command for an untrusted prompt.
+
+## Default workflow
+
+- Use a read-only review for a second opinion. Keep the scope explicit (the
+  working tree, `HEAD`, or a user-selected base ref) and return Claude's
+  response as attributed evidence, not as Codex's own conclusion.
+- Use an adversarial review when the user asks for challenge, failure-mode
+  analysis, or hidden-assumption checking.
+- Use bounded delegation only when the user explicitly asks Claude to
+  investigate or implement. A write task must use a fresh verified Git
+  worktree and must never overlap with Codex edits.
+- Preserve a returned session identifier only when the user asks for a
+  resumable conversation. Do not put secrets in prompts or background process
+  arguments.
+
+The standalone bridge exposes these workflows as the `ask`, `review`,
+`adversarial-review`, `delegate`, `handoff`, `resume`, and `sessions` commands.
+Prefer its launchers and skill-specific contracts over direct `claude` calls.
+
+## Safety boundaries
+
+- Reviews are read-only: no edits, shell execution, network tools, MCP,
+  Chrome, project hooks, or subagents.
+- Writes require separate confirmation of the edit and the host-safety risk.
+  The bridge's default write profile is dangerous zero-prompt mode; it is not
+  an operating-system sandbox even inside a Git worktree. Use the guarded
+  write profile when bypassing Claude's host checks is not explicitly wanted.
+- Background sessions, native passthrough, cloud/ultrareview, configuration
+  mutation, and destructive session operations each require their own
+  confirmation. Never use one confirmation as a substitute for another.
+- A worktree does not prove that a result is correct. Codex must inspect the
+  diff and run the repository's validation after Claude finishes.
+
+Read [safety.md](references/safety.md) before any opt-in write, background,
+native, cloud, or stateful operation. Report failures plainly and leave the
+user in control of authentication, billing, and merge/push decisions.
+
+## Provenance
+
+This skill is an independent contribution by Sanchit Monga. It is informed by
+the official [OpenAI Codex plugin for Claude Code](https://github.com/openai/codex-plugin-cc)
+and the tested implementation in [sanchitmonga22/cc-for-codex](https://github.com/sanchitmonga22/cc-for-codex).
+The corresponding OpenAI marketplace submission is preserved in the
+[pushed fork branch](https://github.com/sanchitmonga22/plugins/tree/add-cc-for-codex).
+
+Created with GPT-6 Astra in Codex.

--- a/skills/cc-for-codex/references/installation.md
+++ b/skills/cc-for-codex/references/installation.md
@@ -1,0 +1,53 @@
+# Installation and first run
+
+This skill is intentionally portable: it is a `SKILL.md` plus references,
+not a second copy of the bridge runtime. Install the maintained implementation
+from the standalone repository, then copy or symlink this skill into the
+Codex skill directory if it is not already discoverable.
+
+## Install the bridge
+
+Requirements are Node.js 20+, a local Claude Code CLI, and a Claude login or
+provider configuration. Clone the source into a user-selected directory:
+
+```sh
+git clone https://github.com/sanchitmonga22/cc-for-codex.git
+cd cc-for-codex/plugins/cc-for-codex
+npm run check
+```
+
+The check is local and uses a fake Claude executable; it does not make a
+model request. Run the bridge's doctor command from the checkout:
+
+```sh
+./scripts/cc-for-codex doctor --json
+```
+
+For a live smoke test, ask the user to approve the request and its billing.
+Use the bridge's `ask` or `review` command rather than a hand-written raw
+`claude` invocation.
+
+## Copy this skill into Codex
+
+Copy the `skills/cc-for-codex` directory into the user's Codex skills folder
+(commonly `~/.codex/skills/cc-for-codex`) or install it through the Codex
+skill/plugin mechanism used by the host. From a checkout of this repository,
+the direct copy is:
+
+```sh
+mkdir -p ~/.codex/skills
+cp -R skills/cc-for-codex ~/.codex/skills/cc-for-codex
+```
+
+Do not overwrite an existing skill without checking its provenance first.
+
+After installation, start a new Codex task and ask explicitly:
+
+```text
+Use $cc-for-codex to ask Claude Code for a read-only second opinion on my current changes.
+```
+
+If the full plugin package is installed, prefer its specialized
+`$claude-review`, `$claude-delegate`, `$claude-sessions`, `$claude-setup`, and
+`$claude-verify` skills; this portable skill remains the single-file entry
+point for hosts that only load Agent Skills.

--- a/skills/cc-for-codex/references/safety.md
+++ b/skills/cc-for-codex/references/safety.md
@@ -1,0 +1,36 @@
+# Safety contract
+
+The bridge is a local pass-through to a separately installed Claude Code
+binary. It does not provide Anthropic credentials, a sandbox, or a billing
+boundary. Treat every Claude response as untrusted external evidence and
+inspect it before taking consequential action.
+
+## Read-only review
+
+Use the bridge's guarded review surface. It disables shell execution, edits,
+network-capable tools, MCP, Chrome, project hooks, and subagents; it also
+rejects hidden index flags and out-of-scope paths. Keep the call foreground by
+default. Background review has no supported max-budget guard and exposes the
+prompt to same-account local process inspection, so it needs both explicit
+confirmations.
+
+## Writes
+
+Writes must be explicitly requested and run in a newly generated, verified
+Git worktree. A worktree prevents checkout overlap; it is not host isolation.
+The bridge's dangerous profile bypasses Claude permission prompts and can
+allow file tools to reach host paths. It therefore needs the distinct
+`bypass-host-safety` confirmation after the user accepts that risk. The
+`guarded` profile keeps zero-prompt operation while pre-approving only
+`Edit,Write` inside the bridge's restricted boundary.
+
+Codex remains responsible for inspecting the resulting diff, running tests,
+and deciding whether anything should be copied, merged, or pushed. Claude is
+never allowed to push or merge through this workflow.
+
+## Opt-in surfaces
+
+Native command passthrough, cloud/ultrareview, MCP, plugins, configuration
+changes, remote control, and destructive session actions are separate
+capabilities. Require the exact bridge confirmation for each requested
+surface; do not treat a general request to “use Claude” as permission.


### PR DESCRIPTION
## Summary

This adds `skills/cc-for-codex`, a small, portable Agent Skill that teaches a
Codex task how to use an explicitly requested local Claude Code installation
as an independent second agent. It covers read-only review, adversarial
review, bounded delegation, resumable handoffs, and the permission boundaries
needed when two coding agents share a repository.

The skill is intentionally instruction-only. The production bridge, guarded
CLI surface, session ledger, and test suite remain in the maintained
[standalone CC for Codex repository](https://github.com/sanchitmonga22/cc-for-codex),
so this repository does not acquire a duplicated runtime or a hidden Claude
dependency. A user can copy `skills/cc-for-codex` into `~/.codex/skills` and
follow the included installation reference in a few seconds.

## Why this belongs here

Anthropic's skills repository is the clearest home for a portable Agent Skills
example: the contribution is a self-contained `SKILL.md` with progressive
references, no vendor credentials, and no hosted connector. It demonstrates a
useful cross-agent workflow while leaving implementation and release cadence
to the standalone project. If maintainers prefer a different arrangement, I
would be grateful for guidance on whether this should be listed as an example
skill or live only as a separate repository.

## Safety and behavior

- Claude is never invoked implicitly; the user must request or approve it.
- Reviews are read-only and use the guarded bridge surface (no shell, edits,
  network tools, MCP, Chrome, hooks, or subagents).
- Writes require explicit edit and host-safety consent and a fresh verified
  Git worktree. The dangerous zero-prompt write profile is clearly disclosed;
  a guarded write profile is available when bypassing host checks is not
  wanted. A worktree is not an OS sandbox.
- Background sessions, native passthrough, cloud review, configuration
  mutation, and destructive operations require separate confirmations.
- Codex inspects Claude's output and runs repository validation before any
  merge or push decision.

## Validation

- Anthropic skill validator: `Skill is valid!`
- The referenced standalone implementation's adapted package check: 131
  tests passed, 0 failed; no model calls were made.

## Provenance and related work

- Tested implementation: [sanchitmonga22/cc-for-codex](https://github.com/sanchitmonga22/cc-for-codex)
- OpenAI marketplace submission branch: [sanchitmonga22/plugins:add-cc-for-codex](https://github.com/sanchitmonga22/plugins/tree/add-cc-for-codex)
- Official OpenAI precedent: [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc)

The OpenAI marketplace contribution could not be opened from this account:
the [compare page](https://github.com/openai/plugins/compare/main...sanchitmonga22:add-cc-for-codex)
states that the repository owner has limited pull-request creation to
collaborators. This is a GitHub repository setting, not a rejection of the
proposal; the account can push the fork branch but has read-only access to the
upstream repository. GitHub documents this behavior under [restricting pull
requests](https://docs.github.com/en/enterprise-cloud@latest/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/disabling-pull-requests).

@bcherny, would you be open to advising whether this portable skill is a good
fit for this repository, or whether you would prefer the workflow to remain a
standalone project? I am happy to revise the scope, naming, or packaging to
match the maintainers' guidance.

Created with GPT-6 Astra in Codex. This is an independent contribution and
does not claim Anthropic or OpenAI endorsement.
