### PR TITLE
fix(skill-creator): scan full turn for skill triggers instead of bailing on first non-Skill tool (#1721)

### DIFF
--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -32,6 +32,88 @@ def find_project_root() -> Path:
     return current
 
 
+class TriggerDetector:
+    """Incrementally consumes parsed `claude -p --output-format stream-json`
+    events for a single query and determines whether the target skill was
+    triggered.
+
+    Feed events one at a time via `process_event`. It returns True/False once
+    the outcome is certain (skill tool_use seen, or the turn/stream completed
+    without one), or None while the outcome is still undetermined. Any tool
+    use that is not the skill (e.g. Bash, Glob, Grep used to inspect files
+    first) must NOT short-circuit detection to False -- the model may still
+    invoke the skill later in the same turn.
+    """
+
+    def __init__(self, clean_name: str):
+        self.clean_name = clean_name
+        self.triggered = False
+        self._pending_tool_name = None
+        self._accumulated_json = ""
+
+    def _check_tool_use(self, tool_name: str, tool_input: dict) -> bool:
+        if tool_name == "Skill" and self.clean_name in tool_input.get("skill", ""):
+            return True
+        if tool_name == "Read" and self.clean_name in tool_input.get("file_path", ""):
+            return True
+        return False
+
+    def process_event(self, event: dict) -> bool | None:
+        event_type = event.get("type")
+
+        if event_type == "stream_event":
+            se = event.get("event", {})
+            se_type = se.get("type", "")
+
+            if se_type == "content_block_start":
+                cb = se.get("content_block", {})
+                if cb.get("type") == "tool_use":
+                    tool_name = cb.get("name", "")
+                    if tool_name in ("Skill", "Read"):
+                        self._pending_tool_name = tool_name
+                        self._accumulated_json = ""
+                    else:
+                        # Some other tool (Bash, Glob, Grep, ...) -- keep
+                        # scanning the rest of the turn instead of bailing.
+                        self._pending_tool_name = None
+                        self._accumulated_json = ""
+
+            elif se_type == "content_block_delta" and self._pending_tool_name:
+                delta = se.get("delta", {})
+                if delta.get("type") == "input_json_delta":
+                    self._accumulated_json += delta.get("partial_json", "")
+                    if self.clean_name in self._accumulated_json:
+                        self.triggered = True
+                        return True
+
+            elif se_type == "content_block_stop":
+                if self._pending_tool_name and self.clean_name in self._accumulated_json:
+                    self.triggered = True
+                    return True
+                self._pending_tool_name = None
+                self._accumulated_json = ""
+
+            # Note: message_stop does not finalize the result -- a turn can
+            # contain multiple content blocks/messages before the skill is
+            # invoked. Only a "result" event (or stream end) is conclusive.
+
+        elif event_type == "assistant":
+            message = event.get("message", {})
+            for content_item in message.get("content", []):
+                if content_item.get("type") != "tool_use":
+                    continue
+                tool_name = content_item.get("name", "")
+                tool_input = content_item.get("input", {})
+                if self._check_tool_use(tool_name, tool_input):
+                    self.triggered = True
+                    return True
+
+        elif event_type == "result":
+            return self.triggered
+
+        return None
+
+
 def run_single_query(
     query: str,
     skill_name: str,
@@ -90,12 +172,9 @@ def run_single_query(
             env=env,
         )
 
-        triggered = False
         start_time = time.time()
         buffer = ""
-        # Track state for stream event detection
-        pending_tool_name = None
-        accumulated_json = ""
+        detector = TriggerDetector(clean_name)
 
         try:
             while time.time() - start_time < timeout:
@@ -125,57 +204,16 @@ def run_single_query(
                     except json.JSONDecodeError:
                         continue
 
-                    # Early detection via stream events
-                    if event.get("type") == "stream_event":
-                        se = event.get("event", {})
-                        se_type = se.get("type", "")
-
-                        if se_type == "content_block_start":
-                            cb = se.get("content_block", {})
-                            if cb.get("type") == "tool_use":
-                                tool_name = cb.get("name", "")
-                                if tool_name in ("Skill", "Read"):
-                                    pending_tool_name = tool_name
-                                    accumulated_json = ""
-                                else:
-                                    return False
-
-                        elif se_type == "content_block_delta" and pending_tool_name:
-                            delta = se.get("delta", {})
-                            if delta.get("type") == "input_json_delta":
-                                accumulated_json += delta.get("partial_json", "")
-                                if clean_name in accumulated_json:
-                                    return True
-
-                        elif se_type in ("content_block_stop", "message_stop"):
-                            if pending_tool_name:
-                                return clean_name in accumulated_json
-                            if se_type == "message_stop":
-                                return False
-
-                    # Fallback: full assistant message
-                    elif event.get("type") == "assistant":
-                        message = event.get("message", {})
-                        for content_item in message.get("content", []):
-                            if content_item.get("type") != "tool_use":
-                                continue
-                            tool_name = content_item.get("name", "")
-                            tool_input = content_item.get("input", {})
-                            if tool_name == "Skill" and clean_name in tool_input.get("skill", ""):
-                                triggered = True
-                            elif tool_name == "Read" and clean_name in tool_input.get("file_path", ""):
-                                triggered = True
-                            return triggered
-
-                    elif event.get("type") == "result":
-                        return triggered
+                    outcome = detector.process_event(event)
+                    if outcome is not None:
+                        return outcome
         finally:
             # Clean up process on any exit path (return, exception, timeout)
             if process.poll() is None:
                 process.kill()
                 process.wait()
 
-        return triggered
+        return detector.triggered
     finally:
         if command_file.exists():
             command_file.unlink()

--- a/skills/skill-creator/scripts/test_run_eval_trigger.py
+++ b/skills/skill-creator/scripts/test_run_eval_trigger.py
@@ -1,0 +1,252 @@
+"""Tests for the trigger-detection state machine in run_eval.py.
+
+Covers the bugs from anthropics/skills#1721 ("skill-creator: trigger
+detection reports 0% recall for every skill"):
+
+1. Seeing a non-Skill/Read tool_use (e.g. Bash, Glob, Grep) used to inspect
+   files before the skill must NOT immediately end detection with False.
+2. `content_block_stop` / `message_stop` must not prematurely finalize the
+   result when a *later* content block or message still invokes the skill.
+3. The fallback "assistant" message handler must scan every content item in
+   the message, not bail out after the first tool_use it finds.
+4. Only a `result` event (or end of stream) with no skill tool_use seen so
+   far should produce a final `False`.
+
+Run with:
+    cd skills/skill-creator && python3 -m unittest scripts.test_run_eval_trigger
+    cd skills/skill-creator && python3 -m pytest scripts/test_run_eval_trigger.py
+"""
+
+import unittest
+
+try:
+    from scripts.run_eval import TriggerDetector
+except ImportError:
+    from run_eval import TriggerDetector
+
+CLEAN_NAME = "my-skill-skill-abc12345"
+
+
+def stream_event(se_type: str, **kwargs) -> dict:
+    return {"type": "stream_event", "event": {"type": se_type, **kwargs}}
+
+
+def tool_use_start(name: str) -> dict:
+    return stream_event(
+        "content_block_start",
+        content_block={"type": "tool_use", "name": name},
+    )
+
+
+def input_delta(partial_json: str) -> dict:
+    return stream_event(
+        "content_block_delta",
+        delta={"type": "input_json_delta", "partial_json": partial_json},
+    )
+
+
+def block_stop() -> dict:
+    return stream_event("content_block_stop")
+
+
+def message_stop() -> dict:
+    return stream_event("message_stop")
+
+
+def result_event(triggered: bool = False) -> dict:
+    return {"type": "result"}
+
+
+def assistant_message(*content) -> dict:
+    return {"type": "assistant", "message": {"content": list(content)}}
+
+
+def tool_use_block(name: str, **input_fields) -> dict:
+    return {"type": "tool_use", "name": name, "input": input_fields}
+
+
+class TriggerDetectorStreamEventTests(unittest.TestCase):
+    """Bug #1 & #2: non-skill tools and block/message stops shouldn't kill detection."""
+
+    def feed(self, detector: TriggerDetector, events: list[dict]):
+        outcome = None
+        for event in events:
+            outcome = detector.process_event(event)
+            if outcome is not None:
+                return outcome
+        return outcome
+
+    def test_bash_then_skill_triggers(self):
+        """Model inspects files with Bash/Glob/Grep, then calls Skill: must be True."""
+        detector = TriggerDetector(CLEAN_NAME)
+        events = [
+            tool_use_start("Bash"),
+            input_delta('{"command": "ls"}'),
+            block_stop(),
+            tool_use_start("Glob"),
+            input_delta('{"pattern": "*.py"}'),
+            block_stop(),
+            tool_use_start("Skill"),
+            input_delta('{"skill": "' + CLEAN_NAME),
+            input_delta('"}'),
+        ]
+        outcome = self.feed(detector, events)
+        self.assertTrue(outcome)
+        self.assertTrue(detector.triggered)
+
+    def test_bash_only_no_skill_returns_false_at_result(self):
+        """Non-skill tool used, no Skill call ever happens -> False only at result."""
+        detector = TriggerDetector(CLEAN_NAME)
+        events = [
+            tool_use_start("Bash"),
+            input_delta('{"command": "ls"}'),
+            block_stop(),
+        ]
+        # Still undetermined mid-stream -- must NOT be False yet.
+        outcome = self.feed(detector, events)
+        self.assertIsNone(outcome)
+
+        outcome = detector.process_event(result_event())
+        self.assertFalse(outcome)
+
+    def test_single_non_skill_tool_start_does_not_return_false(self):
+        """Regression for the literal `else: return False` bug: seeing one
+        non-Skill/Read tool_use content_block_start must not itself resolve
+        the detector to False."""
+        detector = TriggerDetector(CLEAN_NAME)
+        outcome = detector.process_event(tool_use_start("Bash"))
+        self.assertIsNone(outcome)
+
+    def test_message_stop_does_not_finalize_false(self):
+        """A message_stop with no skill seen yet must not finalize to False;
+        only `result` (or end of stream) is conclusive."""
+        detector = TriggerDetector(CLEAN_NAME)
+        events = [
+            tool_use_start("Bash"),
+            input_delta('{"command": "ls"}'),
+            block_stop(),
+            message_stop(),
+        ]
+        outcome = self.feed(detector, events)
+        self.assertIsNone(outcome)
+
+    def test_skill_in_second_message_after_message_stop(self):
+        """Skill call arrives in a second assistant message after an earlier
+        message_stop for an unrelated tool -- must still be detected."""
+        detector = TriggerDetector(CLEAN_NAME)
+        events = [
+            tool_use_start("Bash"),
+            input_delta('{"command": "ls"}'),
+            block_stop(),
+            message_stop(),
+            tool_use_start("Skill"),
+            input_delta('{"skill": "' + CLEAN_NAME + '"}'),
+        ]
+        outcome = self.feed(detector, events)
+        self.assertTrue(outcome)
+
+    def test_content_block_stop_without_match_does_not_finalize(self):
+        detector = TriggerDetector(CLEAN_NAME)
+        events = [
+            tool_use_start("Read"),
+            input_delta('{"file_path": "/tmp/unrelated.txt"}'),
+            block_stop(),
+        ]
+        outcome = self.feed(detector, events)
+        self.assertIsNone(outcome)
+        self.assertFalse(detector.triggered)
+
+    def test_read_matching_skill_file_triggers_on_block_stop(self):
+        detector = TriggerDetector(CLEAN_NAME)
+        events = [
+            tool_use_start("Read"),
+            input_delta('{"file_path": "/proj/.claude/commands/' + CLEAN_NAME + '.md"}'),
+        ]
+        outcome = self.feed(detector, events)
+        self.assertTrue(outcome)
+
+
+class TriggerDetectorAssistantFallbackTests(unittest.TestCase):
+    """Bug #3: the assistant-message fallback must scan every content item."""
+
+    def test_scans_past_first_non_matching_tool_use(self):
+        """Regression for `return triggered` sitting inside the for-loop:
+        a Bash call followed by the Skill call in the same assistant message
+        must be detected, not short-circuited on the first item."""
+        detector = TriggerDetector(CLEAN_NAME)
+        message = assistant_message(
+            {"type": "text", "text": "Let me check the files first."},
+            tool_use_block("Bash", command="ls"),
+            tool_use_block("Skill", skill=CLEAN_NAME),
+        )
+        outcome = detector.process_event(message)
+        self.assertTrue(outcome)
+        self.assertTrue(detector.triggered)
+
+    def test_scans_past_multiple_non_matching_tools(self):
+        detector = TriggerDetector(CLEAN_NAME)
+        message = assistant_message(
+            tool_use_block("Bash", command="ls"),
+            tool_use_block("Glob", pattern="*.py"),
+            tool_use_block("Grep", pattern="foo"),
+            tool_use_block("Read", file_path=f"/proj/.claude/commands/{CLEAN_NAME}.md"),
+        )
+        outcome = detector.process_event(message)
+        self.assertTrue(outcome)
+
+    def test_no_matching_tool_use_returns_none_not_false(self):
+        """A message with only unrelated tool calls should leave the outcome
+        undetermined (None) so the caller keeps waiting for `result`, rather
+        than concluding False after just one assistant message."""
+        detector = TriggerDetector(CLEAN_NAME)
+        message = assistant_message(
+            tool_use_block("Bash", command="ls"),
+            tool_use_block("Glob", pattern="*.py"),
+        )
+        outcome = detector.process_event(message)
+        self.assertIsNone(outcome)
+        self.assertFalse(detector.triggered)
+
+    def test_unrelated_skill_name_does_not_match_substring_false_positive(self):
+        detector = TriggerDetector(CLEAN_NAME)
+        message = assistant_message(
+            tool_use_block("Skill", skill="some-other-skill-def99999"),
+        )
+        outcome = detector.process_event(message)
+        self.assertIsNone(outcome)
+        self.assertFalse(detector.triggered)
+
+
+class TriggerDetectorResultFinalizationTests(unittest.TestCase):
+    """Bug #4: only `result` (or end of stream) with nothing found should be False."""
+
+    def test_result_with_no_tool_use_is_false(self):
+        detector = TriggerDetector(CLEAN_NAME)
+        outcome = detector.process_event(result_event())
+        self.assertFalse(outcome)
+
+    def test_result_after_skill_triggered_is_true(self):
+        detector = TriggerDetector(CLEAN_NAME)
+        detector.process_event(tool_use_start("Skill"))
+        detector.process_event(input_delta('{"skill": "' + CLEAN_NAME + '"}'))
+        outcome = detector.process_event(result_event())
+        self.assertTrue(outcome)
+
+    def test_end_of_stream_without_result_uses_triggered_flag(self):
+        """When the process exits before a `result` event arrives (e.g. it
+        hit the timeout or the CLI didn't emit one), the caller falls back to
+        `detector.triggered`, which must reflect the true state."""
+        detector = TriggerDetector(CLEAN_NAME)
+        detector.process_event(tool_use_start("Bash"))
+        detector.process_event(input_delta('{"command": "ls"}'))
+        detector.process_event(block_stop())
+        self.assertFalse(detector.triggered)
+
+        detector2 = TriggerDetector(CLEAN_NAME)
+        detector2.process_event(tool_use_start("Skill"))
+        detector2.process_event(input_delta('{"skill": "' + CLEAN_NAME + '"}'))
+        self.assertTrue(detector2.triggered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1721

### Summary
Fixes a false-negative trigger detection defect where `run_single_query()` in `skill-creator`'s eval harness reported 0% recall for valid skills whenever an orientation tool (`Bash`, `Glob`, `Grep`, etc.) was invoked before the skill.

### Changes
1. **Full Turn Tool Scanning:** Extracted incremental event processing into `TriggerDetector`. Non-Skill/Read tools no longer trigger early `return False`; instead, detection continues until the skill is invoked or the turn completes (`result` event).
2. **Proper Block Lifecycle:** `content_block_stop` only checks accumulated input for the current block and does not prematurely finalize the entire turn as failed.
3. **Assistant Message Fallback:** Corrected the loop over `message['content']` so all content items are checked, rather than bailing on the first non-matching item.
4. **Unit Tests:** Added 14 unit tests in `test_run_eval_trigger.py` covering all multi-tool sequences, partial deltas, early orientation, and fallback scenarios.

Tested locally: 14/14 tests pass.