### PR TITLE
Fix typo in webapp-testing SKILL.md

### DIFF
--- a/skills/webapp-testing/SKILL.md
+++ b/skills/webapp-testing/SKILL.md
@@ -11,7 +11,7 @@ To test local web applications, write native Python Playwright scripts.
 **Helper Scripts Available**:
 - `scripts/with_server.py` - Manages server lifecycle (supports multiple servers)
 
-**Always run scripts with `--help` first** to see usage. DO NOT read the source until you try running the script first and find that a customized solution is abslutely necessary. These scripts can be very large and thus pollute your context window. They exist to be called directly as black-box scripts rather than ingested into your context window.
+**Always run scripts with `--help` first** to see usage. DO NOT read the source until you try running the script first and find that a customized solution is absolutely necessary. These scripts can be very large and thus pollute your context window. They exist to be called directly as black-box scripts rather than ingested into your context window.
 
 ## Decision Tree: Choosing Your Approach
 


### PR DESCRIPTION
## Summary
- Fixes a small typo in `skills/webapp-testing/SKILL.md`: "abslutely" -> "absolutely"

## Test plan
- N/A (documentation-only typo fix, no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)