### PR TITLE
fix(skill-creator): keep scanning trigger-eval events

### DIFF
--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -32,6 +32,55 @@ def find_project_root() -> Path:
     return current
 
 
+def _handle_stream_event(
+    event: dict,
+    clean_name: str,
+    state: dict[str, str | None],
+) -> bool | None:
+    """Update stream-event detection state until the candidate is found."""
+    if event.get("type") != "stream_event":
+        return None
+
+    stream_event = event.get("event", {})
+    event_type = stream_event.get("type", "")
+    if event_type == "content_block_start":
+        content_block = stream_event.get("content_block", {})
+        tool_name = content_block.get("name", "")
+        state["pending_tool_name"] = tool_name if tool_name in ("Skill", "Read") else None
+        state["accumulated_json"] = ""
+    elif event_type == "content_block_delta" and state.get("pending_tool_name"):
+        delta = stream_event.get("delta", {})
+        if delta.get("type") == "input_json_delta":
+            state["accumulated_json"] = (
+                (state.get("accumulated_json") or "") + delta.get("partial_json", "")
+            )
+            if clean_name in (state.get("accumulated_json") or ""):
+                return True
+    elif event_type == "content_block_stop":
+        if clean_name in (state.get("accumulated_json") or ""):
+            return True
+        # This only closes the current block; a later Skill/Read may match.
+        state["pending_tool_name"] = None
+        state["accumulated_json"] = ""
+    elif event_type == "message_stop":
+        return clean_name in (state.get("accumulated_json") or "")
+    return None
+
+
+def _assistant_message_triggered(message: dict, clean_name: str) -> bool:
+    """Check every tool use in a non-streaming assistant message."""
+    for content_item in message.get("content", []):
+        if content_item.get("type") != "tool_use":
+            continue
+        tool_name = content_item.get("name", "")
+        tool_input = content_item.get("input", {})
+        if tool_name == "Skill" and clean_name in tool_input.get("skill", ""):
+            return True
+        if tool_name == "Read" and clean_name in tool_input.get("file_path", ""):
+            return True
+    return False
+
+
 def run_single_query(
     query: str,
     skill_name: str,
@@ -93,9 +142,10 @@ def run_single_query(
         triggered = False
         start_time = time.time()
         buffer = ""
-        # Track state for stream event detection
-        pending_tool_name = None
-        accumulated_json = ""
+        stream_state: dict[str, str | None] = {
+            "pending_tool_name": None,
+            "accumulated_json": "",
+        }
 
         try:
             while time.time() - start_time < timeout:
@@ -125,47 +175,19 @@ def run_single_query(
                     except json.JSONDecodeError:
                         continue
 
-                    # Early detection via stream events
+                    # Early detection via stream events. Unrelated tools and
+                    # completed blocks are not proof that the skill missed.
                     if event.get("type") == "stream_event":
-                        se = event.get("event", {})
-                        se_type = se.get("type", "")
-
-                        if se_type == "content_block_start":
-                            cb = se.get("content_block", {})
-                            if cb.get("type") == "tool_use":
-                                tool_name = cb.get("name", "")
-                                if tool_name in ("Skill", "Read"):
-                                    pending_tool_name = tool_name
-                                    accumulated_json = ""
-                                else:
-                                    return False
-
-                        elif se_type == "content_block_delta" and pending_tool_name:
-                            delta = se.get("delta", {})
-                            if delta.get("type") == "input_json_delta":
-                                accumulated_json += delta.get("partial_json", "")
-                                if clean_name in accumulated_json:
-                                    return True
-
-                        elif se_type in ("content_block_stop", "message_stop"):
-                            if pending_tool_name:
-                                return clean_name in accumulated_json
-                            if se_type == "message_stop":
-                                return False
+                        stream_result = _handle_stream_event(event, clean_name, stream_state)
+                        if stream_result is not None:
+                            return stream_result
 
                     # Fallback: full assistant message
                     elif event.get("type") == "assistant":
                         message = event.get("message", {})
-                        for content_item in message.get("content", []):
-                            if content_item.get("type") != "tool_use":
-                                continue
-                            tool_name = content_item.get("name", "")
-                            tool_input = content_item.get("input", {})
-                            if tool_name == "Skill" and clean_name in tool_input.get("skill", ""):
-                                triggered = True
-                            elif tool_name == "Read" and clean_name in tool_input.get("file_path", ""):
-                                triggered = True
-                            return triggered
+                        triggered = _assistant_message_triggered(message, clean_name)
+                        if triggered:
+                            return True
 
                     elif event.get("type") == "result":
                         return triggered

--- a/skills/skill-creator/scripts/test_run_eval.py
+++ b/skills/skill-creator/scripts/test_run_eval.py
@@ -1,0 +1,118 @@
+import importlib.util
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("run_eval.py")
+SPEC = importlib.util.spec_from_file_location("run_eval", MODULE_PATH)
+assert SPEC and SPEC.loader
+run_eval = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(run_eval)
+
+
+def stream_event(event_type, **kwargs):
+    return {"type": "stream_event", "event": {"type": event_type, **kwargs}}
+
+
+def test_unrelated_tool_before_skill_does_not_end_evaluation():
+    clean_name = "candidate-skill-test01"
+    state = {"pending_tool_name": None, "accumulated_json": ""}
+
+    assert (
+        run_eval._handle_stream_event(
+            stream_event(
+                "content_block_start",
+                content_block={"type": "tool_use", "name": "Bash"},
+            ),
+            clean_name,
+            state,
+        )
+        is None
+    )
+    assert (
+        run_eval._handle_stream_event(
+            stream_event(
+                "content_block_start",
+                content_block={"type": "tool_use", "name": "Skill"},
+            ),
+            clean_name,
+            state,
+        )
+        is None
+    )
+    assert (
+        run_eval._handle_stream_event(
+            stream_event(
+                "content_block_delta",
+                delta={
+                    "type": "input_json_delta",
+                    "partial_json": '{"skill":"candidate-skill-test01"}',
+                },
+            ),
+            clean_name,
+            state,
+        )
+        is True
+    )
+
+
+def test_finished_unrelated_block_does_not_end_evaluation():
+    clean_name = "candidate-skill-test01"
+    state = {"pending_tool_name": None, "accumulated_json": ""}
+    assert (
+        run_eval._handle_stream_event(
+            stream_event(
+                "content_block_start",
+                content_block={"type": "tool_use", "name": "Read"},
+            ),
+            clean_name,
+            state,
+        )
+        is None
+    )
+    assert (
+        run_eval._handle_stream_event(
+            stream_event("content_block_stop"), clean_name, state
+        )
+        is None
+    )
+    assert (
+        run_eval._handle_stream_event(
+            stream_event(
+                "content_block_start",
+                content_block={"type": "tool_use", "name": "Skill"},
+            ),
+            clean_name,
+            state,
+        )
+        is None
+    )
+    assert (
+        run_eval._handle_stream_event(
+            stream_event(
+                "content_block_delta",
+                delta={
+                    "type": "input_json_delta",
+                    "partial_json": '{"skill":"candidate-skill-test01"}',
+                },
+            ),
+            clean_name,
+            state,
+        )
+        is True
+    )
+
+
+def test_non_streaming_message_checks_all_tool_uses():
+    message = {
+        "content": [
+            {"type": "tool_use", "name": "Bash", "input": {"command": "pwd"}},
+            {
+                "type": "tool_use",
+                "name": "Skill",
+                "input": {"skill": "candidate-skill-test01"},
+            },
+        ]
+    }
+    assert (
+        run_eval._assistant_message_triggered(message, "candidate-skill-test01") is True
+    )


### PR DESCRIPTION
Fixes #1721.

`run_eval.py` currently treats any unrelated first tool as a non-trigger, concludes at the first content-block stop, and returns after only the first tool use in the non-streaming fallback. Realistic queries can therefore be scored as false negatives, producing 0% recall and misleading optimizer output.

This change keeps consuming stream events until the message ends, resets state between tool blocks, and checks every tool use in assistant messages. Added focused regression tests covering unrelated tools before `Skill`, a later `Skill` after a completed unrelated block, and multiple non-streaming tool uses.

Tests:
- `python -m pytest skills/skill-creator/scripts/test_run_eval.py -q` (3 passed)
- `python -m py_compile skills/skill-creator/scripts/run_eval.py skills/skill-creator/scripts/test_run_eval.py`
- `git diff --check`