### PR TITLE
fix(skill-creator): make the trigger-eval harness measure skill triggering

### DIFF
--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -389,6 +389,10 @@ python -m scripts.run_loop \
 
 Use the model ID from your system prompt (the one powering the current session) so the triggering test matches what the user actually experiences.
 
+Each probe runs in its own throwaway directory, so the probe never competes with a real installed copy of the skill and parallel probes can't see each other's commands. For a skill whose queries only make sense somewhere specific (a git repo, a project tree), a bare directory makes Claude answer "there's nothing here" instead of reaching for the skill, and every positive looks like a miss. Pass `--fixture <dir>` to copy a prepared fixture in as each probe's sandbox; probes mutate their copies, never the original. Build the smallest fixture that makes the queries plausible (for a git skill, a `git init` with a few branches is enough).
+
+The isolation covers project scope only. If the skill under test is also installed at user scope (`~/.claude/skills/`) or ships in a plugin, that copy answers the same queries under its real name and outscores the probe's decoy, so the run aborts with an error instead of reporting a fake 0%. Move or rename the installed copy for the duration of the eval.
+
 While it runs, periodically tail the output to give the user updates on which iteration it's on and what the scores look like.
 
 This handles the full optimization loop automatically. It splits the eval set into 60% train and 40% held-out test, evaluates the current description (running each query 3 times to get a reliable trigger rate), then calls Claude to propose improvements based on what failed. It re-evaluates each new description on both train and test, iterating up to 5 times. When it's done, it opens an HTML report in the browser showing the results per iteration and returns JSON with `best_description` — selected by test score rather than train score to avoid overfitting.

--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -9,27 +9,87 @@ import argparse
 import json
 import os
 import select
+import shutil
 import subprocess
 import sys
+import tempfile
 import time
 import uuid
 from concurrent.futures import ProcessPoolExecutor, as_completed
+from contextlib import contextmanager
 from pathlib import Path
 
 from scripts.utils import parse_skill_md
 
+DEFAULT_TIMEOUT = 120
 
-def find_project_root() -> Path:
-    """Find the project root by walking up from cwd looking for .claude/.
+# Triggering is an opening move: Claude orients itself (a pwd, an ls) for a
+# turn or two, then consults the skill. A probe that hasn't reached for it
+# within this many assistant turns is a miss; letting it continue means every
+# non-triggering run executes the entire queried task.
+MAX_PROBE_TURNS = 4
 
-    Mimics how Claude Code discovers its project root, so the command file
-    we create ends up where claude -p will look for it.
+class SkillAlreadyRegistered(RuntimeError):
+    """The skill under test is registered outside the probe root.
+
+    The probe registers a uuid-suffixed decoy and counts invocations of that
+    exact name. An installed copy carrying the same description answers the
+    same queries under the real name, wins the tie, and every genuine trigger
+    scores as a miss -- the 100% precision / 0% recall signature. The probe
+    root only isolates project scope; a user-level install or a plugin still
+    reaches the probe, so the run is aborted rather than scored.
     """
-    current = Path.cwd()
-    for parent in [current, *current.parents]:
-        if (parent / ".claude").is_dir():
-            return parent
-    return current
+
+
+FIXTURE_HELP = (
+    "Directory copied in as each probe's sandbox (default: a bare temp dir). "
+    "Point it at a fixture that makes the queries answerable when the skill "
+    "needs context, e.g. a throwaway git repo. The original stays untouched."
+)
+
+
+@contextmanager
+def probe_root(fixture: Path | None = None):
+    """Yield a private project root for one probe run, removed on exit.
+
+    The probe works by registering a throwaway command whose description is the
+    one under test, then checking whether Claude invokes that exact command. Two
+    things break that, and a private root per probe removes both.
+
+    A root that already registers the real skill loses the race:
+    Claude reaches for the real name and the probe scores its own trigger as a
+    miss. And probes that share a root see each other's commands, which are
+    identical but for the uuid, so a worker can watch for one copy while Claude
+    invokes another.
+
+    Args:
+        fixture: Directory to copy, for skills whose queries need context to be
+            answerable (a git repo, a project tree). Copied rather than used in
+            place so parallel probes cannot collide and the original stays
+            untouched. Any .claude/skills or .claude/commands the fixture
+            carries is stripped from the copy, so the decoy stays the only
+            registered skill. When omitted the probe gets a bare directory.
+
+    Yields:
+        Path to a temporary directory containing .claude/commands/.
+    """
+    root = Path(tempfile.mkdtemp(prefix="skill-eval-"))
+    try:
+        if fixture is not None:
+            shutil.copytree(fixture, root, symlinks=True, dirs_exist_ok=True)
+            # A fixture carrying its own .claude/skills or .claude/commands
+            # would re-register real skills inside the probe root, and the
+            # real name outcompetes the decoy: the exact false-miss failure
+            # this isolation exists to prevent.
+            for leaked in (root / ".claude" / "skills", root / ".claude" / "commands"):
+                if leaked.is_symlink():
+                    leaked.unlink()
+                elif leaked.is_dir():
+                    shutil.rmtree(leaked)
+        (root / ".claude" / "commands").mkdir(parents=True, exist_ok=True)
+        yield root
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
 
 
 def run_single_query(
@@ -37,7 +97,7 @@ def run_single_query(
     skill_name: str,
     skill_description: str,
     timeout: int,
-    project_root: str,
+    fixture: Path | None = None,
     model: str | None = None,
 ) -> bool:
     """Run a single query and return whether the skill was triggered.
@@ -47,17 +107,38 @@ def run_single_query(
     Uses --include-partial-messages to detect triggering early from
     stream events (content_block_start) rather than waiting for the
     full assistant message, which only arrives after tool execution.
+
+    A trigger counts wherever it appears in the run, not only as the opening
+    move. On many runs Claude orients itself first (a `pwd`, an `ls`) and
+    consults the skill on the next turn, so scoring only the first tool call
+    turns that ordering into a coin flip and reports a description as broken
+    when it is not. The run ends early on the first matching Skill or Read
+    call, before the skill body executes, and stops at MAX_PROBE_TURNS
+    assistant turns so a run that was never going to trigger doesn't execute
+    the whole task.
     """
     unique_id = uuid.uuid4().hex[:8]
     clean_name = f"{skill_name}-skill-{unique_id}"
-    project_commands_dir = Path(project_root) / ".claude" / "commands"
-    command_file = project_commands_dir / f"{clean_name}.md"
 
-    try:
-        project_commands_dir.mkdir(parents=True, exist_ok=True)
+    def is_trigger(tool_name: str | None, input_text: str) -> bool:
+        return tool_name in ("Skill", "Read") and clean_name in input_text
+
+    def assert_decoy_is_alone(init_event: dict) -> None:
+        registered = set(init_event.get("skills") or [])
+        registered.update(init_event.get("slash_commands") or [])
+        if skill_name in registered:
+            raise SkillAlreadyRegistered(
+                f"{skill_name!r} is registered outside the probe root (a "
+                f"user-level ~/.claude/skills entry or a plugin). It answers "
+                f"the queries under its real name, so every trigger would be "
+                f"scored as a miss. Remove or rename that copy for the eval."
+            )
+
+    with probe_root(fixture) as project_root:
+        command_file = project_root / ".claude" / "commands" / f"{clean_name}.md"
         # Use YAML block scalar to avoid breaking on quotes in description
         indented_desc = "\n  ".join(skill_description.split("\n"))
-        command_content = (
+        command_file.write_text(
             f"---\n"
             f"description: |\n"
             f"  {indented_desc}\n"
@@ -65,7 +146,6 @@ def run_single_query(
             f"# {skill_name}\n\n"
             f"This skill handles: {skill_description}\n"
         )
-        command_file.write_text(command_content)
 
         cmd = [
             "claude",
@@ -82,17 +162,20 @@ def run_single_query(
         # programmatic subprocess usage is safe.
         env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
 
+        # Without an explicit stdin the CLI waits several seconds on every
+        # probe for piped input that never arrives.
         process = subprocess.Popen(
             cmd,
+            stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             cwd=project_root,
             env=env,
         )
 
-        triggered = False
         start_time = time.time()
         buffer = ""
+        turns = 0
         # Track state for stream event detection
         pending_tool_name = None
         accumulated_json = ""
@@ -125,32 +208,31 @@ def run_single_query(
                     except json.JSONDecodeError:
                         continue
 
+                    if event.get("type") == "system" and event.get("subtype") == "init":
+                        assert_decoy_is_alone(event)
+
                     # Early detection via stream events
-                    if event.get("type") == "stream_event":
+                    elif event.get("type") == "stream_event":
                         se = event.get("event", {})
                         se_type = se.get("type", "")
 
                         if se_type == "content_block_start":
                             cb = se.get("content_block", {})
-                            if cb.get("type") == "tool_use":
-                                tool_name = cb.get("name", "")
-                                if tool_name in ("Skill", "Read"):
-                                    pending_tool_name = tool_name
-                                    accumulated_json = ""
-                                else:
-                                    return False
+                            pending_tool_name = (
+                                cb.get("name", "") if cb.get("type") == "tool_use" else None
+                            )
+                            accumulated_json = ""
 
-                        elif se_type == "content_block_delta" and pending_tool_name:
+                        elif se_type == "content_block_delta":
                             delta = se.get("delta", {})
                             if delta.get("type") == "input_json_delta":
                                 accumulated_json += delta.get("partial_json", "")
-                                if clean_name in accumulated_json:
+                                if is_trigger(pending_tool_name, accumulated_json):
                                     return True
 
-                        elif se_type in ("content_block_stop", "message_stop"):
-                            if pending_tool_name:
-                                return clean_name in accumulated_json
-                            if se_type == "message_stop":
+                        elif se_type == "message_stop":
+                            turns += 1
+                            if turns >= MAX_PROBE_TURNS:
                                 return False
 
                     # Fallback: full assistant message
@@ -159,26 +241,21 @@ def run_single_query(
                         for content_item in message.get("content", []):
                             if content_item.get("type") != "tool_use":
                                 continue
-                            tool_name = content_item.get("name", "")
-                            tool_input = content_item.get("input", {})
-                            if tool_name == "Skill" and clean_name in tool_input.get("skill", ""):
-                                triggered = True
-                            elif tool_name == "Read" and clean_name in tool_input.get("file_path", ""):
-                                triggered = True
-                            return triggered
+                            if is_trigger(
+                                content_item.get("name", ""),
+                                json.dumps(content_item.get("input", {})),
+                            ):
+                                return True
 
                     elif event.get("type") == "result":
-                        return triggered
+                        return False
         finally:
             # Clean up process on any exit path (return, exception, timeout)
             if process.poll() is None:
                 process.kill()
                 process.wait()
 
-        return triggered
-    finally:
-        if command_file.exists():
-            command_file.unlink()
+        return False
 
 
 def run_eval(
@@ -187,7 +264,7 @@ def run_eval(
     description: str,
     num_workers: int,
     timeout: int,
-    project_root: Path,
+    fixture: Path | None = None,
     runs_per_query: int = 1,
     trigger_threshold: float = 0.5,
     model: str | None = None,
@@ -205,7 +282,7 @@ def run_eval(
                     skill_name,
                     description,
                     timeout,
-                    str(project_root),
+                    fixture,
                     model,
                 )
                 future_to_info[future] = (item, run_idx)
@@ -220,6 +297,10 @@ def run_eval(
                 query_triggers[query] = []
             try:
                 query_triggers[query].append(future.result())
+            except SkillAlreadyRegistered:
+                # Scoring this as a failed probe would report the silent 0%
+                # this check exists to catch.
+                raise
             except Exception as e:
                 print(f"Warning: query failed: {e}", file=sys.stderr)
                 query_triggers[query].append(False)
@@ -262,7 +343,8 @@ def main():
     parser.add_argument("--skill-path", required=True, help="Path to skill directory")
     parser.add_argument("--description", default=None, help="Override description to test")
     parser.add_argument("--num-workers", type=int, default=10, help="Number of parallel workers")
-    parser.add_argument("--timeout", type=int, default=30, help="Timeout per query in seconds")
+    parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT, help="Timeout per query in seconds")
+    parser.add_argument("--fixture", default=None, help=FIXTURE_HELP)
     parser.add_argument("--runs-per-query", type=int, default=3, help="Number of runs per query")
     parser.add_argument("--trigger-threshold", type=float, default=0.5, help="Trigger rate threshold")
     parser.add_argument("--model", default=None, help="Model to use for claude -p (default: user's configured model)")
@@ -278,22 +360,33 @@ def main():
 
     name, original_description, content = parse_skill_md(skill_path)
     description = args.description or original_description
-    project_root = find_project_root()
+    fixture = Path(args.fixture) if args.fixture else None
+    if fixture and not fixture.is_dir():
+        # copytree failures inside the pool are caught per probe and scored
+        # False, so a typo'd path would report a plausible 0/N instead of
+        # failing loudly here.
+        print(f"Error: fixture directory not found: {fixture}", file=sys.stderr)
+        sys.exit(1)
 
     if args.verbose:
+        print(f"Fixture: {fixture or 'none (bare temp dir per probe)'}", file=sys.stderr)
         print(f"Evaluating: {description}", file=sys.stderr)
 
-    output = run_eval(
-        eval_set=eval_set,
-        skill_name=name,
-        description=description,
-        num_workers=args.num_workers,
-        timeout=args.timeout,
-        project_root=project_root,
-        runs_per_query=args.runs_per_query,
-        trigger_threshold=args.trigger_threshold,
-        model=args.model,
-    )
+    try:
+        output = run_eval(
+            eval_set=eval_set,
+            skill_name=name,
+            description=description,
+            num_workers=args.num_workers,
+            timeout=args.timeout,
+            fixture=fixture,
+            runs_per_query=args.runs_per_query,
+            trigger_threshold=args.trigger_threshold,
+            model=args.model,
+        )
+    except SkillAlreadyRegistered as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
 
     if args.verbose:
         summary = output["summary"]

--- a/skills/skill-creator/scripts/run_loop.py
+++ b/skills/skill-creator/scripts/run_loop.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 from scripts.generate_report import generate_html
 from scripts.improve_description import improve_description
-from scripts.run_eval import find_project_root, run_eval
+from scripts.run_eval import DEFAULT_TIMEOUT, FIXTURE_HELP, SkillAlreadyRegistered, run_eval
 from scripts.utils import parse_skill_md
 
 
@@ -58,9 +58,9 @@ def run_loop(
     verbose: bool,
     live_report_path: Path | None = None,
     log_dir: Path | None = None,
+    fixture: Path | None = None,
 ) -> dict:
     """Run the eval + improvement loop."""
-    project_root = find_project_root()
     name, original_description, content = parse_skill_md(skill_path)
     current_description = description_override or original_description
 
@@ -92,7 +92,7 @@ def run_loop(
             description=current_description,
             num_workers=num_workers,
             timeout=timeout,
-            project_root=project_root,
+            fixture=fixture,
             runs_per_query=runs_per_query,
             trigger_threshold=trigger_threshold,
             model=model,
@@ -247,7 +247,8 @@ def main():
     parser.add_argument("--skill-path", required=True, help="Path to skill directory")
     parser.add_argument("--description", default=None, help="Override starting description")
     parser.add_argument("--num-workers", type=int, default=10, help="Number of parallel workers")
-    parser.add_argument("--timeout", type=int, default=30, help="Timeout per query in seconds")
+    parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT, help="Timeout per query in seconds")
+    parser.add_argument("--fixture", default=None, help=FIXTURE_HELP)
     parser.add_argument("--max-iterations", type=int, default=5, help="Max improvement iterations")
     parser.add_argument("--runs-per-query", type=int, default=3, help="Number of runs per query")
     parser.add_argument("--trigger-threshold", type=float, default=0.5, help="Trigger rate threshold")
@@ -266,6 +267,14 @@ def main():
         sys.exit(1)
 
     name, _, _ = parse_skill_md(skill_path)
+
+    fixture = Path(args.fixture) if args.fixture else None
+    if fixture and not fixture.is_dir():
+        # copytree failures inside the pool are caught per probe and scored
+        # False, so a typo'd path would report a plausible 0/N instead of
+        # failing loudly here.
+        print(f"Error: fixture directory not found: {fixture}", file=sys.stderr)
+        sys.exit(1)
 
     # Set up live report path
     if args.report != "none":
@@ -290,21 +299,26 @@ def main():
 
     log_dir = results_dir / "logs" if results_dir else None
 
-    output = run_loop(
-        eval_set=eval_set,
-        skill_path=skill_path,
-        description_override=args.description,
-        num_workers=args.num_workers,
-        timeout=args.timeout,
-        max_iterations=args.max_iterations,
-        runs_per_query=args.runs_per_query,
-        trigger_threshold=args.trigger_threshold,
-        holdout=args.holdout,
-        model=args.model,
-        verbose=args.verbose,
-        live_report_path=live_report_path,
-        log_dir=log_dir,
-    )
+    try:
+        output = run_loop(
+            eval_set=eval_set,
+            skill_path=skill_path,
+            description_override=args.description,
+            num_workers=args.num_workers,
+            timeout=args.timeout,
+            max_iterations=args.max_iterations,
+            runs_per_query=args.runs_per_query,
+            trigger_threshold=args.trigger_threshold,
+            holdout=args.holdout,
+            model=args.model,
+            verbose=args.verbose,
+            live_report_path=live_report_path,
+            log_dir=log_dir,
+            fixture=fixture,
+        )
+    except SkillAlreadyRegistered as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
 
     # Save JSON output
     json_output = json.dumps(output, indent=2)


### PR DESCRIPTION
`skills/skill-creator/scripts/run_eval.py` and `run_loop.py` cannot currently measure whether a description triggers a skill. Every positive query scores 0% recall, and the same query alternates between 0.0 and 1.0 across runs — so `run_loop.py` optimizes descriptions against noise.

Five defects, all the same class: the experiment measures something other than the description.

## The defects

**The probe competes with the real skill.** `find_project_root()` walks up from cwd to the nearest `.claude/`, which lands in a tree that already registers the skill under test — the common case, since you run the eval from the repo holding the skill. Claude invokes the real name while the probe watches for its uuid-suffixed decoy, so every genuine trigger scores as a miss. That is the 100% precision / 0% recall signature. Each probe now builds and tears down its own root.

**The detector gives up at the first orienting command.** It returns `False` the moment a tool call is not `Skill` or `Read`. Reading the raw stream, Claude's opening move is usually a `Bash` locating itself (`pwd`, `ls`), and it consults the skill a turn later. That ordering is close to a coin flip, and it is the source of the non-determinism. A trigger now counts anywhere in the run, bounded by `MAX_PROBE_TURNS = 4` so a run that was never going to trigger stops before executing the whole queried task.

**Probes share a directory.** With more than one worker, several decoy commands are live at once. They differ only by uuid, so a worker can watch its own copy while Claude invokes another's.

**No stdin redirect.** `claude -p` is spawned without `stdin`, so every probe waits 3s for piped input that never arrives.

**An installed copy still wins.** A private probe root isolates project scope, but a user-level `~/.claude/skills/<name>` entry or a plugin reaches the probe anyway, and the real name outscores the decoy — the same false-miss, reported silently as 0%. This is easy to hit: testing a skill you actually use. The `system/init` event names what is registered, so the run now aborts with an error naming the offending copy instead of reporting a plausible zero.

## User-facing changes

`--project-root` becomes `--fixture`, reflecting what it now means: a *fixture copied into* each probe's sandbox. The old name invited pointing it at the real project — precisely the false-negative case the isolation exists to prevent. Skills whose queries only make sense somewhere specific need one: in a bare directory Claude answers "there's nothing here" rather than reaching for the skill, and every positive looks like a miss. Any `.claude/skills` or `.claude/commands` the fixture carries is stripped from the copy, so the decoy stays the only registered skill; the rest of the fixture survives intact, and the original is never modified. The default remains a bare temp dir.

`--timeout` rises from 30s to 120s. With the turn cap in place it is a safety net rather than the expected duration of a negative.

As a side effect, the harness stops writing probe files into the caller's `.claude/commands/`. That path is not gitignored, so an interrupted run left untracked files staged for an accidental commit.

## Verification

Against `skills/mcp-builder` (not installed locally, so the collision check passes), two positives and two negatives, 2 runs per query, 4 workers:

| Query | Expected | Stock | This PR |
|---|---|---|---|
| write a FastMCP server that wraps the Stripe API | triggers | 0.5 / 0.5 / 0.5 | 1.0 / 1.0 / 1.0 |
| I need to expose our internal billing API to Claude as tools it can call | triggers | 0.0 / 0.0 / 0.0 | 1.0 / 1.0 / 1.0 |
| the build/ directory has 2GB of stale artifacts, clean it up | no trigger | 0.0 / 0.0 / 0.0 | 0.0 / 0.0 / 0.0 |
| rename the getUser function to fetchUser across the repo | no trigger | 0.0 / 0.0 / 0.0 | 0.0 / 0.0 / 0.0 |

Three independent runs of each. The stock harness never scores a positive above 0.5 and reports one of them as a hard failure; this PR separates positives from negatives cleanly and repeats it.

Also checked: the collision guard fires against a skill installed at user scope (`skill-creator` itself) and exits with a message naming it; no temp roots survive a run; the fixture is never modified; both CLIs exit with a clear error on a missing `--fixture`; `quick_validate.py` passes.

Run 8 probes in ~20s, against minutes before — the turn cap, not a change in what is measured.

## Notes

This was found and fixed downstream while optimizing a skill description, against a vendored copy of `skill-creator` byte-identical to this repo's current `main`. The fifth defect above surfaced only when re-verifying the port here, against a skill installed at user scope. No behavior outside `skill-creator`'s eval scripts changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
