### PR TITLE
fix(webapp-testing): clarify local-only trigger scope (#1717)

### DIFF
--- a/skills/webapp-testing/SKILL.md
+++ b/skills/webapp-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: webapp-testing
-description: Toolkit for interacting with and testing local web applications using Playwright. Supports verifying frontend functionality, debugging UI behavior, capturing browser screenshots, and viewing browser logs.
+description: Toolkit for interacting with and testing local web pages and applications (including static HTML files) using Playwright. For pages and applications under development on your machine, not for extracting data from public websites. Supports verifying frontend functionality, debugging UI behavior, capturing browser screenshots, and viewing browser logs.
 license: Complete terms in LICENSE.txt
 ---
 


### PR DESCRIPTION
Closes #1717

## Summary

Clarifies that `webapp-testing` is for local pages and applications under development, including static local HTML files, and not for extracting data from public websites.

## Why

The trigger description previously emphasized browser interaction and Playwright but did not express its two important boundaries: local target and testing intent. This allowed occasional triggering for public client-rendered site scraping, where the local-server workflow is irrelevant.

## Scope

- Keeps local web application testing in scope.
- Explicitly retains static local HTML coverage, which the skill body already supports.
- Excludes public-site data extraction.

## Validation

- `git diff --check` passed.
- UTF-8/frontmatter delimiter validation passed.
- Independent review found no blocking issue and confirmed the full skill body only describes `localhost`/`file://` workflows.