### PR TITLE
fix(claude-api): replace dead URLs in live-sources and related skills

### DIFF
--- a/skills/academy-guide/SKILL.md
+++ b/skills/academy-guide/SKILL.md
@@ -87,7 +87,7 @@ often the better recommendation than any single item.
    team?") — it is tempting to treat the listing as the answer and
    enumerate everything that applies, but a curated pick serves the
    reader better than a list. Name the best one or two items, then point
-   to the [resources library](https://academy.claude.com/resources) for
+   to the [resources library](https://academy.claude.com/all) for
    the rest. (When one of the five product hubs named in the Purpose
    section covers the topic, that hub is also a good pointer — but those
    five are the only hub pages that exist, so never construct a hub-style
@@ -112,7 +112,7 @@ often the better recommendation than any single item.
    user clearly wants learning content on a Claude topic, point them at
    the matching product hub from the Purpose section or at the searchable
    library at
-   [academy.claude.com/resources](https://academy.claude.com/resources)
+   [academy.claude.com/all](https://academy.claude.com/all)
    instead of recommending a weak match or a title from memory. If they
    were not clearly looking for learning content, say nothing.
 

--- a/skills/claude-api/shared/live-sources.md
+++ b/skills/claude-api/shared/live-sources.md
@@ -18,7 +18,7 @@ This file contains WebFetch URLs for fetching current information from platform.
 | Models Overview | `https://platform.claude.com/docs/en/about-claude/models/overview.md`        | "Extract current model IDs, context windows, and pricing for all Claude models" |
 | Migration Guide | `https://platform.claude.com/docs/en/about-claude/models/migration-guide.md` | "Extract breaking changes, deprecated parameters, and per-model migration steps when moving to a newer Claude model" |
 | Introducing Claude Fable 5 | `https://platform.claude.com/docs/en/about-claude/models/introducing-claude-fable-5.md` | "Extract capabilities, API changes, and availability stages for Claude Fable 5 and Claude Mythos 5" |
-| Pricing         | `https://platform.claude.com/docs/en/pricing.md`                             | "Extract current pricing per million tokens for input and output"               |
+| Pricing         | `https://platform.claude.com/docs/en/about-claude/pricing.md`                             | "Extract current pricing per million tokens for input and output"               |
 | Cost Optimization | `https://platform.claude.com/docs/en/about-claude/models/optimizing-for-cost-and-intelligence.md` | "Extract measured cost levers, cache and batch savings, effort and model cost-per-task comparisons, budget controls, and multi-model guidance" |
 
 ### Core Features
@@ -69,13 +69,13 @@ This file contains WebFetch URLs for fetching current information from platform.
 | Topic          | URL                                                                                    | Extraction Prompt                                                                        |
 | -------------- | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
 | Code Execution | `https://platform.claude.com/docs/en/agents-and-tools/tool-use/code-execution-tool.md` | "Extract code execution tool setup, file upload, container reuse, and response handling" |
-| Computer Use   | `https://platform.claude.com/docs/en/agents-and-tools/tool-use/computer-use.md`        | "Extract computer use tool setup, capabilities, and implementation examples"             |
+| Computer Use   | `https://platform.claude.com/docs/en/agents-and-tools/tool-use/computer-use-tool.md`        | "Extract computer use tool setup, capabilities, and implementation examples"             |
 | Bash Tool      | `https://platform.claude.com/docs/en/agents-and-tools/tool-use/bash-tool.md`           | "Extract bash tool schema, reference implementation, and security considerations"        |
 | Text Editor    | `https://platform.claude.com/docs/en/agents-and-tools/tool-use/text-editor-tool.md`    | "Extract text editor tool commands, schema, and reference implementation"                |
 | Memory Tool    | `https://platform.claude.com/docs/en/agents-and-tools/tool-use/memory-tool.md`         | "Extract memory tool commands, directory structure, and implementation patterns"         |
 | Tool Search    | `https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool.md`    | "Extract tool search setup, when to use, and cache interaction"                          |
 | Programmatic Tool Calling | `https://platform.claude.com/docs/en/agents-and-tools/tool-use/programmatic-tool-calling.md` | "Extract PTC setup, script execution model, and tool invocation from code"    |
-| Skills         | `https://platform.claude.com/docs/en/agents-and-tools/skills.md`                       | "Extract skill folder structure, SKILL.md format, and loading behavior"                  |
+| Skills         | `https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview.md`                       | "Extract skill folder structure, SKILL.md format, and loading behavior"                  |
 | Skills Guide   | `https://platform.claude.com/docs/en/build-with-claude/skills-guide.md`                | "Extract the Skills API (/v1/skills) usage and the migration steps from skills-2025-10-02" |
 
 ### Advanced Features
@@ -124,7 +124,7 @@ The `ant` CLI provides terminal access to the Claude API. Every API resource is 
 
 | Topic         | URL                                                     | Extraction Prompt                                                                                  |
 | ------------- | ------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| Anthropic CLI | `https://platform.claude.com/docs/en/api/sdks/cli.md`   | "Extract CLI install, authentication, command structure, and the beta:agents/environments/sessions commands" |
+| Anthropic CLI | `https://platform.claude.com/docs/en/cli-sdks-libraries/cli/quickstart.md`   | "Extract CLI install, authentication, command structure, and the beta:agents/environments/sessions commands" |
 | Authentication overview | `https://platform.claude.com/docs/en/manage-claude/authentication.md` | "Extract the credential options (API keys, interactive OAuth login, Workload Identity Federation) and when to use each" |
 | WIF reference | `https://platform.claude.com/docs/en/manage-claude/wif-reference.md`  | "Extract credential precedence order, the profile configuration file schema, and the configuration directory layout" |
 

--- a/skills/claude-api/shared/tool-use-concepts.md
+++ b/skills/claude-api/shared/tool-use-concepts.md
@@ -341,7 +341,7 @@ Computer use lets Claude interact with a desktop environment (screenshots, mouse
 
 For full documentation, use WebFetch:
 
-- URL: `https://platform.claude.com/docs/en/agents-and-tools/computer-use/overview`
+- URL: `https://platform.claude.com/docs/en/agents-and-tools/tool-use/computer-use-tool`
 
 ---
 


### PR DESCRIPTION
## Summary
- Replace 7 hard-404 documentation URLs in the claude-api live-sources registry and related skill files with canonical platform/academy URLs (verified HTTP 200 via `curl -sI -L`).
- Files: `skills/claude-api/shared/live-sources.md` (4), `skills/claude-api/shared/tool-use-concepts.md` (1), `skills/academy-guide/SKILL.md` (2).
- Aligns the agent-facing registry with `platform.claude.com/llms.txt` so WebFetch instructions no longer land on 404s.

Fixes #1698

## Test plan
- [x] `curl -sI -L` on each replacement URL returns HTTP 200
- [x] Confirmed original URLs still return 404
- [ ] Spot-check that managed-agents/skills.md row was left unchanged (not part of this issue)