### PR TITLE
docs: clarify skill routing descriptions

### DIFF
--- a/skills/mcp-builder/SKILL.md
+++ b/skills/mcp-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcp-builder
-description: Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Use when building MCP servers to integrate external APIs or services, whether in Python (FastMCP) or Node/TypeScript (MCP SDK).
+description: Build MCP servers that expose external services as tools.
 license: Complete terms in LICENSE.txt
 ---
 

--- a/skills/pdf/SKILL.md
+++ b/skills/pdf/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pdf
-description: Use this skill whenever the user wants to do anything with PDF files. This includes reading or extracting text/tables from PDFs, combining or merging multiple PDFs into one, splitting PDFs apart, rotating pages, adding watermarks, creating new PDFs, filling PDF forms, encrypting/decrypting PDFs, extracting images, and OCR on scanned PDFs to make them searchable. If the user mentions a .pdf file or asks to produce one, use this skill.
+description: Read or edit PDFs; use make-pdf for polished Markdown.
 license: Proprietary. LICENSE.txt has complete terms
 ---
 

--- a/skills/xlsx/SKILL.md
+++ b/skills/xlsx/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: xlsx
-description: "Use this skill any time a spreadsheet file is the primary input or output. This means any task where the user wants to: open, read, edit, or fix an existing .xlsx, .xlsm, .xltx, .csv, or .tsv file (e.g., adding columns, computing formulas, formatting, charting, cleaning messy data); create a new spreadsheet from scratch or from other data sources; or convert between tabular file formats. Trigger especially when the user references a spreadsheet file by name or path — even casually (like \"the xlsx in my downloads\") — and wants something done to it or produced from it. Also trigger for cleaning or restructuring messy tabular data files (malformed rows, misplaced headers, junk data) into proper spreadsheets. The deliverable must be a spreadsheet file. Do NOT trigger when the primary deliverable is a Word document, HTML report, standalone Python script, database pipeline, or Google Sheets API integration, even if tabular data is involved."
+description: Create or edit spreadsheet files as the main deliverable.
 license: Proprietary. LICENSE.txt has complete terms
 ---
 


### PR DESCRIPTION
## Summary
- shorten the routing descriptions for `mcp-builder`, `pdf`, and `xlsx`
- keep trigger boundaries explicit in the compact catalog surface
- leave all skill bodies unchanged

## Validation
- all three YAML frontmatter blocks parse
- every description is within 57 characters and ends with a period